### PR TITLE
feat(grants): agent-connector GRANTS subsystem — approval-gated resource grants (4b-1)

### DIFF
--- a/src/__tests__/admin-agent-grants.test.ts
+++ b/src/__tests__/admin-agent-grants.test.ts
@@ -496,6 +496,28 @@ describe("POST /admin/grants/<id>/approve", () => {
     expect((stored?.material as { kind: string; token: string }).token).toBe("ghp_secret123");
   });
 
+  test("service approve rejects an over-long pasted token (400)", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "service", target: "github", inject: ["env"] },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    const res = await dispatch(
+      cookieReq("POST", `/admin/grants/${id}/approve`, cookie, { token: "x".repeat(9000) }),
+    );
+    expect(res.status).toBe(400);
+    // not stored — the grant stays pending, no oversized material on disk.
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.status).toBe("pending");
+    expect(stored?.material).toBeUndefined();
+  });
+
   test("service: 400 when no token is pasted", async () => {
     const bearer = await moduleBearer();
     const cookie = await operatorCookie();

--- a/src/__tests__/admin-agent-grants.test.ts
+++ b/src/__tests__/admin-agent-grants.test.ts
@@ -286,6 +286,46 @@ describe("PUT /admin/grants (upsert)", () => {
       ).status,
     ).toBe(400);
   });
