### PR TITLE
feat(grants-ui): approve remote-MCP grants in admin (4b-2 operator surface)

### DIFF
--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1764,9 +1764,23 @@ export interface GrantListing {
   id: string;
   agent: string;
   connection: GrantConnection;
-  status: "pending" | "approved" | "revoked";
+  /**
+   * `pending` — never approved. `approved` — secret stored / token minted.
+   * `revoked` — operator dropped the secret. `needs_consent` (mcp/OAuth only) —
+   * an OAuth refresh died and the remote needs re-consent; the action UI treats
+   * it like `pending` (offer Connect / paste-a-token again).
+   */
+  status: "pending" | "approved" | "revoked" | "needs_consent";
   reason?: string;
   approvedAt?: string;
+  /**
+   * Remote-issuer consent URL, returned ONLY by `approveAgentGrant` when starting
+   * an `mcp` (hub-as-OAuth-client) flow with no pasted token. The caller redirects
+   * the browser here (full-page nav) to the remote consent screen; the hub callback
+   * finishes server-side and flips the grant to `approved`. Absent on the list
+   * endpoint and on token-paste / vault / service approvals.
+   */
+  authorizeUrl?: string;
 }
 
 /**
@@ -1791,11 +1805,20 @@ export async function listAgentGrants(): Promise<GrantListing[]> {
 
 /**
  * POST /admin/grants/<id>/approve — operator approves a grant. Cookie-authed
- * (the route is first-admin-session gated, CSRF-belted). For a `service` grant,
- * `token` is the operator-pasted API credential the hub stores. For `vault`,
- * the hub mints the token itself — no `token` needed.
+ * (the route is first-admin-session gated, CSRF-belted). Returns the echoed
+ * `GrantListing`.
+ *
+ *   - `vault`   — the hub mints the token itself; no `token` needed.
+ *   - `service` — `token` is the operator-pasted API credential the hub stores;
+ *     grant flips to `approved` immediately.
+ *   - `mcp` (hub-as-OAuth-client, 4b-2) — call with NO token to START OAuth: the
+ *     returned listing carries `authorizeUrl`, and the caller must full-page
+ *     redirect the browser there (remote consent). Or pass a `token` (a static
+ *     bearer for non-OAuth MCPs) to store it and approve immediately.
+ *
+ * The returned listing lets the caller read `authorizeUrl` to drive the redirect.
  */
