### PR TITLE
feat(agent-grants): least-privilege mcp scope (#671) + grant-GC reconcile (#96)

### DIFF
--- a/src/__tests__/admin-agent-grants.test.ts
+++ b/src/__tests__/admin-agent-grants.test.ts
@@ -23,7 +23,7 @@ import {
   handleAgentGrants,
   handleOAuthGrantCallback,
 } from "../admin-agent-grants.ts";
-import { readGrants } from "../grants-store.ts";
+import { connectionKey, getGrant, readGrants } from "../grants-store.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { findTokenRowByJti } from "../jwt-sign.ts";
 import { signAccessToken } from "../jwt-sign.ts";
@@ -800,6 +800,183 @@ describe("POST /admin/grants/<id>/revoke", () => {
   });
 });
 
+// === POST /admin/grants/reconcile (grant-GC, #96) ===========================
+
+describe("POST /admin/grants/reconcile", () => {
+  /** Create a grant via PUT; return its id + connectionKey. */
+  async function makeGrant(
+    bearer: string,
+    agent: string,
+    connection: Record<string, unknown>,
+  ): Promise<{ id: string; key: string }> {
+    const created = await json(
+      await dispatch(bearerReq("PUT", "/admin/grants", bearer, { agent, connection })),
+    );
+    // connectionKey derives the same key the agent side would compute for liveKeys.
+    return { id: created.id as string, key: connectionKey(connection as never) };
+  }
+
+  test("prunes grants whose key is NOT in liveKeys; keeps those that are", async () => {
+    const bearer = await moduleBearer();
+    const keep = await makeGrant(bearer, "a", {
+      kind: "vault",
+      target: "research",
+      access: "read",
+    });
+    const drop = await makeGrant(bearer, "a", { kind: "service", target: "github" });
+
+    const res = await dispatch(
+      bearerReq("POST", "/admin/grants/reconcile", bearer, {
+        agent: "a",
+        liveKeys: [keep.key], // drop's key is absent → it is pruned
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.pruned).toBe(1);
+    expect(body.prunedIds).toEqual([drop.id]);
+
+    // the kept grant survives; the dropped one is gone (row removed, not revoked)
+    expect(getGrant(harness.storePath, keep.id)?.status).toBe("pending");
+    expect(getGrant(harness.storePath, drop.id)).toBeNull();
+  });
+
+  test("a pruned APPROVED vault grant has its registry token revoked", async () => {
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const g = await makeGrant(bearer, "a", { kind: "vault", target: "research", access: "read" });
+    await dispatch(cookieReq("POST", `/admin/grants/${g.id}/approve`, cookie));
+    const jti = (getGrant(harness.storePath, g.id)?.material as { jti: string }).jti;
+    expect(findTokenRowByJti(harness.db, jti)?.revokedAt).toBeFalsy();
+
+    // reconcile with NO live keys for this agent → prune everything
+    const res = await dispatch(
+      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [] }),
+    );
+    expect(res.status).toBe(200);
+    expect((await json(res)).pruned).toBe(1);
+
+    // the row is removed AND the minted token is revoked in the registry
+    expect(getGrant(harness.storePath, g.id)).toBeNull();
+    expect(findTokenRowByJti(harness.db, jti)?.revokedAt).toBeTruthy();
+  });
+
+  test("liveKeys=[] prunes ALL of the agent's grants", async () => {
+    const bearer = await moduleBearer();
+    await makeGrant(bearer, "a", { kind: "vault", target: "research", access: "read" });
+    await makeGrant(bearer, "a", { kind: "service", target: "github" });
+
+    const res = await dispatch(
+      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [] }),
+    );
+    expect(res.status).toBe(200);
+    expect((await json(res)).pruned).toBe(2);
+    expect(readGrants(harness.storePath).filter((r) => r.agent === "a")).toHaveLength(0);
+  });
+
+  test("leaves OTHER agents' grants untouched", async () => {
+    const bearer = await moduleBearer();
+    const mine = await makeGrant(bearer, "a", { kind: "service", target: "github" });
+    const theirs = await makeGrant(bearer, "b", { kind: "service", target: "github" });
+
+    const res = await dispatch(
+      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [] }),
+    );
+    expect(res.status).toBe(200);
+    expect((await json(res)).pruned).toBe(1);
+    expect(getGrant(harness.storePath, mine.id)).toBeNull();
+    // agent b's grant is untouched even though it has the SAME connectionKey
+    expect(getGrant(harness.storePath, theirs.id)?.agent).toBe("b");
+  });
+
+  test("returns the right count/ids (empty when nothing is pruned)", async () => {
+    const bearer = await moduleBearer();
+    const g = await makeGrant(bearer, "a", { kind: "service", target: "github" });
+
+    const res = await dispatch(
+      bearerReq("POST", "/admin/grants/reconcile", bearer, {
+        agent: "a",
+        liveKeys: [g.key], // the only grant is still live → nothing pruned
+      }),
+    );
+    expect(res.status).toBe(200);
+    const body = await json(res);
+    expect(body.pruned).toBe(0);
+    expect(body.prunedIds).toEqual([]);
+    expect(getGrant(harness.storePath, g.id)).not.toBeNull();
+  });
+
+  test("401 without the module Bearer (auth-gated)", async () => {
+    const bearer = await moduleBearer();
+    await makeGrant(bearer, "a", { kind: "service", target: "github" });
+
+    // No Authorization header at all.
+    const req = new Request(`${HUB_ORIGIN}/admin/grants/reconcile`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ agent: "a", liveKeys: [] }),
+    });
+    const res = await handleAgentGrants(req, "/reconcile", deps());
+    expect(res.status).toBe(401);
+    // nothing was pruned
+    expect(readGrants(harness.storePath).filter((r) => r.agent === "a")).toHaveLength(1);
+  });
+
+  test("a cookie-only request (no Bearer) is rejected — module-auth only", async () => {
+    const bearer = await moduleBearer();
+    await makeGrant(bearer, "a", { kind: "service", target: "github" });
+    const cookie = await operatorCookie();
+    // An operator cookie is NOT module-auth — reconcile is host-admin-Bearer only.
+    const res = await dispatch(
+      cookieReq("POST", "/admin/grants/reconcile", cookie, { agent: "a", liveKeys: [] }),
+    );
+    expect(res.status).toBe(401);
+    expect(readGrants(harness.storePath).filter((r) => r.agent === "a")).toHaveLength(1);
+  });
+
+  test("405 on a non-POST method", async () => {
+    const bearer = await moduleBearer();
+    const res = await dispatch(bearerReq("GET", "/admin/grants/reconcile", bearer));
+    expect(res.status).toBe(405);
+  });
+
+  test("400 on a missing/invalid agent or liveKeys", async () => {
+    const bearer = await moduleBearer();
+    // missing agent
+    expect(
+      (await dispatch(bearerReq("POST", "/admin/grants/reconcile", bearer, { liveKeys: [] })))
+        .status,
+    ).toBe(400);
+    // liveKeys not an array
+    expect(
+      (
+        await dispatch(
+          bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: "x" }),
+        )
+      ).status,
+    ).toBe(400);
+    // a non-string liveKeys entry
+    expect(
+      (
+        await dispatch(
+          bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [1] }),
+        )
+      ).status,
+    ).toBe(400);
+    // a bad agent charset
+    expect(
+      (
+        await dispatch(
+          bearerReq("POST", "/admin/grants/reconcile", bearer, {
+            agent: "bad name",
+            liveKeys: [],
+          }),
+        )
+      ).status,
+    ).toBe(400);
+  });
+});
+
 // === method/routing guards ==================================================
 
 describe("routing", () => {
@@ -966,6 +1143,55 @@ describe("approve(mcp) — start OAuth flow", () => {
     const res = await dispatch(cookieReq("POST", `/admin/grants/${created.id}/approve`, cookie));
     expect(res.status).toBe(502);
     expect(getFlowByState(harness.flowsStorePath, "fixed-state")).toBeNull();
+  });
+
+  // #671: least-privilege scope for a Parachute-vault MCP target. The fake
+  // discovery advertises the broad set (vault:eng:read + vault:eng:write); for a
+  // vault-shaped URL the flow must request ONLY vault:<name>:read instead.
+  test("#671 vault-shaped MCP target → requests least-privilege vault:<name>:read", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          // A Parachute vault MCP URL at this hub's origin.
+          connection: { kind: "mcp", target: "https://hub.test/vault/research/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    const res = await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    expect(res.status).toBe(200);
+    // The persisted flow's scope is the single least-privilege read scope, NOT
+    // the resource's full advertised set.
+    const flow = getFlowByState(harness.flowsStorePath, "fixed-state");
+    expect(flow?.scope).toBe("vault:research:read");
+    // And the authorize URL carries that scope, not the broad one.
+    const body = await json(res);
+    expect(body.authorizeUrl as string).toContain(encodeURIComponent("vault:research:read"));
+    expect(body.authorizeUrl as string).not.toContain("vault%3Aeng%3Awrite");
+  });
+
+  // #671: the complement — a non-vault MCP target keeps the old behavior
+  // (request the resource's advertised scopes_supported).
+  test("#671 non-vault MCP target → falls back to the advertised scopes_supported", async () => {
+    currentOAuth = fakeOAuth();
+    const bearer = await moduleBearer();
+    const cookie = await operatorCookie();
+    const created = await json(
+      await dispatch(
+        bearerReq("PUT", "/admin/grants", bearer, {
+          agent: "a",
+          connection: { kind: "mcp", target: "https://remote.test/mcp" },
+        }),
+      ),
+    );
+    const id = created.id as string;
+    await dispatch(cookieReq("POST", `/admin/grants/${id}/approve`, cookie));
+    const flow = getFlowByState(harness.flowsStorePath, "fixed-state");
+    expect(flow?.scope).toBe("vault:eng:read vault:eng:write");
   });
 });
 