+
+  test("400 on a reserved vault name (no phantom pending row)", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "a",
+        connection: { kind: "vault", target: "admin" },
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(readGrants(harness.storePath)).toHaveLength(0);
+  });
+
+  test("400 on an over-long agent / tags array", async () => {
+    const bearer = await moduleBearer();
+    expect(
+      (
+        await dispatch(
+          bearerReq("PUT", "/admin/grants", bearer, {
+            agent: "x".repeat(200),
+            connection: { kind: "vault", target: "research" },
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await dispatch(
+          bearerReq("PUT", "/admin/grants", bearer, {
+            agent: "a",
+            connection: {
+              kind: "vault",
+              target: "research",
+              tags: Array.from({ length: 100 }, (_, i) => `#t${i}`),
+            },
+          }),
+        )
+      ).status,
+    ).toBe(400);
+  });
 });
 
 // === GET /admin/grants ======================================================
@@ -383,6 +423,57 @@ describe("POST /admin/grants/<id>/approve", () => {
     expect((claims.permissions as { scoped_tags: string[] }).scoped_tags).toEqual(["#published"]);
     // registered → revocable
     expect(findTokenRowByJti(harness.db, mat.jti)).not.toBeNull();
+  });
+
+  test("vault: re-approval revokes the prior minted token (no orphaned live token)", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    const firstJti = (
+      readGrants(harness.storePath).find((r) => r.id === id)?.material as { jti: string }
+    ).jti;
+
+    // approve again — should revoke the first token and mint a fresh one
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    const secondJti = (
+      readGrants(harness.storePath).find((r) => r.id === id)?.material as { jti: string }
+    ).jti;
+
+    expect(secondJti).not.toBe(firstJti);
+    expect(findTokenRowByJti(harness.db, firstJti)?.revokedAt).toBeTruthy();
+    expect(findTokenRowByJti(harness.db, secondJti)?.revokedAt).toBeFalsy();
+  });
+
+  test("vault: a revoked grant can be re-approved (re-mints fresh material)", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/revoke`, cookie));
+    expect(readGrants(harness.storePath).find((r) => r.id === id)?.status).toBe("revoked");
+
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    expect(res.status).toBe(200);
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.status).toBe("approved");
+    expect((stored?.material as { kind: string }).kind).toBe("vault");
   });
 
   test("service: stores the operator-pasted token", async () => {

--- a/src/__tests__/admin-agent-grants.test.ts
+++ b/src/__tests__/admin-agent-grants.test.ts
@@ -1,0 +1,669 @@
+/**
+ * Tests for the agent-connector GRANTS subsystem (`admin-agent-grants.ts`, 4b-1).
+ *
+ * The handler has two auth classes:
+ *   - module-auth (a `parachute:host:admin` Bearer): PUT /admin/grants,
+ *     GET /admin/grants, GET /admin/grants/<id>/material.
+ *   - operator-auth (a first-admin session cookie): POST /admin/grants/<id>/approve,
+ *     POST /admin/grants/<id>/revoke.
+ *
+ * Tokens are real (minted by the actual `signAccessToken`), so an approved vault
+ * grant's `/material` token can be decoded + asserted (scope/aud/permissions) the
+ * way the vault would read it. The store is a real tmpdir JSON file, so the
+ * 0600 + secret-not-in-list invariants are exercised end to end.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { decodeJwt } from "jose";
+import { type AgentGrantsDeps, handleAgentGrants } from "../admin-agent-grants.ts";
+import { readGrants } from "../grants-store.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { findTokenRowByJti } from "../jwt-sign.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const HUB_ORIGIN = "https://hub.test";
+const VAULT_ORIGIN = "http://127.0.0.1:1940";
+
+interface Harness {
+  db: Database;
+  storePath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-agent-grants-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  return {
+    db,
+    storePath: join(dir, "agent-grants.json"),
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+/** Vaults that "exist" for resolveVaultOrigin. */
+let installedVaults = new Set<string>(["research"]);
+beforeEach(() => {
+  installedVaults = new Set<string>(["research"]);
+});
+
+function deps(): AgentGrantsDeps {
+  return {
+    db: harness.db,
+    hubOrigin: HUB_ORIGIN,
+    storePath: harness.storePath,
+    resolveVaultOrigin: (name) => (installedVaults.has(name) ? VAULT_ORIGIN : null),
+  };
+}
+
+// --- Auth helpers -----------------------------------------------------------
+//
+// Robust to call order: the FIRST user created in a test is the first-admin
+// (the operator). `ensureFirstAdmin` lazily creates + memoizes that user so
+// `moduleBearer`/`operatorCookie`/`friendCookie` can be called in any order
+// without tripping the single-user guard.
+
+let firstAdminId: string | null = null;
+beforeEach(() => {
+  firstAdminId = null;
+});
+
+async function ensureFirstAdmin(): Promise<string> {
+  if (firstAdminId) return firstAdminId;
+  const user = await createUser(harness.db, "operator", "pw");
+  firstAdminId = user.id;
+  return user.id;
+}
+
+async function moduleBearer(scopes = ["parachute:host:admin"]): Promise<string> {
+  // The module is some on-box caller — it just needs a valid host-admin Bearer.
+  // Reuse the first-admin as its subject (it's a token-scope gate, not a
+  // session gate, so the subject identity doesn't matter for these routes).
+  const sub = await ensureFirstAdmin();
+  const minted = await signAccessToken(harness.db, {
+    sub,
+    scopes,
+    audience: "hub",
+    clientId: "parachute-hub-spa",
+    issuer: HUB_ORIGIN,
+    ttlSeconds: 600,
+  });
+  return minted.token;
+}
+
+async function operatorCookie(): Promise<string> {
+  const userId = await ensureFirstAdmin();
+  const session = createSession(harness.db, { userId });
+  return buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+}
+
+async function friendCookie(): Promise<string> {
+  await ensureFirstAdmin(); // first-admin must exist
+  const friend = await createUser(harness.db, "friend", "pw", { allowMulti: true });
+  const session = createSession(harness.db, { userId: friend.id });
+  return buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+}
+
+// --- Request builders -------------------------------------------------------
+
+function bearerReq(method: string, path: string, bearer: string, body?: unknown): Request {
+  return new Request(`${HUB_ORIGIN}${path}`, {
+    method,
+    headers: {
+      authorization: `Bearer ${bearer}`,
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+function cookieReq(method: string, path: string, cookie: string, body?: unknown): Request {
+  return new Request(`${HUB_ORIGIN}${path}`, {
+    method,
+    headers: {
+      cookie,
+      origin: HUB_ORIGIN,
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+async function dispatch(req: Request): Promise<Response> {
+  const subPath = new URL(req.url).pathname.slice("/admin/grants".length);
+  return handleAgentGrants(req, subPath, deps());
+}
+
+async function json(res: Response): Promise<Record<string, unknown>> {
+  return (await res.json()) as Record<string, unknown>;
+}
+
+// === PUT /admin/grants ======================================================
+
+describe("PUT /admin/grants (upsert)", () => {
+  test("creates a pending vault grant (201) — no material in the response", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "agent1",
+        connection: { kind: "vault", target: "research", access: "read", tags: ["#published"] },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.status).toBe("pending");
+    expect(body.agent).toBe("agent1");
+    expect(body).not.toHaveProperty("material");
+    expect((body.connection as Record<string, unknown>).tags).toEqual(["#published"]);
+    expect(typeof body.id).toBe("string");
+  });
+
+  test("is idempotent — re-PUT the same connection returns 200, no duplicate row", async () => {
+    const bearer = await moduleBearer();
+    const spec = { kind: "vault", target: "research", access: "read" };
+    const r1 = await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, { agent: "a", connection: spec }),
+    );
+    expect(r1.status).toBe(201);
+    const r2 = await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, { agent: "a", connection: spec }),
+    );
+    expect(r2.status).toBe(200);
+    expect(readGrants(harness.storePath)).toHaveLength(1);
+  });
+
+  test("a service grant carries inject hints", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "a",
+        connection: { kind: "service", target: "github", inject: ["env", "mcp"] },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect((body.connection as Record<string, unknown>).inject).toEqual(["env", "mcp"]);
+  });
+
+  test("an mcp grant stays pending with the slice-2 reason", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "a",
+        connection: { kind: "mcp", target: "https://remote.test/mcp" },
+      }),
+    );
+    expect(res.status).toBe(201);
+    const body = await json(res);
+    expect(body.status).toBe("pending");
+    expect(body.reason).toBe("oauth not yet supported");
+  });
+
+  test("re-declaring an APPROVED grant does not downgrade it to pending", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const spec = { kind: "vault", target: "research", access: "read" };
+    const created = await json(
+      await dispatch(bearerReq("PUT", "/admin/grants", bearer, { agent: "a", connection: spec })),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    // re-declare
+    const re = await json(
+      await dispatch(bearerReq("PUT", "/admin/grants", bearer, { agent: "a", connection: spec })),
+    );
+    expect(re.status).toBe("approved");
+  });
+
+  test("401 without a Bearer", async () => {
+    const req = new Request(`${HUB_ORIGIN}/admin/grants`, {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agent: "a", connection: { kind: "vault", target: "research" } }),
+    });
+    const res = await dispatch(req);
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when the Bearer lacks parachute:host:admin", async () => {
+    const bearer = await moduleBearer(["vault:research:read"]);
+    const res = await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "a",
+        connection: { kind: "vault", target: "research" },
+      }),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("400 on a bad agent name / bad spec", async () => {
+    const bearer = await moduleBearer();
+    expect(
+      (
+        await dispatch(
+          bearerReq("PUT", "/admin/grants", bearer, {
+            agent: "bad name!",
+            connection: { kind: "vault", target: "research" },
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await dispatch(
+          bearerReq("PUT", "/admin/grants", bearer, {
+            agent: "a",
+            connection: { kind: "nope", target: "x" },
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    expect(
+      (
+        await dispatch(
+          bearerReq("PUT", "/admin/grants", bearer, {
+            agent: "a",
+            connection: { kind: "vault", target: "Bad Vault" },
+          }),
+        )
+      ).status,
+    ).toBe(400);
+  });
+});
+
+// === GET /admin/grants ======================================================
+
+describe("GET /admin/grants (list — NO secrets)", () => {
+  test("lists grants, never includes material even for approved grants", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    // pending service grant
+    await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "a",
+        connection: { kind: "service", target: "github" },
+      }),
+    );
+    // approved vault grant (material stored on disk)
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
+
+    const res = await dispatch(bearerReq("GET", "/admin/grants?agent=a", bearer));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    const grants = body.grants as Record<string, unknown>[];
+    expect(grants).toHaveLength(2);
+    for (const g of grants) expect(g).not.toHaveProperty("material");
+    // the raw JSON text must not leak the minted token
+    const raw = JSON.stringify(body);
+    const stored = readGrants(harness.storePath).find((r) => r.connection.kind === "vault");
+    expect(stored?.material).toBeDefined();
+    expect(raw).not.toContain((stored?.material as { token: string }).token);
+  });
+
+  test("?agent filter narrows to one agent", async () => {
+    const bearer = await moduleBearer();
+    await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "a",
+        connection: { kind: "vault", target: "research" },
+      }),
+    );
+    await dispatch(
+      bearerReq("PUT", "/admin/grants", bearer, {
+        agent: "b",
+        connection: { kind: "service", target: "github" },
+      }),
+    );
+    const a = await json(await dispatch(bearerReq("GET", "/admin/grants?agent=a", bearer)));
+    expect((a.grants as unknown[]).length).toBe(1);
+    const all = await json(await dispatch(bearerReq("GET", "/admin/grants", bearer)));
+    expect((all.grants as unknown[]).length).toBe(2);
+  });
+
+  test("401 without a Bearer", async () => {
+    const res = await dispatch(new Request(`${HUB_ORIGIN}/admin/grants`, { method: "GET" }));
+    expect(res.status).toBe(401);
+  });
+});
+
+// === POST /admin/grants/<id>/approve =======================================
+
+describe("POST /admin/grants/<id>/approve", () => {
+  test("vault: MINTS a registered vault:<target>:<access> token with scoped_tags", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research", access: "read", tags: ["#published"] },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.status).toBe("approved");
+    expect(body).not.toHaveProperty("material");
+    expect(body.approvedAt).toBeDefined();
+
+    // material on disk: decode the minted token
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    const mat = stored?.material as { kind: string; token: string; jti: string };
+    expect(mat.kind).toBe("vault");
+    const claims = decodeJwt(mat.token) as Record<string, unknown>;
+    expect(claims.scope).toBe("vault:research:read");
+    expect(claims.aud).toBe("vault.research");
+    expect((claims.permissions as { scoped_tags: string[] }).scoped_tags).toEqual(["#published"]);
+    // registered → revocable
+    expect(findTokenRowByJti(harness.db, mat.jti)).not.toBeNull();
+  });
+
+  test("service: stores the operator-pasted token", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "service", target: "github", inject: ["env"] },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    const res = await dispatch(
+      cookieReq("POST", `/admin/grants/${id}/approve`, cookie, { token: "ghp_secret123" }),
+    );
+    expect(res.status).toBe(200);
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect((stored?.material as { kind: string; token: string }).token).toBe("ghp_secret123");
+  });
+
+  test("service: 400 when no token is pasted", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "service", target: "github" },
+        }),
+      ),
+    );
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
+    expect(res.status).toBe(400);
+  });
+
+  test("mcp: 409 not_grantable (stays pending)", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
+    expect(res.status).toBe(409);
+    expect(readGrants(harness.storePath).find((r) => r.id === created.id)?.status).toBe("pending");
+  });
+
+  test("vault: 400 when the vault no longer exists", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    installedVaults.delete("research");
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
+    expect(res.status).toBe(400);
+  });
+
+  test("401 without a session cookie", async () => {
+    const bearer = await moduleBearer();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const res = await dispatch(
+      new Request(`${HUB_ORIGIN}/admin/grants/${created.id}/approve`, {
+        method: "POST",
+        headers: { origin: HUB_ORIGIN },
+      }),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("403 for a non-first-admin (friend) session", async () => {
+    const bearer = await moduleBearer();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const cookie = await friendCookie();
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
+    expect(res.status).toBe(403);
+  });
+
+  test("404 for an unknown grant id", async () => {
+    const cookie = await operatorCookie();
+    const res = await dispatch(cookieReq("POST", "/admin/grants/does-not-exist/approve", cookie));
+    expect(res.status).toBe(404);
+  });
+});
+
+// === GET /admin/grants/<id>/material =======================================
+
+describe("GET /admin/grants/<id>/material", () => {
+  test("vault: returns token + mcpUrl for an approved grant", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.kind).toBe("vault");
+    expect(typeof body.token).toBe("string");
+    expect(body.mcpUrl).toBe("https://hub.test/vault/research/mcp");
+  });
+
+  test("service: returns token + inject for an approved grant", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "service", target: "github", inject: ["env", "mcp"] },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie, { token: "ghp_x" }));
+
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.kind).toBe("service");
+    expect(body.token).toBe("ghp_x");
+    expect(body.inject).toEqual(["env", "mcp"]);
+  });
+
+  test("409 when the grant is still pending (not approved)", async () => {
+    const bearer = await moduleBearer();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${created.id}/material`, bearer));
+    expect(res.status).toBe(409);
+  });
+
+  test("404 for an unknown grant id", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(bearerReq("GET", "/admin/grants/nope/material", bearer));
+    expect(res.status).toBe(404);
+  });
+
+  test("401 without a Bearer (material is module-auth gated)", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
+    const res = await dispatch(
+      new Request(`${HUB_ORIGIN}/admin/grants/${created.id}/material`, { method: "GET" }),
+    );
+    expect(res.status).toBe(401);
+  });
+});
+
+// === POST /admin/grants/<id>/revoke ========================================
+
+describe("POST /admin/grants/<id>/revoke", () => {
+  test("drops the stored material, revokes the minted token, sets status=revoked", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    const jti = (
+      readGrants(harness.storePath).find((r) => r.id === id)?.material as { jti: string }
+    ).jti;
+
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${id}/revoke`, cookie));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.status).toBe("revoked");
+
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.material).toBeUndefined();
+    // the minted token is now revoked in the registry
+    const row = findTokenRowByJti(harness.db, jti);
+    expect(row?.revokedAt).toBeTruthy();
+
+    // /material now 409s
+    const mat = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(mat.status).toBe(409);
+  });
+
+  test("403 for a non-first-admin session", async () => {
+    const bearer = await moduleBearer();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const cookie = await friendCookie();
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/revoke`, cookie));
+    expect(res.status).toBe(403);
+  });
+
+  test("404 for an unknown grant id", async () => {
+    const cookie = await operatorCookie();
+    const res = await dispatch(cookieReq("POST", "/admin/grants/nope/revoke", cookie));
+    expect(res.status).toBe(404);
+  });
+});
+
+// === method/routing guards ==================================================
+
+describe("routing", () => {
+  test("405 on unsupported collection method", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(bearerReq("DELETE", "/admin/grants", bearer));
+    expect(res.status).toBe(405);
+  });
+
+  test("405 on GET /approve (operator routes are POST-only)", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "vault", target: "research" },
+        }),
+      ),
+    );
+    const res = await dispatch(cookieReq("GET", `/admin/grants/${created.id}/approve`, cookie));
+    expect(res.status).toBe(405);
+  });
+
+  test("404 on an unknown item verb", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(bearerReq("GET", "/admin/grants/x/bogus", bearer));
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/__tests__/grants-store.test.ts
+++ b/src/__tests__/grants-store.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Tests for the agent-connector grant store (`grants-store.ts`, 4b-1).
+ *
+ * Distinct from `grants.test.ts` (the OAuth consent skip-list in SQLite). This
+ * is the on-disk JSON store for approval-gated agent grants: round-trip, 0600
+ * perms (the file holds the granted secrets), idempotency-key derivation, and
+ * the lenient-read posture.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type ConnectionSpec,
+  type GrantRecord,
+  connectionKey,
+  getGrant,
+  grantId,
+  listGrantsForAgent,
+  putGrant,
+  readGrants,
+  removeGrant,
+} from "../grants-store.ts";
+
+let dir: string;
+let storePath: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "phub-grants-store-"));
+  storePath = join(dir, "agent-grants.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function vaultSpec(over: Partial<ConnectionSpec> = {}): ConnectionSpec {
+  return { kind: "vault", target: "research", access: "read", ...over };
+}
+
+function rec(over: Partial<GrantRecord> = {}): GrantRecord {
+  const connection = over.connection ?? vaultSpec();
+  return {
+    id: over.id ?? grantId("agent1", connection),
+    agent: over.agent ?? "agent1",
+    connection,
+    status: over.status ?? "pending",
+    createdAt: over.createdAt ?? "2026-06-17T00:00:00.000Z",
+    ...(over.reason ? { reason: over.reason } : {}),
+    ...(over.material ? { material: over.material } : {}),
+    ...(over.approvedAt ? { approvedAt: over.approvedAt } : {}),
+  };
+}
+
+describe("round-trip", () => {
+  test("a missing file reads as empty", () => {
+    expect(readGrants(storePath)).toEqual([]);
+  });
+
+  test("put → read returns the record", () => {
+    const r = rec();
+    putGrant(storePath, r);
+    const back = readGrants(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]).toEqual(r);
+  });
+
+  test("put upserts by id (no duplicate row)", () => {
+    const r = rec();
+    putGrant(storePath, r);
+    putGrant(storePath, { ...r, status: "approved", approvedAt: "2026-06-18T00:00:00.000Z" });
+    const back = readGrants(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]?.status).toBe("approved");
+  });
+
+  test("getGrant + removeGrant", () => {
+    const r = rec();
+    putGrant(storePath, r);
+    expect(getGrant(storePath, r.id)?.id).toBe(r.id);
+    const removed = removeGrant(storePath, r.id);
+    expect(removed?.id).toBe(r.id);
+    expect(getGrant(storePath, r.id)).toBeNull();
+  });
+
+  test("listGrantsForAgent filters by agent (case-insensitive)", () => {
+    putGrant(storePath, rec({ id: "a", agent: "AgentOne" }));
+    putGrant(
+      storePath,
+      rec({ id: "b", agent: "agenttwo", connection: vaultSpec({ target: "x" }) }),
+    );
+    expect(listGrantsForAgent(storePath, "agentone")).toHaveLength(1);
+    expect(listGrantsForAgent(storePath, "AGENTTWO")).toHaveLength(1);
+    expect(listGrantsForAgent(storePath, "nope")).toHaveLength(0);
+  });
+});
+
+describe("0600 perms (the file holds secrets)", () => {
+  test("the store file is created mode 0600", () => {
+    putGrant(
+      storePath,
+      rec({
+        status: "approved",
+        material: { kind: "service", token: "ghp_secret" },
+        connection: { kind: "service", target: "github" },
+      }),
+    );
+    const mode = statSync(storePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+describe("lenient read", () => {
+  test("garbage JSON reads as empty", () => {
+    writeFileSync(storePath, "not json {{{");
+    expect(readGrants(storePath)).toEqual([]);
+  });
+
+  test("a top-level array (wrong shape) reads as empty", () => {
+    writeFileSync(storePath, JSON.stringify([{ id: "x" }]));
+    expect(readGrants(storePath)).toEqual([]);
+  });
+
+  test("a malformed row is dropped, valid rows survive", () => {
+    const valid = rec();
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        grants: [
+          valid,
+          { id: "missing-agent" }, // no agent/connection/status → dropped
+          { id: "bad-status", agent: "a", connection: vaultSpec(), status: "weird" }, // bad status → dropped
+        ],
+      }),
+    );
+    const back = readGrants(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]?.id).toBe(valid.id);
+  });
+});
+
+describe("connectionKey / grantId derivation (idempotency)", () => {
+  test("vault key includes access + sorted tags", () => {
+    expect(connectionKey(vaultSpec())).toBe("vault:research:read");
+    expect(connectionKey(vaultSpec({ access: "write" }))).toBe("vault:research:write");
+    // tag order doesn't change the key
+    const a = connectionKey(vaultSpec({ tags: ["#b", "#a"] }));
+    const b = connectionKey(vaultSpec({ tags: ["#a", "#b"] }));
+    expect(a).toBe(b);
+    expect(a).toBe("vault:research:read##a,#b");
+  });
+
+  test("service key ignores inject (re-declare with new inject → same key)", () => {
+    const k1 = connectionKey({ kind: "service", target: "github", inject: ["env"] });
+    const k2 = connectionKey({ kind: "service", target: "github", inject: ["env", "mcp"] });
+    expect(k1).toBe(k2);
+    expect(k1).toBe("service:github");
+  });
+
+  test("mcp key is the url target", () => {
+    expect(connectionKey({ kind: "mcp", target: "https://x.test/mcp" })).toBe(
+      "mcp:https://x.test/mcp",
+    );
+  });
+
+  test("grantId is a stable URL-safe slug from agent + key", () => {
+    const id = grantId("agent1", vaultSpec());
+    expect(id).toMatch(/^[a-z0-9][a-z0-9-]*$/);
+    // deterministic
+    expect(grantId("agent1", vaultSpec())).toBe(id);
+    // different connection → different id
+    expect(grantId("agent1", vaultSpec({ access: "write" }))).not.toBe(id);
+  });
+});

--- a/src/admin-agent-grants.ts
+++ b/src/admin-agent-grants.ts
@@ -78,7 +78,7 @@ import {
 } from "./jwt-sign.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
-import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+import { validateVaultName } from "./vault-name.ts";
 
 /**
  * TTL of a minted vault grant token. 90 days — matches the Connections
@@ -97,6 +97,16 @@ const GRANT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
 const SERVICE_KEY_RE = /^[a-z0-9][a-z0-9_-]*$/i;
 /** A tag the agent declares for vault tag-scope. Conservative — no whitespace. */
 const TAG_RE = /^\S+$/;
+
+/**
+ * Input length caps (reviewer N3). A host-admin Bearer is already
+ * high-privilege, but these bound disk bloat from a runaway/misconfigured
+ * module registering grants on the operator's own machine.
+ */
+const MAX_AGENT_LEN = 128;
+const MAX_TARGET_LEN = 512;
+const MAX_TAG_LEN = 128;
+const MAX_TAGS = 64;
 
 export interface AgentGrantsDeps {
   db: Database;
@@ -234,11 +244,11 @@ async function upsertGrant(req: Request, deps: AgentGrantsDeps): Promise<Respons
   const b = body as Record<string, unknown>;
 
   const agent = typeof b.agent === "string" ? b.agent.trim() : "";
-  if (!agent || !AGENT_NAME_RE.test(agent)) {
+  if (!agent || agent.length > MAX_AGENT_LEN || !AGENT_NAME_RE.test(agent)) {
     return jsonError(
       400,
       "invalid_request",
-      "agent is required and must match [a-zA-Z0-9][a-zA-Z0-9_.-]*",
+      `agent is required and must match [a-zA-Z0-9][a-zA-Z0-9_.-]* (max ${MAX_AGENT_LEN} chars)`,
     );
   }
 
@@ -254,6 +264,12 @@ async function upsertGrant(req: Request, deps: AgentGrantsDeps): Promise<Respons
   // material on re-declare (the module re-registering the same want must NOT
   // downgrade an active grant to pending, nor re-open a revoked one). A new
   // grant lands pending — mcp pending with its slice-2 reason.
+  //
+  // Recovery from `revoked` (reviewer N2): re-declaring does NOT re-open it —
+  // the operator re-grants by approving the revoked row directly (the
+  // operator-gated approve path accepts any non-mcp grant regardless of prior
+  // status, re-minting fresh material). So a revoked grant is dormant, not
+  // dead; an explicit operator approve revives it.
   if (existing) {
     // Re-declare may refresh the agent-side `inject` hints on a service spec
     // without changing the grant's identity (inject is not part of the key).
@@ -291,10 +307,17 @@ function parseConnectionSpec(raw: unknown): { spec: ConnectionSpec } | { error: 
   }
   const target = typeof c.target === "string" ? c.target.trim() : "";
   if (!target) return { error: "connection.target is required" };
+  if (target.length > MAX_TARGET_LEN) {
+    return { error: `connection.target exceeds the ${MAX_TARGET_LEN}-char limit` };
+  }
 
   if (kind === "vault") {
-    if (!VAULT_NAME_CHARSET_RE.test(target)) {
-      return { error: `connection.target "${target}" is not a valid vault name` };
+    // Full vault-name validation (reviewer N4) — length + charset + reserved
+    // names (`admin`, `list`, `new`, `assets`). Rejecting reserved names here
+    // stops a phantom pending row that could never be approved.
+    const v = validateVaultName(target);
+    if (!v.ok) {
+      return { error: `connection.target ${v.error}` };
     }
     let access: GrantAccess = "read";
     if (c.access !== undefined) {
@@ -308,15 +331,21 @@ function parseConnectionSpec(raw: unknown): { spec: ConnectionSpec } | { error: 
       if (!Array.isArray(c.tags)) {
         return { error: "connection.tags must be an array of tag strings" };
       }
+      if (c.tags.length > MAX_TAGS) {
+        return { error: `connection.tags exceeds the ${MAX_TAGS}-entry limit` };
+      }
       for (const t of c.tags) {
-        if (typeof t !== "string" || !TAG_RE.test(t.trim()) || t.trim().length === 0) {
-          return { error: "connection.tags entries must be non-empty whitespace-free strings" };
+        const trimmed = typeof t === "string" ? t.trim() : "";
+        if (trimmed.length === 0 || trimmed.length > MAX_TAG_LEN || !TAG_RE.test(trimmed)) {
+          return {
+            error: `connection.tags entries must be non-empty whitespace-free strings (max ${MAX_TAG_LEN} chars)`,
+          };
         }
-        tags.push(t.trim());
+        tags.push(trimmed);
       }
     }
     return {
-      spec: { kind: "vault", target, access, ...(tags.length > 0 ? { tags } : {}) },
+      spec: { kind: "vault", target: v.name, access, ...(tags.length > 0 ? { tags } : {}) },
     };
   }
 

--- a/src/admin-agent-grants.ts
+++ b/src/admin-agent-grants.ts
@@ -106,6 +106,9 @@ const TAG_RE = /^\S+$/;
 const MAX_AGENT_LEN = 128;
 const MAX_TARGET_LEN = 512;
 const MAX_TAG_LEN = 128;
+/** Cap the operator-pasted service token. Operator-gated (nil trust exposure), but
+ *  bounds a fat-finger paste from bloating the on-disk store — matches the other caps. */
+const MAX_TOKEN_LEN = 8192;
 const MAX_TAGS = 64;
 
 export interface AgentGrantsDeps {
@@ -555,6 +558,9 @@ async function approveGrant(req: Request, id: string, deps: AgentGrantsDeps): Pr
       "token_required",
       "approving a service grant requires a non-empty `token` (the API credential to store)",
     );
+  }
+  if (token.length > MAX_TOKEN_LEN) {
+    return jsonError(400, "invalid_request", `token exceeds the ${MAX_TOKEN_LEN}-char limit`);
   }
   // Rebuild from identity fields (drops any pending `reason`).
   const updated: GrantRecord = {

--- a/src/admin-agent-grants.ts
+++ b/src/admin-agent-grants.ts
@@ -1,0 +1,683 @@
+/**
+ * Agent-connector GRANTS — the approval-gated resource-grant subsystem for
+ * vault-native agents (Phase 4b-1, agent-connectors design 2026-06-17).
+ *
+ * An agent (a `#agent/definition` note in the agent module) declares connections
+ * it WANTS beyond its own def-vault — other LOCAL vaults (tag-scoped) and
+ * external SERVICE credentials (GitHub, Cloudflare). The agent module registers
+ * each as a PENDING grant here; the operator approves per-connection in hub
+ * admin; the hub mints (vault) / stores (service) the secret; the agent module
+ * fetches the material at spawn and injects it. The `mcp` (remote/OAuth) kind is
+ * MODELED but not grantable in 4b-1 — it stays `pending` with a clear reason
+ * (slice 2 is hub-as-OAuth-client).
+ *
+ * The one invariant: **a vault note can only REQUEST; it can never GRANT.** A
+ * grant created by the module sits `pending` and grants nothing until the
+ * operator approves. Worst case, a note written by anyone sits pending forever.
+ *
+ * Generalizes the hub's Connections engine from "event→action triggers" to
+ * "approval-gated resource grants": same vault-token mint path (`mintVaultGrant`
+ * mirrors `admin-connections.ts:mintCredential`), same registered-mint /
+ * revoke-on-teardown discipline, same auth gates.
+ *
+ * ── Endpoints (all under `/admin/grants`) ────────────────────────────────────
+ *
+ * MODULE-AUTH (a `parachute:host:admin` Bearer — the agent module presents one,
+ * minted the same way the SPA mints via `/admin/host-admin-token`):
+ *
+ *   PUT  /admin/grants                       { agent, connection } → upsert (idempotent
+ *                                              by (agent, connection-key)); returns the
+ *                                              grant (NO material). New mcp grants land
+ *                                              pending with reason "oauth not yet
+ *                                              supported".
+ *   GET  /admin/grants?agent=<name>          → { grants: [...] } — NO material on any row.
+ *   GET  /admin/grants/<id>/material         → APPROVED grants only: the injectable
+ *                                              secret. vault → { kind, token, mcpUrl };
+ *                                              service → { kind, token, inject }.
+ *                                              404 unknown id, 409 not approved.
+ *
+ * OPERATOR-AUTH (a first-admin session cookie; CSRF-belted by the dispatch in
+ * hub-server.ts, exactly like /admin/connections POST/DELETE):
+ *
+ *   POST /admin/grants/<id>/approve          { token? } → vault: MINT now + store;
+ *                                              service: store the pasted `token`. Returns
+ *                                              the updated grant (no material).
+ *   POST /admin/grants/<id>/revoke           → drop the stored material + status=revoked
+ *                                              (the agent loses it next spawn).
+ *
+ * ── Secret discipline ────────────────────────────────────────────────────────
+ * The minted/pasted secret lives in the grant store on disk (0600), is NEVER
+ * logged, NEVER returned by PUT/GET-list/approve/revoke — ONLY by the
+ * approved-only, module-auth-gated `/material` endpoint.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  type AdminAuthContext,
+  type AdminAuthError,
+  adminAuthErrorResponse,
+  requireScope,
+} from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import {
+  type ConnectionSpec,
+  type GrantAccess,
+  type GrantInject,
+  type GrantRecord,
+  connectionKey,
+  getGrant,
+  grantId,
+  listGrantsForAgent,
+  putGrant,
+  readGrants,
+} from "./grants-store.ts";
+import {
+  type signAccessToken as SignAccessTokenFn,
+  recordTokenMint,
+  revokeTokenByJti,
+  signAccessToken,
+} from "./jwt-sign.ts";
+import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+
+/**
+ * TTL of a minted vault grant token. 90 days — matches the Connections
+ * engine's standing-credential posture (a headless agent re-fetches at spawn;
+ * a long-lived token spares a re-mint every turn). Registered in the tokens
+ * table so revoke can drop it.
+ */
+const VAULT_GRANT_TTL_SECONDS = 90 * 24 * 60 * 60;
+const GRANT_CLIENT_ID = "parachute-hub-spa";
+
+/** Agent-name charset — lands in the grant id + a `?agent=` query. Conservative slug. */
+const AGENT_NAME_RE = /^[a-z0-9][a-z0-9_.-]*$/i;
+/** Grant-id charset — lands in a URL path segment. */
+const GRANT_ID_RE = /^[a-z0-9][a-z0-9-]*$/;
+/** Service key charset — `github`, `cloudflare`, … lands in env-var / MCP names. */
+const SERVICE_KEY_RE = /^[a-z0-9][a-z0-9_-]*$/i;
+/** A tag the agent declares for vault tag-scope. Conservative — no whitespace. */
+const TAG_RE = /^\S+$/;
+
+export interface AgentGrantsDeps {
+  db: Database;
+  /** Hub origin — the minted-token `iss` AND the base of the vault MCP URL. */
+  hubOrigin: string;
+  /** Absolute path to `agent-grants.json` in the hub state dir. */
+  storePath: string;
+  /**
+   * Resolve a vault's loopback origin from services.json, or `null` when no
+   * vault by that name is installed. Mirrors `ConnectionsDeps.resolveVaultOrigin`
+   * — used here purely as the "does this vault exist?" check at approve time.
+   */
+  resolveVaultOrigin: (vaultName: string) => string | null;
+  /** Test seam — defaults to the real `signAccessToken`. */
+  signToken?: typeof SignAccessTokenFn;
+  /** Test seam for the clock. */
+  now?: () => Date;
+}
+
+// ===========================================================================
+// Router
+// ===========================================================================
+
+/**
+ * Dispatch `/admin/grants...`. `subPath` is the path AFTER `/admin/grants`
+ * (`""` for the collection, `/<id>/material|approve|revoke` for items).
+ *
+ * The two auth classes split by route, mirroring the Connections engine:
+ *   - module-auth (host-admin Bearer): PUT collection, GET collection, GET /material.
+ *   - operator-auth (first-admin cookie): POST /approve, POST /revoke.
+ */
+export async function handleAgentGrants(
+  req: Request,
+  subPath: string,
+  deps: AgentGrantsDeps,
+): Promise<Response> {
+  const method = req.method.toUpperCase();
+  const segments = subPath.startsWith("/")
+    ? subPath
+        .slice(1)
+        .split("/")
+        .map((s) => decodeURIComponent(s))
+        .filter((s) => s.length > 0)
+    : [];
+
+  // --- Collection: PUT (upsert) / GET (list) — module-auth. ---
+  if (segments.length === 0) {
+    if (method === "PUT") return upsertGrant(req, deps);
+    if (method === "GET") return listGrants(req, deps);
+    return jsonError(405, "method_not_allowed", "use PUT or GET on /admin/grants");
+  }
+
+  const id = segments[0] ?? "";
+  const verb = segments[1];
+
+  // --- Item: GET /<id>/material — module-auth. ---
+  if (verb === "material") {
+    if (method !== "GET") {
+      return jsonError(405, "method_not_allowed", "use GET on /admin/grants/<id>/material");
+    }
+    return grantMaterial(req, id, deps);
+  }
+
+  // --- Item: POST /<id>/approve | /revoke — operator-auth. ---
+  if (verb === "approve") {
+    if (method !== "POST") {
+      return jsonError(405, "method_not_allowed", "use POST on /admin/grants/<id>/approve");
+    }
+    return approveGrant(req, id, deps);
+  }
+  if (verb === "revoke") {
+    if (method !== "POST") {
+      return jsonError(405, "method_not_allowed", "use POST on /admin/grants/<id>/revoke");
+    }
+    return revokeGrant(req, id, deps);
+  }
+
+  return jsonError(
+    404,
+    "not_found",
+    "use PUT/GET /admin/grants, GET /admin/grants/<id>/material, POST /admin/grants/<id>/approve|revoke",
+  );
+}
+
+// ===========================================================================
+// Auth
+// ===========================================================================
+
+/** Module-auth: a `parachute:host:admin` Bearer (the agent module's host-admin token). */
+async function requireModuleAuth(
+  req: Request,
+  deps: AgentGrantsDeps,
+): Promise<AdminAuthContext | Response> {
+  try {
+    return await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.hubOrigin);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+}
+
+/** Operator-auth: a first-admin session cookie (CSRF belt is applied upstream). */
+function requireOperator(req: Request, deps: AgentGrantsDeps): { userId: string } | Response {
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(deps.db, sid) : null;
+  if (!session) {
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
+  }
+  if (!isFirstAdmin(deps.db, session.userId)) {
+    return jsonError(
+      403,
+      "not_admin",
+      "grant approval is restricted to the hub admin — your account home is at /account/",
+    );
+  }
+  return { userId: session.userId };
+}
+
+// ===========================================================================
+// PUT /admin/grants — upsert a pending grant (module-auth)
+// ===========================================================================
+
+async function upsertGrant(req: Request, deps: AgentGrantsDeps): Promise<Response> {
+  const auth = await requireModuleAuth(req, deps);
+  if (auth instanceof Response) return auth;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonError(400, "invalid_request", "body must be JSON");
+  }
+  if (!body || typeof body !== "object") {
+    return jsonError(400, "invalid_request", "body must be a JSON object");
+  }
+  const b = body as Record<string, unknown>;
+
+  const agent = typeof b.agent === "string" ? b.agent.trim() : "";
+  if (!agent || !AGENT_NAME_RE.test(agent)) {
+    return jsonError(
+      400,
+      "invalid_request",
+      "agent is required and must match [a-zA-Z0-9][a-zA-Z0-9_.-]*",
+    );
+  }
+
+  const parsed = parseConnectionSpec(b.connection);
+  if ("error" in parsed) return jsonError(400, "invalid_request", parsed.error);
+  const spec = parsed.spec;
+
+  const id = grantId(agent, spec);
+  const now = (deps.now?.() ?? new Date()).toISOString();
+  const existing = getGrant(deps.storePath, id);
+
+  // Idempotent upsert. An already-approved/revoked grant keeps its status +
+  // material on re-declare (the module re-registering the same want must NOT
+  // downgrade an active grant to pending, nor re-open a revoked one). A new
+  // grant lands pending — mcp pending with its slice-2 reason.
+  if (existing) {
+    // Re-declare may refresh the agent-side `inject` hints on a service spec
+    // without changing the grant's identity (inject is not part of the key).
+    const merged: GrantRecord = { ...existing, connection: spec };
+    putGrant(deps.storePath, merged);
+    return grantResponse(200, merged);
+  }
+
+  const pendingReason = spec.kind === "mcp" ? "oauth not yet supported" : undefined;
+  const record: GrantRecord = {
+    id,
+    agent,
+    connection: spec,
+    status: "pending",
+    ...(pendingReason ? { reason: pendingReason } : {}),
+    createdAt: now,
+  };
+  putGrant(deps.storePath, record);
+  return grantResponse(201, record);
+}
+
+/**
+ * Parse + validate a connection spec from the request body. Returns either the
+ * normalized spec or a human-readable error. Normalizes `target`/`access`/`tags`
+ * to keep the stored shape + derived key stable.
+ */
+function parseConnectionSpec(raw: unknown): { spec: ConnectionSpec } | { error: string } {
+  if (!raw || typeof raw !== "object") {
+    return { error: "connection is required and must be an object" };
+  }
+  const c = raw as Record<string, unknown>;
+  const kind = c.kind;
+  if (kind !== "vault" && kind !== "service" && kind !== "mcp") {
+    return { error: `connection.kind must be "vault", "service", or "mcp"` };
+  }
+  const target = typeof c.target === "string" ? c.target.trim() : "";
+  if (!target) return { error: "connection.target is required" };
+
+  if (kind === "vault") {
+    if (!VAULT_NAME_CHARSET_RE.test(target)) {
+      return { error: `connection.target "${target}" is not a valid vault name` };
+    }
+    let access: GrantAccess = "read";
+    if (c.access !== undefined) {
+      if (c.access !== "read" && c.access !== "write") {
+        return { error: `connection.access must be "read" or "write"` };
+      }
+      access = c.access;
+    }
+    const tags: string[] = [];
+    if (c.tags !== undefined) {
+      if (!Array.isArray(c.tags)) {
+        return { error: "connection.tags must be an array of tag strings" };
+      }
+      for (const t of c.tags) {
+        if (typeof t !== "string" || !TAG_RE.test(t.trim()) || t.trim().length === 0) {
+          return { error: "connection.tags entries must be non-empty whitespace-free strings" };
+        }
+        tags.push(t.trim());
+      }
+    }
+    return {
+      spec: { kind: "vault", target, access, ...(tags.length > 0 ? { tags } : {}) },
+    };
+  }
+
+  if (kind === "service") {
+    if (!SERVICE_KEY_RE.test(target)) {
+      return { error: `connection.target "${target}" is not a valid service key` };
+    }
+    const inject: GrantInject[] = [];
+    if (c.inject !== undefined) {
+      if (!Array.isArray(c.inject)) {
+        return { error: `connection.inject must be an array of "env"/"mcp"` };
+      }
+      for (const i of c.inject) {
+        if (i !== "env" && i !== "mcp") {
+          return { error: `connection.inject entries must be "env" or "mcp"` };
+        }
+        if (!inject.includes(i)) inject.push(i);
+      }
+    }
+    return {
+      spec: { kind: "service", target, ...(inject.length > 0 ? { inject } : {}) },
+    };
+  }
+
+  // mcp — modeled, not grantable in 4b-1. Accept a URL target; the grant lands
+  // pending with the slice-2 reason. Validate it parses as an http(s) URL so a
+  // typo doesn't sit pending forever masquerading as an OAuth-blocked grant.
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return { error: `connection.target "${target}" must be an absolute URL for kind "mcp"` };
+  }
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return { error: `connection.target must be an http(s) URL for kind "mcp"` };
+  }
+  return { spec: { kind: "mcp", target } };
+}
+
+// ===========================================================================
+// GET /admin/grants?agent=<name> — list (module-auth, NO material)
+// ===========================================================================
+
+async function listGrants(req: Request, deps: AgentGrantsDeps): Promise<Response> {
+  const auth = await requireModuleAuth(req, deps);
+  if (auth instanceof Response) return auth;
+
+  const agent = new URL(req.url).searchParams.get("agent");
+  if (agent !== null && !AGENT_NAME_RE.test(agent)) {
+    return jsonError(400, "invalid_request", "?agent must match [a-zA-Z0-9][a-zA-Z0-9_.-]*");
+  }
+
+  // Default to all grants when no agent filter is given (the approval UI lists
+  // every agent's grants); narrow to one agent for the module's status check.
+  const records = agent ? listGrantsForAgent(deps.storePath, agent) : readGrants(deps.storePath);
+
+  const grants = records.map(toListing);
+  return new Response(JSON.stringify({ grants }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+// ===========================================================================
+// GET /admin/grants/<id>/material — approved-only secret (module-auth)
+// ===========================================================================
+
+async function grantMaterial(req: Request, id: string, deps: AgentGrantsDeps): Promise<Response> {
+  const auth = await requireModuleAuth(req, deps);
+  if (auth instanceof Response) return auth;
+
+  if (!GRANT_ID_RE.test(id)) {
+    return jsonError(400, "invalid_request", "grant id is not a valid identifier");
+  }
+  const grant = getGrant(deps.storePath, id);
+  if (!grant) {
+    return jsonError(404, "not_found", `no grant ${id}`);
+  }
+  if (grant.status !== "approved" || !grant.material) {
+    return jsonError(
+      409,
+      "not_approved",
+      `grant ${id} is ${grant.status}${grant.reason ? ` (${grant.reason})` : ""} — material is available only for approved grants`,
+    );
+  }
+
+  // The injectable secret. vault → token + the vault's MCP URL (so the agent
+  // can add it as an MCP server); service → token + the inject hints.
+  let payload: Record<string, unknown>;
+  if (grant.material.kind === "vault") {
+    payload = {
+      kind: "vault",
+      token: grant.material.token,
+      mcpUrl: vaultMcpUrl(deps.hubOrigin, grant.connection.target),
+    };
+  } else {
+    payload = {
+      kind: "service",
+      token: grant.material.token,
+      inject: grant.connection.kind === "service" ? (grant.connection.inject ?? []) : [],
+    };
+  }
+
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: {
+      "content-type": "application/json",
+      // The body carries a live secret — never cache it.
+      "cache-control": "no-store",
+    },
+  });
+}
+
+/** `<hub-origin>/vault/<name>/mcp` — the MCP endpoint a client connects to. */
+function vaultMcpUrl(hubOrigin: string, vaultName: string): string {
+  return `${hubOrigin.replace(/\/+$/, "")}/vault/${vaultName}/mcp`;
+}
+
+// ===========================================================================
+// POST /admin/grants/<id>/approve — operator approves (operator-auth)
+// ===========================================================================
+
+async function approveGrant(req: Request, id: string, deps: AgentGrantsDeps): Promise<Response> {
+  const op = requireOperator(req, deps);
+  if (op instanceof Response) return op;
+
+  if (!GRANT_ID_RE.test(id)) {
+    return jsonError(400, "invalid_request", "grant id is not a valid identifier");
+  }
+  const grant = getGrant(deps.storePath, id);
+  if (!grant) return jsonError(404, "not_found", `no grant ${id}`);
+
+  let body: { token?: unknown } = {};
+  try {
+    const raw = await req.text();
+    if (raw.trim().length > 0) body = JSON.parse(raw) as { token?: unknown };
+  } catch {
+    return jsonError(400, "invalid_request", "body must be JSON when present");
+  }
+
+  const conn = grant.connection;
+  const now = deps.now?.() ?? new Date();
+  const approvedAt = now.toISOString();
+
+  if (conn.kind === "mcp") {
+    // 4b-1: remote MCP / OAuth is not implemented. Approval is refused; the
+    // grant stays pending with its reason. (Slice 2 wires hub-as-OAuth-client.)
+    return jsonError(
+      409,
+      "not_grantable",
+      "mcp (remote/OAuth) grants are not yet supported — coming in 4b-2",
+    );
+  }
+
+  if (conn.kind === "vault") {
+    // Re-approval of an already-approved vault grant: revoke the prior minted
+    // token first so exactly one live token exists per grant.
+    if (grant.material?.kind === "vault") {
+      try {
+        revokeTokenByJti(deps.db, grant.material.jti, now);
+      } catch {
+        // Best-effort — a missing registry row leaves nothing to revoke.
+      }
+    }
+    // Approve-time existence check: the vault must still be installed.
+    if (deps.resolveVaultOrigin(conn.target) === null) {
+      return jsonError(400, "unknown_vault", `no vault named "${conn.target}" in this hub`);
+    }
+    const access = conn.access ?? "read";
+    const scope = `vault:${conn.target}:${access}`;
+    let minted: { token: string; jti: string; expiresAt: string };
+    try {
+      minted = await mintVaultGrant(deps, op.userId, conn.target, scope, conn.tags ?? []);
+    } catch (err) {
+      return jsonError(
+        500,
+        "mint_failed",
+        `failed to mint vault grant: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    // Rebuild from the identity fields rather than spreading `grant` — that
+    // drops any pending `reason` cleanly (no mutate-after-spread).
+    const updated: GrantRecord = {
+      id: grant.id,
+      agent: grant.agent,
+      connection: grant.connection,
+      status: "approved",
+      createdAt: grant.createdAt,
+      approvedAt,
+      material: {
+        kind: "vault",
+        token: minted.token,
+        jti: minted.jti,
+        expiresAt: minted.expiresAt,
+      },
+    };
+    putGrant(deps.storePath, updated);
+    console.log(`agent grant approved: id=${id} agent=${grant.agent} kind=vault scope=${scope}`);
+    return grantResponse(200, updated);
+  }
+
+  // service — store the operator-pasted API token.
+  const token = typeof body.token === "string" ? body.token : "";
+  if (token.trim().length === 0) {
+    return jsonError(
+      400,
+      "token_required",
+      "approving a service grant requires a non-empty `token` (the API credential to store)",
+    );
+  }
+  // Rebuild from identity fields (drops any pending `reason`).
+  const updated: GrantRecord = {
+    id: grant.id,
+    agent: grant.agent,
+    connection: grant.connection,
+    status: "approved",
+    createdAt: grant.createdAt,
+    approvedAt,
+    material: { kind: "service", token },
+  };
+  putGrant(deps.storePath, updated);
+  // NEVER log the token. Identity fields only.
+  console.log(
+    `agent grant approved: id=${id} agent=${grant.agent} kind=service target=${conn.target}`,
+  );
+  return grantResponse(200, updated);
+}
+
+// ===========================================================================
+// POST /admin/grants/<id>/revoke — operator revokes (operator-auth)
+// ===========================================================================
+
+async function revokeGrant(req: Request, id: string, deps: AgentGrantsDeps): Promise<Response> {
+  const op = requireOperator(req, deps);
+  if (op instanceof Response) return op;
+
+  if (!GRANT_ID_RE.test(id)) {
+    return jsonError(400, "invalid_request", "grant id is not a valid identifier");
+  }
+  const grant = getGrant(deps.storePath, id);
+  if (!grant) return jsonError(404, "not_found", `no grant ${id}`);
+
+  const now = deps.now?.() ?? new Date();
+  // Revoke the minted vault token in the registry so it's dead immediately, not
+  // just absent from the next fetch. Service tokens are operator-owned external
+  // creds — we drop our copy (the operator rotates them upstream if needed).
+  if (grant.material?.kind === "vault") {
+    try {
+      revokeTokenByJti(deps.db, grant.material.jti, now);
+    } catch {
+      // Best-effort.
+    }
+  }
+
+  const updated: GrantRecord = {
+    id: grant.id,
+    agent: grant.agent,
+    connection: grant.connection,
+    status: "revoked",
+    createdAt: grant.createdAt,
+    ...(grant.approvedAt ? { approvedAt: grant.approvedAt } : {}),
+    // material + reason intentionally dropped — the secret leaves the store.
+  };
+  putGrant(deps.storePath, updated);
+  console.log(`agent grant revoked: id=${id} agent=${grant.agent} kind=${grant.connection.kind}`);
+  return grantResponse(200, updated);
+}
+
+// ===========================================================================
+// Mint
+// ===========================================================================
+
+/**
+ * Mint the vault token for an approved vault grant: a REGISTERED
+ * (created_via "agent_grant") `vault:<target>:<access>` JWT, audience-bound +
+ * vault_scope-pinned to the target, carrying `permissions.scoped_tags` when
+ * tags were declared (the vault's tag-scope enforcement reads them). Mirrors
+ * `admin-connections.ts:mintCredential`.
+ */
+async function mintVaultGrant(
+  deps: AgentGrantsDeps,
+  userId: string,
+  vault: string,
+  scope: string,
+  scopedTags: readonly string[],
+): Promise<{ token: string; jti: string; expiresAt: string }> {
+  const sign = deps.signToken ?? signAccessToken;
+  const signed = await sign(deps.db, {
+    sub: userId || "agent-grant",
+    scopes: [scope],
+    audience: `vault.${vault}`,
+    clientId: GRANT_CLIENT_ID,
+    issuer: deps.hubOrigin,
+    ttlSeconds: VAULT_GRANT_TTL_SECONDS,
+    vaultScope: [vault],
+    ...(scopedTags.length > 0
+      ? { extraClaims: { permissions: { scoped_tags: [...scopedTags] } } }
+      : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+  // Register the long-lived mint so revoke can drop it (hub-module-boundary
+  // registered-mint rule — an unregistered long-lived token is unrevocable).
+  recordTokenMint(deps.db, {
+    jti: signed.jti,
+    createdVia: "agent_grant",
+    subject: "agent-grant",
+    ...(userId ? { userId } : {}),
+    clientId: GRANT_CLIENT_ID,
+    scopes: [scope],
+    expiresAt: signed.expiresAt,
+    ...(scopedTags.length > 0
+      ? { permissions: JSON.stringify({ scoped_tags: [...scopedTags] }) }
+      : {}),
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+  return { token: signed.token, jti: signed.jti, expiresAt: signed.expiresAt };
+}
+
+// ===========================================================================
+// Wire shapes
+// ===========================================================================
+
+/**
+ * The list/echo wire shape for a grant — id, agent, connection, status,
+ * optional reason + approvedAt. **Carries NO `material`** (the secret never
+ * leaves via this shape). This is what PUT, GET-list, approve, and revoke all
+ * return.
+ */
+export interface GrantListing {
+  id: string;
+  agent: string;
+  connection: ConnectionSpec;
+  status: GrantRecord["status"];
+  reason?: string;
+  approvedAt?: string;
+}
+
+function toListing(g: GrantRecord): GrantListing {
+  return {
+    id: g.id,
+    agent: g.agent,
+    connection: g.connection,
+    status: g.status,
+    ...(g.reason ? { reason: g.reason } : {}),
+    ...(g.approvedAt ? { approvedAt: g.approvedAt } : {}),
+  };
+}
+
+function grantResponse(status: number, g: GrantRecord): Response {
+  return new Response(JSON.stringify(toListing(g)), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/** Re-exported so callers/tests can reuse the stable key derivation. */
+export { connectionKey, grantId };

--- a/src/grants-store.ts
+++ b/src/grants-store.ts
@@ -131,6 +131,12 @@ const GRANT_ID_CHARSET = /[^a-z0-9]+/g;
  * Derive the grant id from `(agent, connectionKey)`. A conservative slug — it
  * lands in a URL path segment (`/admin/grants/<id>/...`). Deterministic so the
  * same `(agent, connection)` always upserts the same row.
+ *
+ * The slug collapses non-`[a-z0-9]` runs to a single `-`. A collision (two distinct
+ * `(agent, connection)` pairs slugging identically) is infeasible given the upstream
+ * validators — `kind` is an enum, vault `target` passes `validateVaultName`, service
+ * `target` matches `SERVICE_KEY_RE`, `access` is `read|write`, tags are charset-bounded
+ * — so the separators that survive the slug are non-ambiguous in practice.
  */
 export function grantId(agent: string, spec: ConnectionSpec): string {
   const raw = `${agent.trim().toLowerCase()}--${connectionKey(spec)}`;
@@ -184,9 +190,10 @@ function writeAll(storePath: string, records: GrantRecord[]): void {
   mkdirSync(dirname(storePath), { recursive: true });
   const file: GrantsFile = { grants: records };
   // 0600 — UNLIKE connections.json, this file holds the granted secrets
-  // (minted vault tokens + pasted service creds in `material`). Write the file
-  // first, then chmod, so a fresh-create never has a window at the default
-  // umask. chmod is idempotent on re-write.
+  // (minted vault tokens + pasted service creds in `material`). `writeFileSync`'s
+  // `mode` applies at CREATE time (passed to open(O_CREAT)), so a fresh file is
+  // never world-readable even for an instant; the chmodSync below is belt-and-
+  // suspenders for the re-write case (an existing file left at looser perms).
   writeFileSync(storePath, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
   try {
     chmodSync(storePath, 0o600);

--- a/src/grants-store.ts
+++ b/src/grants-store.ts
@@ -1,0 +1,229 @@
+/**
+ * `agent-grants.json` — the persisted registry of approval-gated **agent
+ * connector grants** (Phase 4b-1, agent-connectors design 2026-06-17).
+ *
+ * NOT to be confused with `grants.ts` (the OAuth consent skip-list, one row per
+ * `(user_id, client_id)` in the SQLite `grants` table). THIS store is the
+ * agent-connector subsystem: an agent (a `#agent/definition` note in the agent
+ * module) declares connections it WANTS beyond its own def-vault; the agent
+ * module registers each as a PENDING grant here; the operator approves
+ * per-connection in hub admin; the hub mints/stores the secret; the agent
+ * module fetches the material at spawn and injects it.
+ *
+ * The one invariant (from the design): **a vault note can only REQUEST; it can
+ * never GRANT.** A grant created by the module sits `pending` and grants nothing
+ * until the operator approves in the hub. The minted/pasted secret (`material`)
+ * is the only sensitive field — it lives here on disk (0600), is NEVER logged,
+ * and is NEVER returned by the list endpoint (only by the approved-only
+ * `/material` endpoint).
+ *
+ * One file, a flat array. Cardinality is "a handful of grants per agent", not a
+ * hot path — small + synchronous Bun file I/O, mirroring `connections-store.ts`.
+ * Unlike `connections.json`, this file IS written 0600 because it holds the
+ * granted secrets.
+ */
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** Verb for a vault grant. Service/mcp grants carry no access verb. */
+export type GrantAccess = "read" | "write";
+
+/** Where the agent side injects a resolved grant. */
+export type GrantInject = "env" | "mcp";
+
+/**
+ * A **connection spec** — what the agent WANTS. The wire shape the agent module
+ * sends to `PUT /admin/grants` and the shape echoed back by the list endpoint.
+ *
+ *   - `vault`   — a LOCAL vault other than the def-vault. `target` is the vault
+ *     name; `access` the verb; optional `tags` narrow the grant to a tag set
+ *     (rides the vault's `scoped_tags` tokens). Grant = a hub-minted
+ *     `vault:<target>:<access>` token.
+ *   - `service` — an external service credential (`github`, `cloudflare`).
+ *     `target` is the service key; `inject` hints how the agent side wires it
+ *     (`env` → an env var, `mcp` → the service's MCP server, or both). Grant =
+ *     an operator-pasted API token.
+ *   - `mcp`     — a remote MCP / remote vault. `target` is the MCP URL. Grant =
+ *     an OAuth token — NOT implemented in 4b-1 (slice 2). Modeled here; the
+ *     grant stays `pending` with a clear reason.
+ */
+export interface ConnectionSpec {
+  readonly kind: "vault" | "service" | "mcp";
+  /** Vault name / service key / MCP URL, per `kind`. */
+  readonly target: string;
+  /** Vault grants only — `read` (default) or `write`. */
+  readonly access?: GrantAccess;
+  /** Vault grants only — tag-scope (`scoped_tags`); empty/absent = vault-wide. */
+  readonly tags?: readonly string[];
+  /** Service grants only — injection hints carried for the agent side. */
+  readonly inject?: readonly GrantInject[];
+}
+
+export type GrantStatus = "pending" | "approved" | "revoked";
+
+/**
+ * The granted secret material, kept on disk ONLY. Discriminated by `kind` to
+ * mirror the spec. NEVER returned by the list endpoint; only the approved-only
+ * `/material` endpoint reads it.
+ */
+export type GrantMaterial =
+  | {
+      readonly kind: "vault";
+      /** The minted `vault:<target>:<access>` JWT. */
+      readonly token: string;
+      /** jti of the minted token — registered so revoke can drop it. */
+      readonly jti: string;
+      /** ISO expiry of the minted token. */
+      readonly expiresAt: string;
+    }
+  | {
+      readonly kind: "service";
+      /** The operator-pasted API token. */
+      readonly token: string;
+    };
+
+export interface GrantRecord {
+  readonly id: string;
+  /** Agent name (the `#agent/definition` note's agent identity). */
+  readonly agent: string;
+  /** The declared connection spec. */
+  readonly connection: ConnectionSpec;
+  readonly status: GrantStatus;
+  /** Why a grant is pending/blocked (e.g. mcp "oauth not yet supported"). */
+  readonly reason?: string;
+  /** The secret — present only when `status === "approved"`. Never logged/listed. */
+  readonly material?: GrantMaterial;
+  readonly createdAt: string;
+  readonly approvedAt?: string;
+}
+
+interface GrantsFile {
+  grants: GrantRecord[];
+}
+
+/**
+ * Stable connection key — the idempotency key for `(agent, connection)` upsert.
+ * A spec's identity is its `kind` + `target` + (for vault) the access verb +
+ * the sorted tag set. `inject` is NOT part of the key — it's an agent-side
+ * hint, so re-declaring the same service with different inject modes updates
+ * the existing grant rather than forking a second one. The grant `id` derives
+ * from `agent` + this key.
+ */
+export function connectionKey(spec: ConnectionSpec): string {
+  const target = spec.target.trim().toLowerCase();
+  if (spec.kind === "vault") {
+    const access = spec.access ?? "read";
+    const tags = [...(spec.tags ?? [])].map((t) => t.trim()).sort();
+    return tags.length > 0
+      ? `vault:${target}:${access}#${tags.join(",")}`
+      : `vault:${target}:${access}`;
+  }
+  if (spec.kind === "service") {
+    return `service:${target}`;
+  }
+  // mcp — keyed on the URL only (its target).
+  return `mcp:${target}`;
+}
+
+const GRANT_ID_CHARSET = /[^a-z0-9]+/g;
+
+/**
+ * Derive the grant id from `(agent, connectionKey)`. A conservative slug — it
+ * lands in a URL path segment (`/admin/grants/<id>/...`). Deterministic so the
+ * same `(agent, connection)` always upserts the same row.
+ */
+export function grantId(agent: string, spec: ConnectionSpec): string {
+  const raw = `${agent.trim().toLowerCase()}--${connectionKey(spec)}`;
+  return raw.replace(GRANT_ID_CHARSET, "-").replace(/^-+|-+$/g, "");
+}
+
+function emptyFile(): GrantsFile {
+  return { grants: [] };
+}
+
+function isConnectionSpec(v: unknown): v is ConnectionSpec {
+  if (!v || typeof v !== "object") return false;
+  const s = v as Record<string, unknown>;
+  return (
+    (s.kind === "vault" || s.kind === "service" || s.kind === "mcp") && typeof s.target === "string"
+  );
+}
+
+/** Read the store. A missing/garbage file reads as empty (fresh hub). */
+export function readGrants(storePath: string): GrantRecord[] {
+  let buf: string;
+  try {
+    buf = readFileSync(storePath, "utf8");
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(buf);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  const arr = (parsed as { grants?: unknown }).grants;
+  if (!Array.isArray(arr)) return [];
+  // Lenient: drop a malformed row rather than failing the whole read (mirrors
+  // the connections-store / services.json lenient-read posture).
+  return arr.filter((r): r is GrantRecord => {
+    if (!r || typeof r !== "object") return false;
+    const rec = r as Record<string, unknown>;
+    return (
+      typeof rec.id === "string" &&
+      typeof rec.agent === "string" &&
+      isConnectionSpec(rec.connection) &&
+      (rec.status === "pending" || rec.status === "approved" || rec.status === "revoked")
+    );
+  });
+}
+
+function writeAll(storePath: string, records: GrantRecord[]): void {
+  mkdirSync(dirname(storePath), { recursive: true });
+  const file: GrantsFile = { grants: records };
+  // 0600 — UNLIKE connections.json, this file holds the granted secrets
+  // (minted vault tokens + pasted service creds in `material`). Write the file
+  // first, then chmod, so a fresh-create never has a window at the default
+  // umask. chmod is idempotent on re-write.
+  writeFileSync(storePath, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+  try {
+    chmodSync(storePath, 0o600);
+  } catch {
+    // Best-effort on platforms without POSIX perms (the secret is still only
+    // reachable through the approved-only, auth-gated /material endpoint).
+  }
+}
+
+/** Upsert by id (replace an existing record with the same id, else append). */
+export function putGrant(storePath: string, record: GrantRecord): void {
+  const records = readGrants(storePath);
+  const idx = records.findIndex((r) => r.id === record.id);
+  if (idx >= 0) records[idx] = record;
+  else records.push(record);
+  writeAll(storePath, records);
+}
+
+export function getGrant(storePath: string, id: string): GrantRecord | null {
+  return readGrants(storePath).find((r) => r.id === id) ?? null;
+}
+
+/** All grants for an agent, in stored order. */
+export function listGrantsForAgent(storePath: string, agent: string): GrantRecord[] {
+  const want = agent.trim().toLowerCase();
+  return readGrants(storePath).filter((r) => r.agent.trim().toLowerCase() === want);
+}
+
+/** Remove a grant by id. Returns the removed record, or null if absent. */
+export function removeGrant(storePath: string, id: string): GrantRecord | null {
+  const records = readGrants(storePath);
+  const idx = records.findIndex((r) => r.id === id);
+  if (idx < 0) return null;
+  const [removed] = records.splice(idx, 1);
+  writeAll(storePath, records);
+  return removed ?? null;
+}
+
+/** Re-export for the unused-import linter when only the type is consumed. */
+export const _emptyGrantsFile = emptyFile;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -60,6 +60,10 @@
  *   /admin/connections/<id>/renew (POST)       → credential renewal (H4; Bearer = the credential itself, proof of possession)
  *   /admin/connections/<id>/claim (POST)       → claim/reconcile a directly-delivered credential → pending record (surface#113; Bearer = the credential itself)
  *   /admin/connections/<id>/approve (POST)     → operator approval of a pending claim (cookie-gated; CSRF-belted)
+ *   /admin/grants                 (PUT/GET)    → agent-connector grant upsert/list (4b-1; host-admin Bearer)
+ *   /admin/grants/<id>/material   (GET)        → injectable secret for an APPROVED grant (4b-1; host-admin Bearer)
+ *   /admin/grants/<id>/approve    (POST)       → operator approves a grant — mint (vault) / store (service) (cookie-gated; CSRF-belted)
+ *   /admin/grants/<id>/revoke     (POST)       → operator revokes a grant — drop the stored secret (cookie-gated; CSRF-belted)
  *
  *   # "CSRF-belted" = strict same-origin Origin check on cookie-authed
  *   # mutations (hub#632, boundary C1) — origin-check.ts
@@ -156,6 +160,7 @@ import pkg from "../package.json" with { type: "json" };
 import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
 import { handleAccountVaultAdminTokenPost } from "./account-vault-admin-token.ts";
 import { handleAccountVaultTokenPost } from "./account-vault-token.ts";
+import { type AgentGrantsDeps, handleAgentGrants } from "./admin-agent-grants.ts";
 import { handleAgentToken } from "./admin-agent-token.ts";
 import { handleApproveClient, handleGetClient } from "./admin-clients.ts";
 import {
@@ -1153,6 +1158,11 @@ export interface HubFetchDeps {
    * at a tmpdir; production defaults to `<CONFIG_DIR>/connections.json`.
    */
   connectionsStorePath?: string;
+  /**
+   * Path to `agent-grants.json` (the agent-connector grant store, 4b-1). Tests
+   * point this at a tmpdir; production defaults to `<CONFIG_DIR>/agent-grants.json`.
+   */
+  agentGrantsStorePath?: string;
   /**
    * Directory containing the built SPA bundle (`index.html` + `assets/`). When
    * absent, the hub auto-resolves to `<repo>/web/ui/dist/` — handy for the
@@ -2858,6 +2868,41 @@ export function hubFetch(
         }
         const subPath = pathname.slice("/admin/connections".length);
         return handleConnections(req, subPath, connectionsDeps);
+      }
+
+      // Agent-connector GRANTS — the approval-gated resource-grant subsystem
+      // (Phase 4b-1, agent-connectors design 2026-06-17). Generalizes the
+      // Connections engine from "event→action triggers" to "approval-gated
+      // resource grants": an agent declares connections it WANTS beyond its
+      // def-vault; the agent module registers each as a pending grant (PUT,
+      // host-admin Bearer); the operator approves per-connection (POST
+      // /approve, first-admin cookie); the hub mints (vault) / stores (service)
+      // the secret; the agent module fetches it at spawn (GET /material,
+      // host-admin Bearer). Two auth classes split by route inside the handler.
+      if (pathname === "/admin/grants" || pathname.startsWith("/admin/grants/")) {
+        if (!getDb) return dbNotConfigured();
+        const resolveVaultOrigin = (vaultName: string): string | null => {
+          const match = findVaultUpstream(
+            readManifestLenient(manifestPath).services,
+            `/vault/${vaultName}`,
+          );
+          return match ? `http://127.0.0.1:${match.port}` : null;
+        };
+        const agentGrantsDeps: AgentGrantsDeps = {
+          db: getDb(),
+          hubOrigin: oauthDeps(req).issuer,
+          storePath: deps?.agentGrantsStorePath ?? join(CONFIG_DIR, "agent-grants.json"),
+          resolveVaultOrigin,
+        };
+        // CSRF belt (same posture as /admin/connections, hub#632): a no-op for
+        // the host-admin-Bearer PUT/GET (Bearer → not a browser CSRF), and the
+        // real gate on the cookie-authed POST /approve + /revoke.
+        {
+          const rejected = assertSameOriginForCookieMutation(req, oauthDeps(req).hubBoundOrigins());
+          if (rejected) return rejected;
+        }
+        const subPath = pathname.slice("/admin/grants".length);
+        return handleAgentGrants(req, subPath, agentGrantsDeps);
       }
 
       if (pathname.startsWith("/admin/vault-admin-token/")) {

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -152,7 +152,11 @@ export type TokenCreatedVia =
   | "cli_mint"
   | "operator_mint"
   | "connection_provision"
-  | "connection_credential";
+  | "connection_credential"
+  // Agent-connector grants (Phase 4b-1) — a vault token the hub mints when the
+  // operator approves an agent's `vault:<name>:<verb>` connection grant. Stored
+  // in the agent-grants store; registered here so revoke can drop it.
+  | "agent_grant";
 
 export interface SignedRefreshToken {
   /** Opaque token to return to the client. NOT recoverable from the DB. */

--- a/src/origin-check.ts
+++ b/src/origin-check.ts
@@ -187,6 +187,11 @@ const MUTATION_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
  *     `fetch()` with `credentials: "include"`. The Bearer-authed
  *     `/<id>/renew` + `/<id>/claim` siblings pass the belt via the
  *     Authorization carve-out below.)
+ *   - `POST /admin/grants/<id>/approve` + `POST /admin/grants/<id>/revoke`
+ *     (agent-connector grant approval/revoke — operator cookie-authed in the
+ *     hub SPA, 4b-1. The `PUT /admin/grants` + `GET /admin/grants[/...]`
+ *     siblings are host-admin-Bearer-authed and pass via the Authorization
+ *     carve-out below.)
  *
  * (The legacy `POST/DELETE /admin/channels` pair was belted here until
  * boundary D1 retired the endpoint — superseded by `/admin/connections`.)

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -127,6 +127,7 @@ describe("App — nav structure", () => {
       // dropdown), so the hub-native group no longer carries it.
       "Home",
       "Connections",
+      "Grants",
       "Modules",
       "Users",
       "Tokens",
@@ -156,6 +157,7 @@ describe("App — nav structure", () => {
       "Home",
       "Modules",
       "Connections",
+      "Grants",
       "Users",
       "Tokens",
       "Permissions",

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -44,6 +44,7 @@ import { clearCachedToken } from "./lib/auth.ts";
 import { useAdminLock } from "./lib/useAdminLock.ts";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
 import { Connections } from "./routes/Connections.tsx";
+import { Grants } from "./routes/Grants.tsx";
 import { Home } from "./routes/Home.tsx";
 import { Modules } from "./routes/Modules.tsx";
 import { Permissions } from "./routes/Permissions.tsx";
@@ -251,6 +252,7 @@ export function App() {
             blur the exact boundary the divider marks. */}
         <NavSection to="/" label="Home" exact />
         <NavSection to="/connections" label="Connections" />
+        <NavSection to="/grants" label="Grants" />
         <NavSection to="/modules" label="Modules" />
         <NavSection to="/users" label="Users" />
         <NavSection to="/tokens" label="Tokens" />
@@ -275,6 +277,7 @@ export function App() {
         <Route path="/modules" element={<Modules />} />
         <Route path="/users" element={<Users />} />
         <Route path="/connections" element={<Connections />} />
+        <Route path="/grants" element={<Grants />} />
         {/* The pre-P5 Channels view was retired when P5 moved the feature into
             the general Connections engine. The back-compat route shouldn't
             linger as a dead end — redirect it to Connections. */}

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1741,3 +1741,84 @@ export async function deleteConnection(id: string): Promise<void> {
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
 }
+
+// ===========================================================================
+// Agent-connector GRANTS (4b-1) — /admin/grants
+// ===========================================================================
+
+/** A connection spec — what an agent declared it WANTS. Mirrors `grants-store.ts`. */
+export interface GrantConnection {
+  kind: "vault" | "service" | "mcp";
+  /** Vault name / service key / MCP URL, per `kind`. */
+  target: string;
+  /** Vault only — `read` | `write`. */
+  access?: "read" | "write";
+  /** Vault only — tag-scope. */
+  tags?: string[];
+  /** Service only — agent-side inject hints. */
+  inject?: ("env" | "mcp")[];
+}
+
+/** A grant in the list/echo wire shape (NEVER carries the secret material). */
+export interface GrantListing {
+  id: string;
+  agent: string;
+  connection: GrantConnection;
+  status: "pending" | "approved" | "revoked";
+  reason?: string;
+  approvedAt?: string;
+}
+
+/**
+ * GET /admin/grants — list every agent's connector grants. Host-admin Bearer
+ * (the list endpoint is module-auth; the SPA holds a host-admin token). NO
+ * secret material is ever returned here.
+ */
+export async function listAgentGrants(): Promise<GrantListing[]> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/admin/grants", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { grants?: unknown };
+  return Array.isArray(body.grants) ? (body.grants as GrantListing[]) : [];
+}
+
+/**
+ * POST /admin/grants/<id>/approve — operator approves a grant. Cookie-authed
+ * (the route is first-admin-session gated, CSRF-belted). For a `service` grant,
+ * `token` is the operator-pasted API credential the hub stores. For `vault`,
+ * the hub mints the token itself — no `token` needed.
+ */
+export async function approveAgentGrant(id: string, token?: string): Promise<void> {
+  const res = await fetch(`/admin/grants/${encodeURIComponent(id)}/approve`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    credentials: "same-origin",
+    body: JSON.stringify(token !== undefined ? { token } : {}),
+  });
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/** POST /admin/grants/<id>/revoke — operator revokes a grant (drops the secret). */
+export async function revokeAgentGrant(id: string): Promise<void> {
+  const res = await fetch(`/admin/grants/${encodeURIComponent(id)}/revoke`, {
+    method: "POST",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}

--- a/web/ui/src/routes/Grants.test.tsx
+++ b/web/ui/src/routes/Grants.test.tsx
@@ -62,6 +62,12 @@ const sampleGrants: api.GrantListing[] = [
     approvedAt: "2026-06-17T00:00:00.000Z",
   },
   {
+    id: "agent1-vault-archive-read",
+    agent: "agent1",
+    connection: { kind: "vault", target: "archive", access: "read" },
+    status: "revoked",
+  },
+  {
     id: "agent2-mcp-remote",
     agent: "agent2",
     connection: { kind: "mcp", target: "https://remote.test/mcp" },
@@ -141,6 +147,19 @@ describe("Grants — approve / revoke", () => {
     fireEvent.click(within(row).getByRole("button", { name: /revoke/i }));
     await waitFor(() =>
       expect(api.revokeAgentGrant).toHaveBeenCalledWith("agent1-vault-notes-write"),
+    );
+  });
+
+  it("a revoked vault grant offers Re-approve (re-mints fresh material)", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.approveAgentGrant).mockResolvedValue();
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
+
+    const row = screen.getByText(/vault: archive/i).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: /re-approve/i }));
+    await waitFor(() =>
+      expect(api.approveAgentGrant).toHaveBeenCalledWith("agent1-vault-archive-read"),
     );
   });
 });

--- a/web/ui/src/routes/Grants.test.tsx
+++ b/web/ui/src/routes/Grants.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * Grants route tests (agent-connector grants, 4b-1) — loading, empty state,
+ * grouping by agent, the three status shapes (pending vault → one-click approve,
+ * pending service → token paste then approve, approved → revoke), and the
+ * non-grantable mcp row. The list NEVER carries secret material — the view only
+ * renders the wire shape from `listAgentGrants`.
+ *
+ * Mock `lib/api.ts` so the route's fetch helpers are stubbed; assert on the
+ * rendered DOM + the calls made (notably: approveAgentGrant for a service grant
+ * carries the pasted token; for a vault grant it carries no token).
+ */
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Grants } from "./Grants.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    listAgentGrants: vi.fn(),
+    approveAgentGrant: vi.fn(),
+    revokeAgentGrant: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Grants />
+    </MemoryRouter>,
+  );
+}
+
+const sampleGrants: api.GrantListing[] = [
+  {
+    id: "agent1-vault-research-read",
+    agent: "agent1",
+    connection: { kind: "vault", target: "research", access: "read", tags: ["#published"] },
+    status: "pending",
+  },
+  {
+    id: "agent1-service-github",
+    agent: "agent1",
+    connection: { kind: "service", target: "github", inject: ["env", "mcp"] },
+    status: "pending",
+  },
+  {
+    id: "agent1-vault-notes-write",
+    agent: "agent1",
+    connection: { kind: "vault", target: "notes", access: "write" },
+    status: "approved",
+    approvedAt: "2026-06-17T00:00:00.000Z",
+  },
+  {
+    id: "agent2-mcp-remote",
+    agent: "agent2",
+    connection: { kind: "mcp", target: "https://remote.test/mcp" },
+    status: "pending",
+    reason: "oauth not yet supported",
+  },
+];
+
+describe("Grants — loading + states", () => {
+  it("shows a loading state, then the grants grouped by agent", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    renderRoute();
+    expect(screen.getByText(/loading grants/i)).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
+    expect(screen.getByText("agent2")).toBeInTheDocument();
+    // both agent group sections present
+    expect(screen.getByLabelText("Grants for agent1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Grants for agent2")).toBeInTheDocument();
+  });
+
+  it("shows the empty state when there are no grants", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue([]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/no grant requests yet/i)).toBeInTheDocument());
+  });
+
+  it("shows an error banner + retry on load failure", async () => {
+    vi.mocked(api.listAgentGrants).mockRejectedValueOnce(new Error("boom"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("boom")).toBeInTheDocument());
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+  });
+});
+
+describe("Grants — approve / revoke", () => {
+  it("a pending vault grant approves in one click (no token)", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.approveAgentGrant).mockResolvedValue();
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
+
+    const row = screen.getByText(/vault: research/i).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: /^approve$/i }));
+
+    await waitFor(() =>
+      expect(api.approveAgentGrant).toHaveBeenCalledWith("agent1-vault-research-read"),
+    );
+    // vault approve carries NO token argument
+    expect(vi.mocked(api.approveAgentGrant).mock.calls[0]).toEqual(["agent1-vault-research-read"]);
+  });
+
+  it("a pending service grant reveals a token field, then approves WITH the token", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.approveAgentGrant).mockResolvedValue();
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
+
+    const row = screen.getByText(/service: github/i).closest("tr") as HTMLElement;
+    // first click reveals the paste field
+    fireEvent.click(within(row).getByRole("button", { name: /approve…/i }));
+    const input = within(row).getByLabelText(/api token for github/i);
+    fireEvent.change(input, { target: { value: "ghp_secret" } });
+    fireEvent.click(within(row).getByRole("button", { name: /save & approve/i }));
+
+    await waitFor(() =>
+      expect(api.approveAgentGrant).toHaveBeenCalledWith("agent1-service-github", "ghp_secret"),
+    );
+  });
+
+  it("an approved grant offers Revoke", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.revokeAgentGrant).mockResolvedValue();
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
+
+    const row = screen.getByText(/vault: notes/i).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: /revoke/i }));
+    await waitFor(() =>
+      expect(api.revokeAgentGrant).toHaveBeenCalledWith("agent1-vault-notes-write"),
+    );
+  });
+});
+
+describe("Grants — mcp is modeled but not grantable (4b-1)", () => {
+  it("an mcp grant shows the 4b-2 message and offers no Approve", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent2")).toBeInTheDocument());
+
+    const row = screen.getByText(/mcp: https:\/\/remote\.test\/mcp/i).closest("tr") as HTMLElement;
+    expect(within(row).getByText(/oauth coming in 4b-2/i)).toBeInTheDocument();
+    expect(within(row).queryByRole("button", { name: /approve/i })).toBeNull();
+  });
+});