-export async function approveAgentGrant(id: string, token?: string): Promise<void> {
+export async function approveAgentGrant(id: string, token?: string): Promise<GrantListing> {
   const res = await fetch(`/admin/grants/${encodeURIComponent(id)}/approve`, {
     method: "POST",
     headers: { "content-type": "application/json", accept: "application/json" },
@@ -1803,10 +1826,10 @@ export async function approveAgentGrant(id: string, token?: string): Promise<voi
     body: JSON.stringify(token !== undefined ? { token } : {}),
   });
   if (res.status === 401) {
-    await redirectToLoginAndHang<void>();
-    return;
+    return redirectToLoginAndHang<GrantListing>();
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as GrantListing;
 }
 
 /** POST /admin/grants/<id>/revoke — operator revokes a grant (drops the secret). */

--- a/web/ui/src/routes/Grants.test.tsx
+++ b/web/ui/src/routes/Grants.test.tsx
@@ -1,13 +1,15 @@
 /**
- * Grants route tests (agent-connector grants, 4b-1) — loading, empty state,
- * grouping by agent, the three status shapes (pending vault → one-click approve,
- * pending service → token paste then approve, approved → revoke), and the
- * non-grantable mcp row. The list NEVER carries secret material — the view only
- * renders the wire shape from `listAgentGrants`.
+ * Grants route tests (agent-connector grants, 4b-1 + 4b-2) — loading, empty
+ * state, grouping by agent, and the status shapes: pending vault → one-click
+ * approve, pending service → token paste then approve, approved → revoke, and
+ * the 4b-2 mcp paths (Connect → OAuth redirect, paste-a-token static bearer,
+ * approved → revoke, needs_consent → reconnect). The list NEVER carries secret
+ * material — the view only renders the wire shape from `listAgentGrants`.
  *
  * Mock `lib/api.ts` so the route's fetch helpers are stubbed; assert on the
- * rendered DOM + the calls made (notably: approveAgentGrant for a service grant
- * carries the pasted token; for a vault grant it carries no token).
+ * rendered DOM + the calls made (notably: approveAgentGrant for a service/mcp
+ * token grant carries the pasted token; for a vault grant or an mcp Connect it
+ * carries no token, and Connect full-page redirects to the returned authorizeUrl).
  */
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -72,9 +74,29 @@ const sampleGrants: api.GrantListing[] = [
     agent: "agent2",
     connection: { kind: "mcp", target: "https://remote.test/mcp" },
     status: "pending",
-    reason: "oauth not yet supported",
+  },
+  {
+    id: "agent2-mcp-approved",
+    agent: "agent2",
+    connection: { kind: "mcp", target: "https://granted.test/mcp" },
+    status: "approved",
+    approvedAt: "2026-06-18T00:00:00.000Z",
+  },
+  {
+    id: "agent2-mcp-stale",
+    agent: "agent2",
+    connection: { kind: "mcp", target: "https://stale.test/mcp" },
+    status: "needs_consent",
+    reason: "oauth refresh expired",
   },
 ];
+
+/** Minimal approved-listing echo for stubbing `approveAgentGrant` (no authorizeUrl). */
+function approvedEcho(id: string): api.GrantListing {
+  const src = sampleGrants.find((g) => g.id === id);
+  if (!src) throw new Error(`approvedEcho: no fixture grant with id ${id}`);
+  return { ...src, id, status: "approved" };
+}
 
 describe("Grants — loading + states", () => {
   it("shows a loading state, then the grants grouped by agent", async () => {
@@ -105,7 +127,7 @@ describe("Grants — loading + states", () => {
 describe("Grants — approve / revoke", () => {
   it("a pending vault grant approves in one click (no token)", async () => {
     vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
-    vi.mocked(api.approveAgentGrant).mockResolvedValue();
+    vi.mocked(api.approveAgentGrant).mockResolvedValue(approvedEcho("agent1-vault-research-read"));
     renderRoute();
     await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
 
@@ -121,7 +143,7 @@ describe("Grants — approve / revoke", () => {
 
   it("a pending service grant reveals a token field, then approves WITH the token", async () => {
     vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
-    vi.mocked(api.approveAgentGrant).mockResolvedValue();
+    vi.mocked(api.approveAgentGrant).mockResolvedValue(approvedEcho("agent1-service-github"));
     renderRoute();
     await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
 
@@ -152,7 +174,7 @@ describe("Grants — approve / revoke", () => {
 
   it("a revoked vault grant offers Re-approve (re-mints fresh material)", async () => {
     vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
-    vi.mocked(api.approveAgentGrant).mockResolvedValue();
+    vi.mocked(api.approveAgentGrant).mockResolvedValue(approvedEcho("agent1-vault-archive-read"));
     renderRoute();
     await waitFor(() => expect(screen.getByText("agent1")).toBeInTheDocument());
 
@@ -164,14 +186,112 @@ describe("Grants — approve / revoke", () => {
   });
 });
 
-describe("Grants — mcp is modeled but not grantable (4b-1)", () => {
-  it("an mcp grant shows the 4b-2 message and offers no Approve", async () => {
+describe("Grants — mcp (remote/OAuth) is grantable (4b-2)", () => {
+  // jsdom doesn't implement navigation; spy on window.location.assign so the
+  // Connect-redirect path is observable and doesn't throw "Not implemented".
+  let assignSpy: ReturnType<typeof vi.fn>;
+  beforeEach(() => {
+    assignSpy = vi.fn();
+    Object.defineProperty(window, "location", {
+      configurable: true,
+      value: { ...window.location, assign: assignSpy },
+    });
+  });
+
+  it("a pending mcp grant shows Connect (no stale 4b-1 placeholder)", async () => {
     vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
     renderRoute();
     await waitFor(() => expect(screen.getByText("agent2")).toBeInTheDocument());
 
     const row = screen.getByText(/mcp: https:\/\/remote\.test\/mcp/i).closest("tr") as HTMLElement;
-    expect(within(row).getByText(/oauth coming in 4b-2/i)).toBeInTheDocument();
-    expect(within(row).queryByRole("button", { name: /approve/i })).toBeNull();
+    expect(within(row).getByRole("button", { name: /^connect$/i })).toBeInTheDocument();
+    expect(within(row).queryByText(/oauth coming in 4b-2/i)).toBeNull();
+  });
+
+  it("clicking Connect approves with NO token and redirects to authorizeUrl", async () => {
+    const authorizeUrl = "https://issuer.test/oauth/authorize?client_id=hub&state=xyz";
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.approveAgentGrant).mockResolvedValue({
+      ...(sampleGrants.find((g) => g.id === "agent2-mcp-remote") as api.GrantListing),
+      authorizeUrl,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent2")).toBeInTheDocument());
+
+    const row = screen.getByText(/mcp: https:\/\/remote\.test\/mcp/i).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: /^connect$/i }));
+
+    await waitFor(() => expect(api.approveAgentGrant).toHaveBeenCalledWith("agent2-mcp-remote"));
+    // started OAuth with no token argument
+    expect(vi.mocked(api.approveAgentGrant).mock.calls[0]).toEqual(["agent2-mcp-remote"]);
+    await waitFor(() => expect(assignSpy).toHaveBeenCalledWith(authorizeUrl));
+  });
+
+  it("'Paste a token instead' reveals an input, then approves WITH the token", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.approveAgentGrant).mockResolvedValue(approvedEcho("agent2-mcp-remote"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent2")).toBeInTheDocument());
+
+    const row = screen.getByText(/mcp: https:\/\/remote\.test\/mcp/i).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: /paste a token instead/i }));
+    const input = within(row).getByLabelText(/api token for https:\/\/remote\.test\/mcp/i);
+    expect(input).toHaveAttribute("type", "password");
+    fireEvent.change(input, { target: { value: "static_bearer" } });
+    fireEvent.click(within(row).getByRole("button", { name: /save & approve/i }));
+
+    await waitFor(() =>
+      expect(api.approveAgentGrant).toHaveBeenCalledWith("agent2-mcp-remote", "static_bearer"),
+    );
+    expect(assignSpy).not.toHaveBeenCalled();
+  });
+
+  it("an approved mcp grant offers Revoke", async () => {
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.revokeAgentGrant).mockResolvedValue();
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent2")).toBeInTheDocument());
+
+    const row = screen.getByText(/mcp: https:\/\/granted\.test\/mcp/i).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: /revoke/i }));
+    await waitFor(() => expect(api.revokeAgentGrant).toHaveBeenCalledWith("agent2-mcp-approved"));
+  });
+
+  it("a needs_consent mcp grant offers Reconnect (re-consent path)", async () => {
+    const authorizeUrl = "https://issuer.test/oauth/authorize?reconsent=1";
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.approveAgentGrant).mockResolvedValue({
+      ...(sampleGrants.find((g) => g.id === "agent2-mcp-stale") as api.GrantListing),
+      authorizeUrl,
+    });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent2")).toBeInTheDocument());
+
+    const row = screen.getByText(/mcp: https:\/\/stale\.test\/mcp/i).closest("tr") as HTMLElement;
+    const reconnect = within(row).getByRole("button", { name: /reconnect/i });
+    expect(reconnect).toBeInTheDocument();
+    fireEvent.click(reconnect);
+    await waitFor(() => expect(api.approveAgentGrant).toHaveBeenCalledWith("agent2-mcp-stale"));
+    await waitFor(() => expect(assignSpy).toHaveBeenCalledWith(authorizeUrl));
+  });
+
+  it("Connect with no authorizeUrl returned → reloads (defensive), no redirect", async () => {
+    // Defensive branch: an mcp approve that comes back WITHOUT authorizeUrl must
+    // not navigate — it falls back to a list reload (listAgentGrants re-called).
+    vi.mocked(api.listAgentGrants).mockResolvedValue(sampleGrants);
+    vi.mocked(api.approveAgentGrant).mockResolvedValue(approvedEcho("agent2-mcp-remote"));
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("agent2")).toBeInTheDocument());
+    const callsBefore = vi.mocked(api.listAgentGrants).mock.calls.length;
+
+    const row = screen.getByText(/mcp: https:\/\/remote\.test\/mcp/i).closest("tr") as HTMLElement;
+    fireEvent.click(within(row).getByRole("button", { name: /^connect$/i }));
+
+    await waitFor(() => expect(api.approveAgentGrant).toHaveBeenCalledWith("agent2-mcp-remote"));
+    // No redirect, and the list was re-fetched (reload bump).
+    expect(assignSpy).not.toHaveBeenCalled();
+    await waitFor(() =>
+      expect(vi.mocked(api.listAgentGrants).mock.calls.length).toBeGreaterThan(callsBefore),
+    );
   });
 });

--- a/web/ui/src/routes/Grants.tsx
+++ b/web/ui/src/routes/Grants.tsx
@@ -13,8 +13,12 @@
  * here. So defining agents "from any chat" is safe — worst case a request sits
  * pending.
  *
- * The `mcp` (remote/OAuth) kind is modeled but not grantable in 4b-1 — its
- * Approve is disabled with "OAuth coming in 4b-2 — not yet grantable."
+ * The `mcp` (remote/OAuth) kind is grantable in 4b-2 (hub-as-OAuth-client):
+ * "Connect" starts the OAuth dance (hub returns an `authorizeUrl`; the browser
+ * full-page redirects to the remote consent screen, the hub callback finishes
+ * server-side and flips the grant to `approved`). "Paste a token instead" stores
+ * a static bearer for non-OAuth MCPs. A `needs_consent` mcp grant (OAuth refresh
+ * died) re-offers the same Connect / paste path — treated like pending.
  *
  * Auth: list is host-admin-Bearer (`lib/api.ts:listAgentGrants`); approve/revoke
  * are cookie-authed first-admin routes. The `lib/api.ts` helpers redirect to
@@ -73,6 +77,8 @@ export function Grants(): React.ReactElement {
   async function onApproveVault(id: string): Promise<void> {
     setRowSt({ kind: "working", id });
     try {
+      // The returned listing is only needed by onConnectMcp (for authorizeUrl);
+      // the vault path just mints + reloads.
       await approveAgentGrant(id);
       setRowSt({ kind: "idle" });
       setReload((n) => n + 1);
@@ -88,11 +94,32 @@ export function Grants(): React.ReactElement {
     }
     setRowSt({ kind: "working", id });
     try {
+      // Static-bearer approve (service, or an mcp token-paste): the returned
+      // listing isn't needed here — store + reload.
       await approveAgentGrant(id, token);
       setRowSt({ kind: "idle" });
       setReload((n) => n + 1);
     } catch (err) {
       setRowSt({ kind: "error", id, message: errMessage(err, "Approve") });
+    }
+  }
+
+  // Start the remote-MCP OAuth dance: approve with NO token → the hub returns a
+  // listing carrying `authorizeUrl`; we full-page redirect to the remote consent
+  // (cross-origin, so window.location.assign — NOT react-router). On the rare
+  // no-authorizeUrl case (defensive), fall back to a list reload.
+  async function onConnectMcp(id: string): Promise<void> {
+    setRowSt({ kind: "working", id });
+    try {
+      const listing = await approveAgentGrant(id);
+      if (listing.authorizeUrl) {
+        window.location.assign(listing.authorizeUrl);
+        return; // navigating away — leave the row in its working state
+      }
+      setRowSt({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRowSt({ kind: "error", id, message: errMessage(err, "Connect") });
     }
   }
 
@@ -122,6 +149,7 @@ export function Grants(): React.ReactElement {
       {renderBody(state, rowSt, setRowSt, {
         onApproveVault,
         onApproveService,
+        onConnectMcp,
         onRevoke,
         onRetry: () => setReload((n) => n + 1),
       })}
@@ -132,6 +160,7 @@ export function Grants(): React.ReactElement {
 interface RowActions {
   onApproveVault: (id: string) => Promise<void>;
   onApproveService: (id: string, token: string) => Promise<void>;
+  onConnectMcp: (id: string) => Promise<void>;
   onRevoke: (id: string) => Promise<void>;
   onRetry: () => void;
 }
@@ -235,24 +264,27 @@ function GrantRow({
   const c = grant.connection;
   const isMcp = c.kind === "mcp";
   const isService = c.kind === "service";
+  // A grant is actionable (approve / connect / paste) in any non-approved state —
+  // `pending`, `revoked`, OR `needs_consent` (the mcp re-consent path). The gate
+  // is intentionally `!== "approved"` so a new status lands on the action side.
+  const notApproved = grant.status !== "approved";
+  // The token-paste affordance is shared by service AND mcp (static-bearer MCPs).
   const pasting = rowSt.kind === "pasting" && rowSt.id === grant.id ? rowSt.token : null;
 
   return (
     <tr data-grant-id={grant.id}>
       <td>
         <code>{connectionLabel(c)}</code>
+        {isMcp && <span className="muted"> — remote MCP (OAuth)</span>}
       </td>
       <td>
         <span className={`status status-${grant.status}`}>{grant.status}</span>
         {grant.reason && <span className="muted"> — {grant.reason}</span>}
       </td>
       <td>
-        {/* mcp — modeled, not grantable in 4b-1. */}
-        {isMcp && <span className="muted">OAuth coming in 4b-2 — not yet grantable.</span>}
-
         {/* not-yet-granted vault (pending OR revoked) — single-click approve
             (the hub mints; approving a revoked grant re-mints fresh material). */}
-        {!isMcp && grant.status !== "approved" && c.kind === "vault" && (
+        {notApproved && c.kind === "vault" && (
           <button
             type="button"
             className="primary"
@@ -263,9 +295,34 @@ function GrantRow({
           </button>
         )}
 
+        {/* not-yet-granted mcp (pending / revoked / needs_consent) — primary
+            "Connect" starts the remote OAuth dance (full-page redirect to the
+            issuer's consent), with "Paste a token instead" as the static-bearer
+            fallback. Shown only when not mid-paste. */}
+        {notApproved && isMcp && pasting === null && (
+          <span style={{ display: "inline-flex", gap: "0.5rem", alignItems: "center" }}>
+            <button
+              type="button"
+              className="primary"
+              disabled={busy}
+              onClick={() => actions.onConnectMcp(grant.id)}
+            >
+              {busy ? "Connecting…" : grant.status === "needs_consent" ? "Reconnect" : "Connect"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              disabled={busy}
+              onClick={() => setRowSt({ kind: "pasting", id: grant.id, token: "" })}
+            >
+              Paste a token instead
+            </button>
+          </span>
+        )}
+
         {/* not-yet-granted service (pending OR revoked) — paste the API token,
             then approve. */}
-        {!isMcp && grant.status !== "approved" && isService && pasting === null && (
+        {notApproved && isService && pasting === null && (
           <button
             type="button"
             className="primary"
@@ -275,7 +332,9 @@ function GrantRow({
             {grant.status === "revoked" ? "Re-approve…" : "Approve…"}
           </button>
         )}
-        {!isMcp && grant.status !== "approved" && isService && pasting !== null && (
+
+        {/* token-paste field — shared by service + mcp (static-bearer). */}
+        {notApproved && (isService || isMcp) && pasting !== null && (
           <span style={{ display: "inline-flex", gap: "0.5rem", alignItems: "center" }}>
             <input
               type="password"


### PR DESCRIPTION
Completes **Phase 4b-2** with the operator-facing admin UI. The hub OAuth-client backend (#669) shipped + was verified end-to-end, but `/admin/grants` still showed *"OAuth coming in 4b-2 — not yet grantable"* for `mcp` grants. This wires the approval UX so the operator can actually grant a remote MCP — honoring the locked decision that **the approval surface lives in the hub**.

## What's here (`web/ui`)
- **`routes/Grants.tsx`** — `mcp` grants are now grantable:
  - **Connect** → `approveAgentGrant(id)` (no token) → the hub returns a `GrantListing` carrying `authorizeUrl` → `window.location.assign(authorizeUrl)` (full-page redirect to the remote consent; the hub callback finishes server-side and flips the grant `approved`).
  - **Paste a token instead** → static bearer for non-OAuth MCPs (shared password-input path with the service flow).
  - **`needs_consent`** (OAuth refresh died) → **Reconnect** re-offers the same path. The `notApproved = status !== "approved"` gate covers pending/revoked/needs_consent.
- **`lib/api.ts`** — `GrantListing` gains `authorizeUrl?` + `needs_consent` status; `approveAgentGrant` returns the `GrantListing` (was `void`) so the caller reads `authorizeUrl`. 401→login + !ok→HttpError preserved. (Additive type change; the only callers are in Grants.tsx, all updated.)

## Tests / gates
`web/ui`: typecheck clean; vitest **306 passed**; `bun run build` + post-build verify-base pass. New mcp tests: pending→Connect, Connect→redirect (no token, mocked `window.location.assign`), paste→static-bearer approve, approved→Revoke, needs_consent→Reconnect, and the defensive no-authorizeUrl→reload branch.

## Review
Independent review: LGTM, no blockers. Nits folded (clarifying comments, defensive-branch test, throwing fixture helper). Declined the https-only redirect guard — it would break the loopback/dev `authorizeUrl`; the URL is hub-constructed from OIDC discovery and trusted, and the surface is operator-only.

Token handling: paste input is `type="password"`, token never logged, flows only into the POST body. No rc bump (bump+tag on the ship call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)