--- a/src/__tests__/oauth-client.test.ts
+++ b/src/__tests__/oauth-client.test.ts
@@ -12,6 +12,7 @@ import { createHash } from "node:crypto";
 import {
   OAuthClientError,
   buildAuthorizeUrl,
+  deriveVaultScopeFromMcpUrl,
   discover,
   exchangeCode,
   fetchWithTimeout,
@@ -396,5 +397,50 @@ describe("fetchWithTimeout", () => {
     const fn = (async () => new Response("ok", { status: 200 })) as unknown as FetchFn;
     const res = await fetchWithTimeout("https://fast.test", { timeout: 1000 }, fn);
     expect(res.status).toBe(200);
+  });
+});
+
+// === deriveVaultScopeFromMcpUrl (#671) ======================================
+
+describe("deriveVaultScopeFromMcpUrl", () => {
+  test("a Parachute vault MCP URL → least-privilege vault:<name>:read", () => {
+    expect(deriveVaultScopeFromMcpUrl("https://hub.test/vault/research/mcp")).toBe(
+      "vault:research:read",
+    );
+  });
+
+  test("a trailing slash after /mcp still matches", () => {
+    expect(deriveVaultScopeFromMcpUrl("https://hub.test/vault/research/mcp/")).toBe(
+      "vault:research:read",
+    );
+  });
+
+  test("a vault name with dot/dash/underscore is captured", () => {
+    expect(deriveVaultScopeFromMcpUrl("https://hub.test/vault/my-team_v2.0/mcp")).toBe(
+      "vault:my-team_v2.0:read",
+    );
+  });
+
+  test("a query string / fragment does not break the match", () => {
+    expect(deriveVaultScopeFromMcpUrl("https://hub.test/vault/research/mcp?x=1#frag")).toBe(
+      "vault:research:read",
+    );
+  });
+
+  test("a non-vault MCP URL → null (caller falls back to scopes_supported)", () => {
+    expect(deriveVaultScopeFromMcpUrl("https://remote.test/mcp")).toBeNull();
+    expect(deriveVaultScopeFromMcpUrl("https://remote.test/some/other/mcp")).toBeNull();
+  });
+
+  test("a deeper path after /mcp is NOT a vault MCP (anchored) → null", () => {
+    expect(deriveVaultScopeFromMcpUrl("https://hub.test/vault/research/mcp/extra")).toBeNull();
+  });
+
+  test("a /vault/ path with no name segment → null", () => {
+    expect(deriveVaultScopeFromMcpUrl("https://hub.test/vault//mcp")).toBeNull();
+  });
+
+  test("an unparseable URL → null", () => {
+    expect(deriveVaultScopeFromMcpUrl("not a url")).toBeNull();
   });
 });

