### PR TITLE
feat(grants): hub-as-OAuth-client for remote MCP/vault grants (4b-2)

### DIFF
--- a/src/__tests__/admin-agent-grants.test.ts
+++ b/src/__tests__/admin-agent-grants.test.ts
@@ -18,11 +18,17 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { decodeJwt } from "jose";
-import { type AgentGrantsDeps, handleAgentGrants } from "../admin-agent-grants.ts";
+import {
+  type AgentGrantsDeps,
+  handleAgentGrants,
+  handleOAuthGrantCallback,
+} from "../admin-agent-grants.ts";
 import { readGrants } from "../grants-store.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { findTokenRowByJti } from "../jwt-sign.ts";
 import { signAccessToken } from "../jwt-sign.ts";
+import type { OAuthClient } from "../oauth-client.ts";
+import { getFlowByState } from "../oauth-flows-store.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import { createUser } from "../users.ts";
@@ -33,6 +39,7 @@ const VAULT_ORIGIN = "http://127.0.0.1:1940";
 interface Harness {
   db: Database;
   storePath: string;
+  flowsStorePath: string;
   cleanup: () => void;
 }
 
@@ -43,12 +50,68 @@ function makeHarness(): Harness {
   return {
     db,
     storePath: join(dir, "agent-grants.json"),
+    flowsStorePath: join(dir, "agent-oauth-flows.json"),
     cleanup: () => {
       db.close();
       rmSync(dir, { recursive: true, force: true });
     },
   };
 }
+
+/**
+ * A fake OAuth client. Deterministic verifier/challenge/state so tests can assert
+ * the persisted flow; the network methods return canned values or call recorded
+ * spies. No real network ever happens.
+ */
+function fakeOAuth(over: Partial<OAuthClient> = {}): OAuthClient & {
+  calls: { refresh: number; revoke: number; register: number; exchange: number };
+} {
+  const calls = { refresh: 0, revoke: 0, register: 0, exchange: 0 };
+  const base: OAuthClient = {
+    generateCodeVerifier: () => "fixed-verifier",
+    generateCodeChallenge: (v) => `chal(${v})`,
+    generateState: () => "fixed-state",
+    discover: async () => ({
+      issuer: "https://issuer.test",
+      authorizationEndpoint: "https://issuer.test/oauth/authorize",
+      tokenEndpoint: "https://issuer.test/oauth/token",
+      registrationEndpoint: "https://issuer.test/oauth/register",
+      revocationEndpoint: "https://issuer.test/oauth/revoke",
+      scopesSupported: ["vault:eng:read", "vault:eng:write"],
+    }),
+    registerClient: async () => {
+      calls.register++;
+      return { clientId: "dcr-client-1" };
+    },
+    buildAuthorizeUrl: (o) =>
+      `${o.authorizationEndpoint}?client_id=${o.clientId}&state=${o.state}&code_challenge=${o.codeChallenge}&code_challenge_method=S256${o.scope ? `&scope=${encodeURIComponent(o.scope)}` : ""}`,
+    exchangeCode: async () => {
+      calls.exchange++;
+      return {
+        access_token: "at-fresh",
+        refresh_token: "rt-fresh",
+        expiresAt: "2026-06-18T13:00:00.000Z",
+      };
+    },
+    refreshToken: async () => {
+      calls.refresh++;
+      return {
+        access_token: "at-refreshed",
+        refresh_token: "rt-refreshed",
+        expiresAt: "2026-06-18T14:00:00.000Z",
+      };
+    },
+    revokeRemote: async () => {
+      calls.revoke++;
+    },
+  };
+  return Object.assign({ calls }, base, over);
+}
+
+let currentOAuth: OAuthClient | undefined;
+beforeEach(() => {
+  currentOAuth = undefined;
+});
 
 let harness: Harness;
 beforeEach(() => {
@@ -64,12 +127,15 @@ beforeEach(() => {
   installedVaults = new Set<string>(["research"]);
 });
 
-function deps(): AgentGrantsDeps {
+function deps(over: Partial<AgentGrantsDeps> = {}): AgentGrantsDeps {
   return {
     db: harness.db,
     hubOrigin: HUB_ORIGIN,
     storePath: harness.storePath,
+    flowsStorePath: harness.flowsStorePath,
     resolveVaultOrigin: (name) => (installedVaults.has(name) ? VAULT_ORIGIN : null),
+    ...(currentOAuth ? { oauthClient: currentOAuth } : {}),
+    ...over,
   };
 }
 
@@ -202,7 +268,7 @@ describe("PUT /admin/grants (upsert)", () => {
     expect((body.connection as Record<string, unknown>).inject).toEqual(["env", "mcp"]);
   });
 
-  test("an mcp grant stays pending with the slice-2 reason", async () => {
+  test("an mcp grant lands pending awaiting oauth consent (4b-2)", async () => {
     const bearer = await moduleBearer();
     const res = await dispatch(
       bearerReq("PUT", "/admin/grants", bearer, {
@@ -213,7 +279,7 @@ describe("PUT /admin/grants (upsert)", () => {
     expect(res.status).toBe(201);
     const body = await json(res);
     expect(body.status).toBe("pending");
-    expect(body.reason).toBe("oauth not yet supported");
+    expect(body.reason).toBe("awaiting oauth consent");
   });
 
   test("re-declaring an APPROVED grant does not downgrade it to pending", async () => {
@@ -533,22 +599,6 @@ describe("POST /admin/grants/<id>/approve", () => {
     expect(res.status).toBe(400);
   });
 
-  test("mcp: 409 not_grantable (stays pending)", async () => {
-    const bearer = await moduleBearer();
-    const cookie = await operatorCookie();
-    const created = await json(
-      await dispatch(
-        bearerReq("PUT", "/admin/grants", bearer, {
-          agent: "a",
-          connection: { kind: "mcp", target: "https://remote.test/mcp" },
-        }),
-      ),
-    );
-    const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
-    expect(res.status).toBe(409);
-    expect(readGrants(harness.storePath).find((r) => r.id === created.id)?.status).toBe("pending");
-  });
-
   test("vault: 400 when the vault no longer exists", async () => {
     const bearer = await moduleBearer();
     const cookie = await operatorCookie();
@@ -778,5 +828,455 @@ describe("routing", () => {
     const bearer = await moduleBearer();
     const res = await dispatch(bearerReq("GET", "/admin/grants/x/bogus", bearer));
     expect(res.status).toBe(404);
+  });
+});
+
+// === 4b-2: mcp grants (OAuth client + static bearer) ========================
+
+describe("approve(mcp) — static bearer", () => {
+  test("a pasted token → approved + mcp material (no discovery, no flow)", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    const res = await dispatch(
+      cookieReq("POST", `/admin/grants/${id}/approve`, cookie, { token: "static-paste-123" }),
+    );
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.status).toBe("approved");
+    expect(body).not.toHaveProperty("material");
+    expect(body).not.toHaveProperty("authorizeUrl");
+
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    const mat = stored?.material as { kind: string; access_token: string; mcpUrl: string };
+    expect(mat.kind).toBe("mcp");
+    expect(mat.access_token).toBe("static-paste-123");
+    expect(mat.mcpUrl).toBe("https://remote.test/mcp");
+    // no OAuth machinery ran, no pending flow persisted
+    expect(getFlowByState(harness.flowsStorePath, "fixed-state")).toBeNull();
+  });
+
+  test("a static-bearer /material returns { kind:mcp, token, mcpUrl }", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(
+      cookieReq("POST", `/admin/grants/${id}/approve`, cookie, { token: "static-paste-123" }),
+    );
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.kind).toBe("mcp");
+    expect(body.token).toBe("static-paste-123");
+    expect(body.mcpUrl).toBe("https://remote.test/mcp");
+    // no refresh occurred for a static bearer
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.refresh).toBe(0);
+  });
+
+  test("rejects an over-long pasted token (400)", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const res = await dispatch(
+      cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie, { token: "x".repeat(9000) }),
+    );
+    expect(res.status).toBe(400);
+    expect(readGrants(harness.storePath).find((r) => r.id === created.id)?.status).toBe("pending");
+  });
+});
+
+describe("approve(mcp) — start OAuth flow", () => {
+  test("no token → discover + DCR + persist flow + return authorizeUrl (stays pending)", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.status).toBe("pending");
+    expect(body.reason).toBe("awaiting oauth consent");
+    expect(typeof body.authorizeUrl).toBe("string");
+    expect(body.authorizeUrl as string).toContain("code_challenge_method=S256");
+    expect(body.authorizeUrl as string).toContain("state=fixed-state");
+    // grant is still pending (no material yet)
+    expect(readGrants(harness.storePath).find((r) => r.id === id)?.status).toBe("pending");
+
+    // a pending flow was persisted, bound to (state, grantId)
+    const flow = getFlowByState(harness.flowsStorePath, "fixed-state");
+    expect(flow?.grantId).toBe(id);
+    expect(flow?.clientId).toBe("dcr-client-1");
+    expect(flow?.verifier).toBe("fixed-verifier");
+    expect(flow?.scope).toBe("vault:eng:read vault:eng:write");
+    expect(flow?.redirectUri).toBe("https://hub.test/oauth/agent-grant/callback");
+    // DCR happened once
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.register).toBe(1);
+  });
+
+  test("502 when discovery fails (grant stays pending, no flow)", async () => {
+    currentOAuth = fakeOAuth({
+      discover: async () => {
+        throw new Error("no metadata");
+      },
+    });
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
+    expect(res.status).toBe(502);
+    expect(getFlowByState(harness.flowsStorePath, "fixed-state")).toBeNull();
+  });
+});
+
+// callback dispatch helper (the route is a browser GET, no auth)
+async function callback(query: string): Promise<Response> {
+  const req = new Request(`${HUB_ORIGIN}/oauth/agent-grant/callback${query}`, { method: "GET" });
+  return handleOAuthGrantCallback(req, deps());
+}
+
+describe("GET /oauth/agent-grant/callback", () => {
+  async function startFlow(): Promise<string> {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    return id;
+  }
+
+  test("happy path → exchange + store material + status approved", async () => {
+    currentOAuth = fakeOAuth();
+    const id = await startFlow();
+
+    const res = await callback("?code=auth-code-1&state=fixed-state");
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const html = await res.text();
+    expect(html).toContain("Connected");
+    // NEVER a token in the HTML
+    expect(html).not.toContain("at-fresh");
+    expect(html).not.toContain("rt-fresh");
+
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.status).toBe("approved");
+    const mat = stored?.material as { kind: string; access_token: string; refresh_token: string };
+    expect(mat.kind).toBe("mcp");
+    expect(mat.access_token).toBe("at-fresh");
+    expect(mat.refresh_token).toBe("rt-fresh");
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.exchange).toBe(1);
+
+    // the flow was consumed (single-use)
+    expect(getFlowByState(harness.flowsStorePath, "fixed-state")).toBeNull();
+  });
+
+  test("unknown / replayed state → error HTML, no material", async () => {
+    currentOAuth = fakeOAuth();
+    const id = await startFlow();
+    // first use consumes the flow
+    await callback("?code=auth-code-1&state=fixed-state");
+    // replay
+    const res = await callback("?code=auth-code-1&state=fixed-state");
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("Connection failed");
+    // exchange ran only once (the replay never reached it)
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.exchange).toBe(1);
+    expect(readGrants(harness.storePath).find((r) => r.id === id)?.status).toBe("approved");
+  });
+
+  test("a totally unknown state → 400, no exchange", async () => {
+    currentOAuth = fakeOAuth();
+    const res = await callback("?code=x&state=never-minted");
+    expect(res.status).toBe(400);
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.exchange).toBe(0);
+  });
+
+  test("operator Deny (?error=access_denied) → grant stays pending with reason 'operator declined'", async () => {
+    currentOAuth = fakeOAuth();
+    const id = await startFlow();
+    const res = await callback("?error=access_denied&state=fixed-state");
+    expect(res.status).toBe(400);
+    const html = await res.text();
+    expect(html).toContain("not authorized");
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.status).toBe("pending");
+    // admin can now distinguish "not yet tried" from "tried + denied"
+    expect(stored?.reason).toBe("operator declined");
+    // flow consumed even on deny
+    expect(getFlowByState(harness.flowsStorePath, "fixed-state")).toBeNull();
+  });
+
+  test("token exchange failure → error HTML, grant stays pending", async () => {
+    currentOAuth = fakeOAuth({
+      exchangeCode: async () => {
+        throw new Error("invalid_grant");
+      },
+    });
+    const id = await startFlow();
+    const res = await callback("?code=bad&state=fixed-state");
+    expect(res.status).toBe(502);
+    expect(readGrants(harness.storePath).find((r) => r.id === id)?.status).toBe("pending");
+  });
+
+  test("re-consent replaces material + best-effort revokes the old refresh", async () => {
+    currentOAuth = fakeOAuth();
+    const id = await startFlow();
+    // complete the first consent → approved with rt-fresh + revocationEndpoint
+    await callback("?code=c1&state=fixed-state");
+    const cookie = await operatorCookie();
+    // re-approve (already approved) → starts a fresh flow (reuses clientId, same issuer)
+    const reApprove = await json(
+      await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie)),
+    );
+    expect(reApprove.status).toBe("pending");
+    expect(typeof reApprove.authorizeUrl).toBe("string");
+    // DCR was NOT called again (clientId reused for the same issuer)
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.register).toBe(1);
+
+    // complete the second consent → revokes the prior refresh
+    const res = await callback("?code=c2&state=fixed-state");
+    expect(res.status).toBe(200);
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.revoke).toBe(1);
+  });
+});
+
+describe("material(mcp) — auto-refresh", () => {
+  // Drive a grant to approved-via-OAuth, with expiry in the (near) past/future.
+  async function approvedViaOAuth(expiresAt: string): Promise<string> {
+    currentOAuth = fakeOAuth({
+      exchangeCode: async () => ({
+        access_token: "at-initial",
+        refresh_token: "rt-initial",
+        expiresAt,
+      }),
+    });
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    const req = new Request(`${HUB_ORIGIN}/oauth/agent-grant/callback?code=c&state=fixed-state`, {
+      method: "GET",
+    });
+    await handleOAuthGrantCallback(req, deps());
+    return id;
+  }
+
+  test("fresh token (far from expiry) → returned without a refresh", async () => {
+    const far = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+    const id = await approvedViaOAuth(far);
+    (currentOAuth as ReturnType<typeof fakeOAuth>).calls.refresh = 0;
+    const bearer = await moduleBearer();
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(res.status).toBe(200);
+    expect((await json(res)).token).toBe("at-initial");
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.refresh).toBe(0);
+  });
+
+  test("near-expiry token → refresh first, return the new token, persist it", async () => {
+    // expiry within the 120s skew window
+    const soon = new Date(Date.now() + 60 * 1000).toISOString();
+    const id = await approvedViaOAuth(soon);
+    const before = (currentOAuth as ReturnType<typeof fakeOAuth>).calls.refresh;
+    const bearer = await moduleBearer();
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(res.status).toBe(200);
+    expect((await json(res)).token).toBe("at-refreshed");
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.refresh).toBe(before + 1);
+    // new access + rotated refresh persisted
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    const mat = stored?.material as { access_token: string; refresh_token: string };
+    expect(mat.access_token).toBe("at-refreshed");
+    expect(mat.refresh_token).toBe("rt-refreshed");
+  });
+
+  test("refresh failure → status needs_consent + 409, material dropped", async () => {
+    const soon = new Date(Date.now() + 60 * 1000).toISOString();
+    // approve via OAuth, THEN swap in a client whose refresh fails
+    const id = await approvedViaOAuth(soon);
+    currentOAuth = fakeOAuth({
+      refreshToken: async () => {
+        throw new Error("invalid_grant");
+      },
+    });
+    const bearer = await moduleBearer();
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(res.status).toBe(409);
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.status).toBe("needs_consent");
+    expect(stored?.material).toBeUndefined();
+    expect(stored?.reason).toContain("refresh failed");
+  });
+
+  test("a needs_consent grant's /material 409 reason carries useful text", async () => {
+    const soon = new Date(Date.now() + 60 * 1000).toISOString();
+    const id = await approvedViaOAuth(soon);
+    currentOAuth = fakeOAuth({
+      refreshToken: async () => {
+        throw new Error("invalid_grant");
+      },
+    });
+    const bearer = await moduleBearer();
+    // first call drives it to needs_consent
+    await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    // second call: 409 whose reason text tells the operator to re-consent
+    const res = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(res.status).toBe(409);
+    const body = await json(res);
+    expect(body.error).toBe("not_approved");
+    const desc = body.error_description as string;
+    expect(desc).toContain("needs_consent");
+    expect(desc).toMatch(/re-consent|reconnect|approve/i);
+  });
+
+  test("needs_consent → re-approve → callback revives to approved with fresh material", async () => {
+    // Drive a grant to needs_consent (approved-via-OAuth, then a failed refresh).
+    const soon = new Date(Date.now() + 60 * 1000).toISOString();
+    const id = await approvedViaOAuth(soon);
+    currentOAuth = fakeOAuth({
+      refreshToken: async () => {
+        throw new Error("invalid_grant");
+      },
+    });
+    const bearer = await moduleBearer();
+    await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(readGrants(harness.storePath).find((r) => r.id === id)?.status).toBe("needs_consent");
+
+    // Re-approve (no token) on a needs_consent grant → starts a FRESH OAuth flow.
+    currentOAuth = fakeOAuth();
+    const cookie = await operatorCookie();
+    const reApprove = await json(
+      await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie)),
+    );
+    expect(reApprove.status).toBe("pending");
+    expect(typeof reApprove.authorizeUrl).toBe("string");
+    // a fresh flow was persisted, bound to this grant
+    const flow = getFlowByState(harness.flowsStorePath, "fixed-state");
+    expect(flow?.grantId).toBe(id);
+
+    // Complete the consent → revived to approved with fresh material.
+    const res = await callback("?code=revive&state=fixed-state");
+    expect(res.status).toBe(200);
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.status).toBe("approved");
+    const mat = stored?.material as { kind: string; access_token: string };
+    expect(mat.kind).toBe("mcp");
+    expect(mat.access_token).toBe("at-fresh");
+    // /material now serves a live token (the fake's hardcoded expiry is past, so
+    // the lazy refresh kicks in and returns the refreshed token — proving the
+    // revived grant is fully functional, no longer 409ing).
+    const matRes = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(matRes.status).toBe(200);
+    expect((await json(matRes)).token).toBe("at-refreshed");
+  });
+});
+
+describe("revoke(mcp)", () => {
+  test("best-effort revokes the remote refresh + drops material", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    await callback("?code=c&state=fixed-state"); // → approved with rt-fresh + revocationEndpoint
+
+    const before = (currentOAuth as ReturnType<typeof fakeOAuth>).calls.revoke;
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${id}/revoke`, cookie));
+    expect(res.status).toBe(200);
+    expect((await json(res)).status).toBe("revoked");
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.revoke).toBe(before + 1);
+
+    const stored = readGrants(harness.storePath).find((r) => r.id === id);
+    expect(stored?.material).toBeUndefined();
+    // /material now 409s
+    const mat = await dispatch(bearerReq("GET", `/admin/grants/${id}/material`, bearer));
+    expect(mat.status).toBe(409);
+  });
+
+  test("a static-bearer revoke drops material without a remote revoke call", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(
+      cookieReq("POST", `/admin/grants/${id}/approve`, cookie, { token: "static-paste" }),
+    );
+    const before = (currentOAuth as ReturnType<typeof fakeOAuth>).calls.revoke;
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${id}/revoke`, cookie));
+    expect(res.status).toBe(200);
+    // no remote revoke for a static bearer (no refresh/revocation endpoint)
+    expect((currentOAuth as ReturnType<typeof fakeOAuth>).calls.revoke).toBe(before);
+    expect(readGrants(harness.storePath).find((r) => r.id === id)?.material).toBeUndefined();
   });
 });

