### PR TITLE
release: promote hub 0.7.2 + scope-guard 0.4.1 to stable

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.2-rc.1",
+  "version": "0.7.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.4.1-rc.1",
+  "version": "0.4.1",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
## What
Aaron's ready-for-release call (launch). Drop the `-rc.1` suffix per governance rule 2 — ship the same patch as the rc chain:

- `@openparachute/hub` **0.7.2-rc.1 → 0.7.2** (tag `v0.7.2`)
- `@openparachute/scope-guard` **0.4.1-rc.1 → 0.4.1** (tag `scope-guard-v0.4.1`)

## Why scope-guard too
`@openparachute/vault@0.6.2` declares `@openparachute/scope-guard@^0.4.1` — scope-guard 0.4.1 must exist as a **stable** publish or vault would resolve a prerelease. This PR ships it so the vault 0.6.2 release (separate repo) resolves cleanly.

## What hub 0.7.2 carries
The OAuth-default setup-wizard fix (#680): the done-screen hands a bare OAuth `claude mcp add` command — no minted admin/header token. Verified launch-ready in a wizard audit.

## Verification
- `bun run typecheck` clean.
- `bun.lock` unchanged; `bun install --frozen-lockfile` passes.
- Full `bun test ./src` + scope-guard tests run in CI on the tags (not run locally — hub's lifecycle tests can bootout the live daemon on this box).

## Note
Isolated on `release-hub-0.7.2` rather than `ag-unforced-dev` — the shared dev branch carries another session's unmerged commit (`285eb26`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)