### PR TITLE
fix(connections): gate the agent reply-path prerequisite on message.deliver

### DIFF
--- a/src/__tests__/admin-connections.test.ts
+++ b/src/__tests__/admin-connections.test.ts
@@ -176,6 +176,16 @@ const CHANNEL_MANIFEST: ModuleManifest = {
       scope: "agent:send",
       provision: { type: "vault-trigger" },
     },
+    {
+      // A second agent action that needs NO session reply path — a pure inbound
+      // webhook. Drives the regression test that the channel-reply prerequisite
+      // is gated on the ACTION (message.deliver), not the module (agent#117).
+      key: "definition.reload",
+      title: "Reload a changed agent definition",
+      endpoint: "/api/vault/agent-def",
+      scope: "agent:send",
+      provision: { type: "vault-trigger" },
+    },
   ],
   // Mirrors the declaration the agent module ships in its real module.json
   // (boundary D2) — drives the catalog `templates` round-trip pin below.
@@ -371,9 +381,10 @@ describe("GET /api/connections/catalog", () => {
     );
     expect(res.status).toBe(200);
     const out = (await res.json()) as { events: unknown[]; actions: unknown[] };
-    // vault: 3 events + 1 action; agent: 1 event + 1 action.
+    // vault: 3 events + 1 action; agent: 1 event + 2 actions (message.deliver +
+    // definition.reload).
     expect(out.events.length).toBe(4);
-    expect(out.actions.length).toBe(2);
+    expect(out.actions.length).toBe(3);
   });
 });
 
@@ -827,6 +838,63 @@ describe("POST /admin/connections — channel-backed (the #624 flow as a connect
     const res = await handleConnections(req, "", deps);
     expect(res.status).toBe(503);
     expect(((await res.json()) as { error: string }).error).toBe("agent_unavailable");
+  });
+
+  test("definition.reload agent sink provisions WITH NO channel param (agent#117)", async () => {
+    // Regression: the channel-reply prerequisite was gated on `sinkModule ===
+    // "agent"`, so a non-message.deliver agent sink (no channel param) 400'd
+    // with `agent sink requires sink.params.channel`. The def-reload connectors
+    // could never provision. Now the gate is action-specific — a pure inbound
+    // webhook action provisions the vault trigger and SKIPS the channel config.
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+      // If the prerequisite wrongly ran, it would POST here — left mocked so a
+      // regression surfaces as an unexpected call, not a 599.
+      "POST /api/channels": () => ok({ ok: true }),
+    });
+    const req = new Request(`${HUB_ORIGIN}/admin/connections`, {
+      method: "POST",
+      headers: { cookie },
+      body: JSON.stringify({
+        id: "agentdefs-create-default",
+        requestedBy: "agent",
+        source: {
+          module: "vault",
+          vault: "default",
+          event: "note.created",
+          filter: { tags: ["#agent/definition"] },
+        },
+        sink: { module: "agent", action: "definition.reload" }, // NO params.channel
+      }),
+    });
+    const res = await handleConnections(
+      req,
+      "",
+      baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
+    );
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as { ok: boolean; connection: { id: string }; connect?: unknown };
+    expect(out.ok).toBe(true);
+    expect(out.connection.id).toBe("agentdefs-create-default");
+    // No channel → no connect lines (those are message-delivery-specific).
+    expect(out.connect).toBeUndefined();
+
+    // The channel-reply prerequisite was SKIPPED — no /api/channels POST.
+    expect(calls.some((c) => c.url.endsWith("/api/channels"))).toBe(false);
+
+    // The vault trigger WAS registered, from the def-reload action's declaration.
+    const trigCall = calls.find((c) => c.url.endsWith("/vault/default/api/triggers"));
+    expect(trigCall).toBeDefined();
+    const trig = trigCall!.body as {
+      events: string[];
+      when: Record<string, unknown>;
+      action: { webhook: string; auth: { bearer: string } };
+    };
+    expect(trig.events).toEqual(["created"]);
+    expect(trig.action.webhook).toBe(`${HUB_ORIGIN}/agent/api/vault/agent-def`);
+    expect(scopeOf(trig.action.auth.bearer)).toEqual(["agent:send"]);
+    expect(trig.when).toEqual({ tags: ["#agent/definition"] });
   });
 });
 

--- a/src/__tests__/admin-connections.test.ts
+++ b/src/__tests__/admin-connections.test.ts
@@ -896,6 +896,39 @@ describe("POST /admin/connections — channel-backed (the #624 flow as a connect
     expect(scopeOf(trig.action.auth.bearer)).toEqual(["agent:send"]);
     expect(trig.when).toEqual({ tags: ["#agent/definition"] });
   });