--- a/src/__tests__/grants-store.test.ts
+++ b/src/__tests__/grants-store.test.ts
@@ -137,6 +137,53 @@ describe("lenient read", () => {
   });
 });
 
+describe("4b-2 mcp material + needs_consent (regression)", () => {
+  test("mcp material round-trips (OAuth shape)", () => {
+    const r = rec({
+      status: "approved",
+      connection: { kind: "mcp", target: "https://remote.test/mcp" },
+      material: {
+        kind: "mcp",
+        access_token: "at-1",
+        refresh_token: "rt-1",
+        expiresAt: "2026-06-18T13:00:00.000Z",
+        issuer: "https://issuer.test",
+        clientId: "cid-1",
+        tokenEndpoint: "https://issuer.test/oauth/token",
+        revocationEndpoint: "https://issuer.test/oauth/revoke",
+        mcpUrl: "https://remote.test/mcp",
+      },
+    });
+    putGrant(storePath, r);
+    const back = readGrants(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]).toEqual(r);
+  });
+
+  test("mcp static-bearer material round-trips (no refresh)", () => {
+    const r = rec({
+      status: "approved",
+      connection: { kind: "mcp", target: "https://remote.test/mcp" },
+      material: { kind: "mcp", access_token: "static-paste", mcpUrl: "https://remote.test/mcp" },
+    });
+    putGrant(storePath, r);
+    expect(readGrants(storePath)[0]).toEqual(r);
+  });
+
+  test("a needs_consent row SURVIVES readGrants (the 4b-2 blocker regression)", () => {
+    const r = rec({
+      status: "needs_consent",
+      reason: "refresh failed: invalid_grant",
+      connection: { kind: "mcp", target: "https://remote.test/mcp" },
+    });
+    putGrant(storePath, r);
+    const back = readGrants(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]?.status).toBe("needs_consent");
+    expect(getGrant(storePath, r.id)?.status).toBe("needs_consent");
+  });
+});
+
 describe("connectionKey / grantId derivation (idempotency)", () => {
   test("vault key includes access + sorted tags", () => {
     expect(connectionKey(vaultSpec())).toBe("vault:research:read");

--- a/src/__tests__/oauth-client.test.ts
+++ b/src/__tests__/oauth-client.test.ts
@@ -1,0 +1,400 @@
+/**
+ * Tests for the hub-as-OAuth-CLIENT engine (`oauth-client.ts`, 4b-2).
+ *
+ * Fully offline — every network call goes through an injected `fetchFn`. No real
+ * fetch is ever made. Covers: discovery (9728→8414 + 8414-only fallback), DCR,
+ * authorize-URL building (S256 + state + challenge), code exchange + refresh
+ * (form body + expiresAt computation), best-effort revoke, and the
+ * fetchWithTimeout abort.
+ */
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import {
+  OAuthClientError,
+  buildAuthorizeUrl,
+  discover,
+  exchangeCode,
+  fetchWithTimeout,
+  generateCodeChallenge,
+  generateCodeVerifier,
+  refreshToken,
+  registerClient,
+  revokeRemote,
+} from "../oauth-client.ts";
+
+type FetchFn = typeof fetch;
+
+/** A tiny router-style fake fetch. Maps URL → a handler returning a Response. */
+function fakeFetch(routes: Record<string, (req: { url: string; init?: RequestInit }) => Response>) {
+  const calls: { url: string; init?: RequestInit }[] = [];
+  const fn = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    calls.push({ url, init });
+    // Match by pathname (ignore query) OR full url.
+    const path = new URL(url).pathname;
+    const handler = routes[url] ?? routes[path];
+    if (!handler) return new Response("not found", { status: 404 });
+    return handler({ url, init });
+  }) as unknown as FetchFn;
+  return { fn, calls };
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// === PKCE ===================================================================
+
+describe("PKCE", () => {
+  test("verifier is base64url, challenge is its S256", () => {
+    const v = generateCodeVerifier();
+    expect(v).toMatch(/^[A-Za-z0-9_-]+$/);
+    const c = generateCodeChallenge(v);
+    expect(c).toBe(createHash("sha256").update(v).digest("base64url"));
+  });
+
+  test("verifiers are distinct (random)", () => {
+    expect(generateCodeVerifier()).not.toBe(generateCodeVerifier());
+  });
+});
+
+// === Discovery ==============================================================
+
+describe("discover", () => {
+  test("RFC 9728 → 8414 (resource advertises authorization_servers)", async () => {
+    const { fn } = fakeFetch({
+      "https://remote.test/.well-known/oauth-protected-resource": () =>
+        json({
+          resource: "https://remote.test",
+          authorization_servers: ["https://issuer.test"],
+          scopes_supported: ["vault:eng:read", "vault:eng:write"],
+        }),
+      "https://issuer.test/.well-known/oauth-authorization-server": () =>
+        json({
+          issuer: "https://issuer.test",
+          authorization_endpoint: "https://issuer.test/oauth/authorize",
+          token_endpoint: "https://issuer.test/oauth/token",
+          registration_endpoint: "https://issuer.test/oauth/register",
+          revocation_endpoint: "https://issuer.test/oauth/revoke",
+        }),
+    });
+    const d = await discover("https://remote.test/vault/eng/mcp", fn);
+    expect(d.issuer).toBe("https://issuer.test");
+    expect(d.authorizationEndpoint).toBe("https://issuer.test/oauth/authorize");
+    expect(d.tokenEndpoint).toBe("https://issuer.test/oauth/token");
+    expect(d.registrationEndpoint).toBe("https://issuer.test/oauth/register");
+    expect(d.revocationEndpoint).toBe("https://issuer.test/oauth/revoke");
+    // 9728 scopes win
+    expect(d.scopesSupported).toEqual(["vault:eng:read", "vault:eng:write"]);
+  });
+
+  test("8414-only fallback (no 9728 doc → MCP origin is the issuer)", async () => {
+    const { fn, calls } = fakeFetch({
+      "https://solo.test/.well-known/oauth-protected-resource": () =>
+        new Response("nope", { status: 404 }),
+      "https://solo.test/.well-known/oauth-authorization-server": () =>
+        json({
+          issuer: "https://solo.test",
+          authorization_endpoint: "https://solo.test/authorize",
+          token_endpoint: "https://solo.test/token",
+          scopes_supported: ["mcp:read"],
+        }),
+    });
+    const d = await discover("https://solo.test/mcp", fn);
+    expect(d.issuer).toBe("https://solo.test");
+    expect(d.authorizationEndpoint).toBe("https://solo.test/authorize");
+    // scopes from 8414 (no 9728)
+    expect(d.scopesSupported).toEqual(["mcp:read"]);
+    // it DID try the 9728 doc first
+    expect(calls.some((c) => c.url.includes("oauth-protected-resource"))).toBe(true);
+  });
+
+  test("throws OAuthClientError when the 8414 doc lacks endpoints", async () => {
+    const { fn } = fakeFetch({
+      "https://bad.test/.well-known/oauth-protected-resource": () =>
+        json({ authorization_servers: ["https://bad.test"] }),
+      "https://bad.test/.well-known/oauth-authorization-server": () => json({ issuer: "x" }),
+    });
+    await expect(discover("https://bad.test/mcp", fn)).rejects.toBeInstanceOf(OAuthClientError);
+  });
+
+  test("throws on an invalid mcp url", async () => {
+    const { fn } = fakeFetch({});
+    await expect(discover("not-a-url", fn)).rejects.toBeInstanceOf(OAuthClientError);
+  });
+});
+
+// === DCR ====================================================================
+
+describe("registerClient", () => {
+  test("posts RFC 7591 body, returns client_id", async () => {
+    const { fn, calls } = fakeFetch({
+      "https://issuer.test/oauth/register": () => json({ client_id: "dcr-abc123" }, 201),
+    });
+    const r = await registerClient(
+      "https://issuer.test/oauth/register",
+      "https://hub.test/oauth/agent-grant/callback",
+      fn,
+    );
+    expect(r.clientId).toBe("dcr-abc123");
+    const body = JSON.parse((calls[0]?.init?.body as string) ?? "{}");
+    expect(body.redirect_uris).toEqual(["https://hub.test/oauth/agent-grant/callback"]);
+    expect(body.token_endpoint_auth_method).toBe("none");
+    expect(body.grant_types).toEqual(["authorization_code", "refresh_token"]);
+    expect(body.response_types).toEqual(["code"]);
+  });
+
+  test("throws when the response lacks client_id", async () => {
+    const { fn } = fakeFetch({
+      "https://issuer.test/oauth/register": () => json({ nope: true }),
+    });
+    await expect(
+      registerClient("https://issuer.test/oauth/register", "https://hub.test/cb", fn),
+    ).rejects.toBeInstanceOf(OAuthClientError);
+  });
+
+  test("throws on a non-2xx", async () => {
+    const { fn } = fakeFetch({
+      "https://issuer.test/oauth/register": () => new Response("forbidden", { status: 403 }),
+    });
+    await expect(
+      registerClient("https://issuer.test/oauth/register", "https://hub.test/cb", fn),
+    ).rejects.toBeInstanceOf(OAuthClientError);
+  });
+});
+
+// === buildAuthorizeUrl ======================================================
+
+describe("buildAuthorizeUrl", () => {
+  test("includes S256, state, challenge, and scope", () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        authorizationEndpoint: "https://issuer.test/oauth/authorize",
+        clientId: "cid",
+        redirectUri: "https://hub.test/oauth/agent-grant/callback",
+        scope: "vault:eng:read vault:eng:write",
+        state: "st-123",
+        codeChallenge: "chal-xyz",
+      }),
+    );
+    expect(url.origin + url.pathname).toBe("https://issuer.test/oauth/authorize");
+    expect(url.searchParams.get("response_type")).toBe("code");
+    expect(url.searchParams.get("client_id")).toBe("cid");
+    expect(url.searchParams.get("redirect_uri")).toBe(
+      "https://hub.test/oauth/agent-grant/callback",
+    );
+    expect(url.searchParams.get("scope")).toBe("vault:eng:read vault:eng:write");
+    expect(url.searchParams.get("state")).toBe("st-123");
+    expect(url.searchParams.get("code_challenge")).toBe("chal-xyz");
+    expect(url.searchParams.get("code_challenge_method")).toBe("S256");
+  });
+
+  test("omits scope when not provided", () => {
+    const url = new URL(
+      buildAuthorizeUrl({
+        authorizationEndpoint: "https://issuer.test/oauth/authorize",
+        clientId: "cid",
+        redirectUri: "https://hub.test/cb",
+        state: "st",
+        codeChallenge: "ch",
+      }),
+    );
+    expect(url.searchParams.has("scope")).toBe(false);
+  });
+});
+
+// === exchangeCode + refreshToken ============================================
+
+describe("exchangeCode", () => {
+  test("posts the form, computes expiresAt from expires_in", async () => {
+    const fixedNow = new Date("2026-06-18T12:00:00.000Z");
+    const { fn, calls } = fakeFetch({
+      "https://issuer.test/oauth/token": () =>
+        json({
+          access_token: "at-1",
+          refresh_token: "rt-1",
+          expires_in: 3600,
+          token_type: "Bearer",
+          scope: "vault:eng:read",
+        }),
+    });
+    const res = await exchangeCode(
+      {
+        tokenEndpoint: "https://issuer.test/oauth/token",
+        code: "code-1",
+        redirectUri: "https://hub.test/cb",
+        codeVerifier: "verifier-1",
+        clientId: "cid",
+        now: () => fixedNow,
+      },
+      fn,
+    );
+    expect(res.access_token).toBe("at-1");
+    expect(res.refresh_token).toBe("rt-1");
+    expect(res.expiresAt).toBe(new Date(fixedNow.getTime() + 3600 * 1000).toISOString());
+    expect(res.scope).toBe("vault:eng:read");
+
+    // form body assertions
+    const body = new URLSearchParams((calls[0]?.init?.body as string) ?? "");
+    expect(body.get("grant_type")).toBe("authorization_code");
+    expect(body.get("code")).toBe("code-1");
+    expect(body.get("code_verifier")).toBe("verifier-1");
+    expect(body.get("redirect_uri")).toBe("https://hub.test/cb");
+    expect(body.get("client_id")).toBe("cid");
+    expect((calls[0]?.init?.headers as Record<string, string>)["content-type"]).toBe(
+      "application/x-www-form-urlencoded",
+    );
+  });
+
+  test("throws OAuthClientError on an error response", async () => {
+    const { fn } = fakeFetch({
+      "https://issuer.test/oauth/token": () =>
+        json({ error: "invalid_grant", error_description: "code expired" }, 400),
+    });
+    await expect(
+      exchangeCode(
+        {
+          tokenEndpoint: "https://issuer.test/oauth/token",
+          code: "x",
+          redirectUri: "https://hub.test/cb",
+          codeVerifier: "v",
+          clientId: "cid",
+        },
+        fn,
+      ),
+    ).rejects.toBeInstanceOf(OAuthClientError);
+  });
+
+  test("throws when access_token is missing", async () => {
+    const { fn } = fakeFetch({
+      "https://issuer.test/oauth/token": () => json({ token_type: "Bearer" }),
+    });
+    await expect(
+      exchangeCode(
+        {
+          tokenEndpoint: "https://issuer.test/oauth/token",
+          code: "x",
+          redirectUri: "https://hub.test/cb",
+          codeVerifier: "v",
+          clientId: "cid",
+        },
+        fn,
+      ),
+    ).rejects.toBeInstanceOf(OAuthClientError);
+  });
+});
+
+describe("refreshToken", () => {
+  test("posts grant_type=refresh_token, returns new tokens", async () => {
+    const fixedNow = new Date("2026-06-18T12:00:00.000Z");
+    const { fn, calls } = fakeFetch({
+      "https://issuer.test/oauth/token": () =>
+        json({ access_token: "at-2", refresh_token: "rt-2", expires_in: 1800 }),
+    });
+    const res = await refreshToken(
+      {
+        tokenEndpoint: "https://issuer.test/oauth/token",
+        refreshToken: "rt-1",
+        clientId: "cid",
+        now: () => fixedNow,
+      },
+      fn,
+    );
+    expect(res.access_token).toBe("at-2");
+    expect(res.refresh_token).toBe("rt-2");
+    expect(res.expiresAt).toBe(new Date(fixedNow.getTime() + 1800 * 1000).toISOString());
+    const body = new URLSearchParams((calls[0]?.init?.body as string) ?? "");
+    expect(body.get("grant_type")).toBe("refresh_token");
+    expect(body.get("refresh_token")).toBe("rt-1");
+    expect(body.get("client_id")).toBe("cid");
+  });
+
+  test("rejects on a revoked/expired refresh token", async () => {
+    const { fn } = fakeFetch({
+      "https://issuer.test/oauth/token": () => json({ error: "invalid_grant" }, 400),
+    });
+    await expect(
+      refreshToken(
+        { tokenEndpoint: "https://issuer.test/oauth/token", refreshToken: "dead", clientId: "c" },
+        fn,
+      ),
+    ).rejects.toBeInstanceOf(OAuthClientError);
+  });
+});
+
+// === revokeRemote (best-effort) =============================================
+
+describe("revokeRemote", () => {
+  test("posts the revocation form", async () => {
+    const { fn, calls } = fakeFetch({
+      "https://issuer.test/oauth/revoke": () => new Response(null, { status: 200 }),
+    });
+    await revokeRemote(
+      {
+        revocationEndpoint: "https://issuer.test/oauth/revoke",
+        refreshToken: "rt-1",
+        clientId: "cid",
+      },
+      fn,
+    );
+    const body = new URLSearchParams((calls[0]?.init?.body as string) ?? "");
+    expect(body.get("token")).toBe("rt-1");
+    expect(body.get("token_type_hint")).toBe("refresh_token");
+  });
+
+  test("swallows errors (network failure must not throw)", async () => {
+    const fn = (async () => {
+      throw new Error("network down");
+    }) as unknown as FetchFn;
+    // Must resolve, not reject.
+    await expect(
+      revokeRemote(
+        {
+          revocationEndpoint: "https://issuer.test/oauth/revoke",
+          refreshToken: "x",
+          clientId: "c",
+        },
+        fn,
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  test("swallows a non-2xx response", async () => {
+    const { fn } = fakeFetch({
+      "https://issuer.test/oauth/revoke": () => new Response("nope", { status: 500 }),
+    });
+    await expect(
+      revokeRemote(
+        {
+          revocationEndpoint: "https://issuer.test/oauth/revoke",
+          refreshToken: "x",
+          clientId: "c",
+        },
+        fn,
+      ),
+    ).resolves.toBeUndefined();
+  });
+});
+
+// === fetchWithTimeout =======================================================
+
+describe("fetchWithTimeout", () => {
+  test("aborts a hung request after the timeout", async () => {
+    // A fetch that never resolves until aborted.
+    const fn = ((_url: string, init?: RequestInit) =>
+      new Promise((_resolve, reject) => {
+        const signal = init?.signal;
+        signal?.addEventListener("abort", () => reject(new Error("aborted")));
+      })) as unknown as FetchFn;
+    await expect(fetchWithTimeout("https://slow.test", { timeout: 10 }, fn)).rejects.toBeTruthy();
+  });
+
+  test("passes through a fast response", async () => {
+    const fn = (async () => new Response("ok", { status: 200 })) as unknown as FetchFn;
+    const res = await fetchWithTimeout("https://fast.test", { timeout: 1000 }, fn);
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/oauth-flows-store.test.ts
+++ b/src/__tests__/oauth-flows-store.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the in-flight OAuth consent-flow store (`oauth-flows-store.ts`, 4b-2).
+ *
+ * put / get-by-state / delete-on-use / round-trip / TTL prune / 0600 perms / the
+ * lenient-read posture. The file holds PKCE verifiers (secrets) → 0600.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  FLOW_TTL_MS,
+  type PendingFlow,
+  deleteFlow,
+  getFlowByState,
+  pruneExpiredFlows,
+  putFlow,
+} from "../oauth-flows-store.ts";
+
+let dir: string;
+let storePath: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "phub-oauth-flows-"));
+  storePath = join(dir, "agent-oauth-flows.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function flow(over: Partial<PendingFlow> = {}): PendingFlow {
+  return {
+    state: over.state ?? "state-1",
+    grantId: over.grantId ?? "grant-1",
+    issuer: over.issuer ?? "https://issuer.test",
+    clientId: over.clientId ?? "cid-1",
+    tokenEndpoint: over.tokenEndpoint ?? "https://issuer.test/oauth/token",
+    verifier: over.verifier ?? "pkce-verifier-secret",
+    mcpUrl: over.mcpUrl ?? "https://remote.test/mcp",
+    redirectUri: over.redirectUri ?? "https://hub.test/oauth/agent-grant/callback",
+    createdAt: over.createdAt ?? new Date().toISOString(),
+    ...(over.revocationEndpoint ? { revocationEndpoint: over.revocationEndpoint } : {}),
+    ...(over.scope ? { scope: over.scope } : {}),
+  };
+}
+
+describe("round-trip", () => {
+  test("a missing file returns null for any state", () => {
+    expect(getFlowByState(storePath, "anything")).toBeNull();
+  });
+
+  test("put → get by state", () => {
+    const f = flow();
+    putFlow(storePath, f);
+    const back = getFlowByState(storePath, "state-1");
+    expect(back).toEqual(f);
+  });
+
+  test("put upserts by state (no duplicate)", () => {
+    putFlow(storePath, flow({ clientId: "old" }));
+    putFlow(storePath, flow({ clientId: "new" }));
+    expect(getFlowByState(storePath, "state-1")?.clientId).toBe("new");
+  });
+
+  test("delete-on-use removes the flow (single-use)", () => {
+    putFlow(storePath, flow());
+    const removed = deleteFlow(storePath, "state-1");
+    expect(removed?.state).toBe("state-1");
+    expect(getFlowByState(storePath, "state-1")).toBeNull();
+    // second delete is a no-op
+    expect(deleteFlow(storePath, "state-1")).toBeNull();
+  });
+
+  test("distinct states coexist", () => {
+    putFlow(storePath, flow({ state: "a" }));
+    putFlow(storePath, flow({ state: "b", grantId: "grant-2" }));
+    expect(getFlowByState(storePath, "a")?.grantId).toBe("grant-1");
+    expect(getFlowByState(storePath, "b")?.grantId).toBe("grant-2");
+  });
+});
+
+describe("TTL prune", () => {
+  test("an expired flow is pruned on read (returns null)", () => {
+    const old = new Date(Date.now() - (FLOW_TTL_MS + 60_000)).toISOString();
+    putFlow(storePath, flow({ createdAt: old }));
+    // The default-now read prunes it.
+    expect(getFlowByState(storePath, "state-1")).toBeNull();
+  });
+
+  test("pruneExpiredFlows drops the expired and keeps the live", () => {
+    const now = Date.now();
+    putFlow(storePath, flow({ state: "fresh", createdAt: new Date(now).toISOString() }), now);
+    putFlow(
+      storePath,
+      flow({ state: "stale", createdAt: new Date(now - FLOW_TTL_MS - 1).toISOString() }),
+      now,
+    );
+    const live = pruneExpiredFlows(storePath, now);
+    expect(live.map((f) => f.state).sort()).toEqual(["fresh"]);
+  });
+
+  test("put prunes expired flows before persisting", () => {
+    const now = Date.now();
+    // Seed an expired flow directly.
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        flows: [flow({ state: "stale", createdAt: new Date(now - FLOW_TTL_MS - 1).toISOString() })],
+      }),
+    );
+    putFlow(storePath, flow({ state: "fresh", createdAt: new Date(now).toISOString() }), now);
+    expect(getFlowByState(storePath, "stale", now)).toBeNull();
+    expect(getFlowByState(storePath, "fresh", now)).not.toBeNull();
+  });
+});
+
+describe("0600 perms (holds PKCE verifiers)", () => {
+  test("the store file is created mode 0600", () => {
+    putFlow(storePath, flow());
+    const mode = statSync(storePath).mode & 0o777;
+    expect(mode).toBe(0o600);
+  });
+});
+
+describe("lenient read", () => {
+  test("garbage JSON reads as empty", () => {
+    writeFileSync(storePath, "not json {{{");
+    expect(getFlowByState(storePath, "x")).toBeNull();
+  });
+
+  test("a malformed row is dropped, valid rows survive", () => {
+    const valid = flow({ state: "ok" });
+    writeFileSync(
+      storePath,
+      JSON.stringify({
+        flows: [valid, { state: "bad" /* missing required fields */ }],
+      }),
+    );
+    expect(getFlowByState(storePath, "ok")).not.toBeNull();
+    expect(getFlowByState(storePath, "bad")).toBeNull();
+  });
+});

--- a/src/admin-agent-grants.ts
+++ b/src/admin-agent-grants.ts
@@ -62,6 +62,7 @@ import {
   type ConnectionSpec,
   type GrantAccess,
   type GrantInject,
+  type GrantMaterial,
   type GrantRecord,
   connectionKey,
   getGrant,
@@ -76,6 +77,8 @@ import {
   revokeTokenByJti,
   signAccessToken,
 } from "./jwt-sign.ts";
+import { type OAuthClient, realOAuthClient } from "./oauth-client.ts";
+import { type PendingFlow, deleteFlow, getFlowByState, putFlow } from "./oauth-flows-store.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
 import { validateVaultName } from "./vault-name.ts";
@@ -113,10 +116,16 @@ const MAX_TAGS = 64;
 
 export interface AgentGrantsDeps {
   db: Database;
-  /** Hub origin — the minted-token `iss` AND the base of the vault MCP URL. */
+  /**
+   * Hub origin — the minted-token `iss`, the base of the vault MCP URL, AND the
+   * base of the OAuth-client `redirect_uri`
+   * (`<hubOrigin>/oauth/agent-grant/callback`).
+   */
   hubOrigin: string;
   /** Absolute path to `agent-grants.json` in the hub state dir. */
   storePath: string;
+  /** Absolute path to `agent-oauth-flows.json` (the in-flight OAuth consents, 4b-2). */
+  flowsStorePath: string;
   /**
    * Resolve a vault's loopback origin from services.json, or `null` when no
    * vault by that name is installed. Mirrors `ConnectionsDeps.resolveVaultOrigin`
@@ -125,9 +134,24 @@ export interface AgentGrantsDeps {
   resolveVaultOrigin: (vaultName: string) => string | null;
   /** Test seam — defaults to the real `signAccessToken`. */
   signToken?: typeof SignAccessTokenFn;
+  /** Test seam — the OAuth-client engine (defaults to the real, network-bound one). */
+  oauthClient?: OAuthClient;
   /** Test seam for the clock. */
   now?: () => Date;
 }
+
+/** The OAuth-client engine — injected for tests, the real (network) one by default. */
+function oauth(deps: AgentGrantsDeps): OAuthClient {
+  return deps.oauthClient ?? realOAuthClient;
+}
+
+/** `<hubOrigin>/oauth/agent-grant/callback` — the DCR-registered redirect_uri. */
+function callbackUrl(hubOrigin: string): string {
+  return `${hubOrigin.replace(/\/+$/, "")}/oauth/agent-grant/callback`;
+}
+
+/** Refresh skew — refresh an mcp access token this many ms before its expiry. */
+const REFRESH_SKEW_MS = 120 * 1000;
 
 // ===========================================================================
 // Router
@@ -281,7 +305,9 @@ async function upsertGrant(req: Request, deps: AgentGrantsDeps): Promise<Respons
     return grantResponse(200, merged);
   }
 
-  const pendingReason = spec.kind === "mcp" ? "oauth not yet supported" : undefined;
+  // 4b-2: an mcp want is now grantable — it sits pending awaiting the operator's
+  // OAuth consent (or a pasted static bearer), not "not yet supported".
+  const pendingReason = spec.kind === "mcp" ? "awaiting oauth consent" : undefined;
   const record: GrantRecord = {
     id,
     agent,
@@ -428,15 +454,23 @@ async function grantMaterial(req: Request, id: string, deps: AgentGrantsDeps): P
     return jsonError(404, "not_found", `no grant ${id}`);
   }
   if (grant.status !== "approved" || !grant.material) {
+    // For a needs_consent grant, tell the operator how to revive it (re-approve
+    // re-runs the OAuth consent) so admin/agent surfaces can render an actionable
+    // message rather than a bare "not approved".
+    const hint =
+      grant.status === "needs_consent"
+        ? " — re-consent (approve again) to revive this connection"
+        : " — material is available only for approved grants";
     return jsonError(
       409,
       "not_approved",
-      `grant ${id} is ${grant.status}${grant.reason ? ` (${grant.reason})` : ""} — material is available only for approved grants`,
+      `grant ${id} is ${grant.status}${grant.reason ? ` (${grant.reason})` : ""}${hint}`,
     );
   }
 
   // The injectable secret. vault → token + the vault's MCP URL (so the agent
-  // can add it as an MCP server); service → token + the inject hints.
+  // can add it as an MCP server); service → token + the inject hints; mcp →
+  // refresh-if-needed then token + the remote MCP URL.
   let payload: Record<string, unknown>;
   if (grant.material.kind === "vault") {
     payload = {
@@ -444,11 +478,22 @@ async function grantMaterial(req: Request, id: string, deps: AgentGrantsDeps): P
       token: grant.material.token,
       mcpUrl: vaultMcpUrl(deps.hubOrigin, grant.connection.target),
     };
-  } else {
+  } else if (grant.material.kind === "service") {
     payload = {
       kind: "service",
       token: grant.material.token,
       inject: grant.connection.kind === "service" ? (grant.connection.inject ?? []) : [],
+    };
+  } else {
+    // mcp — refresh first if it's an OAuth grant near/past expiry. A refresh
+    // FAILURE flips the grant to needs_consent (material dropped) and 409s.
+    const resolved = await resolveMcpMaterial(grant, deps);
+    if (resolved instanceof Response) return resolved;
+    payload = {
+      kind: "mcp",
+      // Field-name seam: store field is `access_token`; wire field is `token`.
+      token: resolved.access_token,
+      mcpUrl: resolved.mcpUrl,
     };
   }
 
@@ -460,6 +505,90 @@ async function grantMaterial(req: Request, id: string, deps: AgentGrantsDeps): P
       "cache-control": "no-store",
     },
   });