--- a/src/admin-agent-grants.ts
+++ b/src/admin-agent-grants.ts
@@ -70,6 +70,7 @@ import {
   listGrantsForAgent,
   putGrant,
   readGrants,
+  removeGrant,
 } from "./grants-store.ts";
 import {
   type signAccessToken as SignAccessTokenFn,
@@ -77,7 +78,7 @@ import {
   revokeTokenByJti,
   signAccessToken,
 } from "./jwt-sign.ts";
-import { type OAuthClient, realOAuthClient } from "./oauth-client.ts";
+import { type OAuthClient, deriveVaultScopeFromMcpUrl, realOAuthClient } from "./oauth-client.ts";
 import { type PendingFlow, deleteFlow, getFlowByState, putFlow } from "./oauth-flows-store.ts";
 import { findSession, parseSessionCookie } from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
@@ -113,6 +114,15 @@ const MAX_TAG_LEN = 128;
  *  bounds a fat-finger paste from bloating the on-disk store — matches the other caps. */
 const MAX_TOKEN_LEN = 8192;
 const MAX_TAGS = 64;
+/**
+ * Reconcile caps (#96). A host-admin Bearer is high-privilege, but these bound a
+ * runaway/misconfigured module from POSTing a giant liveKeys array. The cap is
+ * generous vs. realistic agent connection counts ("a handful per agent").
+ */
+const MAX_LIVE_KEYS = 256;
+/** A connectionKey is `kind:target[:access][#tags]` — bounded by the upstream
+ *  target/tag caps, so this is a loose safety bound, not the real limit. */
+const MAX_CONNECTION_KEY_LEN = 1024;
 
 export interface AgentGrantsDeps {
   db: Database;
@@ -184,6 +194,18 @@ export async function handleAgentGrants(
     if (method === "PUT") return upsertGrant(req, deps);
     if (method === "GET") return listGrants(req, deps);
     return jsonError(405, "method_not_allowed", "use PUT or GET on /admin/grants");
+  }
+
+  // --- Collection sub-action: POST /reconcile (grant-GC, #96) — module-auth. ---
+  // `reconcile` is a reserved single-segment action, NOT a grant id (the
+  // GRANT_ID_RE slug never collides — but anchoring it here makes the routing
+  // explicit). The agent module POSTs the live connection keys for one holder;
+  // the hub prunes every grant for that holder whose key is no longer live.
+  if (segments.length === 1 && segments[0] === "reconcile") {
+    if (method !== "POST") {
+      return jsonError(405, "method_not_allowed", "use POST on /admin/grants/reconcile");
+    }
+    return reconcileGrants(req, deps);
   }
 
   const id = segments[0] ?? "";
@@ -816,8 +838,19 @@ async function approveMcpGrant(
   const verifier = client.generateCodeVerifier();
   const challenge = client.generateCodeChallenge(verifier);
   const state = client.generateState();
-  // Scope: the resource's advertised scopes (9728→8414), space-joined; omit if none.
-  const scope = discovery.scopesSupported?.length ? discovery.scopesSupported.join(" ") : undefined;
+  // Scope (#671). When the target is a Parachute vault MCP (`…/vault/<name>/mcp`),
+  // request a single least-privilege `vault:<name>:read` scope rather than the
+  // resource's full advertised set (which for a vault includes hub:admin,
+  // vault:<name>:write, … — wildly over-privileged for a read-only agent).
+  // Write is a deliberate future knob, not the default. For any non-vault MCP
+  // URL, fall back to the resource's advertised scopes (9728→8414), space-joined;
+  // omit if none.
+  const vaultScope = deriveVaultScopeFromMcpUrl(mcpUrl);
+  const scope = vaultScope
+    ? vaultScope
+    : discovery.scopesSupported?.length
+      ? discovery.scopesSupported.join(" ")
+      : undefined;
 
   const flow: PendingFlow = {
     state,
@@ -1066,30 +1099,7 @@ async function revokeGrant(req: Request, id: string, deps: AgentGrantsDeps): Pro
   if (!grant) return jsonError(404, "not_found", `no grant ${id}`);
 
   const now = deps.now?.() ?? new Date();
-  // Revoke the minted vault token in the registry so it's dead immediately, not
-  // just absent from the next fetch. Service tokens are operator-owned external
-  // creds — we drop our copy (the operator rotates them upstream if needed).
-  if (grant.material?.kind === "vault") {
-    try {
-      revokeTokenByJti(deps.db, grant.material.jti, now);
-    } catch {
-      // Best-effort.
-    }
-  } else if (
-    // mcp OAuth grant — best-effort revoke the refresh token at the issuer so the
-    // remote credential dies, not just our local copy. A static bearer has no
-    // refresh/revocation endpoint, so this is a no-op (operator rotates upstream).
-    grant.material?.kind === "mcp" &&
-    grant.material.refresh_token &&
-    grant.material.revocationEndpoint &&
-    grant.material.clientId
-  ) {
-    await oauth(deps).revokeRemote({
-      revocationEndpoint: grant.material.revocationEndpoint,
-      refreshToken: grant.material.refresh_token,
-      clientId: grant.material.clientId,
-    });
-  }
+  await tearDownGrantMaterial(grant, deps, now);
 
   const updated: GrantRecord = {
     id: grant.id,
@@ -1103,6 +1113,145 @@ async function revokeGrant(req: Request, id: string, deps: AgentGrantsDeps): Pro
   putGrant(deps.storePath, updated);
   console.log(`agent grant revoked: id=${id} agent=${grant.agent} kind=${grant.connection.kind}`);
   return grantResponse(200, updated);
+}
+
+/**
+ * Tear down a grant's credential material — shared by `revoke` (operator intent,
+ * keeps the row at status:revoked) and `reconcile` (the holder is gone, the row is
+ * then removed entirely). Idempotent + best-effort: a missing registry row or a
+ * failed remote revoke must not throw.
+ *
+ *   - vault   → revoke the minted token in the registry so it's dead immediately,
+ *               not just absent from the next fetch.
+ *   - mcp     → best-effort revoke the refresh token at the issuer so the remote
+ *               credential dies, not just our local copy. A static bearer (no
+ *               refresh/revocation endpoint) is a no-op (operator rotates upstream).
+ *   - service → operator-owned external cred; nothing to revoke remotely — the
+ *               caller drops our copy (the operator rotates upstream if needed).
+ */
+async function tearDownGrantMaterial(
+  grant: GrantRecord,
+  deps: AgentGrantsDeps,
+  now: Date,
+): Promise<void> {
+  if (grant.material?.kind === "vault") {
+    try {
+      revokeTokenByJti(deps.db, grant.material.jti, now);
+    } catch {
+      // Best-effort — a missing registry row leaves nothing to revoke.
+    }
+  } else if (
+    grant.material?.kind === "mcp" &&
+    grant.material.refresh_token &&
+    grant.material.revocationEndpoint &&
+    grant.material.clientId
+  ) {
+    // Best-effort + locally guarded (reviewer NIT2): `revokeRemote` swallows its
+    // own errors today, but don't rely on that — a throwing impl/test-double must
+    // not abort a reconcile mid-loop and leave the remaining grants un-pruned.
+    try {
+      await oauth(deps).revokeRemote({
+        revocationEndpoint: grant.material.revocationEndpoint,
+        refreshToken: grant.material.refresh_token,
+        clientId: grant.material.clientId,
+      });
+    } catch {
+      // best-effort — the local material is dropped by the caller regardless.
+    }
+  }
+}
+
+// ===========================================================================
+// POST /admin/grants/reconcile — grant-GC for a holder (#96; module-auth)
+// ===========================================================================
+
+/**
+ * Reconcile (garbage-collect) one holder's grants against its CURRENTLY-declared
+ * connections. The agent module computes the `connectionKey()` of every
+ * connection a holder still wants and POSTs them as `liveKeys`; the hub prunes
+ * every grant for that holder whose key is NOT in the live set — tearing down its
+ * material exactly like `revoke`, then REMOVING the row (the holder is gone, so a
+ * lingering status:revoked row is just cruft).
+ *
+ * Module-auth (host-admin Bearer), mirroring PUT/GET — NOT operator-cookie-gated.
+ * Pruning only ever REMOVES access (never escalates), so the "a note can only
+ * REQUEST, never GRANT" invariant is untouched: this can't mint or approve.
+ *
+ * Body: `{ agent: "<name>", liveKeys: ["<connectionKey>", ...] }`.
+ * `liveKeys: []` (the agent/def is gone) prunes ALL of that holder's grants.
+ * The keys MUST be computed by the agent side via the same `connectionKey()`
+ * exported from grants-store.ts so the comparison is exact.
+ *
+ * Returns `{ pruned: <number>, prunedIds: ["<id>", ...] }`.
+ */
+async function reconcileGrants(req: Request, deps: AgentGrantsDeps): Promise<Response> {
+  const auth = await requireModuleAuth(req, deps);
+  if (auth instanceof Response) return auth;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return jsonError(400, "invalid_request", "body must be JSON");
+  }
+  if (!body || typeof body !== "object") {
+    return jsonError(400, "invalid_request", "body must be a JSON object");
+  }
+  const b = body as Record<string, unknown>;
+
+  const agent = typeof b.agent === "string" ? b.agent.trim() : "";
+  if (!agent || agent.length > MAX_AGENT_LEN || !AGENT_NAME_RE.test(agent)) {
+    return jsonError(
+      400,
+      "invalid_request",
+      `agent is required and must match [a-zA-Z0-9][a-zA-Z0-9_.-]* (max ${MAX_AGENT_LEN} chars)`,
+    );
+  }
+
+  if (!Array.isArray(b.liveKeys)) {
+    return jsonError(
+      400,
+      "invalid_request",
+      "liveKeys is required and must be an array of strings",
+    );
+  }
+  if (b.liveKeys.length > MAX_LIVE_KEYS) {
+    return jsonError(400, "invalid_request", `liveKeys exceeds the ${MAX_LIVE_KEYS}-entry limit`);
+  }
+  const liveKeys = new Set<string>();
+  for (const k of b.liveKeys) {
+    if (typeof k !== "string") {
+      return jsonError(400, "invalid_request", "liveKeys entries must be strings");
+    }
+    if (k.length > MAX_CONNECTION_KEY_LEN) {
+      return jsonError(
+        400,
+        "invalid_request",
+        `a liveKeys entry exceeds the ${MAX_CONNECTION_KEY_LEN}-char limit`,
+      );
+    }
+    liveKeys.add(k);
+  }
+
+  const now = deps.now?.() ?? new Date();
+  const held = listGrantsForAgent(deps.storePath, agent);
+  const prunedIds: string[] = [];
+  for (const grant of held) {
+    // connectionKey() derives the SAME key the agent side computed for liveKeys.
+    if (liveKeys.has(connectionKey(grant.connection))) continue;
+    await tearDownGrantMaterial(grant, deps, now);
+    removeGrant(deps.storePath, grant.id);
+    prunedIds.push(grant.id);
+  }
+
+  if (prunedIds.length > 0) {
+    // Identity fields + count only — NEVER a token.
+    console.log(`agent grants reconciled: agent=${agent} pruned=${prunedIds.length}`);
+  }
+  return new Response(JSON.stringify({ pruned: prunedIds.length, prunedIds }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
 }
 
 // ===========================================================================

--- a/src/oauth-client.ts
+++ b/src/oauth-client.ts
@@ -191,6 +191,48 @@ export async function discover(mcpUrl: string, fetchFn: FetchFn = fetch): Promis
 }
 
 // ===========================================================================
+// Least-privilege scope derivation for Parachute-vault MCP URLs (#671)
+// ===========================================================================
+
+/**
+ * `…/vault/<name>/mcp` — a Parachute vault MCP endpoint. Anchored: the path must
+ * END at `/mcp` right after the vault name so a longer path
+ * (`/vault/x/mcp/extra`) doesn't masquerade as a vault MCP. `<name>` is the
+ * vault-name charset (the same conservative slug `validateVaultName` enforces —
+ * a non-empty run of letters/digits/`._-`), captured group 1.
+ */
+const VAULT_MCP_PATH_RE = /\/vault\/([a-z0-9][a-z0-9._-]*)\/mcp\/?$/i;
+
+/**
+ * Derive the least-privilege OAuth scope to request when starting an mcp-grant
+ * OAuth flow against a remote MCP URL (#671).
+ *
+ * The OAuth-start path historically requested the resource's ENTIRE advertised
+ * `scopes_supported`. For a Parachute vault MCP that set includes broad scopes
+ * (`hub:admin`, `vault:<name>:write`, …) — wildly over-privileged for an agent
+ * that only needs to READ the vault. So when the target URL is a Parachute vault
+ * MCP (`…/vault/<name>/mcp`), request a single least-privilege
+ * `vault:<name>:read` scope instead of the full set. Write is a deliberate
+ * future knob, not the default.
+ *
+ * For any non-vault-shaped MCP URL (or one with no parseable vault name), returns
+ * `null` — the caller keeps the existing behavior (request `scopes_supported`, or
+ * omit `scope` when the resource advertises none).
+ */
+export function deriveVaultScopeFromMcpUrl(mcpUrl: string): string | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(mcpUrl);
+  } catch {
+    return null;
+  }
+  const match = VAULT_MCP_PATH_RE.exec(parsed.pathname);
+  const name = match?.[1];
+  if (!name) return null;
+  return `vault:${name}:read`;
+}
+
+// ===========================================================================
 // Dynamic client registration (RFC 7591)
 // ===========================================================================
 


### PR DESCRIPTION
Two agent-grants follow-ups from the 4b-2 work + the boundary audit. **No generalization** — the agent-grants subsystem keeps its current shape (the boundary red-team confirmed generalizing now would be premature; one consumer, and the hub already has the generic `kind:"credential"` path surface uses).

## #671 — least-privilege scope for mcp OAuth grants
The OAuth-start path requested the resource's *entire* advertised `scopes_supported` (for a Parachute vault MCP that included `hub:admin` — wildly over-privileged). New `deriveVaultScopeFromMcpUrl(url)` helper: a vault-shaped MCP URL (`…/vault/<name>/mcp`) → request just `vault:<name>:read` (least-privilege; write deferred). Non-vault / unparseable URLs fall back to `scopes_supported`. Wired into `approveMcpGrant`.

## #96 — grant GC (hub side)
New module-auth `POST /admin/grants/reconcile { agent, liveKeys }` — prunes every grant for `agent` whose `connectionKey` ∉ `liveKeys`, tearing down its material (vault → registry revoke; mcp → best-effort issuer revoke) then removing the row. `liveKeys: []` prunes all (def deleted). Returns `{ pruned, prunedIds }`. The agent module calls this when a def's wants change or a def is deleted, so grants no longer orphan. Extracted the shared `tearDownGrantMaterial` so reconcile and operator-revoke use one teardown path. Pruning only *removes* access — the "a note can only REQUEST, never GRANT" invariant is untouched.

## Tests / gates
`bun test ./src`: **3562 pass, 1 skip, 0 fail**. typecheck clean; biome clean. The reconcile suite covers prune-some/keep-some, registry-revoke-on-prune, prune-all, other-agents-untouched, all auth/validation rejections; #671 covers vault-narrowing + non-vault fallback.

## Review
Independent review: LGTM, no blockers. Folded NIT2 (guard `revokeRemote` locally so a future throwing impl can't abort a reconcile mid-loop). No rc bump (bump+tag on ship call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)