### PR TITLE
fix(agent-grants): reconcile takes live connection SPECS, not keys (cross-repo key drift)

### DIFF
--- a/src/__tests__/admin-agent-grants.test.ts
+++ b/src/__tests__/admin-agent-grants.test.ts
@@ -23,7 +23,7 @@ import {
   handleAgentGrants,
   handleOAuthGrantCallback,
 } from "../admin-agent-grants.ts";
-import { connectionKey, getGrant, readGrants } from "../grants-store.ts";
+import { getGrant, readGrants } from "../grants-store.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { findTokenRowByJti } from "../jwt-sign.ts";
 import { signAccessToken } from "../jwt-sign.ts";
@@ -803,20 +803,19 @@ describe("POST /admin/grants/<id>/revoke", () => {
 // === POST /admin/grants/reconcile (grant-GC, #96) ===========================
 
 describe("POST /admin/grants/reconcile", () => {
-  /** Create a grant via PUT; return its id + connectionKey. */
+  /** Create a grant via PUT; return its id + the connection spec (sent back as a liveConnection). */
   async function makeGrant(
     bearer: string,
     agent: string,
     connection: Record<string, unknown>,
-  ): Promise<{ id: string; key: string }> {
+  ): Promise<{ id: string; connection: Record<string, unknown> }> {
     const created = await json(
       await dispatch(bearerReq("PUT", "/admin/grants", bearer, { agent, connection })),
     );
-    // connectionKey derives the same key the agent side would compute for liveKeys.
-    return { id: created.id as string, key: connectionKey(connection as never) };
+    return { id: created.id as string, connection };
   }
 
-  test("prunes grants whose key is NOT in liveKeys; keeps those that are", async () => {
+  test("prunes grants whose spec is NOT in liveConnections; keeps those that are", async () => {
     const bearer = await moduleBearer();
     const keep = await makeGrant(bearer, "a", {
       kind: "vault",
@@ -828,7 +827,7 @@ describe("POST /admin/grants/reconcile", () => {
     const res = await dispatch(
       bearerReq("POST", "/admin/grants/reconcile", bearer, {
         agent: "a",
-        liveKeys: [keep.key], // drop's key is absent → it is pruned
+        liveConnections: [keep.connection], // drop's spec is absent → it is pruned
       }),
     );
     expect(res.status).toBe(200);
@@ -841,6 +840,37 @@ describe("POST /admin/grants/reconcile", () => {
     expect(getGrant(harness.storePath, drop.id)).toBeNull();
   });
 
+  test("REGRESSION: a still-wanted service / tagged-vault grant is NOT pruned (spec-based, no cross-repo key drift)", async () => {
+    // The hub derives keys from the live SPECS with its own connectionKey — so a
+    // service grant (hub key `service:github`) sent back as its spec matches and
+    // survives. (Under the old "agent sends pre-computed keys" contract, the agent
+    // would send `env:github`, the hub key `service:github` wouldn't match, and this
+    // still-wanted grant would be WRONGLY pruned. Caught by live verification.)
+    const bearer = await moduleBearer();
+    const svc = await makeGrant(bearer, "a", {
+      kind: "service",
+      target: "github",
+      inject: ["env"],
+    });
+    const tagged = await makeGrant(bearer, "a", {
+      kind: "vault",
+      target: "research",
+      access: "read",
+      tags: ["#published", "#wip"],
+    });
+
+    const res = await dispatch(
+      bearerReq("POST", "/admin/grants/reconcile", bearer, {
+        agent: "a",
+        liveConnections: [svc.connection, tagged.connection],
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect((await json(res)).pruned).toBe(0);
+    expect(getGrant(harness.storePath, svc.id)).not.toBeNull();
+    expect(getGrant(harness.storePath, tagged.id)).not.toBeNull();
+  });
+
   test("a pruned APPROVED vault grant has its registry token revoked", async () => {
     const bearer = await moduleBearer();
     const cookie = await operatorCookie();
@@ -849,9 +879,9 @@ describe("POST /admin/grants/reconcile", () => {
     const jti = (getGrant(harness.storePath, g.id)?.material as { jti: string }).jti;
     expect(findTokenRowByJti(harness.db, jti)?.revokedAt).toBeFalsy();
 
-    // reconcile with NO live keys for this agent → prune everything
+    // reconcile with NO live connections for this agent → prune everything
     const res = await dispatch(
-      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [] }),
+      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveConnections: [] }),
     );
     expect(res.status).toBe(200);
     expect((await json(res)).pruned).toBe(1);
@@ -861,13 +891,13 @@ describe("POST /admin/grants/reconcile", () => {
     expect(findTokenRowByJti(harness.db, jti)?.revokedAt).toBeTruthy();
   });
 
-  test("liveKeys=[] prunes ALL of the agent's grants", async () => {
+  test("liveConnections=[] prunes ALL of the agent's grants", async () => {
     const bearer = await moduleBearer();
     await makeGrant(bearer, "a", { kind: "vault", target: "research", access: "read" });
     await makeGrant(bearer, "a", { kind: "service", target: "github" });
 
     const res = await dispatch(
-      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [] }),
+      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveConnections: [] }),
     );
     expect(res.status).toBe(200);
     expect((await json(res)).pruned).toBe(2);
@@ -880,7 +910,7 @@ describe("POST /admin/grants/reconcile", () => {
     const theirs = await makeGrant(bearer, "b", { kind: "service", target: "github" });
 
     const res = await dispatch(
-      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [] }),
+      bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveConnections: [] }),
     );
     expect(res.status).toBe(200);
     expect((await json(res)).pruned).toBe(1);
@@ -896,7 +926,7 @@ describe("POST /admin/grants/reconcile", () => {
     const res = await dispatch(
       bearerReq("POST", "/admin/grants/reconcile", bearer, {
         agent: "a",
-        liveKeys: [g.key], // the only grant is still live → nothing pruned
+        liveConnections: [g.connection], // the only grant is still live → nothing pruned
       }),
     );
     expect(res.status).toBe(200);
@@ -914,7 +944,7 @@ describe("POST /admin/grants/reconcile", () => {
     const req = new Request(`${HUB_ORIGIN}/admin/grants/reconcile`, {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ agent: "a", liveKeys: [] }),
+      body: JSON.stringify({ agent: "a", liveConnections: [] }),
     });
     const res = await handleAgentGrants(req, "/reconcile", deps());
     expect(res.status).toBe(401);
@@ -928,7 +958,7 @@ describe("POST /admin/grants/reconcile", () => {
     const cookie = await operatorCookie();
     // An operator cookie is NOT module-auth — reconcile is host-admin-Bearer only.
     const res = await dispatch(
-      cookieReq("POST", "/admin/grants/reconcile", cookie, { agent: "a", liveKeys: [] }),
+      cookieReq("POST", "/admin/grants/reconcile", cookie, { agent: "a", liveConnections: [] }),
     );
     expect(res.status).toBe(401);
     expect(readGrants(harness.storePath).filter((r) => r.agent === "a")).toHaveLength(1);
@@ -940,26 +970,35 @@ describe("POST /admin/grants/reconcile", () => {
     expect(res.status).toBe(405);
   });
 
-  test("400 on a missing/invalid agent or liveKeys", async () => {
+  test("400 on a missing/invalid agent or liveConnections", async () => {
     const bearer = await moduleBearer();
     // missing agent
     expect(
-      (await dispatch(bearerReq("POST", "/admin/grants/reconcile", bearer, { liveKeys: [] })))
-        .status,
-    ).toBe(400);
-    // liveKeys not an array
-    expect(
       (
         await dispatch(
-          bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: "x" }),
+          bearerReq("POST", "/admin/grants/reconcile", bearer, { liveConnections: [] }),
         )
       ).status,
     ).toBe(400);
-    // a non-string liveKeys entry
+    // liveConnections not an array
     expect(
       (
         await dispatch(
-          bearerReq("POST", "/admin/grants/reconcile", bearer, { agent: "a", liveKeys: [1] }),
+          bearerReq("POST", "/admin/grants/reconcile", bearer, {
+            agent: "a",
+            liveConnections: "x",
+          }),
+        )
+      ).status,
+    ).toBe(400);
+    // an invalid liveConnections entry (not a valid connection spec)
+    expect(
+      (
+        await dispatch(
+          bearerReq("POST", "/admin/grants/reconcile", bearer, {
+            agent: "a",
+            liveConnections: [{ kind: "bogus" }],
+          }),
         )
       ).status,
     ).toBe(400);
@@ -969,7 +1008,7 @@ describe("POST /admin/grants/reconcile", () => {
         await dispatch(
           bearerReq("POST", "/admin/grants/reconcile", bearer, {
             agent: "bad name",
-            liveKeys: [],
+            liveConnections: [],
           }),
         )
       ).status,

--- a/src/admin-agent-grants.ts
+++ b/src/admin-agent-grants.ts
@@ -115,14 +115,12 @@ const MAX_TAG_LEN = 128;
 const MAX_TOKEN_LEN = 8192;
 const MAX_TAGS = 64;
 /**
- * Reconcile caps (#96). A host-admin Bearer is high-privilege, but these bound a
- * runaway/misconfigured module from POSTing a giant liveKeys array. The cap is
- * generous vs. realistic agent connection counts ("a handful per agent").
+ * Reconcile cap (#96). A host-admin Bearer is high-privilege, but this bounds a
+ * runaway/misconfigured module from POSTing a giant liveConnections array. The cap
+ * is generous vs. realistic agent connection counts ("a handful per agent"); each
+ * entry is further validated + bounded by parseConnectionSpec.
  */
 const MAX_LIVE_KEYS = 256;
-/** A connectionKey is `kind:target[:access][#tags]` — bounded by the upstream
- *  target/tag caps, so this is a loose safety bound, not the real limit. */
-const MAX_CONNECTION_KEY_LEN = 1024;
 
 export interface AgentGrantsDeps {
   db: Database;
@@ -1167,8 +1165,8 @@ async function tearDownGrantMaterial(
 
 /**
  * Reconcile (garbage-collect) one holder's grants against its CURRENTLY-declared
- * connections. The agent module computes the `connectionKey()` of every
- * connection a holder still wants and POSTs them as `liveKeys`; the hub prunes
+ * connections. The agent module POSTs the live connection SPECS a holder still
+ * wants; the hub re-derives each key with its OWN `connectionKey()` and prunes
  * every grant for that holder whose key is NOT in the live set — tearing down its
  * material exactly like `revoke`, then REMOVING the row (the holder is gone, so a
  * lingering status:revoked row is just cruft).
@@ -1177,10 +1175,13 @@ async function tearDownGrantMaterial(
  * Pruning only ever REMOVES access (never escalates), so the "a note can only
  * REQUEST, never GRANT" invariant is untouched: this can't mint or approve.
  *
- * Body: `{ agent: "<name>", liveKeys: ["<connectionKey>", ...] }`.
- * `liveKeys: []` (the agent/def is gone) prunes ALL of that holder's grants.
- * The keys MUST be computed by the agent side via the same `connectionKey()`
- * exported from grants-store.ts so the comparison is exact.
+ * Body: `{ agent: "<name>", liveConnections: [<ConnectionSpec>, ...] }`.
+ * `liveConnections: []` (the agent/def is gone) prunes ALL of that holder's grants.
+ * Sending SPECS (not pre-computed keys) is deliberate: the hub re-derives keys with
+ * the same normalization it stored them under, so there is NO dependency on the
+ * agent module's separate connectionKey() impl (which diverges for service /
+ * tagged-vault / mixed-case-mcp grants — a still-wanted grant would otherwise be
+ * wrongly pruned; caught by live verification 2026-06-18).
  *
  * Returns `{ pruned: <number>, prunedIds: ["<id>", ...] }`.
  */
@@ -1208,36 +1209,41 @@ async function reconcileGrants(req: Request, deps: AgentGrantsDeps): Promise<Res
     );
   }
 
-  if (!Array.isArray(b.liveKeys)) {
+  // The caller sends the live CONNECTION SPECS (not pre-computed keys): the hub
+  // re-derives each key with its OWN connectionKey() — the same normalization +
+  // function it used to store/grantId the grants — so the keep-set is guaranteed
+  // to match the stored keys. (Sending agent-computed keys would couple to the
+  // agent module's separate connectionKey() impl, which diverges for service /
+  // tagged-vault / mixed-case-mcp grants — caught live 2026-06-18.)
+  if (!Array.isArray(b.liveConnections)) {
     return jsonError(
       400,
       "invalid_request",
-      "liveKeys is required and must be an array of strings",
+      "liveConnections is required and must be an array of connection specs",
     );
   }
-  if (b.liveKeys.length > MAX_LIVE_KEYS) {
-    return jsonError(400, "invalid_request", `liveKeys exceeds the ${MAX_LIVE_KEYS}-entry limit`);
+  if (b.liveConnections.length > MAX_LIVE_KEYS) {
+    return jsonError(
+      400,
+      "invalid_request",
+      `liveConnections exceeds the ${MAX_LIVE_KEYS}-entry limit`,
+    );
   }
   const liveKeys = new Set<string>();
-  for (const k of b.liveKeys) {
-    if (typeof k !== "string") {
-      return jsonError(400, "invalid_request", "liveKeys entries must be strings");
+  for (const raw of b.liveConnections) {
+    const parsed = parseConnectionSpec(raw);
+    if ("error" in parsed) {
+      return jsonError(400, "invalid_request", `liveConnections entry invalid: ${parsed.error}`);
     }
-    if (k.length > MAX_CONNECTION_KEY_LEN) {
-      return jsonError(
-        400,
-        "invalid_request",
-        `a liveKeys entry exceeds the ${MAX_CONNECTION_KEY_LEN}-char limit`,
-      );
-    }
-    liveKeys.add(k);
+    liveKeys.add(connectionKey(parsed.spec));
   }
 
   const now = deps.now?.() ?? new Date();
   const held = listGrantsForAgent(deps.storePath, agent);
   const prunedIds: string[] = [];
   for (const grant of held) {
-    // connectionKey() derives the SAME key the agent side computed for liveKeys.
+    // Both sides of this comparison use the HUB's connectionKey (stored grant +
+    // re-derived live spec) — no cross-repo key-format dependency.
     if (liveKeys.has(connectionKey(grant.connection))) continue;
     await tearDownGrantMaterial(grant, deps, now);
     removeGrant(deps.storePath, grant.id);


### PR DESCRIPTION
**Bug fix for #96's reconcile — caught by live verification 2026-06-18.**

The reconcile contract had the agent POST pre-computed `connectionKey`s that the hub matched against its *own* `connectionKey()`. But those are two separate implementations in two repos, and they **diverge**:

| kind | hub (grants-store.ts) | agent (grants.ts) |
|---|---|---|
| service | `service:github` | `env:github` |
| vault+tags | `…read#a,#b` | `…read#a#b` |
| mcp | lowercased | original case |

So a still-wanted **service / tagged-vault / mixed-case-mcp** grant had its hub-key absent from the agent-sent keys → it was **wrongly pruned and its token revoked on every reconcile**. (Each side's unit tests used its own `connectionKey`, so isolation hid it; the cross-repo match is only exercised live.)

## Fix
Reconcile now accepts the live connection **specs**, not keys: `POST /admin/grants/reconcile { agent, liveConnections }`. The hub re-derives each key with its own `connectionKey` (via the same `parseConnectionSpec` normalization it stored them under) — **no cross-repo key dependency**. Added a **regression test** asserting a still-wanted service + tagged-vault grant survives reconcile.

`bun test ./src`: **3564 pass, 1 skip, 0 fail**. typecheck + biome clean. Pairs with the agent-side fix. No rc bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)