+}
+
+/**
+ * Resolve an approved mcp grant's live access token, refreshing first if it's an
+ * OAuth grant that's expired or within the skew window. A static-bearer grant (no
+ * refresh_token / no expiresAt) returns its stored token unchanged. A refresh
+ * FAILURE flips the grant to `needs_consent` (material dropped) and returns a 409
+ * Response — the connection is simply absent next spawn until the operator
+ * re-consents.
+ *
+ * Returns the live mcp material on success, or a `Response` (the 409) on failure.
+ */
+async function resolveMcpMaterial(
+  grant: GrantRecord,
+  deps: AgentGrantsDeps,
+): Promise<Extract<GrantMaterial, { kind: "mcp" }> | Response> {
+  const mat = grant.material;
+  if (!mat || mat.kind !== "mcp") {
+    return jsonError(409, "not_approved", `grant ${grant.id} has no mcp material`);
+  }
+
+  // Static bearer — no refresh token / no expiry → return as-is.
+  if (!mat.refresh_token || !mat.expiresAt || !mat.tokenEndpoint || !mat.clientId) {
+    return mat;
+  }
+
+  const now = deps.now?.() ?? new Date();
+  const expiresMs = new Date(mat.expiresAt).getTime();
+  const needsRefresh = !Number.isFinite(expiresMs) || expiresMs - now.getTime() <= REFRESH_SKEW_MS;
+  if (!needsRefresh) return mat;
+
+  // Refresh.
+  try {
+    const refreshed = await oauth(deps).refreshToken(
+      {
+        tokenEndpoint: mat.tokenEndpoint,
+        refreshToken: mat.refresh_token,
+        clientId: mat.clientId,
+        now: deps.now ?? (() => new Date()),
+      },
+      undefined,
+    );
+    const updatedMaterial: GrantMaterial = {
+      kind: "mcp",
+      access_token: refreshed.access_token,
+      // Rotated refresh, if returned; else keep the existing one.
+      refresh_token: refreshed.refresh_token ?? mat.refresh_token,
+      ...(refreshed.expiresAt ? { expiresAt: refreshed.expiresAt } : {}),
+      ...(mat.issuer ? { issuer: mat.issuer } : {}),
+      clientId: mat.clientId,
+      tokenEndpoint: mat.tokenEndpoint,
+      ...(mat.revocationEndpoint ? { revocationEndpoint: mat.revocationEndpoint } : {}),
+      mcpUrl: mat.mcpUrl,
+    };
+    const updated: GrantRecord = {
+      id: grant.id,
+      agent: grant.agent,
+      connection: grant.connection,
+      status: "approved",
+      createdAt: grant.createdAt,
+      ...(grant.approvedAt ? { approvedAt: grant.approvedAt } : {}),
+      material: updatedMaterial,
+    };
+    putGrant(deps.storePath, updated);
+    return updatedMaterial;
+  } catch (err) {
+    // Refresh died (refresh token revoked/expired). Flip to needs_consent + drop
+    // material — the operator re-consents to revive. NEVER log the token/error
+    // detail that could carry one; the reason is the error message only.
+    const reason = `refresh failed: ${err instanceof Error ? err.message : "unknown error"}`;
+    const downgraded: GrantRecord = {
+      id: grant.id,
+      agent: grant.agent,
+      connection: grant.connection,
+      status: "needs_consent",
+      reason,
+      createdAt: grant.createdAt,
+      ...(grant.approvedAt ? { approvedAt: grant.approvedAt } : {}),
+      // material dropped.
+    };
+    putGrant(deps.storePath, downgraded);
+    console.log(`agent grant needs re-consent: id=${grant.id} agent=${grant.agent} kind=mcp`);
+    return jsonError(409, "not_approved", `grant ${grant.id} ${reason} — re-consent required`);
+  }
 }
 
 /** `<hub-origin>/vault/<name>/mcp` — the MCP endpoint a client connects to. */