--- a/web/ui/src/routes/Grants.tsx
+++ b/web/ui/src/routes/Grants.tsx
@@ -250,30 +250,32 @@ function GrantRow({
         {/* mcp — modeled, not grantable in 4b-1. */}
         {isMcp && <span className="muted">OAuth coming in 4b-2 — not yet grantable.</span>}
 
-        {/* pending vault — single-click approve (the hub mints). */}
-        {!isMcp && grant.status === "pending" && c.kind === "vault" && (
+        {/* not-yet-granted vault (pending OR revoked) — single-click approve
+            (the hub mints; approving a revoked grant re-mints fresh material). */}
+        {!isMcp && grant.status !== "approved" && c.kind === "vault" && (
           <button
             type="button"
             className="primary"
             disabled={busy}
             onClick={() => actions.onApproveVault(grant.id)}
           >
-            {busy ? "Approving…" : "Approve"}
+            {busy ? "Approving…" : grant.status === "revoked" ? "Re-approve" : "Approve"}
           </button>
         )}
 
-        {/* pending service — paste the API token, then approve. */}
-        {!isMcp && grant.status === "pending" && isService && pasting === null && (
+        {/* not-yet-granted service (pending OR revoked) — paste the API token,
+            then approve. */}
+        {!isMcp && grant.status !== "approved" && isService && pasting === null && (
           <button
             type="button"
             className="primary"
             disabled={busy}
             onClick={() => setRowSt({ kind: "pasting", id: grant.id, token: "" })}
           >
-            Approve…
+            {grant.status === "revoked" ? "Re-approve…" : "Approve…"}
           </button>
         )}
-        {!isMcp && grant.status === "pending" && isService && pasting !== null && (
+        {!isMcp && grant.status !== "approved" && isService && pasting !== null && (
           <span style={{ display: "inline-flex", gap: "0.5rem", alignItems: "center" }}>
             <input
               type="password"
@@ -307,9 +309,6 @@ function GrantRow({
             {busy ? "Revoking…" : "Revoke"}
           </button>
         )}
-
-        {/* revoked — re-approval happens after the agent re-declares. */}
-        {grant.status === "revoked" && <span className="muted">revoked</span>}
 
         {rowError && <span className="error-inline"> {rowError}</span>}
       </td>

--- a/web/ui/src/routes/Grants.tsx
+++ b/web/ui/src/routes/Grants.tsx
@@ -1,0 +1,318 @@
+/**
+ * /admin/grants — the agent-connector GRANTS approval view (Phase 4b-1).
+ *
+ * An agent (a `#agent/definition` note in the agent module) declares connections
+ * it WANTS beyond its own def-vault — other LOCAL vaults (tag-scoped) and
+ * external SERVICE credentials (GitHub, Cloudflare). The agent module registers
+ * each as a PENDING grant with the hub; THIS view is where the operator approves
+ * per-connection. On approve, the hub mints (vault) / stores the pasted token
+ * (service). Revoke drops the stored secret — the agent loses it next spawn.
+ *
+ * The one invariant (design 2026-06-17): a vault note can only REQUEST; it can
+ * never GRANT. A pending grant grants nothing until the operator clicks Approve
+ * here. So defining agents "from any chat" is safe — worst case a request sits
+ * pending.
+ *
+ * The `mcp` (remote/OAuth) kind is modeled but not grantable in 4b-1 — its
+ * Approve is disabled with "OAuth coming in 4b-2 — not yet grantable."
+ *
+ * Auth: list is host-admin-Bearer (`lib/api.ts:listAgentGrants`); approve/revoke
+ * are cookie-authed first-admin routes. The `lib/api.ts` helpers redirect to
+ * login on 401 and surface `error_description` verbatim. Modeled on
+ * Connections.tsx for visual continuity.
+ */
+import { useEffect, useState } from "react";
+import {
+  type GrantConnection,
+  type GrantListing,
+  HttpError,
+  approveAgentGrant,
+  listAgentGrants,
+  revokeAgentGrant,
+} from "../lib/api.ts";
+
+type ListState =
+  | { kind: "loading" }
+  | { kind: "ok"; grants: GrantListing[] }
+  | { kind: "error"; message: string };
+
+/** Per-row action state. `tokenFor` carries the in-progress service token paste. */
+type RowState =
+  | { kind: "idle" }
+  | { kind: "pasting"; id: string; token: string }
+  | { kind: "working"; id: string }
+  | { kind: "error"; id: string; message: string };
+
+function errMessage(err: unknown, verb: string): string {
+  if (err instanceof HttpError) return err.message;
+  if (err instanceof Error) return err.message;
+  return `${verb} failed`;
+}
+
+export function Grants(): React.ReactElement {
+  const [state, setState] = useState<ListState>({ kind: "loading" });
+  const [rowSt, setRowSt] = useState<RowState>({ kind: "idle" });
+  const [reload, setReload] = useState(0);
+
+  useEffect(() => {
+    void reload; // re-run on manual reload bumps (Approve/Revoke/Retry)
+    let cancelled = false;
+    setState({ kind: "loading" });
+    listAgentGrants()
+      .then((grants) => {
+        if (!cancelled) setState({ kind: "ok", grants });
+      })
+      .catch((err) => {
+        if (!cancelled) setState({ kind: "error", message: errMessage(err, "Load") });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  async function onApproveVault(id: string): Promise<void> {
+    setRowSt({ kind: "working", id });
+    try {
+      await approveAgentGrant(id);
+      setRowSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRowSt({ kind: "error", id, message: errMessage(err, "Approve") });
+    }
+  }
+
+  async function onApproveService(id: string, token: string): Promise<void> {
+    if (token.trim().length === 0) {
+      setRowSt({ kind: "error", id, message: "Paste the API token before approving." });
+      return;
+    }
+    setRowSt({ kind: "working", id });
+    try {
+      await approveAgentGrant(id, token);
+      setRowSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRowSt({ kind: "error", id, message: errMessage(err, "Approve") });
+    }
+  }
+
+  async function onRevoke(id: string): Promise<void> {
+    setRowSt({ kind: "working", id });
+    try {
+      await revokeAgentGrant(id);
+      setRowSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRowSt({ kind: "error", id, message: errMessage(err, "Revoke") });
+    }
+  }
+
+  return (
+    <div data-route-content="true">
+      <div className="list-header">
+        <h1>Grants</h1>
+      </div>
+
+      <p className="muted">
+        Agents declare connections they want beyond their own vault — other vaults (tag-scoped) and
+        external service credentials. Each one waits here for your approval. A vault note can only{" "}
+        <em>request</em>; nothing is granted until you approve it below.
+      </p>
+
+      {renderBody(state, rowSt, setRowSt, {
+        onApproveVault,
+        onApproveService,
+        onRevoke,
+        onRetry: () => setReload((n) => n + 1),
+      })}
+    </div>
+  );
+}
+
+interface RowActions {
+  onApproveVault: (id: string) => Promise<void>;
+  onApproveService: (id: string, token: string) => Promise<void>;
+  onRevoke: (id: string) => Promise<void>;
+  onRetry: () => void;
+}
+
+function renderBody(
+  state: ListState,
+  rowSt: RowState,
+  setRowSt: (s: RowState) => void,
+  actions: RowActions,
+): React.ReactElement {
+  if (state.kind === "loading") return <p className="muted">Loading grants…</p>;
+  if (state.kind === "error") {
+    return (
+      <div>
+        <div className="error-banner">{state.message}</div>
+        <button type="button" onClick={actions.onRetry} className="secondary">
+          Retry
+        </button>
+      </div>
+    );
+  }
+  if (state.grants.length === 0) {
+    return (
+      <div className="empty empty-rich">
+        <p className="empty-headline">No grant requests yet.</p>
+        <p className="muted">
+          When an agent declares a connection it wants, it shows up here for approval.
+        </p>
+      </div>
+    );
+  }
+
+  // Group by agent for the approval UI.
+  const byAgent = new Map<string, GrantListing[]>();
+  for (const g of state.grants) {
+    const list = byAgent.get(g.agent) ?? [];
+    list.push(g);
+    byAgent.set(g.agent, list);
+  }
+  const agents = [...byAgent.keys()].sort();
+
+  return (
+    <div className="grants-groups">
+      {agents.map((agent) => (
+        <section key={agent} aria-label={`Grants for ${agent}`} style={{ marginBottom: "1.5rem" }}>
+          <h3 style={{ marginBottom: "0.25rem" }}>{agent}</h3>
+          <div className="table-scroll">
+            <table className="channel-table">
+              <thead>
+                <tr>
+                  <th>Connection</th>
+                  <th>Status</th>
+                  <th>Actions</th>
+                </tr>
+              </thead>
+              <tbody>
+                {(byAgent.get(agent) ?? []).map((g) => (
+                  <GrantRow
+                    key={g.id}
+                    grant={g}
+                    rowSt={rowSt}
+                    setRowSt={setRowSt}
+                    actions={actions}
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function connectionLabel(c: GrantConnection): string {
+  if (c.kind === "vault") {
+    const access = c.access ?? "read";
+    const tags = c.tags && c.tags.length > 0 ? ` (${c.tags.join(", ")})` : "";
+    return `vault: ${c.target} · ${access}${tags}`;
+  }
+  if (c.kind === "service") {
+    const inject = c.inject && c.inject.length > 0 ? ` · inject: ${c.inject.join("+")}` : "";
+    return `service: ${c.target}${inject}`;
+  }
+  return `mcp: ${c.target}`;
+}
+
+function GrantRow({
+  grant,
+  rowSt,
+  setRowSt,
+  actions,
+}: {
+  grant: GrantListing;
+  rowSt: RowState;
+  setRowSt: (s: RowState) => void;
+  actions: RowActions;
+}): React.ReactElement {
+  const busy = rowSt.kind === "working" && rowSt.id === grant.id;
+  const rowError = rowSt.kind === "error" && rowSt.id === grant.id ? rowSt.message : null;
+  const c = grant.connection;
+  const isMcp = c.kind === "mcp";
+  const isService = c.kind === "service";
+  const pasting = rowSt.kind === "pasting" && rowSt.id === grant.id ? rowSt.token : null;
+
+  return (
+    <tr data-grant-id={grant.id}>
+      <td>
+        <code>{connectionLabel(c)}</code>
+      </td>
+      <td>
+        <span className={`status status-${grant.status}`}>{grant.status}</span>
+        {grant.reason && <span className="muted"> — {grant.reason}</span>}
+      </td>
+      <td>
+        {/* mcp — modeled, not grantable in 4b-1. */}
+        {isMcp && <span className="muted">OAuth coming in 4b-2 — not yet grantable.</span>}
+
+        {/* pending vault — single-click approve (the hub mints). */}
+        {!isMcp && grant.status === "pending" && c.kind === "vault" && (
+          <button
+            type="button"
+            className="primary"
+            disabled={busy}
+            onClick={() => actions.onApproveVault(grant.id)}
+          >
+            {busy ? "Approving…" : "Approve"}
+          </button>
+        )}
+
+        {/* pending service — paste the API token, then approve. */}
+        {!isMcp && grant.status === "pending" && isService && pasting === null && (
+          <button
+            type="button"
+            className="primary"
+            disabled={busy}
+            onClick={() => setRowSt({ kind: "pasting", id: grant.id, token: "" })}
+          >
+            Approve…
+          </button>
+        )}
+        {!isMcp && grant.status === "pending" && isService && pasting !== null && (
+          <span style={{ display: "inline-flex", gap: "0.5rem", alignItems: "center" }}>
+            <input
+              type="password"
+              aria-label={`API token for ${c.target}`}
+              placeholder={`${c.target} API token`}
+              value={pasting}
+              onChange={(e) => setRowSt({ kind: "pasting", id: grant.id, token: e.target.value })}
+            />
+            <button
+              type="button"
+              className="primary"
+              disabled={busy}
+              onClick={() => actions.onApproveService(grant.id, pasting)}
+            >
+              {busy ? "Approving…" : "Save & approve"}
+            </button>
+            <button type="button" className="secondary" onClick={() => setRowSt({ kind: "idle" })}>
+              Cancel
+            </button>
+          </span>
+        )}
+
+        {/* approved — revoke. */}
+        {grant.status === "approved" && (
+          <button
+            type="button"
+            className="secondary"
+            disabled={busy}
+            onClick={() => actions.onRevoke(grant.id)}
+          >
+            {busy ? "Revoking…" : "Revoke"}
+          </button>
+        )}
+
+        {/* revoked — re-approval happens after the agent re-declares. */}
+        {grant.status === "revoked" && <span className="muted">revoked</span>}
+
+        {rowError && <span className="error-inline"> {rowError}</span>}
+      </td>
+    </tr>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1071,6 +1071,20 @@ a.btn:hover {
   background: var(--bg-soft);
   color: var(--fg-dim);
 }
+/*
+ * Agent-connector grant statuses (4b-1). `pending` reuses `.status-pending`;
+ * `approved` is the success terminal state; `revoked` reuses the muted rule
+ * above. `.error-inline` is the per-row action error beside the Approve/Revoke
+ * buttons in the Grants view.
+ */
+.status-approved {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.error-inline {
+  color: var(--error);
+  font-size: 0.85rem;
+}
 
 /*
  * Back-compat aliases for the pre-F vocabulary. Modules / SDKs that


### PR DESCRIPTION
The **hub side of Phase 4b-1** — the approval-gated **agent-connector GRANTS** subsystem. Design of record: `parachute-agent` `design/2026-06-17-agent-connectors-4b.md`.

## What this delivers

An agent (a `#agent/definition` note in the agent module) declares connections it WANTS beyond its own def-vault. The agent module registers each as a **pending grant** with the hub; the operator **approves per-connection** in hub admin; the hub **mints (vault) / stores (service)** the secret; the agent module **fetches the material at spawn** and injects it.

**The one invariant:** a vault note can only REQUEST; it can never GRANT. A grant created by the module sits `pending` and grants nothing until the operator approves — so defining agents "from any chat" is safe (worst case a request sits pending).

This **generalizes the existing Connections engine** ("event→action triggers") to "approval-gated resource grants" — it reuses the existing vault-token mint path (registered-mint + revoke discipline) and the host-admin / first-admin auth gates rather than building a parallel system.

**4b-1 = vault + service kinds only.** The `mcp` (remote/OAuth) kind is modeled but not grantable — it stays `pending` with reason `"oauth not yet supported"` (4b-2 is hub-as-OAuth-client). No OAuth client work here.

## The wire contract (the agent module must match this exactly)

**Connection spec** — what the agent wants:
```ts
{ kind: "vault" | "service" | "mcp", target: string,
  access?: "read" | "write",        // vault only (default "read")
  tags?: string[],                   // vault only — tag-scope (scoped_tags)
  inject?: ("env" | "mcp")[] }       // service only — agent-side inject hints
```

**Endpoints** (all under `/admin/grants`):

| Method + path | Auth | Body | Returns |
|---|---|---|---|
| `PUT /admin/grants` | host-admin Bearer | `{ agent, connection }` | `{ id, agent, connection, status, reason? }` — idempotent upsert keyed by `(agent, stable-connection-key)`; **no material**. 201 new / 200 existing. New `mcp` → `pending` + reason. |
| `GET /admin/grants?agent=<name>` | host-admin Bearer | — | `{ grants: [{ id, agent, connection, status, reason?, approvedAt? }] }` — **no material**. Omit `?agent` → all grants (approval UI). |
| `GET /admin/grants/<id>/material` | host-admin Bearer | — | **approved-only**: vault → `{ kind:"vault", token, mcpUrl }`; service → `{ kind:"service", token, inject }`. `404` unknown id, `409` not approved. |
| `POST /admin/grants/<id>/approve` | first-admin cookie + CSRF | `{ token? }` | vault: MINT `vault:<target>:<access>` (+`scoped_tags`) now + store; service: store the pasted `token`. Returns the updated grant (no material). `409 not_grantable` for `mcp`. |
| `POST /admin/grants/<id>/revoke` | first-admin cookie + CSRF | — | drop the stored secret + revoke the minted token + `status=revoked`. |

- `mcpUrl` is `<hub-origin>/vault/<target>/mcp` — add it as an MCP server with `Authorization: Bearer <token>`.
- **Idempotency key** = `kind` + `target` + (vault) access + sorted tags; `inject` is NOT part of the key (re-declaring a service with new inject modes updates the existing grant). Grant `id` is a deterministic slug of `agent` + that key.
- Re-PUT of an approved grant keeps it approved (no downgrade); a revoked grant stays revoked on re-PUT — the operator re-grants by approving it directly (re-mints fresh material).

## Auth posture (mirrors the Connections engine)
- **Module-auth** (`PUT`, `GET`, `GET /material`): a `parachute:host:admin` Bearer — the agent module presents one the same way the SPA mints via `/admin/host-admin-token`.
- **Operator-auth** (`POST /approve`, `POST /revoke`): a first-admin session cookie, CSRF-belted by the dispatch (Bearer-authed siblings pass the belt's Authorization carve-out).

## Secret discipline
The minted/pasted token (`material`) lives in `agent-grants.json` (**0600**), is **NEVER logged** (log lines carry identity fields only), **NEVER returned** by PUT/GET-list/approve/revoke — only by the approved-only, module-auth-gated `/material`. The minted vault token is **registered** (`created_via "agent_grant"`) so revoke can drop it; re-approval revokes the prior token (no orphaned live tokens).

## Files
- `src/grants-store.ts` — the 0600 JSON store (round-trip, lenient-read, idempotency-key derivation). **Distinct** from the pre-existing `src/grants.ts` (OAuth consent skip-list, SQLite) + `src/admin-grants.ts` (mounted at `/api/grants`). New store file is `agent-grants.json`; routes at `/admin/grants`. No collision.
- `src/admin-agent-grants.ts` — the handler (router + both auth classes + mint).
- `src/hub-server.ts` — route wiring + `agentGrantsStorePath` dep.
- `src/jwt-sign.ts` — `"agent_grant"` added to `TokenCreatedVia` (additive).
- `src/origin-check.ts` — CSRF-belt docstring.
- `web/ui` — `Grants.tsx` admin view (list grouped by agent; per-connection Approve / token-paste Approve for service / Revoke / Re-approve; `mcp` shows the 4b-2 message) + `api.ts` helpers + nav/route + CSS + tests.

## Gates
- hub `bun test ./src`: **3490 pass, 1 skip, 0 fail** (+47 new)
- hub `tsc --noEmit`: clean
- web/ui `vitest run`: **301 pass** (+11 new)
- web/ui `tsc --noEmit`: clean
- biome clean on all touched files

## Review
Independent reviewer pass: **LGTM with nits, no blocking issues**. All nits folded inline (reserved-name guard via `validateVaultName`, input length caps, revoked-grant re-approve made real in code + UI, plus the double-approve orphan-token test + reserved-name/over-long-input/re-approve tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)