### PR TITLE
feat(vault): CLI `parachute vault remove` drives the hub identity cascade (B3)

### DIFF
--- a/src/__tests__/vault-remove.test.ts
+++ b/src/__tests__/vault-remove.test.ts
@@ -1,0 +1,393 @@
+import { describe, expect, test } from "bun:test";
+import { vaultRemove } from "../commands/vault-remove.ts";
+
+const BEARER = "header.payload.signature";
+
+interface FakeCall {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body?: string;
+}
+
+/**
+ * Fake `fetch` that records each call and returns canned responses in sequence.
+ * Lets a test assert method / path / body / auth header without a real socket.
+ */
+function fakeFetch(responses: Array<{ status: number; body: unknown }>): {
+  fetch: typeof fetch;
+  calls: FakeCall[];
+} {
+  const calls: FakeCall[] = [];
+  let i = 0;
+  const f = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string" ? input : input.toString();
+    const headers: Record<string, string> = {};
+    if (init?.headers) {
+      for (const [k, v] of Object.entries(init.headers as Record<string, string>)) {
+        headers[k.toLowerCase()] = v;
+      }
+    }
+    const call: FakeCall = { url, method: init?.method ?? "GET", headers };
+    if (typeof init?.body === "string") call.body = init.body;
+    calls.push(call);
+    const r = responses[Math.min(i, responses.length - 1)];
+    i++;
+    return new Response(JSON.stringify(r?.body ?? {}), {
+      status: r?.status ?? 200,
+      headers: { "content-type": "application/json" },
+    });
+  }) as unknown as typeof fetch;
+  return { fetch: f, calls };
+}
+
+/** Collect log + error output for assertions. */
+function makeSinks() {
+  const out: string[] = [];
+  const err: string[] = [];
+  return {
+    out,
+    err,
+    log: (l: string) => out.push(l),
+    logError: (l: string) => err.push(l),
+    text: () => out.join("\n"),
+    errText: () => err.join("\n"),
+  };
+}
+
+/**
+ * Spy that fails the test if `Bun.spawn` is ever invoked. The 409 guardrail is
+ * "never spawn `parachute-vault`" — this proves it at the runtime boundary, not
+ * just by reading the fetch log.
+ */
+function withSpawnSpy<T>(fn: (spawned: { count: number }) => Promise<T>): Promise<T> {
+  const original = Bun.spawn;
+  const spawned = { count: 0 };
+  // biome-ignore lint/suspicious/noExplicitAny: test-only monkeypatch of Bun.spawn.
+  (Bun as any).spawn = (...a: unknown[]) => {
+    spawned.count++;
+    return (original as unknown as (...args: unknown[]) => unknown)(...a);
+  };
+  return fn(spawned).finally(() => {
+    // biome-ignore lint/suspicious/noExplicitAny: restore the original.
+    (Bun as any).spawn = original;
+  });
+}
+
+const SUCCESS_BODY = {
+  ok: true,
+  name: "scratch",
+  cascade: {
+    tokens_revoked: 3,
+    grants_rewritten: 1,
+    grants_dropped: 2,
+    user_vaults_removed: 4,
+    invites_invalidated: 1,
+    connections_torn_down: 1,
+    orphaned_channels: [],
+    vault_removed: true,
+    module_restarted: true,
+  },
+};
+
+describe("vaultRemove — request shape", () => {
+  test("sends DELETE /vaults/<name> with the confirm body + operator bearer", async () => {
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      baseUrl: "http://127.0.0.1:1939",
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call?.method).toBe("DELETE");
+    expect(call?.url).toBe("http://127.0.0.1:1939/vaults/scratch");
+    expect(call?.headers.authorization).toBe(`Bearer ${BEARER}`);
+    expect(call?.headers["content-type"]).toBe("application/json");
+    expect(JSON.parse(call?.body ?? "{}")).toEqual({ confirm: "scratch" });
+  });
+
+  test("URL-encodes the vault name in the path", async () => {
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    await vaultRemove(["my vault"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(calls[0]?.url).toContain("/vaults/my%20vault");
+    // The confirm body carries the RAW name (matches the endpoint's check).
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({ confirm: "my vault" });
+  });
+
+  test("--yes is accepted and does not change behaviour (no extra prompt)", async () => {
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch", "--yes"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).toBe(0);
+    expect(calls).toHaveLength(1);
+    expect(JSON.parse(calls[0]?.body ?? "{}")).toEqual({ confirm: "scratch" });
+  });
+});
+
+describe("vaultRemove — 200 success", () => {
+  test("renders the cascade summary and returns 0", async () => {
+    const { fetch } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).toBe(0);
+    const text = sinks.text();
+    expect(text).toContain("tokens revoked:");
+    expect(text).toContain("3");
+    expect(text).toContain("user_vaults removed:");
+    expect(text).toContain("4");
+    expect(text).toContain("vault removed:");
+  });
+
+  test("warns about orphaned_channels and prints warnings[]", async () => {
+    const body = {
+      ok: true,
+      name: "scratch",
+      cascade: {
+        tokens_revoked: 0,
+        grants_rewritten: 0,
+        grants_dropped: 0,
+        user_vaults_removed: 0,
+        invites_invalidated: 0,
+        connections_torn_down: 0,
+        orphaned_channels: ["telegram-main", "sms-alerts"],
+        vault_removed: true,
+        module_restarted: false,
+      },
+      warnings: [{ step: "module_restart", detail: "no supervisor available" }],
+    };
+    const { fetch } = fakeFetch([{ status: 200, body }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).toBe(0);
+    const text = sinks.text();
+    expect(text).toContain("telegram-main");
+    expect(text).toContain("sms-alerts");
+    expect(text).toContain("agent UI");
+    expect(text).toContain("module_restart");
+    expect(text).toContain("no supervisor available");
+  });
+});
+
+describe("vaultRemove — 409 last_vault GUARDRAIL", () => {
+  test("returns NON-ZERO and NEVER spawns parachute-vault", async () => {
+    await withSpawnSpy(async (spawned) => {
+      const { fetch, calls } = fakeFetch([
+        {
+          status: 409,
+          body: {
+            error: "last_vault",
+            error_description:
+              '"scratch" is the last vault on this hub. Create another vault first, or use the CLI.',
+          },
+        },
+      ]);
+      const sinks = makeSinks();
+      const code = await vaultRemove(["scratch"], {
+        resolveBearer: async () => BEARER,
+        fetch,
+        log: sinks.log,
+        logError: sinks.logError,
+      });
+      // Non-zero exit.
+      expect(code).not.toBe(0);
+      // Exactly ONE fetch (the DELETE) — no fall-through retry path.
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.method).toBe("DELETE");
+      // The load-bearing invariant: no `parachute-vault` spawn.
+      expect(spawned.count).toBe(0);
+      // Surfaces the endpoint message + the cascade-skip warning on the escape hatch.
+      const errText = sinks.errText();
+      expect(errText).toContain("last vault");
+      expect(errText).toContain("SKIPS the identity cascade");
+    });
+  });
+});
+
+describe("vaultRemove — 404 not_found (idempotent)", () => {
+  test("renders a clean 'already removed' message and returns 0", async () => {
+    const { fetch } = fakeFetch([
+      {
+        status: 404,
+        body: { error: "not_found", error_description: 'no vault named "ghost" on this hub' },
+      },
+    ]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["ghost"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).toBe(0);
+    const text = sinks.text();
+    expect(text.toLowerCase()).toContain("already removed");
+    // Not scary — no "error" framing in the error sink.
+    expect(sinks.errText()).toBe("");
+  });
+});
+
+describe("vaultRemove — 400 confirm_mismatch", () => {
+  test("passes the hub message through and returns non-zero", async () => {
+    const { fetch } = fakeFetch([
+      {
+        status: 400,
+        body: {
+          error: "confirm_mismatch",
+          error_description: 'deleting a vault requires the body {"confirm": "scratch"}',
+        },
+      },
+    ]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).not.toBe(0);
+    expect(sinks.errText()).toContain('{"confirm": "scratch"}');
+  });
+});
+
+describe("vaultRemove — arg validation", () => {
+  test("missing name → error + non-zero, no fetch", async () => {
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove([], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).not.toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(sinks.errText().toLowerCase()).toContain("vault name is required");
+  });
+
+  test("unknown flag → error + non-zero, no fetch", async () => {
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch", "--force"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).not.toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(sinks.errText()).toContain("unknown flag");
+  });
+});
+
+describe("vaultRemove — missing operator token", () => {
+  test("actionable error, no DELETE sent", async () => {
+    const { NoOperatorTokenError } = await import("../commands/vault-remove.ts");
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch"], {
+      resolveBearer: async () => {
+        throw new NoOperatorTokenError();
+      },
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).not.toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(sinks.errText()).toContain("rotate-operator");
+  });
+
+  test("expired operator token → same actionable error, no DELETE sent", async () => {
+    const { OperatorTokenExpiredError } = await import("../commands/vault-remove.ts");
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch"], {
+      resolveBearer: async () => {
+        // The real error carries its actionable message at the throw site; assert
+        // the handler surfaces it verbatim (not a raw 401).
+        throw new OperatorTokenExpiredError(
+          "operator token expired — run `parachute auth rotate-operator`",
+        );
+      },
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).not.toBe(0);
+    expect(calls).toHaveLength(0);
+    expect(sinks.errText()).toContain("rotate-operator");
+  });
+});
+
+describe("vaultRemove — --hub-origin override", () => {
+  test("--hub-origin <url> targets the given hub base", async () => {
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch", "--hub-origin", "http://127.0.0.1:19390"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).toBe(0);
+    expect(calls[0]?.url).toBe("http://127.0.0.1:19390/vaults/scratch");
+  });
+
+  test("--hub-origin with no URL argument → error, no DELETE sent", async () => {
+    const { fetch, calls } = fakeFetch([{ status: 200, body: SUCCESS_BODY }]);
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch", "--hub-origin"], {
+      resolveBearer: async () => BEARER,
+      fetch,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).not.toBe(0);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe("vaultRemove — hub not running", () => {
+  test("ECONNREFUSED on loopback → actionable 'hub must be running', non-zero", async () => {
+    const f = (async () => {
+      throw new Error("connect ECONNREFUSED 127.0.0.1:1939");
+    }) as unknown as typeof fetch;
+    const sinks = makeSinks();
+    const code = await vaultRemove(["scratch"], {
+      resolveBearer: async () => BEARER,
+      fetch: f,
+      log: sinks.log,
+      logError: sinks.logError,
+    });
+    expect(code).not.toBe(0);
+    const errText = sinks.errText();
+    expect(errText).toContain("hub must be running");
+    expect(errText).toContain("parachute start");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -939,7 +939,19 @@ async function main(argv: string[]): Promise<number> {
       // after `vault` (including --help) is passed through verbatim.
       if (rest.length === 0) return await mod.dispatchVault(["--help"]);
 
-      // Everything under `vault` forwards transparently to `parachute-vault`.
+      // Intercept the delete verbs BEFORE the transparent passthrough (B3):
+      // `parachute vault remove <name>` must route through the hub's identity
+      // cascade (`DELETE /vaults/<name>`), NOT forward verbatim to
+      // `parachute-vault remove` (mechanics-only — orphans hub-side tokens,
+      // grants, user_vaults rows). `rm` is a convenience alias to the same path.
+      const sub = rest[0];
+      if (sub === "remove" || sub === "rm") {
+        const rm = await loadCommand("vault-remove", () => import("./commands/vault-remove.ts"));
+        if (!rm) return 1;
+        return await rm.vaultRemove(rest.slice(1));
+      }
+
+      // Everything else under `vault` forwards transparently to `parachute-vault`.
       // `vault tokens create` used to route through a guided interactive
       // wrapper, but the pvt_* DROP (vault#412 / hub#466) removed that vault
       // subcommand — it now exits 1 with migration guidance. Access tokens are

--- a/src/commands/vault-remove.ts
+++ b/src/commands/vault-remove.ts
@@ -1,0 +1,361 @@
+/**
+ * `parachute vault remove <name>` — route the CLI vault-delete verb through the
+ * hub's identity cascade instead of the mechanics-only `parachute-vault remove`.
+ *
+ * ## Why this command exists (B3)
+ *
+ * The transparent `parachute vault <args>` passthrough (`commands/vault.ts`)
+ * forwards `remove <name>` verbatim to `parachute-vault remove` — which only
+ * does the MECHANICS of destruction (`rmSync` the vault dir + rewrite the vault
+ * module's own config). That path BYPASSES every hub-side identity artifact tied
+ * to the vault: live `vault:<name>:*` access tokens stay valid (and reachable
+ * via the polled revocation list), `user_vaults` rows linger, grants keep their
+ * `vault:<name>:*` entries, unredeemed invites pinned to the vault stay
+ * redeemable, and Connections that source/provision the vault keep their
+ * long-lived mints. Deleting a vault that way orphans all of it.
+ *
+ * The hub ALREADY ships the correct path: `DELETE /vaults/<name>`
+ * (`admin-vaults.ts:handleDeleteVault`) runs the full 7-step identity cascade
+ * (revoke tokens → rewrite grants → drop user_vaults → revoke invites → tear
+ * down connections → shell `parachute-vault remove` → restart vault) and is
+ * exactly what the vault-admin SPA drives. This command routes the CLI verb
+ * through that SAME endpoint over loopback, so `parachute vault remove` and the
+ * SPA delete are one code path.
+ *
+ * ## Credential + transport (reused from module-ops-client.ts)
+ *
+ * We drive the RUNNING hub over loopback — never open hub.db's vault registry
+ * directly (the daemon holds it). The bearer is the on-disk
+ * `~/.parachute/operator.token`, read (never minted) via
+ * `useOperatorTokenWithAutoRotate`. Its default `admin` scope-set carries
+ * `parachute:host:admin` — exactly the scope the endpoint gates on. This is the
+ * same read-never-mint credential path `parachute start/stop/restart <svc>` use.
+ *
+ * ## The 409 guardrail (load-bearing)
+ *
+ * On a `409 last_vault` the endpoint refuses (deleting the last vault would let
+ * vault's boot silently resurrect a fresh `default`). We print the endpoint's
+ * message + note the raw escape hatch (`parachute-vault remove <name> --yes`)
+ * which SKIPS the cascade, then return NON-ZERO. We MUST NOT fall through to
+ * spawning `parachute-vault` ourselves: a "helpful" fall-through would re-open
+ * the exact orphaning bug B3 closes. The test locks this invariant.
+ */
+
+import { CONFIG_DIR } from "../config.ts";
+import { readExposeState } from "../expose-state.ts";
+import { readHubPort } from "../hub-control.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { HUB_UNIT_DEFAULT_PORT } from "../hub-unit.ts";
+import {
+  DEFAULT_HUB_BASE_URL,
+  ModuleOpHttpError,
+  NoOperatorTokenError,
+  OperatorTokenExpiredError,
+  resolveOperatorBearer,
+} from "../module-ops-client.ts";
+
+/**
+ * Injectable seams. Production wires the real operator-token bearer resolver +
+ * the global `fetch`; tests inject fakes to assert the request shape + lock the
+ * 409 guardrail without a live hub or a real socket.
+ */
+export interface VaultRemoveDeps {
+  /**
+   * Resolve the operator-token bearer to present to the loopback hub. Default
+   * opens hub.db, reads `~/.parachute/operator.token` (auto-rotating if near
+   * expiry), and returns the JWT. Throws {@link NoOperatorTokenError} /
+   * {@link OperatorTokenExpiredError} with already-actionable messages.
+   */
+  readonly resolveBearer?: () => Promise<string>;
+  /** fetch seam — `globalThis.fetch` in production; a recorder in tests. */
+  readonly fetch?: typeof fetch;
+  /** Loopback hub base URL. Defaults to {@link DEFAULT_HUB_BASE_URL}. */
+  readonly baseUrl?: string;
+  /** Output sink. Defaults to `console.log`. */
+  readonly log?: (line: string) => void;
+  /** Error sink. Defaults to `console.error`. */
+  readonly logError?: (line: string) => void;
+}
+
+/** Wire shape of the cascade summary nested under `cascade` in the 200 body. */
+interface CascadeSummaryWire {
+  tokens_revoked?: number;
+  grants_rewritten?: number;
+  grants_dropped?: number;
+  user_vaults_removed?: number;
+  invites_invalidated?: number;
+  connections_torn_down?: number;
+  orphaned_channels?: unknown;
+  vault_removed?: boolean;
+  module_restarted?: boolean;
+}
+
+interface DeleteVaultSuccessWire {
+  ok?: boolean;
+  name?: string;
+  cascade?: CascadeSummaryWire;
+  warnings?: unknown;
+}
+
+/**
+ * Resolve the hub origin the operator token's `iss` is validated against —
+ * mirrors `lifecycle.ts:resolveOperatorTokenIssuer`. Unlike the spawn-env
+ * derivation, the operator token always carries an `iss`, so we fall back to
+ * the canonical loopback origin (never `undefined`). The known-issuer SET inside
+ * `useOperatorTokenWithAutoRotate` also accepts the public `iss` from
+ * expose-state, so a seed of loopback still validates an exposed-origin token.
+ */
+function resolveOperatorTokenIssuer(configDir: string): string {
+  const state = readExposeState(`${configDir}/expose-state.json`);
+  if (state?.hubOrigin) return state.hubOrigin;
+  const port = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Default bearer resolver: open hub.db, read+auto-rotate the operator token,
+ * return the JWT. Closes the db before returning. Read-never-mint — no second
+ * SQLite writer racing the running hub.
+ */
+async function defaultResolveBearer(configDir: string): Promise<string> {
+  const issuer = resolveOperatorTokenIssuer(configDir);
+  const db = openHubDb(hubDbPath(configDir));
+  try {
+    return await resolveOperatorBearer({ db, issuer, configDir });
+  } finally {
+    db.close();
+  }
+}
+
+function n(v: number | undefined): number {
+  return typeof v === "number" ? v : 0;
+}
+
+function asStringArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.filter((x): x is string => typeof x === "string") : [];
+}
+
+/**
+ * Render the structured cascade summary the endpoint returns — the operator's
+ * proof every identity artifact was revoked, not just the vault dir removed.
+ */
+function renderCascadeSummary(
+  name: string,
+  body: DeleteVaultSuccessWire,
+  log: (line: string) => void,
+): void {
+  const c = body.cascade ?? {};
+  log(`Removed vault "${name}" with the full identity cascade:`);
+  log(`  tokens revoked:        ${n(c.tokens_revoked)}`);
+  log(`  grants rewritten:      ${n(c.grants_rewritten)}`);
+  log(`  grants dropped:        ${n(c.grants_dropped)}`);
+  log(`  user_vaults removed:   ${n(c.user_vaults_removed)}`);
+  log(`  invites invalidated:   ${n(c.invites_invalidated)}`);
+  log(`  connections torn down: ${n(c.connections_torn_down)}`);
+  log(`  vault removed:         ${c.vault_removed === true ? "yes" : "no"}`);
+  log(`  vault module restarted:${c.module_restarted === true ? " yes" : " no"}`);
+
+  const orphaned = asStringArray(c.orphaned_channels);
+  if (orphaned.length > 0) {
+    log("");
+    log(`WARNING: ${orphaned.length} vault-backed agent channel(s) still reference "${name}":`);
+    for (const ch of orphaned) log(`  - ${ch}`);
+    log("Remove them in the agent UI — the hub does not delete the agent's config.");
+  }
+
+  // Top-level warnings[] — each a { step, detail } the cascade recorded
+  // (e.g. daemon-restart skipped, a partial connection teardown).
+  const warnings = Array.isArray(body.warnings) ? body.warnings : [];
+  if (warnings.length > 0) {
+    log("");
+    log("Warnings:");
+    for (const w of warnings) {
+      const rec = (w ?? {}) as { step?: unknown; detail?: unknown };
+      const step = typeof rec.step === "string" ? rec.step : "warning";
+      const detail = typeof rec.detail === "string" ? rec.detail : JSON.stringify(w);
+      log(`  - [${step}] ${detail}`);
+    }
+  }
+}
+
+const USAGE = "usage: parachute vault remove <name> [--yes] [--hub-origin <url>]";
+
+/**
+ * Route `parachute vault remove <name>` (and the `rm` alias) through the hub's
+ * `DELETE /vaults/<name>` identity cascade. Returns the process exit code.
+ */
+export async function vaultRemove(args: string[], deps: VaultRemoveDeps = {}): Promise<number> {
+  const log = deps.log ?? ((line: string) => console.log(line));
+  const logError = deps.logError ?? ((line: string) => console.error(line));
+
+  // --- Parse args: positional <name> + flags (--yes/-y, --hub-origin <url>). --
+  let name: string | undefined;
+  let baseUrlOverride: string | undefined = deps.baseUrl;
+  // `--yes`/`-y` is accepted for parity with `parachute-vault remove --yes` and
+  // to telegraph non-interactive intent; the endpoint's confirm guard is
+  // satisfied from the name arg, so no extra prompt is shown either way. We
+  // parse it so it isn't mistaken for a positional, but the behaviour is the
+  // same with or without it (this is an admin op that already requires the
+  // operator token + a deliberate name retype on the wire).
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--yes" || a === "-y") continue;
+    if (a === "--hub-origin") {
+      const v = args[i + 1];
+      if (!v) {
+        logError("parachute vault remove: --hub-origin requires a URL argument");
+        return 1;
+      }
+      baseUrlOverride = v;
+      i++;
+      continue;
+    }
+    if (a?.startsWith("--hub-origin=")) {
+      baseUrlOverride = a.slice("--hub-origin=".length);
+      continue;
+    }
+    if (a?.startsWith("-")) {
+      logError(`parachute vault remove: unknown flag "${a}"`);
+      logError(USAGE);
+      return 1;
+    }
+    if (name === undefined) {
+      name = a;
+      continue;
+    }
+    logError(`parachute vault remove: unexpected argument "${a}"`);
+    logError(USAGE);
+    return 1;
+  }
+
+  if (!name) {
+    logError("parachute vault remove: a vault name is required");
+    logError(USAGE);
+    return 1;
+  }
+
+  // --- Resolve the operator-token bearer (read, never mint). ------------------
+  let bearer: string;
+  try {
+    bearer = deps.resolveBearer
+      ? await deps.resolveBearer()
+      : await defaultResolveBearer(CONFIG_DIR);
+  } catch (err) {
+    if (err instanceof NoOperatorTokenError || err instanceof OperatorTokenExpiredError) {
+      // Already-actionable ("run `parachute auth rotate-operator`") — surface
+      // verbatim, never a raw 401.
+      logError(`parachute vault remove: ${err.message}`);
+      return 1;
+    }
+    logError(`parachute vault remove: ${err instanceof Error ? err.message : String(err)}`);
+    return 1;
+  }
+
+  // --- DELETE /vaults/<name> with the confirm body. --------------------------
+  const doFetch = deps.fetch ?? fetch;
+  const baseUrl = (baseUrlOverride ?? DEFAULT_HUB_BASE_URL).replace(/\/+$/, "");
+  const url = `${baseUrl}/vaults/${encodeURIComponent(name)}`;
+
+  let res: Response;
+  try {
+    res = await doFetch(url, {
+      method: "DELETE",
+      headers: {
+        authorization: `Bearer ${bearer}`,
+        "content-type": "application/json",
+      },
+      body: JSON.stringify({ confirm: name }),
+    });
+  } catch (err) {
+    // Loopback connection refused → the hub isn't running. The cascade needs
+    // the live hub; there's no DB-side fallback we'd take (that's the bug).
+    const msg = err instanceof Error ? err.message : String(err);
+    const refused = /econnrefused|connection refused|failed to fetch|unable to connect/i.test(msg);
+    if (refused) {
+      logError(
+        "parachute vault remove: the hub must be running to delete a vault with the identity cascade.",
+      );
+      logError("Run `parachute start`, then retry.");
+      logError(
+        `(The raw escape hatch \`parachute-vault remove ${name} --yes\` deletes the vault dir but SKIPS the cascade, leaving orphaned tokens.)`,
+      );
+      return 1;
+    }
+    logError(`parachute vault remove: request failed: ${msg}`);
+    return 1;
+  }
+
+  const body = await parseJsonSafe(res);
+
+  // --- Success: render the cascade summary. ----------------------------------
+  if (res.status === 200) {
+    renderCascadeSummary(name, (body ?? {}) as DeleteVaultSuccessWire, log);
+    return 0;
+  }
+
+  // --- Error mapping (actionable, never a raw status dump). -------------------
+  const { error, error_description } = asErrorBody(body, res.status);
+
+  if (res.status === 404 && error === "not_found") {
+    // Idempotent: a re-run after a successful delete lands here. Not scary.
+    log(`Vault "${name}" does not exist on this hub (already removed). Nothing to do.`);
+    return 0;
+  }
+
+  if (res.status === 409 && error === "last_vault") {
+    // CRITICAL GUARDRAIL: print + exit non-zero. Do NOT fall through to spawning
+    // `parachute-vault` — that would re-open the orphaned-identity bug B3 closes.
+    logError(`parachute vault remove: ${error_description}`);
+    logError("");
+    logError(
+      `The raw mechanics-only path \`parachute-vault remove ${name} --yes\` can delete the last vault,`,
+    );
+    logError(
+      "but it SKIPS the identity cascade — live tokens, grants, and user_vaults rows for that",
+    );
+    logError("vault would be left orphaned. Create another vault first if you can.");
+    return 1;
+  }
+
+  if (res.status === 400 && error === "confirm_mismatch") {
+    // Pass the hub's confirm message through.
+    logError(`parachute vault remove: ${error_description}`);
+    return 1;
+  }
+
+  if (res.status === 401 || res.status === 403) {
+    // The operator token was rejected by the hub — guide to re-mint rather than
+    // dumping the raw status (matches module-ops-client's posture).
+    logError(`parachute vault remove: the hub rejected the operator token (${error_description}).`);
+    logError("Run `parachute auth rotate-operator` to mint a fresh one, then retry.");
+    return 1;
+  }
+
+  // Any other non-2xx — name the failure class without a raw dump.
+  logError(`parachute vault remove: ${error}: ${error_description}`);
+  return 1;
+}
+
+async function parseJsonSafe(res: Response): Promise<unknown> {
+  try {
+    return await res.json();
+  } catch {
+    return undefined;
+  }
+}
+
+function asErrorBody(body: unknown, status: number): { error: string; error_description: string } {
+  const fallback = `hub returned HTTP ${status} with no error detail`;
+  if (body && typeof body === "object") {
+    const b = body as Record<string, unknown>;
+    const error = typeof b.error === "string" ? b.error : "error";
+    const error_description =
+      typeof b.error_description === "string" ? b.error_description : fallback;
+    return { error, error_description };
+  }
+  return { error: "error", error_description: fallback };
+}
+
+// Re-export so the test (and future CLI callers) can catch the typed errors
+// without a second import path.
+export { ModuleOpHttpError, NoOperatorTokenError, OperatorTokenExpiredError };

--- a/src/help.ts
+++ b/src/help.ts
@@ -31,6 +31,9 @@ Usage:
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
                                     etc.) — forwards to parachute-vault.
                                     For lifecycle, use \`parachute start|stop|restart|logs vault\`.
+                                    \`vault remove <name>\` is routed through the hub's
+                                    identity cascade (revokes the vault's tokens/grants),
+                                    not the raw mechanics-only delete.
 
 Flags:
   --help, -h                        show this help (also per-subcommand: \`parachute <cmd> --help\`)


### PR DESCRIPTION
**B3 from the 2026-06-18 boundary audit — closes the vault delete-cascade gap.**

`parachute vault remove <name>` forwarded verbatim to `parachute-vault remove` (mechanics-only: rmSync + config), **bypassing the hub's identity cascade**. A deleted vault left **live, unrevocable `vault:<name>:*` tokens** (still on the polled revocation list), orphaned `user_vaults` rows, and surviving grants/invites/connection-mints.

The diagnostic confirmed the hub **already ships the correct path**: `DELETE /vaults/<name>` → `handleDeleteVault` runs the full 7-step cascade and is exactly what the **vault-admin SPA already drives**. So B3 is *not* "build the cascade" — it's **route the CLI verb through the cascade the SPA already uses.** One engine, two front doors.

## Changes (CLI-routing only — cascade engine UNTOUCHED)
- **New `src/commands/vault-remove.ts`** — drives `DELETE /vaults/<name>` over loopback with the **operator-token Bearer** (read-never-mint via `resolveOperatorBearer`, the same path `start/stop/restart` use — never opens the vault registry directly), `{confirm:name}` body; renders the cascade summary (tokens_revoked / grants / user_vaults_removed / invites / connections / orphaned_channels warning / warnings[]); actionable error mapping.
- **`src/cli.ts`** — intercept `remove`/`rm` in `case "vault"` (after the no-arg guard); everything else still passes through.
- **Load-bearing guardrail**: on `409 last_vault`, print the escape-hatch note + exit non-zero, **never** fall through to spawning `parachute-vault` (locked by a `Bun.spawn`-spy test — a fall-through would re-open the exact bug). No `--force`/`--all`. 404 is idempotent (exit 0). `help.ts` notes the carve-out.

## Tests / verify
`bun test ./src`: **3579 pass, 1 skip, 0 fail** (15 in the new vault-remove suite incl. the 409-no-spawn spy, 404-idempotent, 400/401/403, ECONNREFUSED, expired-token, `--hub-origin`). typecheck + biome clean. **Live-verified** the CLI→endpoint→operator-auth→response seam against the running hub via the non-destructive 404 path (operator Bearer accepted, idempotent render). The destructive cascade itself is the existing endpoint (#637, SPA-driven, admin-vaults.test.ts) — unchanged.

Follow-ups filed (out of B3 scope): default-not-name-protected, cascadeVaultIdentity() extraction, last-vault-cascade design. No rc bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)