### PR TITLE
fix(setup-wizard): hand out bare OAuth MCP command, not header-auth (drop done-screen auto-mint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.2-rc.1] - 2026-06-23
+
+### Fixed
+
+- **Setup wizard "Connect Claude Code (MCP)" done-screen now hands out the bare OAuth command, not a header-auth one** (reported by Austen). Vault/init is OAuth-default now ([parachute-vault #491](https://github.com/ParachuteComputer/parachute-vault/pull/491)); the wizard was still auto-minting a full-scope operator token in the expose step and pre-filling the MCP install command with `--header "Authorization: Bearer <token>"`, which is the wrong default for an OAuth-default vault and broke the user's connect. The done screen now always renders the bare `claude mcp add` command, which triggers browser OAuth on first use. Headless clients that can't do the browser flow mint a scoped token at `/admin/tokens` and append the header themselves (the tile's fine print points there).
+
+### Security
+
+- **Dropped a privilege over-grant.** The retired auto-mint baked a full admin-scope bearer token into a copy-pasted command (with a masked-reveal/Copy widget) — a single shoulder-surf or screencast leaked an admin credential. No token is minted or stored by default anymore. The standalone `/admin/tokens` mint path is unchanged. The done-step GET defensively clears any stale `setup_minted_token` row a pre-upgrade hub may have left behind.
+
 ## [0.6.4] - 2026-06-06
 
 **Fresh-install onboarding overhaul + a multi-user/account security wave.** The 0.6.4-rc chain (rc.1–rc.10) promoted to stable. Driven by real field transcripts of operators hitting dead-ends on fresh boxes.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.1",
+  "version": "0.7.2-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -2151,9 +2151,19 @@ describe("handleSetupExposePost", () => {
   });
 });
 
-// --- hub#272 Item A: auto-mint operator token + MCP command rendering ---
+// --- hub#272 Item A → OAuth-default MCP command (no auto-mint) ---
+//
+// History: hub#272 Item A auto-minted a full-scope operator token in the
+// expose POST + pre-filled the done-screen MCP command with a
+// `--header "Authorization: Bearer <token>"` flag (plus a masked-reveal /
+// Copy widget). Removed 2026-06-23 after Austen reported the header-auth
+// command broke his connect: vault/init is OAuth-default now (parachute-
+// vault #491), so the bare `claude mcp add` command — which triggers
+// browser OAuth on first use — is the correct UX. These tests pin the new
+// contract: no token minted/stored by default, and the done screen never
+// emits a Bearer header.
 