@@ -494,13 +623,7 @@ async function approveGrant(req: Request, id: string, deps: AgentGrantsDeps): Pr
   const approvedAt = now.toISOString();
 
   if (conn.kind === "mcp") {
-    // 4b-1: remote MCP / OAuth is not implemented. Approval is refused; the
-    // grant stays pending with its reason. (Slice 2 wires hub-as-OAuth-client.)
-    return jsonError(
-      409,
-      "not_grantable",
-      "mcp (remote/OAuth) grants are not yet supported — coming in 4b-2",
-    );
+    return approveMcpGrant(grant, body, deps, approvedAt);
   }
 
   if (conn.kind === "vault") {
@@ -551,8 +674,11 @@ async function approveGrant(req: Request, id: string, deps: AgentGrantsDeps): Pr
   }
 
   // service — store the operator-pasted API token.
-  const token = typeof body.token === "string" ? body.token : "";
-  if (token.trim().length === 0) {
+  // Trim — a pasted "  tok  " must not inject whitespace into the eventual
+  // `Authorization: Bearer` header (drive-by correctness fix; the mcp
+  // static-bearer path has the same trim).
+  const token = typeof body.token === "string" ? body.token.trim() : "";
+  if (token.length === 0) {
     return jsonError(
       400,
       "token_required",
@@ -581,6 +707,351 @@ async function approveGrant(req: Request, id: string, deps: AgentGrantsDeps): Pr
 }
 
 // ===========================================================================
+// approve(mcp) — static bearer OR start the OAuth consent flow (4b-2)
+// ===========================================================================
+
+/**
+ * Approve a `kind:mcp` grant. Two paths:
+ *
+ *   - body `{ token }` (a pasted static bearer) → store
+ *     `material:{kind:"mcp", access_token, mcpUrl}` (no refresh) + status
+ *     `approved` immediately. No discovery. Weaker lifecycle (no expiry, no
+ *     refresh, no issuer-side revoke).
+ *   - body `{}` (no token) → START OAuth: discover → DCR (reuse a stored clientId
+ *     for the SAME issuer, else register) → mint PKCE + state → persist a pending
+ *     flow → return a `GrantListing` with `authorizeUrl` (status stays pending,
+ *     reason "awaiting oauth consent"). The operator's browser follows the URL;
+ *     the callback completes the flow.
+ *
+ * A re-approve of an already-approved mcp grant starts a FRESH flow; the callback
+ * replaces the material + best-effort revokes the old refresh token.
+ */
+async function approveMcpGrant(
+  grant: GrantRecord,
+  body: { token?: unknown },
+  deps: AgentGrantsDeps,
+  approvedAt: string,
+): Promise<Response> {
+  const mcpUrl = grant.connection.target;
+
+  // --- Static-bearer path: a pasted token short-circuits discovery. ---
+  if (typeof body.token === "string" && body.token.trim().length > 0) {
+    // Trim — a pasted "  tok  " must not inject whitespace into the eventual
+    // `Authorization: Bearer` header.
+    const token = body.token.trim();
+    if (token.length > MAX_TOKEN_LEN) {
+      return jsonError(400, "invalid_request", `token exceeds the ${MAX_TOKEN_LEN}-char limit`);
+    }
+    const updated: GrantRecord = {
+      id: grant.id,
+      agent: grant.agent,
+      connection: grant.connection,
+      status: "approved",
+      createdAt: grant.createdAt,
+      approvedAt,
+      material: { kind: "mcp", access_token: token, mcpUrl },
+    };
+    putGrant(deps.storePath, updated);
+    // NEVER log the token.
+    console.log(
+      `agent grant approved: id=${grant.id} agent=${grant.agent} kind=mcp mode=static-bearer`,
+    );
+    return grantResponse(200, updated);
+  }
+  // A non-empty-but-non-string token, or an over-long one, was handled above; a
+  // present-but-empty token falls through to the OAuth path (treated as "no token").
+  if (body.token !== undefined && typeof body.token !== "string") {
+    return jsonError(400, "invalid_request", "token must be a string when present");
+  }
+
+  // --- OAuth path: discover → DCR → PKCE/state → persist flow → authorizeUrl. ---
+  const client = oauth(deps);
+  const redirectUri = callbackUrl(deps.hubOrigin);
+
+  let discovery: Awaited<ReturnType<OAuthClient["discover"]>>;
+  try {
+    discovery = await client.discover(mcpUrl);
+  } catch (err) {
+    return jsonError(
+      502,
+      "discovery_failed",
+      `could not discover OAuth metadata for ${mcpUrl}: ${err instanceof Error ? err.message : "unknown error"}`,
+    );
+  }
+
+  // DCR client reuse: if the grant already has mcp material with a clientId for
+  // the SAME issuer (a re-consent), reuse it; else register a fresh client.
+  // ACCEPTED (per design): if the issuer rotates its registration (so the stored
+  // clientId is no longer valid), a fresh register orphans the old DCR client at
+  // the issuer. There is no cross-issuer client GC — orphans accrue only on issuer
+  // rotation, which is rare; noted, not built.
+  let clientId: string | undefined;
+  if (
+    grant.material?.kind === "mcp" &&
+    grant.material.clientId &&
+    grant.material.issuer === discovery.issuer
+  ) {
+    clientId = grant.material.clientId;
+  }
+  if (!clientId) {
+    if (!discovery.registrationEndpoint) {
+      return jsonError(
+        502,
+        "registration_unsupported",
+        `the issuer ${discovery.issuer} does not advertise a registration_endpoint (RFC 7591 DCR) — paste a static bearer token instead`,
+      );
+    }
+    try {
+      const reg = await client.registerClient(discovery.registrationEndpoint, redirectUri);
+      clientId = reg.clientId;
+    } catch (err) {
+      return jsonError(
+        502,
+        "registration_failed",
+        `dynamic client registration failed: ${err instanceof Error ? err.message : "unknown error"}`,
+      );
+    }
+  }
+
+  const verifier = client.generateCodeVerifier();
+  const challenge = client.generateCodeChallenge(verifier);
+  const state = client.generateState();
+  // Scope: the resource's advertised scopes (9728→8414), space-joined; omit if none.
+  const scope = discovery.scopesSupported?.length ? discovery.scopesSupported.join(" ") : undefined;
+
+  const flow: PendingFlow = {
+    state,
+    grantId: grant.id,
+    issuer: discovery.issuer,
+    clientId,
+    tokenEndpoint: discovery.tokenEndpoint,
+    ...(discovery.revocationEndpoint ? { revocationEndpoint: discovery.revocationEndpoint } : {}),
+    verifier,
+    mcpUrl,
+    ...(scope ? { scope } : {}),
+    redirectUri,
+    createdAt: (deps.now?.() ?? new Date()).toISOString(),
+  };
+  putFlow(deps.flowsStorePath, flow, (deps.now?.() ?? new Date()).getTime());
+
+  const authorizeUrl = client.buildAuthorizeUrl({
+    authorizationEndpoint: discovery.authorizationEndpoint,
+    clientId,
+    redirectUri,
+    ...(scope ? { scope } : {}),
+    state,
+    codeChallenge: challenge,
+  });
+
+  // Keep the grant pending with the slice-2 reason; surface authorizeUrl so the
+  // admin UI can redirect the browser. NEVER log the verifier/state.
+  console.log(
+    `agent grant oauth flow started: id=${grant.id} agent=${grant.agent} issuer=${discovery.issuer}`,
+  );
+  const listing: GrantListing & { authorizeUrl: string } = {
+    id: grant.id,
+    agent: grant.agent,
+    connection: grant.connection,
+    status: "pending",
+    reason: "awaiting oauth consent",
+    authorizeUrl,
+  };
+  return new Response(JSON.stringify(listing), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+// ===========================================================================
+// GET /oauth/agent-grant/callback — the operator's browser redirect target (4b-2)
+// ===========================================================================
+
+/**
+ * The OAuth-client callback. The remote issuer redirects the operator's browser
+ * here with `?code&state` (success) or `?error&state` (RFC 6749 §4.1.2.1 — e.g.
+ * the operator clicked Deny). GET, no Bearer; the single-use `state` is the CSRF
+ * defense (this is a cross-site redirect IN — same-origin is NOT required).
+ *
+ * On success: look up the flow by `state` (delete-on-use), exchange the code,
+ * store the mcp material, flip the grant `approved`. If the grant previously had
+ * mcp material with a refresh_token + revocationEndpoint, best-effort revoke the
+ * OLD one first (one live credential per grant).
+ *
+ * Renders minimal HTML — NEVER a token. On any error, an HTML error page; the
+ * grant stays pending/needs_consent.
+ */
+export async function handleOAuthGrantCallback(
+  req: Request,
+  deps: AgentGrantsDeps,
+): Promise<Response> {
+  const url = new URL(req.url);
+  const state = url.searchParams.get("state") ?? "";
+  const code = url.searchParams.get("code");
+  const errorParam = url.searchParams.get("error");
+
+  if (!state) {
+    return htmlPage(400, "Connection failed", "The authorization response was missing its state.");
+  }
+
+  // Single-use: look up, then delete the flow (delete-on-use). The get→delete
+  // pair is NOT atomic, but the race is benign: the auth `code` is single-use at
+  // the ISSUER (RFC 6749 §10.5), so a concurrent second callback with the same
+  // `state` exchanges the same code and the issuer rejects the second exchange.
+  // The design's concurrency posture is first-wins; the loser sees a token-error
+  // page, the grant ends approved exactly once.
+  const flow = getFlowByState(deps.flowsStorePath, state, (deps.now?.() ?? new Date()).getTime());
+  if (!flow) {
+    // Unknown / replayed / expired state — never mint anything.
+    return htmlPage(
+      400,
+      "Connection failed",
+      "This authorization link is unknown, already used, or expired. Start the connection again from the admin page.",
+    );
+  }
+  deleteFlow(deps.flowsStorePath, state);
+
+  // The operator clicked Deny (or the issuer returned an error). Leave the grant
+  // pending, but record WHY so admin can distinguish "not yet tried" from
+  // "tried + denied". (htmlPage single-escapes its args — pass the RAW string.)
+  if (errorParam) {
+    const denied = getGrant(deps.storePath, flow.grantId);
+    if (denied && denied.status === "pending") {
+      putGrant(deps.storePath, {
+        id: denied.id,
+        agent: denied.agent,
+        connection: denied.connection,
+        status: "pending",
+        reason: "operator declined",
+        createdAt: denied.createdAt,
+        ...(denied.approvedAt ? { approvedAt: denied.approvedAt } : {}),
+      });
+    }
+    return htmlPage(
+      400,
+      "Connection not authorized",
+      `The remote service did not grant access (${errorParam}). The connection stays pending — you can try again from the admin page.`,
+    );
+  }
+
+  if (!code) {
+    return htmlPage(
+      400,
+      "Connection failed",
+      "The authorization response was missing its code. Start the connection again from the admin page.",
+    );
+  }
+
+  const grant = getGrant(deps.storePath, flow.grantId);
+  if (!grant) {
+    // The grant was removed mid-consent — nothing to populate.
+    return htmlPage(
+      404,
+      "Connection failed",
+      "The grant this authorization belonged to no longer exists.",
+    );
+  }
+
+  const client = oauth(deps);
+  let tokens: Awaited<ReturnType<OAuthClient["exchangeCode"]>>;
+  try {
+    tokens = await client.exchangeCode({
+      tokenEndpoint: flow.tokenEndpoint,
+      code,
+      redirectUri: flow.redirectUri,
+      codeVerifier: flow.verifier,
+      clientId: flow.clientId,
+      now: deps.now ?? (() => new Date()),
+    });
+  } catch (err) {
+    // Token exchange failed — grant stays pending (the operator can retry).
+    // htmlPage single-escapes its args — pass the RAW message.
+    return htmlPage(
+      502,
+      "Connection failed",
+      `The token exchange with the remote service failed: ${err instanceof Error ? err.message : "unknown error"}. The connection stays pending — try again from the admin page.`,
+    );
+  }
+
+  // Best-effort revoke a prior refresh token (re-consent replaces material).
+  if (
+    grant.material?.kind === "mcp" &&
+    grant.material.refresh_token &&
+    grant.material.revocationEndpoint
+  ) {
+    await client.revokeRemote({
+      revocationEndpoint: grant.material.revocationEndpoint,
+      refreshToken: grant.material.refresh_token,
+      clientId: flow.clientId,
+    });
+  }
+
+  const material: GrantMaterial = {
+    kind: "mcp",
+    access_token: tokens.access_token,
+    ...(tokens.refresh_token ? { refresh_token: tokens.refresh_token } : {}),
+    ...(tokens.expiresAt ? { expiresAt: tokens.expiresAt } : {}),
+    issuer: flow.issuer,
+    clientId: flow.clientId,
+    tokenEndpoint: flow.tokenEndpoint,
+    ...(flow.revocationEndpoint ? { revocationEndpoint: flow.revocationEndpoint } : {}),
+    mcpUrl: flow.mcpUrl,
+  };
+  const updated: GrantRecord = {
+    id: grant.id,
+    agent: grant.agent,
+    connection: grant.connection,
+    status: "approved",
+    createdAt: grant.createdAt,
+    approvedAt: (deps.now?.() ?? new Date()).toISOString(),
+    material,
+  };
+  putGrant(deps.storePath, updated);
+  // NEVER log a token.
+  console.log(`agent grant approved: id=${grant.id} agent=${grant.agent} kind=mcp mode=oauth`);
+
+  return htmlPage(
+    200,
+    "Connected",
+    "The connection is authorized. You can close this tab — the agent will use it on its next run.",
+  );
+}
+
+/** Minimal server-rendered HTML — NEVER carries a token. */
+function htmlPage(status: number, heading: string, message: string): Response {
+  const html = `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(heading)} — Parachute</title>
+<style>
+  body { font-family: system-ui, -apple-system, sans-serif; max-width: 32rem; margin: 4rem auto; padding: 0 1.5rem; color: #1a1a1a; }
+  h1 { font-size: 1.5rem; }
+  p { line-height: 1.6; color: #444; }
+</style>
+</head>
+<body>
+<h1>${escapeHtml(heading)}</h1>
+<p>${escapeHtml(message)}</p>
+</body>
+</html>
+`;
+  return new Response(html, {
+    status,
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-store" },
+  });
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+// ===========================================================================
 // POST /admin/grants/<id>/revoke — operator revokes (operator-auth)
 // ===========================================================================
 
@@ -604,6 +1075,20 @@ async function revokeGrant(req: Request, id: string, deps: AgentGrantsDeps): Pro
     } catch {
       // Best-effort.
     }
+  } else if (
+    // mcp OAuth grant — best-effort revoke the refresh token at the issuer so the
+    // remote credential dies, not just our local copy. A static bearer has no
+    // refresh/revocation endpoint, so this is a no-op (operator rotates upstream).
+    grant.material?.kind === "mcp" &&
+    grant.material.refresh_token &&
+    grant.material.revocationEndpoint &&
+    grant.material.clientId
+  ) {
+    await oauth(deps).revokeRemote({
+      revocationEndpoint: grant.material.revocationEndpoint,
+      refreshToken: grant.material.refresh_token,
+      clientId: grant.material.clientId,
+    });
   }
 
   const updated: GrantRecord = {
@@ -687,6 +1172,13 @@ export interface GrantListing {
   status: GrantRecord["status"];
   reason?: string;
   approvedAt?: string;
+  /**
+   * Present ONLY on a fresh `approve(mcp)` that started an OAuth flow — the URL
+   * the admin UI redirects the operator's browser to. A superset of the 4b-1
+   * listing shape; the UI ignores it for vault/service approves (absent there).
+   * Never persisted; `toListing` never emits it (it's a response-only field).
+   */
+  authorizeUrl?: string;
 }
 
 function toListing(g: GrantRecord): GrantListing {

--- a/src/grants-store.ts
+++ b/src/grants-store.ts
@@ -59,7 +59,13 @@ export interface ConnectionSpec {
   readonly inject?: readonly GrantInject[];
 }
 
-export type GrantStatus = "pending" | "approved" | "revoked";
+/**
+ * Grant lifecycle. `needs_consent` (added 4b-2) is distinct from `revoked`
+ * (operator-intended teardown) — it means "an mcp grant was working, its refresh
+ * died, re-consent to revive." The status resolver treats it as not-approved
+ * (so the agent def shows it in `pending:[…]`).
+ */
+export type GrantStatus = "pending" | "approved" | "revoked" | "needs_consent";
 
 /**
  * The granted secret material, kept on disk ONLY. Discriminated by `kind` to
@@ -80,6 +86,30 @@ export type GrantMaterial =
       readonly kind: "service";
       /** The operator-pasted API token. */
       readonly token: string;
+    }
+  | {
+      readonly kind: "mcp";
+      /**
+       * The remote MCP access token — OAuth-issued (auto-refreshed) OR an
+       * operator-pasted static bearer (no refresh). The `/material` WIRE shape
+       * projects this as `token` (matching the vault/service material the agent
+       * already consumes); the internal store field is `access_token`.
+       */
+      readonly access_token: string;
+      /** OAuth refresh token. Absent for a static-bearer grant. */
+      readonly refresh_token?: string;
+      /** ISO expiry of the access token. Absent for a static bearer (never refreshed). */
+      readonly expiresAt?: string;
+      /** Issuer (for refresh + revoke). Absent for a static bearer. */
+      readonly issuer?: string;
+      /** DCR client_id (for refresh). Absent for a static bearer. */
+      readonly clientId?: string;
+      /** Cached token endpoint (for refresh). Absent for a static bearer. */
+      readonly tokenEndpoint?: string;
+      /** Cached revocation endpoint (for revoke). Absent for a static bearer / non-advertising issuer. */
+      readonly revocationEndpoint?: string;
+      /** The remote MCP URL the agent connects to. */
+      readonly mcpUrl: string;
     };
 
 export interface GrantRecord {
@@ -181,7 +211,13 @@ export function readGrants(storePath: string): GrantRecord[] {
       typeof rec.id === "string" &&
       typeof rec.agent === "string" &&
       isConnectionSpec(rec.connection) &&
-      (rec.status === "pending" || rec.status === "approved" || rec.status === "revoked")
+      // NOTE (4b-2): `needs_consent` MUST be accepted here — else a row that
+      // flipped to needs_consent on a failed mcp refresh is silently dropped on
+      // re-read and `/material` 404s instead of 409ing. Regression-tested.
+      (rec.status === "pending" ||
+        rec.status === "approved" ||
+        rec.status === "revoked" ||
+        rec.status === "needs_consent")
     );
   });
 }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -62,8 +62,9 @@
  *   /admin/connections/<id>/approve (POST)     → operator approval of a pending claim (cookie-gated; CSRF-belted)
  *   /admin/grants                 (PUT/GET)    → agent-connector grant upsert/list (4b-1; host-admin Bearer)
  *   /admin/grants/<id>/material   (GET)        → injectable secret for an APPROVED grant (4b-1; host-admin Bearer)
- *   /admin/grants/<id>/approve    (POST)       → operator approves a grant — mint (vault) / store (service) (cookie-gated; CSRF-belted)
- *   /admin/grants/<id>/revoke     (POST)       → operator revokes a grant — drop the stored secret (cookie-gated; CSRF-belted)
+ *   /admin/grants/<id>/approve    (POST)       → operator approves a grant — mint (vault) / store (service) / static-bearer-or-start-OAuth (mcp, 4b-2) (cookie-gated; CSRF-belted)
+ *   /admin/grants/<id>/revoke     (POST)       → operator revokes a grant — drop the stored secret + best-effort issuer revoke (mcp, 4b-2) (cookie-gated; CSRF-belted)
+ *   /oauth/agent-grant/callback   (GET)        → OAuth-client redirect target for an mcp grant consent (4b-2; single-use state, no Bearer, NOT same-origin-belted — cross-site redirect in)
  *
  *   # "CSRF-belted" = strict same-origin Origin check on cookie-authed
  *   # mutations (hub#632, boundary C1) — origin-check.ts
@@ -160,7 +161,11 @@ import pkg from "../package.json" with { type: "json" };
 import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
 import { handleAccountVaultAdminTokenPost } from "./account-vault-admin-token.ts";
 import { handleAccountVaultTokenPost } from "./account-vault-token.ts";
-import { type AgentGrantsDeps, handleAgentGrants } from "./admin-agent-grants.ts";
+import {
+  type AgentGrantsDeps,
+  handleAgentGrants,
+  handleOAuthGrantCallback,
+} from "./admin-agent-grants.ts";
 import { handleAgentToken } from "./admin-agent-token.ts";
 import { handleApproveClient, handleGetClient } from "./admin-clients.ts";
 import {
@@ -1163,6 +1168,12 @@ export interface HubFetchDeps {
    * point this at a tmpdir; production defaults to `<CONFIG_DIR>/agent-grants.json`.
    */
   agentGrantsStorePath?: string;
+  /**
+   * Path to `agent-oauth-flows.json` (the in-flight agent-grant OAuth consents,
+   * 4b-2). Tests point this at a tmpdir; production defaults to
+   * `<CONFIG_DIR>/agent-oauth-flows.json`.
+   */
+  agentOAuthFlowsStorePath?: string;
   /**
    * Directory containing the built SPA bundle (`index.html` + `assets/`). When
    * absent, the hub auto-resolves to `<repo>/web/ui/dist/` — handy for the
@@ -2704,6 +2715,38 @@ export function hubFetch(
         return applyCorsHeaders(req, await handleRevoke(getDb(), req, oauthDeps(req)));
       }
 
+      // Agent-connector OAuth-client callback (Phase 4b-2). The operator's
+      // browser is redirected here by a REMOTE issuer after consenting to a
+      // `kind:mcp` grant. Standalone server-rendered route — NOT under /admin/*,
+      // so the SPA catch-all never swallows it. GET, no Bearer: the single-use
+      // `state` it carries is the CSRF defense (this is a cross-site redirect IN
+      // from the remote issuer, so the same-origin belt does NOT apply). The
+      // handler looks up the pending flow by `state`, exchanges the code at the
+      // remote token endpoint, stores the grant material, and renders a tiny
+      // HTML "connected" / error page (never a token).
+      if (pathname === "/oauth/agent-grant/callback") {
+        if (!getDb) return dbNotConfigured();
+        if (req.method !== "GET") {
+          return new Response("method not allowed", { status: 405 });
+        }
+        const resolveVaultOrigin = (vaultName: string): string | null => {
+          const match = findVaultUpstream(
+            readManifestLenient(manifestPath).services,
+            `/vault/${vaultName}`,
+          );
+          return match ? `http://127.0.0.1:${match.port}` : null;
+        };
+        const agentGrantsDeps: AgentGrantsDeps = {
+          db: getDb(),
+          hubOrigin: oauthDeps(req).issuer,
+          storePath: deps?.agentGrantsStorePath ?? join(CONFIG_DIR, "agent-grants.json"),
+          flowsStorePath:
+            deps?.agentOAuthFlowsStorePath ?? join(CONFIG_DIR, "agent-oauth-flows.json"),
+          resolveVaultOrigin,
+        };
+        return handleOAuthGrantCallback(req, agentGrantsDeps);
+      }
+
       if (pathname === "/vaults") {
         if (!getDb) return dbNotConfigured();
         return handleCreateVault(req, {
@@ -2892,6 +2935,8 @@ export function hubFetch(
           db: getDb(),
           hubOrigin: oauthDeps(req).issuer,
           storePath: deps?.agentGrantsStorePath ?? join(CONFIG_DIR, "agent-grants.json"),
+          flowsStorePath:
+            deps?.agentOAuthFlowsStorePath ?? join(CONFIG_DIR, "agent-oauth-flows.json"),
           resolveVaultOrigin,
         };
         // CSRF belt (same posture as /admin/connections, hub#632): a no-op for

--- a/src/oauth-client.ts
+++ b/src/oauth-client.ts
@@ -1,0 +1,455 @@
+/**
+ * Hub-as-OAuth-CLIENT engine (Phase 4b-2, agent-connectors design 2026-06-18).
+ *
+ * A Parachute hub is a spec-compliant OAuth *issuer* (RFC 8414 / 9728 / 7591,
+ * PKCE S256, authorization_code + refresh_token). 4b-2 makes THIS hub act as a
+ * *client* of ANOTHER hub's issuer (or any RFC-compliant MCP issuer): discover →
+ * dynamic-client-register → build an authorize URL the operator's browser
+ * follows → exchange the returned code → refresh / revoke headlessly.
+ *
+ * Every function takes an injected `fetchFn` so the engine is fully unit-testable
+ * offline (the tests mock all network). The default is the global `fetch`.
+ *
+ * Security: the PKCE verifier + every token are SECRETS — this module never logs
+ * them. Callers persist them only to the 0600 flow / grant stores.
+ */
+import { createHash, randomBytes } from "node:crypto";
+
+/** A typed error for any OAuth-client failure (discovery, DCR, token exchange). */
+export class OAuthClientError extends Error {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause !== undefined ? { cause } : undefined);
+    this.name = "OAuthClientError";
+  }
+}
+
+export type FetchFn = typeof fetch;
+
+/** Default outbound timeout for every OAuth-client request. */
+const DEFAULT_TIMEOUT_MS = 15_000;
+
+/**
+ * `fetch` with an AbortController timeout. The hub has no shared fetch wrapper,
+ * so this lives here for all outbound OAuth-client calls — a slow/hung remote
+ * issuer must not stall the approve request indefinitely.
+ */
+export async function fetchWithTimeout(
+  url: string,
+  init: (RequestInit & { timeout?: number }) | undefined = undefined,
+  fetchFn: FetchFn = fetch,
+): Promise<Response> {
+  const { timeout = DEFAULT_TIMEOUT_MS, ...rest } = init ?? {};
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeout);
+  try {
+    return await fetchFn(url, { ...rest, signal: controller.signal });
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+// ===========================================================================
+// PKCE
+// ===========================================================================
+
+/** Generate a PKCE code verifier — 32 random bytes, base64url. SECRET. */
+export function generateCodeVerifier(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+/** S256 challenge for a verifier (matches `auth-codes.ts:verifyPkce`). */
+export function generateCodeChallenge(verifier: string): string {
+  return createHash("sha256").update(verifier).digest("base64url");
+}
+
+/** Random single-use `state` — 32 random bytes, base64url. */
+export function generateState(): string {
+  return randomBytes(32).toString("base64url");
+}
+
+// ===========================================================================
+// Discovery (RFC 9728 → RFC 8414)
+// ===========================================================================
+
+export interface DiscoveryResult {
+  readonly issuer: string;
+  readonly authorizationEndpoint: string;
+  readonly tokenEndpoint: string;
+  readonly registrationEndpoint?: string;
+  readonly revocationEndpoint?: string;
+  /** From RFC 9728 protected-resource metadata, falling back to RFC 8414. */
+  readonly scopesSupported?: readonly string[];
+}
+
+function originOf(url: string): string {
+  try {
+    return new URL(url).origin;
+  } catch {
+    throw new OAuthClientError(`invalid mcp url: ${url}`);
+  }
+}
+
+async function fetchJson(
+  url: string,
+  fetchFn: FetchFn,
+  what: string,
+): Promise<Record<string, unknown>> {
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(url, { headers: { accept: "application/json" } }, fetchFn);
+  } catch (err) {
+    throw new OAuthClientError(`${what}: request to ${url} failed`, err);
+  }
+  if (!res.ok) {
+    throw new OAuthClientError(`${what}: ${url} returned ${res.status}`);
+  }
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    throw new OAuthClientError(`${what}: ${url} returned non-JSON`, err);
+  }
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw new OAuthClientError(`${what}: ${url} returned a non-object body`);
+  }
+  return body as Record<string, unknown>;
+}
+
+function asString(v: unknown): string | undefined {
+  return typeof v === "string" && v.length > 0 ? v : undefined;
+}
+
+function asStringArray(v: unknown): string[] | undefined {
+  if (!Array.isArray(v)) return undefined;
+  const out = v.filter((x): x is string => typeof x === "string");
+  return out.length > 0 ? out : undefined;
+}
+
+/**
+ * Discover the issuer + endpoints for a remote MCP URL.
+ *
+ *   1. RFC 9728: GET <mcp-origin>/.well-known/oauth-protected-resource →
+ *      authorization_servers[0] = issuer (+ scopes_supported).
+ *   2. RFC 8414: GET <issuer>/.well-known/oauth-authorization-server →
+ *      authorization_endpoint, token_endpoint, registration_endpoint,
+ *      revocation_endpoint (+ scopes_supported fallback).
+ *
+ * If the resource has no 9728 doc, falls back to treating the MCP origin itself
+ * as the issuer and reading its 8414 doc directly (8414-only resources).
+ */
+export async function discover(mcpUrl: string, fetchFn: FetchFn = fetch): Promise<DiscoveryResult> {
+  const origin = originOf(mcpUrl);
+
+  // Step 1 — RFC 9728 (best-effort; some resources only expose 8414).
+  let issuer: string | undefined;
+  let prScopes: string[] | undefined;
+  try {
+    const pr = await fetchJson(
+      `${origin}/.well-known/oauth-protected-resource`,
+      fetchFn,
+      "protected-resource discovery",
+    );
+    const servers = asStringArray(pr.authorization_servers);
+    issuer = servers?.[0];
+    prScopes = asStringArray(pr.scopes_supported);
+  } catch {
+    // No 9728 doc — fall back to the MCP origin as issuer.
+    issuer = undefined;
+  }
+  if (!issuer) issuer = origin;
+
+  // Step 2 — RFC 8414 on the issuer.
+  const as = await fetchJson(
+    `${issuer.replace(/\/+$/, "")}/.well-known/oauth-authorization-server`,
+    fetchFn,
+    "authorization-server discovery",
+  );
+
+  const authorizationEndpoint = asString(as.authorization_endpoint);
+  const tokenEndpoint = asString(as.token_endpoint);
+  if (!authorizationEndpoint || !tokenEndpoint) {
+    throw new OAuthClientError(
+      "authorization-server metadata missing authorization_endpoint or token_endpoint",
+    );
+  }
+  const asIssuer = asString(as.issuer) ?? issuer;
+  const asScopes = asStringArray(as.scopes_supported);
+
+  return {
+    issuer: asIssuer,
+    authorizationEndpoint,
+    tokenEndpoint,
+    ...(asString(as.registration_endpoint)
+      ? { registrationEndpoint: asString(as.registration_endpoint) }
+      : {}),
+    ...(asString(as.revocation_endpoint)
+      ? { revocationEndpoint: asString(as.revocation_endpoint) }
+      : {}),
+    // 9728 scopes win (they describe THIS resource); 8414 is the fallback.
+    ...((prScopes ?? asScopes) ? { scopesSupported: prScopes ?? asScopes } : {}),
+  };
+}
+
+// ===========================================================================
+// Dynamic client registration (RFC 7591)
+// ===========================================================================
+
+export interface RegisterResult {
+  readonly clientId: string;
+}
+
+/** Register THIS hub as a public OAuth client at the issuer's DCR endpoint. */
+export async function registerClient(
+  registrationEndpoint: string,
+  redirectUri: string,
+  fetchFn: FetchFn = fetch,
+): Promise<RegisterResult> {
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(
+      registrationEndpoint,
+      {
+        method: "POST",
+        headers: { "content-type": "application/json", accept: "application/json" },
+        body: JSON.stringify({
+          client_name: "Parachute Hub (agent connector)",
+          redirect_uris: [redirectUri],
+          grant_types: ["authorization_code", "refresh_token"],
+          response_types: ["code"],
+          token_endpoint_auth_method: "none",
+        }),
+      },
+      fetchFn,
+    );
+  } catch (err) {
+    throw new OAuthClientError("dynamic client registration request failed", err);
+  }
+  if (!res.ok) {
+    throw new OAuthClientError(`dynamic client registration returned ${res.status}`);
+  }
+  let body: unknown;
+  try {
+    body = await res.json();
+  } catch (err) {
+    throw new OAuthClientError("dynamic client registration returned non-JSON", err);
+  }
+  const clientId = asString((body as Record<string, unknown>)?.client_id);
+  if (!clientId) {
+    throw new OAuthClientError("dynamic client registration response missing client_id");
+  }
+  return { clientId };
+}
+
+// ===========================================================================
+// Authorize URL
+// ===========================================================================
+
+export interface BuildAuthorizeUrlOpts {
+  readonly authorizationEndpoint: string;
+  readonly clientId: string;
+  readonly redirectUri: string;
+  readonly scope?: string;
+  readonly state: string;
+  readonly codeChallenge: string;
+}
+
+/** Build the authorize URL the operator's browser follows (PKCE S256). */
+export function buildAuthorizeUrl(opts: BuildAuthorizeUrlOpts): string {
+  const url = new URL(opts.authorizationEndpoint);
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("client_id", opts.clientId);
+  url.searchParams.set("redirect_uri", opts.redirectUri);
+  if (opts.scope) url.searchParams.set("scope", opts.scope);
+  url.searchParams.set("state", opts.state);
+  url.searchParams.set("code_challenge", opts.codeChallenge);
+  url.searchParams.set("code_challenge_method", "S256");
+  return url.toString();
+}
+
+// ===========================================================================
+// Token exchange + refresh
+// ===========================================================================
+
+export interface TokenResult {
+  readonly access_token: string;
+  readonly refresh_token?: string;
+  /** ISO — computed from `expires_in` at exchange time. Absent if not advertised. */
+  readonly expiresAt?: string;
+  readonly scope?: string;
+}
+
+async function postToken(
+  tokenEndpoint: string,
+  form: Record<string, string>,
+  fetchFn: FetchFn,
+  now: () => Date,
+): Promise<TokenResult> {
+  const body = new URLSearchParams(form);
+  let res: Response;
+  try {
+    res = await fetchWithTimeout(
+      tokenEndpoint,
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          accept: "application/json",
+        },
+        body: body.toString(),
+      },
+      fetchFn,
+    );
+  } catch (err) {
+    throw new OAuthClientError("token request failed", err);
+  }
+  let parsed: Record<string, unknown> = {};
+  try {
+    parsed = (await res.json()) as Record<string, unknown>;
+  } catch {
+    // fall through — handled by the !res.ok branch / missing-token branch
+  }
+  if (!res.ok) {
+    const err = asString(parsed.error) ?? `http ${res.status}`;
+    const desc = asString(parsed.error_description);
+    throw new OAuthClientError(`token endpoint error: ${err}${desc ? ` (${desc})` : ""}`);
+  }
+  const accessToken = asString(parsed.access_token);
+  if (!accessToken) {
+    throw new OAuthClientError("token response missing access_token");
+  }
+  let expiresAt: string | undefined;
+  const expiresIn = parsed.expires_in;
+  if (typeof expiresIn === "number" && Number.isFinite(expiresIn)) {
+    expiresAt = new Date(now().getTime() + expiresIn * 1000).toISOString();
+  }
+  return {
+    access_token: accessToken,
+    ...(asString(parsed.refresh_token) ? { refresh_token: asString(parsed.refresh_token) } : {}),
+    ...(expiresAt ? { expiresAt } : {}),
+    ...(asString(parsed.scope) ? { scope: asString(parsed.scope) } : {}),
+  };
+}
+
+export interface ExchangeCodeOpts {
+  readonly tokenEndpoint: string;
+  readonly code: string;
+  readonly redirectUri: string;
+  readonly codeVerifier: string;
+  readonly clientId: string;
+  /** Test seam for the clock (expiresAt computation). */
+  readonly now?: () => Date;
+}
+
+/** Exchange an authorization code for tokens (PKCE). */
+export function exchangeCode(
+  opts: ExchangeCodeOpts,
+  fetchFn: FetchFn = fetch,
+): Promise<TokenResult> {
+  return postToken(
+    opts.tokenEndpoint,
+    {
+      grant_type: "authorization_code",
+      code: opts.code,
+      redirect_uri: opts.redirectUri,
+      code_verifier: opts.codeVerifier,
+      client_id: opts.clientId,
+    },
+    fetchFn,
+    opts.now ?? (() => new Date()),
+  );
+}
+
+export interface RefreshTokenOpts {
+  readonly tokenEndpoint: string;
+  readonly refreshToken: string;
+  readonly clientId: string;
+  readonly now?: () => Date;
+}
+
+/** Refresh an access token. */
+export function refreshToken(
+  opts: RefreshTokenOpts,
+  fetchFn: FetchFn = fetch,
+): Promise<TokenResult> {
+  return postToken(
+    opts.tokenEndpoint,
+    {
+      grant_type: "refresh_token",
+      refresh_token: opts.refreshToken,
+      client_id: opts.clientId,
+    },
+    fetchFn,
+    opts.now ?? (() => new Date()),
+  );
+}
+
+// ===========================================================================
+// Revocation (RFC 7009) — best-effort
+// ===========================================================================
+
+export interface RevokeRemoteOpts {
+  readonly revocationEndpoint: string;
+  readonly refreshToken: string;
+  readonly clientId: string;
+}
+
+/**
+ * Best-effort revoke the refresh token at the issuer's revocation endpoint.
+ * Swallows all errors — revocation is a courtesy; a failure must not block the
+ * local teardown (the grant material is dropped regardless).
+ */
+export async function revokeRemote(
+  opts: RevokeRemoteOpts,
+  fetchFn: FetchFn = fetch,
+): Promise<void> {
+  try {
+    await fetchWithTimeout(
+      opts.revocationEndpoint,
+      {
+        method: "POST",
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+        body: new URLSearchParams({
+          token: opts.refreshToken,
+          token_type_hint: "refresh_token",
+          client_id: opts.clientId,
+        }).toString(),
+      },
+      fetchFn,
+    );
+  } catch {
+    // Best-effort — never throw.
+  }
+}
+
+/**
+ * The OAuth-client module surface, gathered as an interface so it can be injected
+ * into the grants handler for testing (a fake replaces the real network calls).
+ */
+export interface OAuthClient {
+  generateCodeVerifier(): string;
+  generateCodeChallenge(verifier: string): string;
+  generateState(): string;
+  discover(mcpUrl: string, fetchFn?: FetchFn): Promise<DiscoveryResult>;
+  registerClient(
+    registrationEndpoint: string,
+    redirectUri: string,
+    fetchFn?: FetchFn,
+  ): Promise<RegisterResult>;
+  buildAuthorizeUrl(opts: BuildAuthorizeUrlOpts): string;
+  exchangeCode(opts: ExchangeCodeOpts, fetchFn?: FetchFn): Promise<TokenResult>;
+  refreshToken(opts: RefreshTokenOpts, fetchFn?: FetchFn): Promise<TokenResult>;
+  revokeRemote(opts: RevokeRemoteOpts, fetchFn?: FetchFn): Promise<void>;
+}
+
+/** The real OAuth-client implementation (the default injected into the handler). */
+export const realOAuthClient: OAuthClient = {
+  generateCodeVerifier,
+  generateCodeChallenge,
+  generateState,
+  discover,
+  registerClient,
+  buildAuthorizeUrl,
+  exchangeCode,
+  refreshToken,
+  revokeRemote,
+};