+
+  test("definition.reload provisions even when agentOrigin is null (no reply path)", async () => {
+    // Unlike message.deliver (503 agent_unavailable above), a def-reload sink
+    // never touches the agent daemon at provision time — it only registers a
+    // vault trigger. So a null agentOrigin must NOT block it.
+    const { cookie } = await adminCookie();
+    const { fetchImpl } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+    });
+    const deps = {
+      ...baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
+      agentOrigin: null,
+    };
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "agentdefs-edit-default",
+          source: {
+            module: "vault",
+            vault: "default",
+            event: "note.updated",
+            filter: { tags: ["#agent/definition"] },
+          },
+          sink: { module: "agent", action: "definition.reload" },
+        }),
+      }),
+      "",
+      deps,
+    );
+    expect(res.status).toBe(200);
+  });
 });
 
 // ===========================================================================
@@ -1023,6 +1056,59 @@ describe("DELETE /admin/connections/:id — teardown", () => {
           c.method === "DELETE" && c.url.endsWith("/vault/default/api/triggers/conn_agent-eng"),
       ),
     ).toBe(true);
+  });
+
+  test("definition.reload teardown removes the trigger but NOT a channel (agent#117)", async () => {
+    // Symmetric to the create-side fix: a channel-less agent action created no
+    // channel config entry, so teardown must not issue a spurious
+    // DELETE /api/channels/<id> (the old module-level gate fell back to record.id
+    // as the channel name → a delete against a never-created channel).
+    const { cookie } = await adminCookie();
+    const { fetchImpl, calls } = mockFetch({
+      "POST /vault/default/api/triggers": () => ok({ ok: true }),
+      "DELETE /vault/default/api/triggers/conn_agentdefs-create-default": () => ok({ ok: true }),
+      // Present so a regression surfaces as an unexpected matched call, not a 599.
+      "DELETE /api/channels/agentdefs-create-default": () => ok({ ok: true }),
+    });
+    const deps = baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST));
+    await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections`, {
+        method: "POST",
+        headers: { cookie },
+        body: JSON.stringify({
+          id: "agentdefs-create-default",
+          source: {
+            module: "vault",
+            vault: "default",
+            event: "note.created",
+            filter: { tags: ["#agent/definition"] },
+          },
+          sink: { module: "agent", action: "definition.reload" },
+        }),
+      }),
+      "",
+      deps,
+    );
+    const res = await handleConnections(
+      new Request(`${HUB_ORIGIN}/admin/connections/agentdefs-create-default`, {
+        method: "DELETE",
+        headers: { cookie },
+      }),
+      "/agentdefs-create-default",
+      deps,
+    );
+    expect(res.status).toBe(200);
+    // NO channel delete (the channel-reply path was never created).
+    expect(calls.some((c) => c.method === "DELETE" && c.url.includes("/api/channels/"))).toBe(false);
+    // The vault trigger WAS torn down.
+    expect(
+      calls.some(
+        (c) =>
+          c.method === "DELETE" &&
+          c.url.endsWith("/vault/default/api/triggers/conn_agentdefs-create-default"),
+      ),
+    ).toBe(true);
+    expect(readConnections(harness.storePath)).toHaveLength(0);
   });
 
   test("404 deleting an unknown connection", async () => {

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -601,13 +601,19 @@ async function createConnection(
   // the record so teardown can revoke them (registered-mint rule).
   const mintedJtis: string[] = [];
 
-  // --- Sink prerequisite (agent reply path), fenced to the agent sink. ------
+  // --- Sink prerequisite (agent message-delivery reply path). --------------
   // Everything below this is general; THIS block is the only sink-specific step.
-  // The channel name comes from the action params (`sink.params.channel`) — it
-  // becomes a services.json key + an MCP server name, so it must be a slug.
-  // (The session-channel concept is kept; only the MODULE renamed
-  // channel → agent in the 2026-06-17 rename — `sink.module === "agent"`.)
-  if (sinkModule === "agent") {
+  // It is gated on the ACTION, not just the module: ONLY `message.deliver` needs
+  // a session reply path (a vault-backed channel's connected session replies via
+  // a `vault:<v>:write` token + a `channels.json` entry). Other agent actions —
+  // e.g. `definition.reload`, a pure inbound webhook with no session and no
+  // reply — need none of it. A module-level gate here 400'd every
+  // non-`message.deliver` agent sink for want of a `channel` param (agent#117:
+  // the def-reload connectors could never provision). The channel name comes
+  // from `sink.params.channel` — it becomes a services.json key + an MCP server
+  // name, so it must be a slug. (The session-channel concept is kept; only the
+  // MODULE renamed channel → agent in the 2026-06-17 rename.)
+  if (sinkModule === "agent" && sinkAction === "message.deliver") {
     const channelName = typeof sinkParams?.channel === "string" ? sinkParams.channel : "";
     if (!CHANNEL_NAME_RE.test(channelName)) {
       return jsonError(

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -698,8 +698,9 @@ async function createConnection(
 /**
  * The agent sink's reply-path prerequisite (mirrors hub#624). Mints a
  * `vault:<v>:write` for the channel + writes the `channels.json` entry on the
- * agent daemon so the session can reply. Fenced to `sink.module === "agent"`
- * — this is sink-specific config, not part of the general vault-trigger engine.
+ * agent daemon so the session can reply. Fenced to the agent `message.deliver`
+ * action (the only one with a reply path) — sink-specific config, not part of
+ * the general vault-trigger engine.
  * Returns `{ error }` on failure, or `{ error: null, replyTokenJti }` on
  * success — the jti of the long-lived reply token, so the caller can persist
  * it for teardown revocation. (Renamed from `prepareChannelSink` 2026-06-17;
@@ -1544,9 +1545,20 @@ export async function teardownConnection(
   }
 
   // --- Agent-sink teardown (remove the channel config entry). --------------
-  // Fenced to event→action records: a credential connection whose HOLDER is
-  // the agent module must not delete an unrelated channel config entry.
-  if (record.kind !== "credential" && record.sink.module === "agent" && deps.agentOrigin) {
+  // Fenced to event→action records (a credential connection whose HOLDER is the
+  // agent module must not delete an unrelated channel config entry) AND — like
+  // the create-side prerequisite — to the `message.deliver` action: only that
+  // action created a channel config entry, so only it has one to remove. A
+  // module-level gate here would issue a spurious DELETE /api/channels/<id> for
+  // a channel-less action (e.g. definition.reload — `record.id` as the channel
+  // fallback), wasting an agent:admin mint on a never-created channel and
+  // risking a real same-named channel. Symmetric to the create-side gate.
+  if (
+    record.kind !== "credential" &&
+    record.sink.module === "agent" &&
+    record.sink.action === "message.deliver" &&
+    deps.agentOrigin
+  ) {
     const channelName =
       typeof record.sink.params?.channel === "string" ? record.sink.params.channel : record.id;
     try {


### PR DESCRIPTION
## What

`createConnection` ran the agent **reply-path prerequisite** (`prepareAgentSink` — mint a `vault:<v>:write` + write a `channels.json` entry, which **requires `sink.params.channel`**) for *every* agent sink (`sinkModule === "agent"`). Only `message.deliver` needs that path: a vault-backed channel's connected session replies. Other agent actions — `definition.reload`, a pure inbound webhook with no session and no reply — carry no channel param, so the module-level gate **400'd** them (`agent sink requires sink.params.channel`) before they could provision.

## Why it was latent

Only `message.deliver` connections had ever been provisioned, so the over-broad gate was never exercised. It surfaced while building the agent's **def-reload connectors** ([agent#117](https://github.com/ParachuteComputer/parachute-agent/pull/117)): a `vault note.created/updated (filter #agent/definition) → agent definition.reload` connection could never be created — every POST 400'd.

## Fix

Gate the prerequisite on `sinkAction === "message.deliver"`, not the module. Everything else in `createConnection` is already general:
- webhook + scope derived from the action declaration,
- trigger build from source event + filter,
- the end-of-function connect-lines guard already keys on `sinkParams?.channel`.

`definition.reload` now provisions its vault trigger and **skips** the channel config.

## Test

New regression: a `definition.reload` agent sink provisions with **no** channel param — asserts `200`, **no `/api/channels` POST** (prerequisite skipped), and the vault trigger registered from the action declaration (webhook `/agent/api/vault/agent-def`, bearer `agent:send`, `when {tags:[#agent/definition]}`). A second agent fixture action was added; the catalog action-count assertion updated to match.

## Gates

- hub **3579 pass / 0 fail** (`bun test ./src`), typecheck clean.

No version bump (governance: PRs don't bump; bump+tag on ship). Unblocks agent#117.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