-describe("done screen auto-minted token (hub#272 Item A)", () => {
+describe("done screen MCP command — OAuth-default, no auto-mint", () => {
   let h: Harness;
   beforeEach(() => {
     h = makeHarness();
@@ -2191,7 +2201,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
     return { user, session, csrf };
   }
 
-  test("expose POST mints + stores an operator token in hub_settings (setup_minted_token)", async () => {
+  test("expose POST does NOT mint or store an operator token (setup_minted_token stays unset)", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const { session, csrf } = await bringWizardToExposeStep(db);
@@ -2218,18 +2228,47 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
         },
       );
       expect(res.status).toBe(303);
-      // Token is a JWT (three base64url segments). We don't assert the
-      // exact value — the load-bearing surface is "a non-empty token
-      // exists" so the done-step renderer has something to inject.
-      const stored = getSetting(db, "setup_minted_token");
-      expect(stored).toBeDefined();
-      expect(stored?.split(".").length).toBe(3);
+      // The auto-mint was removed (Austen's report) — vault is OAuth-
+      // default, so nothing should land in hub_settings.
+      expect(getSetting(db, "setup_minted_token")).toBeUndefined();
     } finally {
       db.close();
     }
   });
 
-  test("done screen renders the MCP command with a Bearer header when a minted token exists", async () => {
+  test("expose POST JSON response carries no minted_token", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const { session, csrf } = await bringWizardToExposeStep(db);
+      const res = await handleSetupExposePost(
+        req("/admin/setup/expose", {
+          method: "POST",
+          body: JSON.stringify({ expose_mode: "localhost", [CSRF_FIELD_NAME]: csrf }),
+          headers: {
+            "content-type": "application/json",
+            cookie: `${CSRF_COOKIE_NAME}=${csrf}; ${SESSION_COOKIE_NAME}=${session.id}`,
+          },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
+          issuer: "https://hub.example",
+          registry: getDefaultOperationsRegistry(),
+        },
+      );
+      expect(res.status).toBe(200);
+      const json = (await res.json()) as Record<string, unknown>;
+      expect(json.step).toBe("done");
+      expect(json).not.toHaveProperty("minted_token");
+      expect(getSetting(db, "setup_minted_token")).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("done screen renders the bare OAuth MCP command with NO Bearer header by default", async () => {
     const db = openHubDb(hubDbPath(h.dir));
     try {
       const user = await createUser(db, "owner", "pw");
@@ -2248,7 +2287,6 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
         h.manifestPath,
       );
       setSetting(db, "setup_expose_mode", "localhost");
-      setSetting(db, "setup_minted_token", "test-jwt-token-abc");
       const { createSession } = await import("../sessions.ts");
       const session = createSession(db, { userId: user.id });
       const res = handleSetupGet(
@@ -2266,332 +2304,109 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
       );
       expect(res.status).toBe(200);
       const html = await res.text();
-      // Real token rides in the hidden script-tag stash as JSON-encoded
-      // text — script element content is raw-text per the HTML spec
-      // (entities aren't parsed), so JSON encoding round-trips through
-      // textContent + JSON.parse without `&quot;` polluting the copied
-      // command. Verify the JSON-encoded form appears in the document.
+      // The bare OAuth command is the rendered command.
       expect(html).toContain(
-        '"claude mcp add --transport http parachute-default https://hub.example/vault/default/mcp --header \\"Authorization: Bearer test-jwt-token-abc\\""',
+        "claude mcp add --transport http parachute-default https://hub.example/vault/default/mcp",
       );
-      expect(html).toContain('id="mcp-cmd"');
-      expect(html).toContain('id="mcp-cmd-real"');
-      // The hidden stash is `<script type="application/json">` so the
-      // browser doesn't execute it but textContent is still readable.
-      expect(html).toContain('<script type="application/json" id="mcp-cmd-real">');
-      // The visible default state is masked: the <pre> body is wrapped
-      // with data-state="masked" and renders • placeholder characters
-      // rather than the live token. Verified by the masked Bearer
-      // header substring (• repeated).
-      expect(html).toContain('data-state="masked"');
-      expect(html).toMatch(/Bearer •+/);
-      // Show button + Copy button both present.
-      expect(html).toContain('id="mcp-cmd-show"');
-      expect(html).toContain('id="mcp-cmd-copy"');
+      // Load-bearing regression (Austen's report): the rendered COMMAND
+      // (the MCP tile's <pre> block) must NOT carry a `--header
+      // "Authorization: Bearer ..."` flag. This is the assertion that
+      // would have caught the bug — the prior build baked the header into
+      // the command. The headless-client fine print legitimately mentions
+      // the header form with an escaped `<token>` placeholder, so we
+      // scope the negative assertion to the command block, not the whole
+      // document. Anchor to the MCP-tile <h2> so the regex can't drift
+      // onto another tile's <pre> (e.g. the tailnet/public reachable
+      // tile's bare Tailscale command) under a different expose mode.
+      const cmdPre = html.match(/<h2>Connect Claude Code \(MCP\)<\/h2>[\s\S]*?<pre>([^<]*)<\/pre>/);
+      expect(cmdPre).not.toBeNull();
+      const cmdText = cmdPre?.[1] ?? "";
+      expect(cmdText).not.toContain("--header");
+      expect(cmdText).not.toContain("Authorization");
+      expect(cmdText).not.toContain("Bearer");
+      // The document must NOT carry a real or masked Bearer token — the
+      // only legitimate `Bearer` mention is the escaped placeholder in
+      // the guidance.
+      expect(html).not.toMatch(/Bearer •/);
+      expect(html).not.toContain("Authorization: Bearer test");
+      // Explanatory text leads with the OAuth path; the only mention of
+      // a Bearer header is the escaped `<token>` placeholder in the
+      // headless-client guidance.
+      expect(html).toContain("browser OAuth");
+      expect(html).toContain("Bearer &lt;token&gt;");
+      expect(html).not.toContain("pvt_");
+      expect(html).toContain("parachute auth mint-token");
       expect(html).toContain("/admin/tokens");
-      // The token is single-use — consumed on first render.
+      // None of the masked-token / Copy-widget DOM survives — the
+      // token-present branch was removed.
+      expect(html).not.toContain('id="mcp-cmd"');
+      expect(html).not.toContain('id="mcp-cmd-real"');
+      expect(html).not.toContain('id="mcp-cmd-copy"');
+      expect(html).not.toContain('data-state="masked"');
+    } finally {
+      db.close();
+    }
+  });
+
+  test("done screen never renders a stale setup_minted_token row + clears it defensively", async () => {
+    // Upgrade path: a pre-upgrade hub may have left a stale
+    // setup_minted_token row behind. The done-step GET must never paint
+    // it (no token surface anymore) and should clear it so it can't
+    // linger.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      // Plant a stale row as if a pre-upgrade hub had minted one.
+      setSetting(db, "setup_minted_token", "stale-token-from-old-hub");
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const res = handleSetupGet(
+        req("/admin/setup?just_finished=1", {
+          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
+        }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
+          issuer: "https://hub.example",
+          registry: getDefaultOperationsRegistry(),
+        },
+      );
+      const html = await res.text();
+      // The stale token is NOT painted anywhere in the document, and the
+      // rendered command carries no Bearer header (the only `Bearer`
+      // mention is the escaped `<token>` placeholder in the guidance).
+      expect(html).not.toContain("stale-token-from-old-hub");
+      expect(html).not.toContain("Authorization: Bearer stale-token-from-old-hub");
+      const cmdPre = html.match(/<h2>Connect Claude Code \(MCP\)<\/h2>[\s\S]*?<pre>([^<]*)<\/pre>/);
+      expect(cmdPre?.[1] ?? "").not.toContain("Authorization");
+      // And the row is cleared so it can't linger across renders.
       expect(getSetting(db, "setup_minted_token")).toBeUndefined();
     } finally {
       db.close();
     }
   });
 
-  test("done screen falls back to bare MCP command + admin/tokens hint when no minted token", async () => {
-    const db = openHubDb(hubDbPath(h.dir));
-    try {
-      const user = await createUser(db, "owner", "pw");
-      writeManifest(
-        {
-          services: [
-            {
-              name: "parachute-vault",
-              version: "0.1.0",
-              port: 1940,
-              paths: ["/vault/default"],
-              health: "/health",
-            },
-          ],
-        },
-        h.manifestPath,
-      );
-      setSetting(db, "setup_expose_mode", "localhost");
-      const { createSession } = await import("../sessions.ts");
-      const session = createSession(db, { userId: user.id });
-      const res = handleSetupGet(
-        req("/admin/setup?just_finished=1", {
-          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
-        }),
-        {
-          db,
-          manifestPath: h.manifestPath,
-          configDir: h.dir,
-          readExposeStateFn: h.readExposeStateFn,
-          issuer: "https://hub.example",
-          registry: getDefaultOperationsRegistry(),
-        },
-      );
-      const html = await res.text();
-      expect(html).toContain("claude mcp add --transport http parachute-default");
-      // The fallback explanatory text leads with the OAuth path (no token
-      // needed) and, for headless clients, references a hub JWT placeholder
-      // — NOT the retired `pvt_*` format (gap #4). The `--header` flag must
-      // also NOT be appended to the command line itself.
-      expect(html).toContain("browser OAuth");
-      expect(html).toContain("Bearer &lt;token&gt;");
-      expect(html).not.toContain("pvt_");
-      expect(html).toContain("parachute auth mint-token");
-      expect(html).toContain("/admin/tokens");
-      // Specifically no Copy button — that's a token-present surface.
-      expect(html).not.toContain('id="mcp-cmd"');
-    } finally {
-      db.close();
-    }
-  });
-
-  test("minted token is consumed after first render — refresh shows the fallback shape", async () => {
-    const db = openHubDb(hubDbPath(h.dir));
-    try {
-      const user = await createUser(db, "owner", "pw");
-      writeManifest(
-        {
-          services: [
-            {
-              name: "parachute-vault",
-              version: "0.1.0",
-              port: 1940,
-              paths: ["/vault/default"],
-              health: "/health",
-            },
-          ],
-        },
-        h.manifestPath,
-      );
-      setSetting(db, "setup_expose_mode", "localhost");
-      setSetting(db, "setup_minted_token", "test-token-xyz");
-      const { createSession } = await import("../sessions.ts");
-      const session = createSession(db, { userId: user.id });
-      const deps = {
-        db,
-        manifestPath: h.manifestPath,
-        configDir: h.dir,
-        readExposeStateFn: h.readExposeStateFn,
-        issuer: "https://hub.example",
-        registry: getDefaultOperationsRegistry(),
-      };
-      const sessionedReq = () =>
-        req("/admin/setup?just_finished=1", {
-          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
-        });
-      const first = handleSetupGet(sessionedReq(), deps);
-      const firstHtml = await first.text();
-      expect(firstHtml).toContain("test-token-xyz");
-      const second = handleSetupGet(sessionedReq(), deps);
-      const secondHtml = await second.text();
-      expect(secondHtml).not.toContain("test-token-xyz");
-      // The MCP command tile has no Copy button on the fallback shape.
-      expect(secondHtml).not.toContain('id="mcp-cmd"');
-    } finally {
-      db.close();
-    }
-  });
-
-  // rc.11 — token visible by default on the done screen was a
-  // shoulder-surf hazard. The fix: render the visible command with
-  // a masked Bearer token, stash the real command in a
-  // hidden script tag, and surface a Show button + Copy button. Copy
-  // ALWAYS pulls the real command from the script tag so the
-  // operator's terminal paste never breaks regardless of mask state.
-  test("done screen masks the Bearer token in the visible <pre> by default", async () => {
-    const db = openHubDb(hubDbPath(h.dir));
-    try {
-      const user = await createUser(db, "owner", "pw");
-      writeManifest(
-        {
-          services: [
-            {
-              name: "parachute-vault",
-              version: "0.1.0",
-              port: 1940,
-              paths: ["/vault/default"],
-              health: "/health",
-            },
-          ],
-        },
-        h.manifestPath,
-      );
-      setSetting(db, "setup_expose_mode", "localhost");
-      setSetting(db, "setup_minted_token", "pvt_super_secret_token_payload");
-      const { createSession } = await import("../sessions.ts");
-      const session = createSession(db, { userId: user.id });
-      const res = handleSetupGet(
-        req("/admin/setup?just_finished=1", {
-          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
-        }),
-        {
-          db,
-          manifestPath: h.manifestPath,
-          configDir: h.dir,
-          readExposeStateFn: h.readExposeStateFn,
-          issuer: "https://hub.example",
-          registry: getDefaultOperationsRegistry(),
-        },
-      );
-      const html = await res.text();
-      // Extract the visible <pre id="mcp-cmd"> text only — the masked
-      // shape must live there, with no occurrence of the literal token
-      // string. The real token still appears elsewhere (the hidden
-      // script tag) so a plain `toContain` would miss the leak.
-      const preMatch = html.match(/<pre id="mcp-cmd">([^<]*)<\/pre>/);
-      expect(preMatch).not.toBeNull();
-      const preBody = preMatch?.[1] ?? "";
-      expect(preBody).not.toContain("pvt_super_secret_token_payload");
-      // Masked Bearer header is present in the <pre> text.
-      expect(preBody).toMatch(/Bearer •+/);
-      // Real command still in the document (hidden JSON stash) so the
-      // Copy handler can read it.
-      expect(html).toContain('<script type="application/json" id="mcp-cmd-real">');
-      expect(html).toContain("pvt_super_secret_token_payload");
-      // Default state is masked.
-      expect(html).toContain('data-state="masked"');
-    } finally {
-      db.close();
-    }
-  });
-
-  test("done screen JSON-encodes the stashed command so `</script>` in a token can't break out", async () => {
-    // Defense-in-depth: an attacker-shaped token containing `</script>`
-    // would prematurely close the stash tag if we just dropped it into
-    // the HTML. The renderer JSON-encodes the command AND replaces
-    // `</` with `<\/` inside the encoded string so the sequence can't
-    // appear in the document. Decode round-trips via JSON.parse.
-    const db = openHubDb(hubDbPath(h.dir));
-    try {
-      const user = await createUser(db, "owner", "pw");
-      writeManifest(
-        {
-          services: [
-            {
-              name: "parachute-vault",
-              version: "0.1.0",
-              port: 1940,
-              paths: ["/vault/default"],
-              health: "/health",
-            },
-          ],
-        },
-        h.manifestPath,
-      );
-      setSetting(db, "setup_expose_mode", "localhost");
-      // Token contains characters that would be load-bearing in the
-      // HTML/JS layer if mis-encoded: a quote (would close the JSON
-      // string) and `</script>` (would close the stash tag).
-      const hostileToken = `weird-token-with-"-and-</script>-inside`;
-      setSetting(db, "setup_minted_token", hostileToken);
-      const { createSession } = await import("../sessions.ts");
-      const session = createSession(db, { userId: user.id });
-      const res = handleSetupGet(
-        req("/admin/setup?just_finished=1", {
-          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
-        }),
-        {
-          db,
-          manifestPath: h.manifestPath,
-          configDir: h.dir,
-          readExposeStateFn: h.readExposeStateFn,
-          issuer: "https://hub.example",
-          registry: getDefaultOperationsRegistry(),
-        },
-      );
-      const html = await res.text();
-      // `</script>` must NOT appear inside the stash element. We
-      // verify by extracting the stash text via the literal HTML
-      // boundaries and asserting no close-tag escape escaped the
-      // encoder.
-      const stashMatch = html.match(
-        /<script type="application\/json" id="mcp-cmd-real">([\s\S]*?)<\/script>/,
-      );
-      expect(stashMatch).not.toBeNull();
-      const stashBody = stashMatch?.[1] ?? "";
-      // The encoder replaces `</` with `<\/` inside the JSON, so the
-      // raw bytes between the opening and the first `</script>` should
-      // not contain `</`.
-      expect(stashBody).not.toContain("</");
-      // Round-trips: `<\/` decodes back to `</` after JSON.parse +
-      // the script-end-sequence escape — the operator's clipboard
-      // gets the original bytes.
-      const decoded = JSON.parse(stashBody) as string;
-      expect(decoded).toContain(hostileToken);
-    } finally {
-      db.close();
-    }
-  });
-
-  test("done screen wires Show + Copy buttons that read from the hidden real-command stash", async () => {
-    const db = openHubDb(hubDbPath(h.dir));
-    try {
-      const user = await createUser(db, "owner", "pw");
-      writeManifest(
-        {
-          services: [
-            {
-              name: "parachute-vault",
-              version: "0.1.0",
-              port: 1940,
-              paths: ["/vault/default"],
-              health: "/health",
-            },
-          ],
-        },
-        h.manifestPath,
-      );
-      setSetting(db, "setup_expose_mode", "localhost");
-      setSetting(db, "setup_minted_token", "live-token-AAA");
-      const { createSession } = await import("../sessions.ts");
-      const session = createSession(db, { userId: user.id });
-      const res = handleSetupGet(
-        req("/admin/setup?just_finished=1", {
-          headers: { cookie: `${SESSION_COOKIE_NAME}=${session.id}` },
-        }),
-        {
-          db,
-          manifestPath: h.manifestPath,
-          configDir: h.dir,
-          readExposeStateFn: h.readExposeStateFn,
-          issuer: "https://hub.example",
-          registry: getDefaultOperationsRegistry(),
-        },
-      );
-      const html = await res.text();
-      // Both buttons present, both wired via addEventListener (no
-      // inline onclick — the script runs in a single IIFE).
-      expect(html).toContain('id="mcp-cmd-show"');
-      expect(html).toContain('id="mcp-cmd-copy"');
-      expect(html).toContain("'click'");
-      // The Copy handler reads from the hidden script tag, not from
-      // the visible <pre>. Regression: this was the load-bearing
-      // contract Aaron called out ("Copy still works without reveal").
-      expect(html).toContain("getElementById('mcp-cmd-real')");
-      // The stash holds JSON-encoded text and the handler decodes via
-      // JSON.parse so the clipboard receives the exact byte sequence of
-      // the command — `&quot;`-style HTML entities can't survive into
-      // the operator's shell because script-element content is raw text
-      // (the HTML parser doesn't decode entities inside <script>).
-      expect(html).toContain("JSON.parse(real.textContent");
-      // Auto-hide timer present so a stray reveal doesn't leak into a
-      // subsequent screencast capture.
-      expect(html).toContain("setTimeout(setMasked, 10000)");
-    } finally {
-      db.close();
-    }
-  });
-
-  test("GET /admin/setup?just_finished=1 without a session does NOT consume the minted token (hub#274 security fold)", async () => {
-    // Regression — without the session gate, any HTTP client racing the
-    // operator's browser between the expose POST (which mints + stores)
-    // and the done GET (which reads + consumes) walks off with a
-    // full-scope operator JWT. The gate sends sessionless GETs to
-    // /login + leaves the row in place so the operator's subsequent
-    // legitimate GET still surfaces the token.
+  test("GET /admin/setup?just_finished=1 without a session redirects to /login (done screen is post-setup admin)", async () => {
+    // The done screen is a post-setup admin surface and shouldn't render
+    // to a drive-by unauthenticated GET. (This gate originally protected
+    // the minted-token read; the mint is gone, but the gate stays.)
     const db = openHubDb(hubDbPath(h.dir));
     try {
       await createUser(db, "owner", "pw");
@@ -2610,10 +2425,7 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
         h.manifestPath,
       );
       setSetting(db, "setup_expose_mode", "localhost");
-      setSetting(db, "setup_minted_token", "test-secret-token-must-not-leak");
-      // No session cookie on this request — simulating a drive-by GET
-      // from an attacker or a stale bookmark in a different browser
-      // tab that doesn't carry the wizard's session.
+      // No session cookie — a drive-by GET.
       const res = handleSetupGet(req("/admin/setup?just_finished=1"), {
         db,
         manifestPath: h.manifestPath,
@@ -2622,14 +2434,8 @@ describe("done screen auto-minted token (hub#272 Item A)", () => {
         issuer: "https://hub.example",
         registry: getDefaultOperationsRegistry(),
       });
-      // The gate redirects to /login (302) rather than rendering the
-      // done screen. Body must NOT contain the token.
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toBe("/login");
-      // The setup_minted_token row is STILL present — the unauthed GET
-      // didn't consume it, so the legitimate operator's session-bearing
-      // GET will still see the token on the done screen.
-      expect(getSetting(db, "setup_minted_token")).toBe("test-secret-token-must-not-leak");
     } finally {
       db.close();
     }

--- a/src/commands/wizard.ts
+++ b/src/commands/wizard.ts
@@ -749,10 +749,10 @@ export async function runCliWizard(opts: RunCliWizardOpts): Promise<number> {
     state = await fetchWizardState(hubUrl, jar, fetchImpl);
   }
   // Done screen — fetch + show a brief summary. The browser wizard's
-  // done screen surfaces the MCP install command + auto-minted token;
-  // we mirror that by reading the same `setup_minted_token` row via
-  // the GET endpoint's JSON envelope. Best-effort: a missing token
-  // just means we point the operator at /admin/tokens instead.
+  // done screen surfaces the bare OAuth `claude mcp add` command (no
+  // token, no header — vault is OAuth-default per parachute-vault #491);
+  // the CLI path never minted a token, so we just point the operator at
+  // the admin SPA + /admin/tokens for the headless-client case.
   log("");
   log("✓ Setup complete.");
   log(`  Visit ${hubUrl}/admin/ to open the admin SPA.`);

--- a/src/hub-settings.ts
+++ b/src/hub-settings.ts
@@ -28,13 +28,14 @@ import type { Database } from "bun:sqlite";
 export type HubSettingKey =
   | "setup_expose_mode"
   | "pending_first_client_auto_approve_until"
-  // hub#272: auto-minted operator token surfaced once on the wizard's
-  // done screen. Single-use — the done-step renderer reads + deletes the
-  // row so a subsequent GET (page refresh, back button) doesn't re-show
-  // the secret. Lives in hub_settings rather than tokens because it's a
-  // wizard-flow ephemeral, not a persistent issued credential — the
-  // mintOperatorToken call still records the jti in the `tokens`
-  // registry, so revocation works as usual.
+  // hub#272: DEPRECATED 2026-06-23 (Austen's report). Used to hold an
+  // auto-minted operator token surfaced once on the wizard's done screen
+  // so the MCP command could pre-fill a `--header "Authorization: Bearer
+  // <token>"` flag. The auto-mint was removed when vault went OAuth-
+  // default (parachute-vault #491) — nothing writes this row anymore.
+  // The key is retained so the done-step GET can defensively clear any
+  // stale row a pre-upgrade hub left behind (it never renders the value).
+  // Drop the member once no live hub_settings tables carry the row.
   | "setup_minted_token"
   // hub#267: the typed vault name. Persisted at vault POST time so the
   // done step can render the operator's choice in the MCP URL +

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -3257,64 +3257,6 @@ const STYLES = `
   .btn-secondary:hover {
     background: ${PALETTE.accentSoft};
   }
-  /* Copy + Show buttons ride the right edge of the MCP command pre.
-     Compact vertical sizing so they don't dwarf the snippet on narrow
-     widths; full text wrap on the pre keeps the snippet readable
-     behind them. The Show button toggles the visible mask on the
-     auto-minted Bearer token (rc.11 — discoverable
-     but not shoulder-surf-able). Both buttons share a small flex
-     container so they stack predictably on the wrap; layout-wise we
-     keep the right-edge padding on .mcp-cmd-wrap pre so the buttons
-     never overlap the command text. */
-  .mcp-cmd-wrap {
-    position: relative;
-    margin: 0.5rem 0;
-  }
-  .mcp-cmd-wrap pre {
-    background: ${PALETTE.bg};
-    border: 1px solid ${PALETTE.borderLight};
-    border-radius: 6px;
-    padding: 0.5rem 8.5rem 0.5rem 0.75rem;
-    overflow-x: auto;
-    font-size: 0.82rem;
-    margin: 0;
-    white-space: pre-wrap;
-    word-break: break-all;
-  }
-  .mcp-cmd-actions {
-    position: absolute;
-    top: 0.35rem;
-    right: 0.35rem;
-    display: flex;
-    gap: 0.3rem;
-  }
-  .btn-copy, .btn-mcp-aux {
-    padding: 0.25rem 0.6rem;
-    font-size: 0.78rem;
-    min-height: auto;
-    background: ${PALETTE.cardBg};
-    color: ${PALETTE.fg};
-    border: 1px solid ${PALETTE.border};
-    border-radius: 4px;
-    cursor: pointer;
-    font: inherit;
-    font-size: 0.78rem;
-  }
-  .btn-copy:hover, .btn-mcp-aux:hover {
-    border-color: ${PALETTE.accent};
-    color: ${PALETTE.accent};
-  }
-  .mcp-cmd-wrap[data-state="revealed"] pre {
-    /* Subtle visual cue that the token is currently visible — a warm
-       border so the operator notices on a screencast even at low
-       resolution. */
-    border-color: #d4a017;
-    background: rgba(212, 160, 23, 0.04);
-  }
-  .mcp-cmd-wrap[data-state="revealed"] .btn-mcp-aux {
-    border-color: #d4a017;
-    color: #6b4a00;
-  }
   /* Install-tile section (hub#272 Item B). Lives above the .done-grid;
      primary "what's next?" surface. Tiles render in a responsive grid
      that collapses to one column on narrow viewports. */

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -71,7 +71,6 @@ import {
   type IssueOperatorTokenResult,
   type MintOperatorTokenOpts,
   issueOperatorToken,
-  mintOperatorToken,
   readOperatorTokenFile,
 } from "./operator-token.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
@@ -1155,16 +1154,6 @@ export interface RenderDoneStepProps {
    */
   exposeMode?: SetupExposeMode;
   /**
-   * Auto-minted operator token surfaced once on the done screen
-   * (hub#272 Item A). When present, the MCP install command renders
-   * with `--header "Authorization: Bearer <token>"` pre-filled and a
-   * one-click Copy button. Absent means the mint either failed or
-   * the operator already consumed the single-use surface — the tile
-   * falls back to the un-headered command + a "mint at /admin/tokens"
-   * hint.
-   */
-  mintedToken?: string;
-  /**
    * Optional per-module install tiles to render alongside the MCP
    * command (hub#272 Item B). When omitted, the done step renders
    * only the MCP tile + the admin-UI fallback link. Production wires
@@ -1175,9 +1164,9 @@ export interface RenderDoneStepProps {
 }
 
 export function renderDoneStep(props: RenderDoneStepProps): string {
-  const { vaultName, hubOrigin, exposeMode, mintedToken, installTiles } = props;
+  const { vaultName, hubOrigin, exposeMode, installTiles } = props;
   const reachable = exposeMode ? renderReachableTile(exposeMode, hubOrigin) : "";
-  const mcpTile = renderMcpTile(vaultName, hubOrigin, mintedToken);
+  const mcpTile = renderMcpTile(vaultName, hubOrigin);
   const tiles = installTiles && installTiles.length > 0 ? installTiles : [];
   const installSection = tiles.length > 0 ? renderInstallTiles(tiles) : "";
   const startTile = renderStartUsingTile(vaultName, hubOrigin);
@@ -1241,129 +1230,26 @@ export function renderDoneStep(props: RenderDoneStepProps): string {
 }
 
 /**
- * The MCP-connect tile. With a freshly-minted token the command renders
- * fully formed with a `--header "Authorization: Bearer <token>"` flag +
- * a Copy button. Without one, we fall back to the bare command + a
- * pointer to `/admin/tokens` (the canonical mint surface). The Copy
- * button is a tiny inline `<script>` — no SPA bundle, no module deps,
- * the wizard stays server-rendered.
+ * The MCP-connect tile. Renders the bare `claude mcp add` command —
+ * no token, no `--header`. Vault/init is OAuth-default (parachute-vault
+ * #491), so the command triggers browser OAuth on first use: the
+ * operator signs in to this hub + approves access, and Claude Code
+ * stores the resulting credential. For headless clients that can't do
+ * the browser flow, the fine print points at `/admin/tokens` (the
+ * canonical mint surface) + the `--header "Authorization: Bearer
+ * <token>"` form they append themselves.
+ *
+ * History: an earlier build (hub#272 Item A) auto-minted a full-scope
+ * operator token here and pre-filled the command with a Bearer header
+ * + a masked-reveal/Copy widget. That was removed 2026-06-23 (Austen's
+ * report): header-auth was the wrong default once vault went OAuth-
+ * default, and baking an admin-scope bearer into a copy-pasted command
+ * was a privilege over-grant + a shoulder-surf hazard. The bare OAuth
+ * command was always the correct UX; it's now the only one.
  */
-function renderMcpTile(
-  vaultName: string,
-  hubOrigin: string,
-  mintedToken: string | undefined,
-): string {
+function renderMcpTile(vaultName: string, hubOrigin: string): string {
   const safeVault = escapeHtml(vaultName);
   const bareCmd = `claude mcp add --transport http parachute-${vaultName} ${hubOrigin}/vault/${vaultName}/mcp`;
-  if (mintedToken) {
-    // The token contents are surfaced once + then forgotten by the
-    // server (single-use hub_setting). Two visible variants of the
-    // command live in the DOM:
-    //
-    //   * `pre#mcp-cmd` — what the operator sees. The Bearer token is
-    //     replaced with a fixed-width row of • so shoulder-surfers,
-    //     screencasts, and over-the-shoulder photos don't capture
-    //     credentials by default. This is the "discoverable but not
-    //     shoulder-surf-able" framing Aaron asked for.
-    //   * `script#mcp-cmd-real` (type=text/plain) — the real command
-    //     with the live token, stashed in a non-rendering script tag.
-    //     The Copy + Show handlers read from this so the operator's
-    //     terminal paste still gets the real header without the page
-    //     ever painting the token.
-    //
-    // The view-source threat model is unchanged from rc.9 — the token
-    // is part of the response body either way. The improvement is
-    // *visibly hidden by default*, which is what an over-the-shoulder
-    // observer needs (and what existing screencasts of the wizard
-    // currently leak).
-    //
-    // Show toggles textContent between masked + real and flips a
-    // data-state attribute so a screencast / pair-programming session
-    // can briefly reveal-and-rehide without the operator losing the
-    // line of sight on which mode they're in. Auto-hide after 10s so
-    // a forgotten reveal doesn't leak the token into a subsequent
-    // recording.
-    const fullCmd = `${bareCmd} --header "Authorization: Bearer ${mintedToken}"`;
-    // Clamp the dot count to a 8–40 range so very-short or very-long
-    // tokens don't render comically — token format is fixed-width
-    // (JTI-derived), so this is purely visual.
-    const maskedToken = "•".repeat(Math.max(8, Math.min(40, mintedToken.length)));
-    const maskedCmd = `${bareCmd} --header "Authorization: Bearer ${maskedToken}"`;
-    // The real command rides in a hidden <script type="application/json">
-    // block as a JSON-encoded string. <script> element content is parsed
-    // as raw text (no entity references), so HTML escaping would put
-    // literal `&quot;` into the string — and Copy would paste that into
-    // the operator's terminal. JSON encoding (with `</` escaped so the
-    // sequence can't prematurely close the tag) round-trips safely:
-    // textContent returns the JSON, JSON.parse decodes back to the
-    // exact bytes of the original command. Caught while smoke-testing
-    // the rc.11 reveal/copy UX — pre-fix, the copied command included
-    // `&quot;` placeholders that broke shell parsing.
-    const fullCmdJson = JSON.stringify(fullCmd).replace(/<\//g, "<\\/");
-    return `<div class="done-tile">
-      <h2>Connect Claude Code (MCP)</h2>
-      <p>Wire <code>vault:${safeVault}</code> into Claude Code as an MCP server:</p>
-      <div class="mcp-cmd-wrap" data-state="masked">
-        <pre id="mcp-cmd">${escapeHtml(maskedCmd)}</pre>
-        <script type="application/json" id="mcp-cmd-real">${fullCmdJson}</script>
-        <div class="mcp-cmd-actions">
-          <button type="button" class="btn btn-mcp-aux" id="mcp-cmd-show">Show token</button>
-          <button type="button" class="btn btn-copy" id="mcp-cmd-copy">Copy</button>
-        </div>
-      </div>
-      <p class="fine">We minted this token for your first MCP connection.
-        It's masked above so it's safe to leave open on screen; Copy
-        copies the real command. It's a full-scope operator token tied
-        to your admin account; manage and revoke tokens at
-        <a href="/admin/tokens"><code>/admin/tokens</code></a>.</p>
-      <script>
-        (function () {
-          var wrap = document.querySelector('.mcp-cmd-wrap[data-state]');
-          var pre = document.getElementById('mcp-cmd');
-          var real = document.getElementById('mcp-cmd-real');
-          var copyBtn = document.getElementById('mcp-cmd-copy');
-          var showBtn = document.getElementById('mcp-cmd-show');
-          if (!wrap || !pre || !real || !copyBtn || !showBtn) return;
-          var realCmd;
-          try { realCmd = JSON.parse(real.textContent || '""'); }
-          catch (e) { realCmd = ''; }
-          var maskedCmd = pre.textContent || '';
-          var revealTimer = null;
-          function setMasked() {
-            pre.textContent = maskedCmd;
-            wrap.setAttribute('data-state', 'masked');
-            showBtn.textContent = 'Show token';
-            if (revealTimer) { clearTimeout(revealTimer); revealTimer = null; }
-          }
-          function setRevealed() {
-            pre.textContent = realCmd;
-            wrap.setAttribute('data-state', 'revealed');
-            showBtn.textContent = 'Hide token';
-            // Auto-hide after 10s so a stray reveal doesn't leak the
-            // token into a screencast capture that started after the
-            // click.
-            if (revealTimer) { clearTimeout(revealTimer); revealTimer = null; }
-            revealTimer = setTimeout(setMasked, 10000);
-          }
-          showBtn.addEventListener('click', function () {
-            if (wrap.getAttribute('data-state') === 'masked') setRevealed();
-            else setMasked();
-          });
-          copyBtn.addEventListener('click', function () {
-            // Copy ALWAYS pulls from the real command — the operator's
-            // terminal needs the live token regardless of whether the
-            // page is currently masked. This is the load-bearing path:
-            // the visible mask is a UX nicety; the clipboard must
-            // carry the real header.
-            navigator.clipboard.writeText(realCmd).then(function () {
-              copyBtn.textContent = 'Copied ✓';
-              setTimeout(function () { copyBtn.textContent = 'Copy'; }, 2000);
-            });
-          });
-        })();
-      </script>
-    </div>`;
-  }
   return `<div class="done-tile">
     <h2>Connect Claude Code (MCP)</h2>
     <p>Wire <code>vault:${safeVault}</code> into Claude Code as an MCP server:</p>
@@ -1755,25 +1641,21 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
   // request from step 2.
   if (state.hasAdmin && state.hasVault && state.hasExposeMode) {
     if (url.searchParams.get("just_finished") === "1") {
-      // hub#274 security fold: session-gate this branch. The
-      // `?just_finished=1` GET reads + consumes `setup_minted_token`
-      // (full-scope operator JWT) below; without a session check, any
-      // HTTP client that races the operator's browser between the
-      // expose POST (which writes the row) and the done GET (which
-      // reads it) walks off with admin-scope creds. The dispatcher
-      // in `hub-server.ts`'s `shouldGateForSetup` lets `/admin/setup*`
-      // through the pre-admin lockout, and that path stays open
-      // post-setup — so this gate has to live here, not at the
-      // dispatcher layer.
+      // hub#274 security fold: session-gate this branch. Originally this
+      // protected the `setup_minted_token` read-and-consume below (a
+      // full-scope operator JWT a racing client could have walked off
+      // with). The auto-mint was removed 2026-06-23 (Austen's report —
+      // vault is OAuth-default now, see the expose POST), so no secret
+      // is surfaced here anymore. The gate stays: the done screen is a
+      // post-setup admin surface and shouldn't render to a drive-by
+      // unauthenticated GET. The dispatcher in `hub-server.ts`'s
+      // `shouldGateForSetup` lets `/admin/setup*` through the pre-admin
+      // lockout, and that path stays open post-setup — so this gate has
+      // to live here, not at the dispatcher layer.
       //
       // A legitimate operator carrying the session cookie minted on
       // the account POST sails through. A drive-by GET without the
-      // cookie 302s to /login: if it's a stale bookmark in the
-      // operator's other tab, they sign in + the row is already
-      // consumed by the legitimate done-GET (the single-use shape
-      // guarantees they see the fallback shape, never the secret).
-      // If it's an attacker, they can't pass /login without the
-      // password.
+      // cookie 302s to /login.
       const session = findActiveSession(deps.db, req);
       if (!session) {
         // Preserve the CSRF set-cookie header on the 302 — same shape as
@@ -1790,13 +1672,17 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
       }
       const stored = getSetting(deps.db, "setup_expose_mode");
       const exposeMode = isSetupExposeMode(stored) ? stored : undefined;
-      // hub#272 Item A: read + consume the single-use minted-token row.
-      // Render-and-forget keeps the secret from re-appearing on
-      // refresh / back-button. The mint is non-fatal (see expose POST);
-      // its absence renders the bare MCP command + a hint at
-      // /admin/tokens.
-      const mintedToken = getSetting(deps.db, "setup_minted_token");
-      if (mintedToken) deleteSetting(deps.db, "setup_minted_token");
+      // No minted-token read here anymore — the auto-mint was removed
+      // 2026-06-23 (Austen's report). The done step always renders the
+      // bare OAuth `claude mcp add` command (no Bearer header), which is
+      // the correct UX for OAuth-default vaults. Headless clients mint a
+      // scoped token at /admin/tokens themselves (the bare tile points
+      // there). The defensive `deleteSetting` below clears any stale row
+      // a pre-upgrade hub left behind, so it never leaks on first render
+      // after upgrade.
+      if (getSetting(deps.db, "setup_minted_token") !== undefined) {
+        deleteSetting(deps.db, "setup_minted_token");
+      }
       // Prefer the LIVE vault name from services.json over the
       // operator-typed value cached in hub_settings (smoke
       // 2026-05-27, finding 2). The cached value is what the
@@ -1834,7 +1720,7 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
         installTiles,
       };
       if (exposeMode !== undefined) doneProps.exposeMode = exposeMode;
-      if (mintedToken) doneProps.mintedToken = mintedToken;
+      // No `doneProps.mintedToken` — see the OAuth-default note above.
       // Substitute CSRF placeholder for the install-tile forms with
       // the current CSRF token. Keeping the per-tile renderer pure
       // means the substitution lives here (one rewrite per render).
@@ -2861,35 +2747,23 @@ export async function handleSetupExposePost(
   console.log(
     `[setup-wizard] opened first-client auto-approve window (60min) after expose-mode=${rawMode}`,
   );
-  // hub#272 Item A: auto-mint an operator token under the broad `admin`
-  // scope-set + persist it once so the done-step renderer can pre-fill
-  // the MCP install command with a Bearer header. The token is single-
-  // use surface on the done page — the renderer deletes it from
-  // hub_settings after one read so a stale tab refresh / back button
-  // doesn't re-disclose the secret. The jti is still in the `tokens`
-  // registry so revocation via the admin UI works as usual. Failures
-  // are non-fatal: the done page falls back to the un-headered MCP
-  // command + a "mint manually at /admin/tokens" hint.
-  let mintedTokenForJson: string | undefined;
-  try {
-    const minted = await mintOperatorToken(deps.db, session.userId, {
-      issuer: deps.issuer,
-      scopeSet: "admin",
-    });
-    setSetting(deps.db, "setup_minted_token", minted.token);
-    mintedTokenForJson = minted.token;
-    console.log(
-      `[setup-wizard] auto-minted operator token (jti=${minted.jti}, scope-set=admin) for done-screen MCP command`,
-    );
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    console.warn(`[setup-wizard] failed to auto-mint operator token: ${msg}`);
-  }
+  // hub#272 Item A USED to auto-mint a broad `admin`-scope operator token
+  // here + stash it (`setup_minted_token`) so the done screen could
+  // pre-fill the MCP install command with a `--header "Authorization:
+  // Bearer <token>"` flag. Removed 2026-06-23 (Austen's report): vault/
+  // init is OAuth-default now (parachute-vault #491), so the bare
+  // `claude mcp add` command is the correct UX — it triggers browser
+  // OAuth on first use. Baking a full admin-scope bearer into a copy-
+  // pasted command was both the wrong default and a privilege over-grant
+  // (a single shoulder-surf / screencast leaked an admin token). The
+  // done step now always renders the bare OAuth command; headless
+  // clients that can't do the browser flow mint a scoped token at
+  // /admin/tokens + append the header themselves (the bare tile points
+  // there). No token is minted or stored by default.
   if (form.isJson) {
     return jsonOkResponse({
       step: "done",
       message: "expose mode set",
-      ...(mintedTokenForJson ? { minted_token: mintedTokenForJson } : {}),
     });
   }
   return redirect("/admin/setup?just_finished=1");


### PR DESCRIPTION
## What

The hub setup wizard's **"Connect Claude Code (MCP)"** done-screen handed out a `claude mcp add … --header "Authorization: Bearer <token>"` command. Vault/init is **OAuth-default** now ([parachute-vault #491](https://github.com/ParachuteComputer/parachute-vault/pull/491)), so the header-auth command is the wrong default — it broke the connect for a real user (**Austen**, 2026-06-23: *"the wizard gives him a command with header auth, but we use oauth as default now"*).

The wizard was auto-minting a full admin-scope operator token in the expose-step POST (hub#272 Item A), stashing it in `setup_minted_token`, and pre-filling the MCP command with a Bearer header (plus a masked-reveal/Copy widget). This PR removes that path so the done screen **always renders the bare OAuth command**, which triggers browser OAuth on first use.

Complements parachute-vault #491.

### Before
```
claude mcp add --transport http parachute-default https://hub.example/vault/default/mcp --header "Authorization: Bearer <admin-scope-token>"
```
(rendered as a masked `Bearer •••` with a Show/Copy widget; the real token in a hidden stash)

### After
```
claude mcp add --transport http parachute-default https://hub.example/vault/default/mcp
```
Fine print: *"No token needed — triggers browser OAuth on first use … for headless clients that can't do the browser flow, mint a hub token at `/admin/tokens` and append `--header "Authorization: Bearer <token>"`."* The standalone `/admin/tokens` mint path is unchanged.

## Security

Also drops a **privilege over-grant**: the auto-mint baked a full admin-scope bearer into a copy-pasted command — a single shoulder-surf or screencast leaked an admin credential. No token is minted or stored by default anymore. The done-step GET defensively clears any stale `setup_minted_token` row a pre-upgrade hub may have left behind. The post-setup session gate on the done GET (hub#274) is preserved.

## Changes

- **`src/setup-wizard.ts`**: remove the expose-POST auto-mint block + the done-screen token read/consume; `renderMcpTile` renders the bare OAuth command only (token-present masked-reveal branch deleted, ~100 lines of inline JS/HTML gone); drop the unused `mintOperatorToken` import + the `RenderDoneStepProps.mintedToken` field.
- **`src/commands/wizard.ts`** (CLI): comment-only refresh (the CLI path never minted).
- **`src/hub-settings.ts`**: mark the `setup_minted_token` key DEPRECATED (retained for defensive cleanup of stale rows; nothing writes it).
- **tests** (`src/__tests__/setup-wizard.test.ts`): rewrote the hub#272-Item-A block to assert no token is minted/stored by default, the JSON expose response carries no `minted_token`, and the done-screen command carries **NO Bearer header** by default (the assertion that would have caught the bug), plus stale-row cleanup + session-gate coverage. The negative assertion is scoped to the MCP tile's `<pre>` (the fine print legitimately mentions `Bearer &lt;token&gt;`).

## Gates

- `bun run test` (= `bun test ./src`): **3578 pass, 1 skip, 0 fail** (3579 across 140 files)
- `bun run typecheck`: clean
- `biome check`: clean

## Release

Bumped `package.json` → `0.7.2-rc.1` (per the resumed per-PR rc policy; no active 0.7.x rc chain). CHANGELOG rc entry added. **No tag pushed** (happens on merge).

## Review

Independent reviewer pass: **LGTM**, no critical issues. Test-hardening nit (anchor the regression regex to the MCP-tile `<h2>` so it can't drift onto another tile's `<pre>` under a different expose mode) folded in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)