--- a/src/oauth-flows-store.ts
+++ b/src/oauth-flows-store.ts
@@ -1,0 +1,163 @@
+/**
+ * `agent-oauth-flows.json` — the persisted registry of **in-flight agent-grant
+ * OAuth consent flows** (Phase 4b-2, agent-connectors design 2026-06-18).
+ *
+ * When the operator approves a `kind:mcp` grant that speaks OAuth, the hub (as
+ * the OAuth CLIENT) starts a consent flow: it mints a PKCE verifier + a random
+ * `state`, persists a record HERE keyed by `state`, and returns an authorize URL
+ * the operator's browser follows. The remote issuer redirects back to
+ * `GET /oauth/agent-grant/callback?code=&state=`; that handler looks the record
+ * up by `state` (single-use, delete-on-use), exchanges the code, and stores the
+ * grant material.
+ *
+ * Why ON-DISK (not in-memory): the 10-minute consent window can span a hub
+ * restart (the supervisor may restart the hub mid-consent). An in-memory map
+ * would orphan the `state` on restart — the callback would then fail to find the
+ * flow and the operator would have to re-approve.
+ *
+ * The `verifier` is a PKCE SECRET — this file is written 0600 (same discipline
+ * as `agent-grants.json`), and the verifier is NEVER logged, NEVER returned.
+ *
+ * One file, a flat array. Cardinality is "a handful of concurrent consents", and
+ * stale records self-prune on every read/write (10-min TTL).
+ */
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
+
+/** TTL for a pending consent flow — 10 minutes (spans a possible hub restart). */
+export const FLOW_TTL_MS = 10 * 60 * 1000;
+
+/**
+ * An in-flight OAuth consent flow, bound to a single-use `state`. Persisted so a
+ * mid-consent hub restart doesn't orphan the `state`.
+ */
+export interface PendingFlow {
+  /** Single-use CSRF token — the lookup key + the callback's only gate. */
+  readonly state: string;
+  /** The grant this consent will populate on success. */
+  readonly grantId: string;
+  /** Discovered issuer (for the authorize/token endpoints). */
+  readonly issuer: string;
+  /** DCR client_id (or a reused one for the same issuer). */
+  readonly clientId: string;
+  /** Discovered token endpoint — where the callback exchanges the code. */
+  readonly tokenEndpoint: string;
+  /** Discovered revocation endpoint (cached for the eventual revoke). */
+  readonly revocationEndpoint?: string;
+  /** PKCE verifier — a SECRET. 0600 at rest; never logged, never returned. */
+  readonly verifier: string;
+  /** The remote MCP URL the grant connects to (stored into material on success). */
+  readonly mcpUrl: string;
+  /** Requested scope (space-joined), or absent to let the issuer default. */
+  readonly scope?: string;
+  /** The hub's callback URL registered for this flow. */
+  readonly redirectUri: string;
+  readonly createdAt: string;
+}
+
+interface FlowsFile {
+  flows: PendingFlow[];
+}
+
+function isPendingFlow(v: unknown): v is PendingFlow {
+  if (!v || typeof v !== "object") return false;
+  const f = v as Record<string, unknown>;
+  return (
+    typeof f.state === "string" &&
+    typeof f.grantId === "string" &&
+    typeof f.issuer === "string" &&
+    typeof f.clientId === "string" &&
+    typeof f.tokenEndpoint === "string" &&
+    typeof f.verifier === "string" &&
+    typeof f.mcpUrl === "string" &&
+    typeof f.redirectUri === "string" &&
+    typeof f.createdAt === "string"
+  );
+}
+
+/** Read the store. A missing/garbage file reads as empty (mirrors grants-store). */
+function readAll(storePath: string): PendingFlow[] {
+  let buf: string;
+  try {
+    buf = readFileSync(storePath, "utf8");
+  } catch {
+    return [];
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(buf);
+  } catch {
+    return [];
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  const arr = (parsed as { flows?: unknown }).flows;
+  if (!Array.isArray(arr)) return [];
+  return arr.filter(isPendingFlow);
+}
+
+function writeAll(storePath: string, flows: PendingFlow[]): void {
+  mkdirSync(dirname(storePath), { recursive: true });
+  const file: FlowsFile = { flows };
+  // 0600 — this file holds PKCE verifiers (secrets). `writeFileSync`'s `mode`
+  // applies at CREATE time, so a fresh file is never world-readable even for an
+  // instant; the chmodSync is belt-and-suspenders for the re-write case.
+  writeFileSync(storePath, `${JSON.stringify(file, null, 2)}\n`, { mode: 0o600 });
+  try {
+    chmodSync(storePath, 0o600);
+  } catch {
+    // Best-effort on platforms without POSIX perms.
+  }
+}
+
+/** Drop flows older than `ttlMs` relative to `now`. Returns the survivors. */
+function prune(flows: PendingFlow[], now: number, ttlMs: number): PendingFlow[] {
+  return flows.filter((f) => {
+    const created = new Date(f.createdAt).getTime();
+    if (!Number.isFinite(created)) return false;
+    return now - created < ttlMs;
+  });
+}
+
+/**
+ * Opportunistically prune expired flows + persist if anything was dropped.
+ * Called inside put/get so stale records never accumulate.
+ */
+export function pruneExpiredFlows(
+  storePath: string,
+  now = Date.now(),
+  ttlMs = FLOW_TTL_MS,
+): PendingFlow[] {
+  const all = readAll(storePath);
+  const live = prune(all, now, ttlMs);
+  if (live.length !== all.length) writeAll(storePath, live);
+  return live;
+}
+
+/** Persist a new pending flow (pruning expired ones first). Upsert by `state`. */
+export function putFlow(storePath: string, flow: PendingFlow, now = Date.now()): void {
+  const live = prune(readAll(storePath), now, FLOW_TTL_MS);
+  const idx = live.findIndex((f) => f.state === flow.state);
+  if (idx >= 0) live[idx] = flow;
+  else live.push(flow);
+  writeAll(storePath, live);
+}
+
+/** Look up a flow by `state` (pruning expired ones first). Returns null if absent/expired. */
+export function getFlowByState(
+  storePath: string,
+  state: string,
+  now = Date.now(),
+): PendingFlow | null {
+  const live = pruneExpiredFlows(storePath, now);
+  return live.find((f) => f.state === state) ?? null;
+}
+
+/** Delete a flow by `state` (single-use). Returns the removed flow, or null. */
+export function deleteFlow(storePath: string, state: string): PendingFlow | null {
+  const all = readAll(storePath);
+  const idx = all.findIndex((f) => f.state === state);
+  if (idx < 0) return null;
+  const [removed] = all.splice(idx, 1);
+  writeAll(storePath, all);
+  return removed ?? null;
+}


### PR DESCRIPTION
**Phase 4b-2** — the hub becomes a proper **OAuth client** so an agent can reach a **remote MCP** (incl. a remote Parachute vault) after a one-time operator browser consent. Implements [the 4b-2 design-of-record](https://github.com/ParachuteComputer/parachute-agent/blob/main/design/2026-06-18-agent-connectors-4b2-oauth.md) (merged agent#94).

`claude -p` never does an interactive OAuth dance — it gets a valid Bearer in its per-spawn `.mcp.json`; tokens auto-refresh lazily.

## What's here
- **`src/oauth-client.ts`** (new) — discovery (RFC 9728 → 8414, with 8414-only fallback), dynamic client registration (RFC 7591), PKCE-S256 verifier/challenge/state generators, `buildAuthorizeUrl`, `exchangeCode`/`refreshToken` (form-encoded), best-effort `revokeRemote` (RFC 7009), `fetchWithTimeout`. Fully injectable (`OAuthClient` interface) → offline-testable.
- **`src/oauth-flows-store.ts`** (new) — `agent-oauth-flows.json` (0600), the in-flight consent records keyed by single-use `state`, 10-min TTL, delete-on-use, opportunistic prune.
- **`src/grants-store.ts`** — `GrantStatus` gains `needs_consent`; `GrantMaterial` gains the `mcp` variant (access/refresh/expiresAt/issuer/clientId/tokenEndpoint/revocationEndpoint/mcpUrl); `readGrants` filter accepts `needs_consent` (else silent-drop → 404).
- **`src/admin-agent-grants.ts`** — `approve`(mcp): static-bearer (pasted token) OR start-OAuth (discover→DCR-or-reuse→PKCE→persist flow→return `GrantListing`+`authorizeUrl`); `handleOAuthGrantCallback` (state delete-on-use, code exchange, store material, best-effort revoke prior refresh on re-consent, HTML pages that never carry a token); `material`(mcp): lazy refresh within a 120s skew, refresh-fail → `needs_consent`+409; `revoke`(mcp): best-effort issuer revoke. Field-name seam: stored `access_token` → wire `token`.
- **`src/hub-server.ts`** — `GET /oauth/agent-grant/callback` standalone route (outside the `/admin/*` SPA catch-all; GET, no Bearer — single-use `state` is the CSRF defense, NOT same-origin-belted because it's a cross-site redirect in).

## The one invariant (held)
A vault note can only **REQUEST**, never **GRANT** — `PUT /admin/grants` (module-auth) registers a *pending* want; the outbound OAuth fetch happens only on operator-gated `approve`. No note path reaches the network without operator action.

## Security
PKCE S256 every flow; single-use TTL'd `state`; tokens/verifier never logged, never in HTML, never returned except the access token via approved + host-admin-Bearer `/material`; 0600 stores; approve/revoke stay operator-cookie + same-origin-belted; static-bearer + SSRF + http:// caveats documented in the design.

## Tests
`bun test ./src`: **3543 pass, 1 skip, 0 fail** (37273 expect). 100 of those are the four new/extended 4b-2 suites (oauth-client, oauth-flows-store, grants-store, admin-agent-grants) — all offline (fetch mocked). `bun run typecheck` clean; biome clean.

## Reviews + real-path verification
- Independent code review: LGTM, no blockers; 7 nits folded inline (double-escape fix, token-trim, TOCTOU comment, deny-reason UX, DCR-orphan note, +revive-path coverage test).
- **Live end-to-end verified** against a real public-origin Parachute issuer (tailnet): register → real discovery+DCR → operator consent → callback real code-exchange → material → **the OAuth-obtained token authenticates against the live vault MCP** → forced-expiry lazy-refresh → revoke → 409. (Cloudflare-fronted custom domains block S2S; the `.ts.net` tailnet origin is the reachable production-shaped target.)

No rc bump (per practice: bump+tag on the ship call). Release (rc + tag → CI publish) awaits the ship signal; the bun-linked local hub already runs this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)