### PR TITLE
feat(invites): multi-use public-signup links + email capture + per-vault caps (B1+B2+B4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.3",
+  "version": "0.7.3-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -733,6 +733,7 @@ import { findGrant, recordGrant } from "../grants.ts";
 import { findInviteByHash, issueInvite } from "../invites.ts";
 import { findTokenRowByJti, listActiveRevocations, recordTokenMint } from "../jwt-sign.ts";
 import { createUser, setUserVaults } from "../users.ts";
+import { getVaultCapBytes, setVaultCap } from "../vault-caps.ts";
 
 const VAULT_ORIGIN = "http://127.0.0.1:19400";
 const AGENT_ORIGIN = "http://127.0.0.1:19410";
@@ -1034,6 +1035,12 @@ describe("DELETE /vaults/<name> — the identity cascade", () => {
           "UPDATE invites SET used_at = ?, used_count = 1, redeemed_user_id = ? WHERE token = ?",
         ).run(new Date().toISOString(), alice.id, redeemedWork.invite.tokenHash);
 
+        // 4b. vault_caps (v15): one row per vault. The work row is dropped by
+        //     the cascade; the default row stays (a re-created same-name vault
+        //     must not inherit a stale cap).
+        setVaultCap(db, "work", 1024 * 1024 * 1024);
+        setVaultCap(db, "default", 2 * 1024 * 1024 * 1024);
+
         // 5. Connections: one sourced on work (torn down), one on default (kept).
         putConnection(store, {
           id: "conn-work",
@@ -1094,6 +1101,7 @@ describe("DELETE /vaults/<name> — the identity cascade", () => {
             grants_dropped: number;
             user_vaults_removed: number;
             invites_invalidated: number;
+            vault_cap_removed: boolean;
             connections_torn_down: number;
             orphaned_channels: string[];
             vault_removed: boolean;
@@ -1135,6 +1143,11 @@ describe("DELETE /vaults/<name> — the identity cascade", () => {
         expect(findInviteByHash(db, pendingDefault.invite.tokenHash)?.revokedAt).toBeNull();
         expect(findInviteByHash(db, redeemedWork.invite.tokenHash)?.usedAt).not.toBeNull();
         expect(findInviteByHash(db, redeemedWork.invite.tokenHash)?.revokedAt).toBeNull();
+
+        // 4b. vault_caps: the work cap row dropped; the default cap row stays.
+        expect(out.cascade.vault_cap_removed).toBe(true);
+        expect(getVaultCapBytes(db, "work")).toBeNull();
+        expect(getVaultCapBytes(db, "default")).toBe(2 * 1024 * 1024 * 1024);
 
         // 5. Connections: work connection torn down (trigger deregistered +
         //    channel entry deleted + record removed); default connection kept.

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -1026,11 +1026,13 @@ describe("DELETE /vaults/<name> — the identity cascade", () => {
         const pendingWork = issueInvite(db, { createdBy: alice.id, vaultName: "work" });
         const pendingDefault = issueInvite(db, { createdBy: alice.id, vaultName: "default" });
         const redeemedWork = issueInvite(db, { createdBy: alice.id, vaultName: "work" });
-        db.prepare("UPDATE invites SET used_at = ?, redeemed_user_id = ? WHERE token = ?").run(
-          new Date().toISOString(),
-          alice.id,
-          redeemedWork.invite.tokenHash,
-        );
+        // Simulate a fully-redeemed single-use invite exactly as the redeem path
+        // leaves it (v15): used_at stamped AND used_count bumped to max_uses, so
+        // the cascade's `used_count < max_uses` exhaustion guard treats it as
+        // terminal (untouched), same as the pre-v15 `used_at IS NULL` guard did.
+        db.prepare(
+          "UPDATE invites SET used_at = ?, used_count = 1, redeemed_user_id = ? WHERE token = ?",
+        ).run(new Date().toISOString(), alice.id, redeemedWork.invite.tokenHash);
 
         // 5. Connections: one sourced on work (torn down), one on default (kept).
         putConnection(store, {

--- a/src/__tests__/public-signup.test.ts
+++ b/src/__tests__/public-signup.test.ts
@@ -1,0 +1,577 @@
+/**
+ * Multi-use public-signup links + email-as-username + per-vault caps
+ * (DEMO-PREP-2026-06-25 Workstream B: B1 multi-use invite, B2 email capture,
+ * B4 public signup page; the cap value persisted for B3's Phase-2 enforcement).
+ *
+ * Coverage required by the brief:
+ *   - multi-use exhaustion (used_count == max_uses → refused)
+ *   - expiry refusal (multi-use link past expires_at → 410)
+ *   - email capture (stored on users + on the invite, validated)
+ *   - signup → vault provision with the cap PERSISTED to vault_caps
+ *   - backwards-compat with legacy single-use invites
+ *
+ * Plus: the migration is backwards-compatible (legacy rows redeem unchanged),
+ * the invite primitive's seat accounting, and the API mint gates.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleAccountSetupGet, handleAccountSetupPost } from "../account-setup.ts";
+import type { RunResult } from "../admin-vaults.ts";
+import { handleCreateInvite } from "../api-invites.ts";
+import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  InviteExhaustedError,
+  InviteUsedError,
+  assertInviteRedeemable,
+  findInviteByRawToken,
+  inviteStatus,
+  issueInvite,
+  recordInviteRedemption,
+} from "../invites.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { __resetForTests } from "../rate-limit.ts";
+import { createUser, getUserByUsernameCI } from "../users.ts";
+import { getVaultCapBytes } from "../vault-caps.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-public-signup-"));
+  const db = openHubDb(hubDbPath(dir));
+  const manifestPath = join(dir, "services.json");
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      services: [
+        {
+          name: "parachute-vault",
+          port: 4101,
+          paths: ["/vault/seed"],
+          health: "/health",
+          version: "0.0.0-test",
+        },
+      ],
+    }),
+  );
+  return {
+    db,
+    manifestPath,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+  __resetForTests();
+});
+afterEach(() => {
+  harness.cleanup();
+  __resetForTests();
+});
+
+/** Stub vault create: append the named vault path to services.json. */
+function makeStubRunCommand() {
+  const calls: string[][] = [];
+  const run = async (cmd: readonly string[]): Promise<RunResult> => {
+    calls.push([...cmd]);
+    const name = cmd[2] ?? "";
+    const manifest = JSON.parse(readFileSync(harness.manifestPath, "utf8")) as {
+      services: { name: string; paths: string[] }[];
+    };
+    const vaultSvc = manifest.services.find((s) => s.name === "parachute-vault");
+    if (vaultSvc && !vaultSvc.paths.includes(`/vault/${name}`)) {
+      vaultSvc.paths.push(`/vault/${name}`);
+      writeFileSync(harness.manifestPath, JSON.stringify(manifest));
+    }
+    const createJson = {
+      name,
+      token: "",
+      paths: {
+        vault_dir: `/d/${name}`,
+        vault_db: `/d/${name}/v.db`,
+        vault_config: `/d/${name}/v.yaml`,
+      },
+      set_as_default: false,
+    };
+    return { exitCode: 0, stdout: JSON.stringify(createJson), stderr: "" };
+  };
+  return { run, calls };
+}
+
+function csrfPair(): { token: string; cookieFragment: string } {
+  const token = generateCsrfToken();
+  const cookie = buildCsrfCookie(token, { secure: false }).split(";")[0] ?? "";
+  return { token, cookieFragment: cookie };
+}
+
+function postReq(token: string, fields: Record<string, string>, csrfCookie: string): Request {
+  const form = new URLSearchParams(fields);
+  return new Request(`${ISSUER}/account/setup/${token}`, {
+    method: "POST",
+    headers: { "content-type": "application/x-www-form-urlencoded", cookie: csrfCookie },
+    body: form.toString(),
+  });
+}
+
+function deps(runCommand?: (cmd: readonly string[]) => Promise<RunResult>) {
+  return {
+    db: harness.db,
+    hubOrigin: ISSUER,
+    manifestPath: harness.manifestPath,
+    ...(runCommand !== undefined ? { runCommand } : {}),
+  };
+}
+
+/** Drive one full public-signup redemption (multi-use shape) for a new account. */
+async function signup(
+  rawToken: string,
+  username: string,
+  email: string,
+  run: (cmd: readonly string[]) => Promise<RunResult>,
+): Promise<Response> {
+  const { token: csrfToken, cookieFragment } = csrfPair();
+  __resetForTests(); // each signup is a distinct IP-bucket attempt window
+  return handleAccountSetupPost(
+    postReq(
+      rawToken,
+      {
+        [CSRF_FIELD_NAME]: csrfToken,
+        username,
+        email,
+        password: `${username}-strong-password-1`,
+        password_confirm: `${username}-strong-password-1`,
+        vault_name: username,
+      },
+      cookieFragment,
+    ),
+    rawToken,
+    deps(run),
+  );
+}
+
+// ===========================================================================
+// B1 — multi-use seat accounting (primitive level)
+// ===========================================================================
+
+describe("invite primitive — multi-use seats (v15)", () => {
+  test("legacy default is single-use: max_uses=1, used_count=0", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { invite } = issueInvite(harness.db, { createdBy: admin.id });
+    expect(invite.maxUses).toBe(1);
+    expect(invite.usedCount).toBe(0);
+    expect(invite.email).toBeNull();
+    expect(invite.vaultCapBytes).toBeNull();
+  });
+
+  // recordInviteRedemption's redeemed_user_id FKs users(id), so tests pass
+  // real committed user ids (as the production redeem path does).
+  async function makeUsers(...names: string[]): Promise<string[]> {
+    const ids: string[] = [];
+    for (const n of names) {
+      const u = await createUser(harness.db, n, `${n}-password-1`, { allowMulti: true });
+      ids.push(u.id);
+    }
+    return ids;
+  }
+
+  test("recordInviteRedemption bumps used_count, stamps used_at on first only", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const [u1, u2] = await makeUsers("ra", "rb");
+    const { rawToken, invite } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 3 });
+    const t0 = new Date("2026-06-25T00:00:00Z");
+    const t1 = new Date("2026-06-25T01:00:00Z");
+    expect(recordInviteRedemption(harness.db, invite.tokenHash, u1!, "a@x.io", t0)).toBe(true);
+    let row = findInviteByRawToken(harness.db, rawToken);
+    expect(row?.usedCount).toBe(1);
+    expect(row?.usedAt).toBe(t0.toISOString());
+    expect(row?.email).toBe("a@x.io");
+    // Second redeem: used_count bumps, used_at preserved (COALESCE), email updates.
+    expect(recordInviteRedemption(harness.db, invite.tokenHash, u2!, "b@x.io", t1)).toBe(true);
+    row = findInviteByRawToken(harness.db, rawToken);
+    expect(row?.usedCount).toBe(2);
+    expect(row?.usedAt).toBe(t0.toISOString()); // unchanged
+    expect(row?.email).toBe("b@x.io"); // latest redeemer
+  });
+
+  test("exhaustion: the (max_uses+1)th record is refused (zero rows)", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const [u1, u2, u3] = await makeUsers("ea", "eb", "ec");
+    const { invite } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 2 });
+    expect(recordInviteRedemption(harness.db, invite.tokenHash, u1!)).toBe(true);
+    expect(recordInviteRedemption(harness.db, invite.tokenHash, u2!)).toBe(true);
+    // Third — over cap.
+    expect(recordInviteRedemption(harness.db, invite.tokenHash, u3!)).toBe(false);
+  });
+
+  test("status: partially-used multi-use link stays 'pending'; exhausted → 'redeemed'", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const [u1, u2] = await makeUsers("sa", "sb");
+    const { rawToken, invite } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 2 });
+    recordInviteRedemption(harness.db, invite.tokenHash, u1!);
+    expect(inviteStatus(findInviteByRawToken(harness.db, rawToken)!)).toBe("pending");
+    recordInviteRedemption(harness.db, invite.tokenHash, u2!);
+    expect(inviteStatus(findInviteByRawToken(harness.db, rawToken)!)).toBe("redeemed");
+  });
+
+  test("assertInviteRedeemable: exhausted single-use throws InviteUsedError, multi-use throws InviteExhaustedError", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const [u1, u2, u3] = await makeUsers("aa", "ab", "ac");
+    const single = issueInvite(harness.db, { createdBy: admin.id, maxUses: 1 });
+    recordInviteRedemption(harness.db, single.invite.tokenHash, u1!);
+    expect(() => assertInviteRedeemable(harness.db, single.rawToken)).toThrow(InviteUsedError);
+
+    const multi = issueInvite(harness.db, { createdBy: admin.id, maxUses: 2 });
+    recordInviteRedemption(harness.db, multi.invite.tokenHash, u2!);
+    recordInviteRedemption(harness.db, multi.invite.tokenHash, u3!);
+    expect(() => assertInviteRedeemable(harness.db, multi.rawToken)).toThrow(InviteExhaustedError);
+  });
+});
+
+// ===========================================================================
+// B4 — public signup page end-to-end (multi-use redemption)
+// ===========================================================================
+
+describe("public signup page — multi-use redemption + caps", () => {
+  test("two strangers redeem ONE link → two accounts, two vaults, cap persisted, used_count=2", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const cap = 1024 * 1024 * 1024; // 1 GiB
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      maxUses: 5,
+      vaultCapBytes: cap,
+    });
+    const stub = makeStubRunCommand();
+
+    const r1 = await signup(rawToken, "alice", "alice@example.com", stub.run);
+    expect(r1.status).toBe(302);
+    const r2 = await signup(rawToken, "bob", "bob@example.com", stub.run);
+    expect(r2.status).toBe(302);
+
+    // Two distinct accounts with their emails stored.
+    const alice = getUserByUsernameCI(harness.db, "alice");
+    const bob = getUserByUsernameCI(harness.db, "bob");
+    expect(alice?.email).toBe("alice@example.com");
+    expect(bob?.email).toBe("bob@example.com");
+    expect(alice?.assignedVaults).toEqual(["alice"]);
+    expect(bob?.assignedVaults).toEqual(["bob"]);
+
+    // Each provisioned vault carries the cap (B4 persistence for the Phase-2 reader).
+    expect(getVaultCapBytes(harness.db, "alice")).toBe(cap);
+    expect(getVaultCapBytes(harness.db, "bob")).toBe(cap);
+
+    // The link recorded two redemptions, still has seats, stays pending.
+    const after = findInviteByRawToken(harness.db, rawToken);
+    expect(after?.usedCount).toBe(2);
+    expect(after?.maxUses).toBe(5);
+    expect(inviteStatus(after!)).toBe("pending");
+  });
+
+  test("multi-use link with NO cap on the invite → provisioned vault has NO vault_caps row (uncapped contract)", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    // issueInvite directly (bypasses the API's auto-default) with no cap.
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 5 });
+    const stub = makeStubRunCommand();
+    expect((await signup(rawToken, "nina", "nina@example.com", stub.run)).status).toBe(302);
+    // No cap row → the Phase-2 reader treats the vault as uncapped.
+    expect(getVaultCapBytes(harness.db, "nina")).toBeNull();
+  });
+
+  test("exhaustion refusal: the (N+1)th signup on a maxed link → 410", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 1 + 1 });
+    const stub = makeStubRunCommand();
+    expect((await signup(rawToken, "alice", "alice@example.com", stub.run)).status).toBe(302);
+    expect((await signup(rawToken, "bob", "bob@example.com", stub.run)).status).toBe(302);
+    // Third — link is exhausted.
+    const r3 = await signup(rawToken, "carol", "carol@example.com", stub.run);
+    expect(r3.status).toBe(410);
+    expect(await r3.text()).toContain("Signups closed");
+    expect(getUserByUsernameCI(harness.db, "carol")).toBeNull();
+  });
+
+  test("expiry refusal: a multi-use link past expires_at → 410, no account created", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const t0 = new Date("2026-06-25T00:00:00Z");
+    const { rawToken } = issueInvite(harness.db, {
+      createdBy: admin.id,
+      maxUses: 10,
+      expiresInSeconds: 60,
+      now: () => t0,
+    });
+    const stub = makeStubRunCommand();
+    const later = new Date(t0.getTime() + 120_000);
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "dave",
+          email: "dave@example.com",
+          password: "dave-strong-password-1",
+          password_confirm: "dave-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      { ...deps(stub.run), now: () => later },
+    );
+    expect(res.status).toBe(410);
+    expect(getUserByUsernameCI(harness.db, "dave")).toBeNull();
+  });
+
+  test("email capture: GET renders the email field for a multi-use link", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 5 });
+    const html = await handleAccountSetupGet(
+      new Request(`${ISSUER}/account/setup/${rawToken}`),
+      rawToken,
+      deps(),
+    ).text();
+    expect(html).toContain('name="email"');
+    expect(html).toContain('type="email"');
+  });
+
+  test("email validation: malformed email → 400 re-render, no account", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 5 });
+    const stub = makeStubRunCommand();
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "eve",
+          email: "not-an-email",
+          password: "eve-strong-password-1",
+          password_confirm: "eve-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(400);
+    expect(await res.text()).toContain("valid email");
+    expect(getUserByUsernameCI(harness.db, "eve")).toBeNull();
+  });
+
+  test("missing email on a multi-use link → 400, no account", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 5 });
+    const stub = makeStubRunCommand();
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "frank",
+          password: "frank-strong-password-1",
+          password_confirm: "frank-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(400);
+    expect(getUserByUsernameCI(harness.db, "frank")).toBeNull();
+  });
+});
+
+// ===========================================================================
+// Backwards-compat — legacy single-use invites redeem unchanged
+// ===========================================================================
+
+describe("backwards-compat — legacy single-use invites", () => {
+  test("a legacy invite row (no v15 columns set) redeems with NO email field and single-use", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    // Simulate a legacy invite: a default issueInvite is max_uses=1 / no email
+    // / no cap — exactly what a pre-v15 row looks like after the migration's
+    // column defaults backfill it.
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, vaultName: "maya" });
+
+    // GET form has NO email field (single-use → friends flow, no email).
+    const html = await handleAccountSetupGet(
+      new Request(`${ISSUER}/account/setup/${rawToken}`),
+      rawToken,
+      deps(),
+    ).text();
+    expect(html).not.toContain('name="email"');
+
+    const stub = makeStubRunCommand();
+    const { token: csrfToken, cookieFragment } = csrfPair();
+    const res = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "maya",
+          // No email submitted — single-use doesn't require it.
+          password: "maya-strong-password-1",
+          password_confirm: "maya-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(res.status).toBe(302);
+
+    const user = getUserByUsernameCI(harness.db, "maya");
+    expect(user).not.toBeNull();
+    expect(user?.email).toBeNull(); // no email captured on the friends flow
+    expect(user?.assignedVaults).toEqual(["maya"]);
+
+    // Vault provisioned WITHOUT a cap (legacy invites carry no cap).
+    expect(getVaultCapBytes(harness.db, "maya")).toBeNull();
+
+    // Single-use: a replay is refused (used → 410).
+    __resetForTests();
+    const replay = await handleAccountSetupPost(
+      postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username: "maya2",
+          password: "maya2-strong-password-1",
+          password_confirm: "maya2-strong-password-1",
+        },
+        cookieFragment,
+      ),
+      rawToken,
+      deps(stub.run),
+    );
+    expect(replay.status).toBe(410);
+    expect(await replay.text()).toContain("already used");
+  });
+});
+
+// ===========================================================================
+// API mint gates (POST /api/invites) — admin creates a multi-use capped link
+// ===========================================================================
+
+describe("POST /api/invites — multi-use + cap mint gates", () => {
+  async function adminBearer(adminId: string): Promise<string> {
+    const minted = await signAccessToken(harness.db, {
+      sub: adminId,
+      scopes: ["parachute:host:admin"],
+      audience: "hub",
+      clientId: "parachute-hub-spa",
+      issuer: ISSUER,
+      ttlSeconds: 300,
+      vaultScope: [],
+    });
+    return minted.token;
+  }
+
+  function createReq(bearer: string, body: Record<string, unknown>): Request {
+    return new Request(`${ISSUER}/api/invites`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${bearer}`, "content-type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  test("mints a multi-use capped link; wire shape carries the new fields", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const bearer = await adminBearer(admin.id);
+    const cap = 1024 * 1024 * 1024;
+    const res = await handleCreateInvite(
+      createReq(bearer, { max_uses: 25, vault_cap_bytes: cap }),
+      { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath },
+    );
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as {
+      invite: { max_uses: number; used_count: number; vault_cap_bytes: number; email: null };
+      url: string;
+    };
+    expect(body.invite.max_uses).toBe(25);
+    expect(body.invite.used_count).toBe(0);
+    expect(body.invite.vault_cap_bytes).toBe(cap);
+    expect(body.url).toContain("/account/setup/");
+  });
+
+  test("auto-applies the ~1 GiB default cap to a multi-use provisioning link with no explicit cap", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const bearer = await adminBearer(admin.id);
+    const res = await handleCreateInvite(createReq(bearer, { max_uses: 10 }), {
+      db: harness.db,
+      issuer: ISSUER,
+      manifestPath: harness.manifestPath,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invite: { vault_cap_bytes: number } };
+    expect(body.invite.vault_cap_bytes).toBe(1024 * 1024 * 1024);
+  });
+
+  test("single-use link with no explicit cap stays uncapped (no auto-default)", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const bearer = await adminBearer(admin.id);
+    const res = await handleCreateInvite(createReq(bearer, {}), {
+      db: harness.db,
+      issuer: ISSUER,
+      manifestPath: harness.manifestPath,
+    });
+    expect(res.status).toBe(201);
+    const body = (await res.json()) as { invite: { vault_cap_bytes: number | null } };
+    expect(body.invite.vault_cap_bytes).toBeNull();
+  });
+
+  test("rejects max_uses > 1 with a pre-named username", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const bearer = await adminBearer(admin.id);
+    const res = await handleCreateInvite(
+      createReq(bearer, { max_uses: 10, username: "jonathan" }),
+      { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects max_uses > 1 with a pinned NEW vault name", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const bearer = await adminBearer(admin.id);
+    const res = await handleCreateInvite(
+      createReq(bearer, { max_uses: 10, vault_name: "shared", provision_vault: true }),
+      { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects vault_cap_bytes on a non-provisioning invite", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const bearer = await adminBearer(admin.id);
+    const res = await handleCreateInvite(
+      createReq(bearer, { provision_vault: false, vault_cap_bytes: 1000 }),
+      { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("rejects max_uses out of range", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const bearer = await adminBearer(admin.id);
+    const res = await handleCreateInvite(createReq(bearer, { max_uses: 0 }), {
+      db: harness.db,
+      issuer: ISSUER,
+      manifestPath: harness.manifestPath,
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/src/__tests__/public-signup.test.ts
+++ b/src/__tests__/public-signup.test.ts
@@ -290,6 +290,48 @@ describe("public signup page — multi-use redemption + caps", () => {
     expect(getVaultCapBytes(harness.db, "nina")).toBeNull();
   });
 
+  test("CONCURRENT redeem of a max_uses=1 link: exactly one 302, one 410 (atomic exhaustion guard)", async () => {
+    const admin = await createUser(harness.db, "operator", "operator-password-1");
+    const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 1 });
+    const stub = makeStubRunCommand();
+
+    // Build two complete POST requests up front, then fire them together with
+    // NO reset between them — a genuine race for the single seat. (The `signup`
+    // helper resets the rate-limiter per call, which would serialize the
+    // window; here both share one generous signup bucket, so neither 429s.)
+    const mkPost = (username: string): Request => {
+      const { token: csrfToken, cookieFragment } = csrfPair();
+      return postReq(
+        rawToken,
+        {
+          [CSRF_FIELD_NAME]: csrfToken,
+          username,
+          email: `${username}@example.com`,
+          password: `${username}-strong-password-1`,
+          password_confirm: `${username}-strong-password-1`,
+          vault_name: username,
+        },
+        cookieFragment,
+      );
+    };
+    const [r1, r2] = await Promise.all([
+      handleAccountSetupPost(mkPost("racea"), rawToken, deps(stub.run)),
+      handleAccountSetupPost(mkPost("raceb"), rawToken, deps(stub.run)),
+    ]);
+
+    // Exactly one winner (302) and one loser (410) — never two 302s.
+    expect([r1.status, r2.status].sort()).toEqual([302, 410]);
+
+    // The link recorded exactly ONE redemption; exactly one account exists.
+    const after = findInviteByRawToken(harness.db, rawToken);
+    expect(after?.usedCount).toBe(1);
+    const accounts = [
+      getUserByUsernameCI(harness.db, "racea"),
+      getUserByUsernameCI(harness.db, "raceb"),
+    ].filter((u) => u !== null);
+    expect(accounts.length).toBe(1);
+  });
+
   test("exhaustion refusal: the (N+1)th signup on a maxed link → 410", async () => {
     const admin = await createUser(harness.db, "operator", "operator-password-1");
     const { rawToken } = issueInvite(harness.db, { createdBy: admin.id, maxUses: 1 + 1 });

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -23,6 +23,7 @@ import {
   setPassword,
   setUserVaults,
   userCount,
+  validateEmail,
   validatePassword,
   validateUsername,
   vaultVerbsForRole,
@@ -428,6 +429,38 @@ describe("validatePassword", () => {
     // toward passphrases we'll layer it as a separate signal, not a
     // hard gate.
     expect(validatePassword("aaaaaaaaaaaa").valid).toBe(true);
+  });
+});
+
+describe("validateEmail (v15, B2)", () => {
+  test("accepts ordinary addresses, canonicalizing to lowercase/trimmed", () => {
+    const r = validateEmail("  Alice@Example.com ");
+    expect(r.valid).toBe(true);
+    if (r.valid) expect(r.email).toBe("alice@example.com");
+    expect(validateEmail("a.b+tag@sub.domain.co.uk").valid).toBe(true);
+    expect(validateEmail("user_name@x.io").valid).toBe(true);
+  });
+
+  test("rejects malformed shapes", () => {
+    for (const bad of [
+      "",
+      "not-an-email",
+      "@example.com",
+      "alice@",
+      "alice@example",
+      "alice example@x.io",
+      "two@@x.io",
+      "alice@x.c",
+    ]) {
+      expect(validateEmail(bad).valid).toBe(false);
+    }
+  });
+
+  test("rejects over-length addresses (>254)", () => {
+    const long = `${"a".repeat(250)}@x.io`;
+    const r = validateEmail(long);
+    expect(r.valid).toBe(false);
+    if (!r.valid) expect(r.reason).toBe("length");
   });
 });
 

--- a/src/__tests__/vault-caps.test.ts
+++ b/src/__tests__/vault-caps.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Per-vault storage cap store (`src/vault-caps.ts`, migration v15, B4). The
+ * cap is PERSISTED here at provision time; a separate Phase-2 PR reads + enforces
+ * it. These tests cover the read/write/upsert/remove primitives + the "no row
+ * = uncapped" contract the Phase-2 reader relies on.
+ */
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  DEFAULT_VAULT_CAP_BYTES,
+  getVaultCap,
+  getVaultCapBytes,
+  removeVaultCap,
+  setVaultCap,
+} from "../vault-caps.ts";
+
+function makeDb() {
+  const dir = mkdtempSync(join(tmpdir(), "phub-vault-caps-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("vault-caps", () => {
+  test("default cap constant is ~1 GiB", () => {
+    expect(DEFAULT_VAULT_CAP_BYTES).toBe(1024 * 1024 * 1024);
+  });
+
+  test("no row = uncapped (null) — the Phase-2 reader's contract", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(getVaultCap(db, "nope")).toBeNull();
+      expect(getVaultCapBytes(db, "nope")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("setVaultCap persists, getVaultCapBytes reads it back", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const now = new Date("2026-06-25T00:00:00Z");
+      const cap = setVaultCap(db, "alice", DEFAULT_VAULT_CAP_BYTES, now);
+      expect(cap.vaultName).toBe("alice");
+      expect(cap.capBytes).toBe(DEFAULT_VAULT_CAP_BYTES);
+      expect(cap.createdAt).toBe(now.toISOString());
+      expect(getVaultCapBytes(db, "alice")).toBe(DEFAULT_VAULT_CAP_BYTES);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("upsert: re-set overwrites cap_bytes, bumps updated_at, preserves created_at", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const t0 = new Date("2026-06-25T00:00:00Z");
+      const t1 = new Date("2026-06-26T00:00:00Z");
+      setVaultCap(db, "alice", 1000, t0);
+      const updated = setVaultCap(db, "alice", 2000, t1);
+      expect(updated.capBytes).toBe(2000);
+      expect(updated.createdAt).toBe(t0.toISOString()); // preserved
+      expect(updated.updatedAt).toBe(t1.toISOString()); // bumped
+      expect(getVaultCapBytes(db, "alice")).toBe(2000);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("removeVaultCap drops the row (cascade parity) — returns count", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      setVaultCap(db, "alice", 1000);
+      expect(removeVaultCap(db, "alice")).toBe(1);
+      expect(getVaultCapBytes(db, "alice")).toBeNull();
+      // Idempotent — removing a missing row is 0.
+      expect(removeVaultCap(db, "alice")).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -75,7 +75,7 @@ import {
   assertInviteRedeemable,
   recordInviteRedemption,
 } from "./invites.ts";
-import { checkAndRecord, clientIpFromRequest } from "./rate-limit.ts";
+import { clientIpFromRequest, signupRateLimiter } from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "./sessions.ts";
 import {
@@ -241,11 +241,15 @@ export async function handleAccountSetupPost(
     );
   }
 
-  // Rate limit — reuse the /login IP bucket so a redeem flood and a login
-  // flood share the same throttle. After CSRF (so a junk cross-site POST
-  // doesn't burn the bucket), before any account/vault work.
+  // Rate limit — a DEDICATED signup bucket (per-IP, 60/15min), NOT the /login
+  // bucket. A public multi-use signup link is redeemed by a room of people
+  // sharing one NAT'd egress IP, so the /login-sized 5/15min cap would 429 the
+  // ~6th legitimate signer mid-demo. Generous-but-bounded: the invite's own
+  // max_uses + expiry are the primary bound; this is the abuse floor. After
+  // CSRF (so a junk cross-site POST doesn't burn the bucket), before any
+  // account/vault work.
   const clientIp = clientIpFromRequest(req);
-  const gate = checkAndRecord(clientIp, now);
+  const gate = signupRateLimiter.checkAndRecord(clientIp, now);
   if (!gate.allowed) {
     return htmlResponse(
       renderAdminError({

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -6,10 +6,21 @@
  * account-claim flow (`setup-wizard.ts` `handleSetupAccountPost`). A brand-new
  * invitee opens the link with no session and no JS:
  *
- *   GET  → render the "pick username + password (+ vault name)" form.
+ * MULTI-USE (v15, DEMO-PREP-2026-06-25 Workstream B): this same surface is the
+ * PUBLIC SIGNUP PAGE (B4). A multi-use invite link (`max_uses > 1`) lets many
+ * strangers redeem the one link until its seats run out — each redeem creates
+ * a fresh account + vault. Such a link also collects the redeemer's EMAIL (B2,
+ * so the operator can reach signups) and STAMPS a per-vault storage cap (B4)
+ * onto each provisioned vault. A legacy single-use admin/friends invite
+ * (`max_uses = 1`, the default) behaves exactly as before — no email field, no
+ * cap, single redeem.
+ *
+ *   GET  → render the "pick username + password (+ email, + vault name)" form.
  *   POST → redeem: look up the invite by sha256(token), validate it's still
- *          redeemable, validate credentials, provision the vault, create the
- *          user, stamp the invite used, mint a session, 302 → /account/.
+ *          redeemable (seats left, not expired/revoked), validate credentials
+ *          (+ email for public links), provision the vault (stamping its cap),
+ *          create the user, record the redemption (bump used_count, capture
+ *          email), mint a session, 302 → /account/.
  *
  * Redeem ORDERING (the re-usability guarantee, mirroring the wizard):
  *   1. lookup + validate the invite (not-found/expired/used/revoked)
@@ -27,14 +38,17 @@
  *        The vault must still exist in services.json (the vault-delete
  *        cascade revokes pending invites, so this re-check is defense in
  *        depth against manual manifest edits).
- *   4. createUser (the commit point)
- *   5. consumeInvite — stamp used_at + redeemed_user_id ONLY AFTER (4) commits
- *   6. createSession + cookie + 302
+ *   4. createUser (the commit point) — and INSIDE its transaction (the
+ *      `withinTx` hook): recordInviteRedemption (bump used_count + stamp
+ *      used_at/email/redeemed_user_id) AND, for a capped provisioning link,
+ *      setVaultCap. All three commit atomically with the user row.
+ *   5. createSession + cookie + 302
  *
- * Because the invite is consumed only after the user row commits, a
- * createUser exception (UNIQUE collision, disk full, anything) leaves the
- * invite re-usable — the invitee can simply retry. `consumeInvite`'s
- * `used_at IS NULL` guard makes the stamp itself single-use / race-free.
+ * Because the redemption is recorded only inside the user-row transaction, a
+ * createUser exception (UNIQUE collision, disk full, anything) rolls back the
+ * used_count bump + cap write together — the seat stays available and the
+ * invitee can simply retry. `recordInviteRedemption`'s `used_count < max_uses`
+ * guard makes the increment itself exhaustion-safe / race-free.
  *
  * What an invite pre-authorizes: EXACTLY one account + the one named/created/
  * shared vault at the baked-in role — NEVER host:admin, NEVER another vault.
@@ -53,12 +67,13 @@ import { type RunResult, provisionVault } from "./admin-vaults.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import {
+  InviteExhaustedError,
   InviteExpiredError,
   InviteNotFoundError,
   InviteRevokedError,
   InviteUsedError,
   assertInviteRedeemable,
-  consumeInvite,
+  recordInviteRedemption,
 } from "./invites.ts";
 import { checkAndRecord, clientIpFromRequest } from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
@@ -68,9 +83,11 @@ import {
   UsernameTakenError,
   createUser,
   getUserByUsernameCI,
+  validateEmail,
   validatePassword,
   validateUsername,
 } from "./users.ts";
+import { setVaultCap } from "./vault-caps.ts";
 import { validateVaultName } from "./vault-name.ts";
 import { listVaultNamesFromPath } from "./vault-names.ts";
 
@@ -127,6 +144,16 @@ function rejectInvite(err: unknown): Response {
       410,
     );
   }
+  if (err instanceof InviteExhaustedError) {
+    return htmlResponse(
+      renderAdminError({
+        title: "Signups closed",
+        message:
+          "This signup link has reached its maximum number of accounts. Ask your hub operator for a new link.",
+      }),
+      410,
+    );
+  }
   if (err instanceof InviteRevokedError) {
     return htmlResponse(
       renderAdminError({
@@ -166,10 +193,23 @@ export function handleAccountSetupGet(
       pinnedUsername: invite.username,
       role: invite.role,
       provisionVault: invite.provisionVault,
+      collectEmail: collectsEmail(invite),
     }),
     200,
     setCookie,
   );
+}
+
+/**
+ * Whether this redemption captures the redeemer's email (B2). Multi-use
+ * public-signup links collect it (the operator must be able to reach the
+ * stranger who signed up); legacy single-use admin invites don't bother
+ * (the admin already knows who they handed the link to). The signal: a
+ * multi-use link (`max_uses > 1`). Public-signup links always mint with
+ * `max_uses > 1`, so this cleanly distinguishes them from the friends flow.
+ */
+function collectsEmail(invite: { maxUses: number }): boolean {
+  return invite.maxUses > 1;
 }
 
 /** POST /account/setup/<token> — redeem the invite (see file docstring for ordering). */
@@ -223,6 +263,10 @@ export async function handleAccountSetupPost(
     invite.username !== null ? invite.username : String(form.get("username") ?? "").trim();
   const password = String(form.get("password") ?? "");
   const confirm = String(form.get("password_confirm") ?? "");
+  // Email (B2) — captured only for public-signup links (multi-use). The raw
+  // value is echoed back on a re-render so the redeemer doesn't retype it.
+  const collectEmail = collectsEmail(invite);
+  const emailRaw = String(form.get("email") ?? "").trim();
 
   const csrf = ensureCsrfToken(req);
   const setCookie: Record<string, string> = csrf.setCookie ? { "set-cookie": csrf.setCookie } : {};
@@ -236,7 +280,9 @@ export async function handleAccountSetupPost(
         pinnedUsername: invite.username,
         role: invite.role,
         provisionVault: invite.provisionVault,
+        collectEmail,
         username,
+        ...(collectEmail ? { email: emailRaw } : {}),
         ...(vaultNameEcho !== undefined ? { vaultName: vaultNameEcho } : {}),
         errorMessage: message,
       }),
@@ -265,6 +311,21 @@ export async function handleAccountSetupPost(
   }
   if (password !== confirm) {
     return rerender(400, "The two passwords don't match.");
+  }
+  // (2b) Email (B2) — required + format-validated ONLY for public-signup
+  // (multi-use) links, where the operator must be able to reach the stranger
+  // who signed up. Legacy single-use admin invites don't collect it. The
+  // canonical form is lowercased/trimmed by validateEmail.
+  let email: string | null = null;
+  if (collectEmail) {
+    if (emailRaw.length === 0) {
+      return rerender(400, "Enter your email so the hub operator can reach you.");
+    }
+    const e = validateEmail(emailRaw);
+    if (!e.valid) {
+      return rerender(400, "Enter a valid email address (e.g. you@example.com).");
+    }
+    email = e.email;
   }
   // Case-insensitive uniqueness — same gate as /api/users. For a pre-named
   // invite the name can't be changed by the invitee, so a collision (someone
@@ -393,22 +454,33 @@ export async function handleAccountSetupPost(
           : undefined,
       );
     }
+
+    // NOTE: the per-vault storage cap (B4) is PERSISTED below, inside
+    // createUser's transaction (the `withinTx` hook), so the cap write +
+    // redemption record + user insert all commit (or roll back) atomically —
+    // no stranded cap row for a vault whose account creation failed. The
+    // vault itself is provisioned here (the CLI shell-out can't join the
+    // sqlite tx), but the cap METADATA is hub-DB state, so it belongs in the
+    // atomic hook.
   }
 
-  // (4) Create the user + consume the invite ATOMICALLY — the COMMIT POINT.
-  // The invite is consumed INSIDE createUser's transaction (the `withinTx`
-  // hook), so the two single-use guarantees compose:
+  // (4) Create the user + record the redemption ATOMICALLY — the COMMIT POINT.
+  // The redemption is recorded INSIDE createUser's transaction (the `withinTx`
+  // hook), so the seat-accounting guarantees compose:
   //
-  //   - Single-use under concurrency: two redeems of one invite both pass
-  //     `assertInviteRedeemable` above, but only one's `consumeInvite` UPDATE
-  //     (`used_at IS NULL AND revoked_at IS NULL`) changes a row. The loser's
-  //     hook throws `InviteUsedError`, which rolls back ITS user insert — no
-  //     orphan account. Exactly one account results.
+  //   - Exhaustion under concurrency: two redeems of the LAST seat both pass
+  //     `assertInviteRedeemable` above, but only one's `recordInviteRedemption`
+  //     UPDATE (`used_count < max_uses AND revoked_at IS NULL`) changes a row.
+  //     The loser's hook throws (InviteExhaustedError for a multi-use link,
+  //     InviteUsedError for single-use), which rolls back ITS user insert — no
+  //     orphan account. Exactly one account per remaining seat results.
   //   - Re-usable on failure: if createUser throws (UNIQUE collision, etc.)
-  //     before the hook, the invite was never touched; if the hook itself
-  //     throws (lost race), the consume + the user insert roll back together.
-  //     Either way nothing commits, so the invite stays re-usable.
+  //     before the hook, used_count was never bumped; if the hook itself
+  //     throws (lost race), the increment + the user insert roll back together.
+  //     Either way nothing commits, so the seat stays available.
   //
+  // The email (B2) is recorded with the redemption (latest redeemer) AND on
+  // the account row (`users.email`, the canonical per-account field) below.
   // passwordChanged: TRUE (the invitee chose their own password → no force-
   // change). assignedVaults pins them to exactly their one vault at the
   // invite's role. allowMulti because the first admin already exists.
@@ -419,17 +491,27 @@ export async function handleAccountSetupPost(
       passwordChanged: true,
       assignedVaults: vaultName !== null ? [vaultName] : [],
       role: invite.role,
+      ...(email !== null ? { email } : {}),
       withinTx: (newUserId) => {
-        if (!consumeInvite(deps.db, invite.tokenHash, newUserId, now)) {
-          // Lost the redeem race (or a concurrent revoke landed). Throw to
-          // roll back this user insert; surfaced as the used/410 path below.
-          throw new InviteUsedError();
+        if (!recordInviteRedemption(deps.db, invite.tokenHash, newUserId, email, now)) {
+          // Lost the redeem race (or a concurrent revoke landed). Throw the
+          // shape-appropriate error to roll back this user insert; surfaced
+          // as the 410 path below.
+          throw invite.maxUses > 1 ? new InviteExhaustedError() : new InviteUsedError();
+        }
+        // (3b) Persist the per-vault storage cap (B4) atomically with the
+        // account + redemption. Only for a freshly-provisioned vault carrying
+        // an invite cap; legacy/uncapped links leave the vault with no
+        // vault_caps row ("uncapped" for the Phase-2 reader). The vault was
+        // confirmed freshly created above; `setVaultCap` is a plain upsert.
+        if (invite.provisionVault && vaultName !== null && invite.vaultCapBytes !== null) {
+          setVaultCap(deps.db, vaultName, invite.vaultCapBytes, now);
         }
       },
     });
     userId = created.id;
   } catch (err) {
-    if (err instanceof InviteUsedError) {
+    if (err instanceof InviteUsedError || err instanceof InviteExhaustedError) {
       return rejectInvite(err);
     }
     if (err instanceof UsernameTakenError) {

--- a/src/admin-login-ui.ts
+++ b/src/admin-login-ui.ts
@@ -175,7 +175,16 @@ export interface InviteSetupProps {
   role: string;
   /** Whether redemption provisions a vault at all (shows the vault row iff true). */
   provisionVault: boolean;
+  /**
+   * Whether to collect the redeemer's email (B2). True for public-signup
+   * (multi-use) links — the operator must be able to reach the stranger who
+   * signed up; false for legacy single-use admin/friends invites. Default
+   * false (omitted) preserves the friends flow's no-email form.
+   */
+  collectEmail?: boolean;
   username?: string;
+  /** Echoed email value on a re-render so the redeemer doesn't retype it. */
+  email?: string;
   vaultName?: string;
   errorMessage?: string;
 }
@@ -194,12 +203,28 @@ export function renderInviteSetup(props: InviteSetupProps): string {
     pinnedUsername,
     role,
     provisionVault,
+    collectEmail,
     username,
+    email,
     vaultName,
     errorMessage,
   } = props;
   const error = errorMessage ? `<p class="error-banner">${escapeHtml(errorMessage)}</p>` : "";
   const usernameAttr = username ? ` value="${escapeAttr(username)}"` : "";
+  const emailAttr = email ? ` value="${escapeAttr(email)}"` : "";
+
+  // Email row (B2): shown ONLY for public-signup (multi-use) links so the
+  // operator can reach the stranger who signed up. `type=email` gets the
+  // browser's built-in client-side format check (the server re-validates).
+  const emailRow = collectEmail
+    ? `
+        <label class="field">
+          <span class="field-label">Email</span>
+          <input type="email" name="email" autocomplete="email" required
+            spellcheck="false" autocapitalize="off"${emailAttr} />
+          <span class="field-hint">So your hub operator can reach you.</span>
+        </label>`
+    : "";
 
   // Username row: pre-named → read-only display (the server ENFORCES the
   // invite's username; the disabled input never submits and the handler
@@ -304,6 +329,7 @@ export function renderInviteSetup(props: InviteSetupProps): string {
       <form method="POST" action="/account/setup/${escapeAttr(token)}" class="auth-form">
         ${renderCsrfHiddenInput(csrfToken)}
         ${usernameRow}
+        ${emailRow}
         <label class="field">
           <span class="field-label">Password</span>
           <input type="password" name="password" autocomplete="new-password"
@@ -405,7 +431,7 @@ const STYLES = `
     letter-spacing: 0.01em;
     font-family: ${FONT_MONO};
   }
-  input[type=text], input[type=password] {
+  input[type=text], input[type=password], input[type=email] {
     font: inherit;
     width: 100%;
     padding: 0.6rem 0.75rem;
@@ -415,7 +441,7 @@ const STYLES = `
     color: ${PALETTE.fg};
     transition: border-color 0.15s ease, background 0.15s ease;
   }
-  input[type=text]:focus, input[type=password]:focus {
+  input[type=text]:focus, input[type=password]:focus, input[type=email]:focus {
     outline: none;
     border-color: ${PALETTE.accent};
     background: ${PALETTE.cardBg};
@@ -461,10 +487,10 @@ const STYLES = `
     .card { background: #25221d; border-color: #3a362f; box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3); }
     h1 { color: #f0ece4; }
     .subtitle, .field-label { color: #a8a29a; }
-    input[type=text], input[type=password] {
+    input[type=text], input[type=password], input[type=email] {
       background: #1f1c18; border-color: #3a362f; color: #e8e4dc;
     }
-    input[type=text]:focus, input[type=password]:focus {
+    input[type=text]:focus, input[type=password]:focus, input[type=email]:focus {
       background: #25221d;
     }
     .brand-tag { border-color: #3a362f; color: #a8a29a; }

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -68,6 +68,7 @@ import { revokeTokensNamingVault, signAccessToken } from "./jwt-sign.ts";
 import { findService, type readManifest, readManifestLenient } from "./services-manifest.ts";
 import { enrichedPath } from "./spawn-path.ts";
 import { removeVaultAssignments } from "./users.ts";
+import { removeVaultCap } from "./vault-caps.ts";
 import { RESERVED_VAULT_NAMES, VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
@@ -577,6 +578,7 @@ interface CascadeSummary {
   grants_dropped: number;
   user_vaults_removed: number;
   invites_invalidated: number;
+  vault_cap_removed: boolean;
   connections_torn_down: number;
   /**
    * Vault-backed channel-daemon entries still referencing the deleted vault
@@ -596,6 +598,7 @@ function emptyCascadeSummary(): CascadeSummary {
     grants_dropped: 0,
     user_vaults_removed: 0,
     invites_invalidated: 0,
+    vault_cap_removed: false,
     connections_torn_down: 0,
     orphaned_channels: [],
     vault_removed: false,
@@ -648,7 +651,8 @@ function listVaultInstanceNames(manifestPath: string): Set<string> {
  *      it empties — a (user,client) grant can span multiple vaults);
  *   3. `user_vaults` rows;
  *   4. unredeemed invites pinned to the vault (redemption would resurrect
- *      the name);
+ *      the name); the per-vault storage-cap row (v15) so a re-created
+ *      same-name vault doesn't inherit a stale cap;
  *   5. connections whose source/provisioned vault is the deleted vault
  *      (via `teardownConnection`, which post-B0 also revokes the registered
  *      long-lived mints) + a report-only scan of the agent's `/api/channels`
@@ -752,6 +756,10 @@ export async function handleDeleteVault(
 
   // --- 4. Unredeemed invites pinned to the vault. ----------------------------
   summary.invites_invalidated = revokeInvitesForVault(deps.db, name, now);
+
+  // --- 4b. Per-vault storage cap row (v15). ----------------------------------
+  // A re-created same-name vault must not inherit a stale cap; drop it.
+  summary.vault_cap_removed = removeVaultCap(deps.db, name) > 0;
 
   // --- 5. Connections teardown (+ legacy channel scan, report-only). --------
   // Runs BEFORE the CLI remove so the vault daemon is still alive to accept

--- a/src/api-invites.ts
+++ b/src/api-invites.ts
@@ -15,6 +15,18 @@
  *
  * Wire shape is snake_case (matches `/api/users`). An invite's raw token
  * NEVER appears in a GET/list response — only in the POST-create `url`.
+ *
+ * v15 (DEMO-PREP Workstream B) extends POST /api/invites with `max_uses`
+ * (multi-use public-signup links, default 1 = single-use) and
+ * `vault_cap_bytes` (per-vault storage cap stamped at provision, B4). A
+ * multi-use PROVISIONING link with no explicit `vault_cap_bytes` auto-defaults
+ * to ~1 GB (DEFAULT_VAULT_CAP_BYTES) so a public link never provisions
+ * uncapped by omission; single-use friends links stay uncapped unless opted
+ * in. The list/create wire shape gains `max_uses`, `used_count`, `email`
+ * (latest redeemer, B2), and `vault_cap_bytes`. `expires_in` already bounded
+ * the link lifetime (B1's expiry). A multi-use link can't pre-name a username
+ * or pin a single new vault name (every seat past the first would collide —
+ * rejected at mint).
  */
 import type { Database } from "bun:sqlite";
 import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
@@ -32,6 +44,7 @@ import {
   usernameReservedByPendingInvite,
 } from "./invites.ts";
 import { getUserByUsernameCI, validateUsername } from "./users.ts";
+import { DEFAULT_VAULT_CAP_BYTES } from "./vault-caps.ts";
 import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 import { listVaultNamesFromPath } from "./vault-names.ts";
 
@@ -47,6 +60,18 @@ export interface ApiInvitesDeps {
 const ALLOWED_ROLES = new Set(["read", "write"]);
 /** Cap an invite TTL so a typo can't mint a ~forever link. 90 days. */
 const MAX_INVITE_TTL_SECONDS = 90 * 24 * 60 * 60;
+/**
+ * Cap `max_uses` (v15) so a typo can't mint a runaway public-signup link on a
+ * shared box. 1000 is comfortably above any demo cohort while still bounding
+ * the abuse surface. The DEMO-PREP shared box uses small values (tens of seats).
+ */
+const MAX_INVITE_USES = 1000;
+/**
+ * Ceiling on a per-vault cap an invite may carry (v15, B4). 100 GiB — far
+ * above the ~1 GB default, but bounds a fat-finger that would make the cap
+ * meaningless on a shared box. The minimum is 1 byte (a positive integer).
+ */
+const MAX_VAULT_CAP_BYTES = 100 * 1024 * 1024 * 1024;
 
 interface InviteWireShape {
   /** sha256 hash — the stable id for list/revoke. NOT the raw token. */
@@ -57,6 +82,14 @@ interface InviteWireShape {
   role: string;
   provision_vault: boolean;
   default_mirror: string | null;
+  /** v15 — how many accounts this link may create (1 = single-use). */
+  max_uses: number;
+  /** v15 — how many it has created so far. */
+  used_count: number;
+  /** v15 — most-recent redeemer's email (B2), or null. */
+  email: string | null;
+  /** v15 — per-vault storage cap to stamp at provision (B4), or null (uncapped). */
+  vault_cap_bytes: number | null;
   expires_at: string;
   used_at: string | null;
   redeemed_user_id: string | null;
@@ -73,6 +106,10 @@ function toWire(invite: Invite, status: InviteStatus): InviteWireShape {
     role: invite.role,
     provision_vault: invite.provisionVault,
     default_mirror: invite.defaultMirror,
+    max_uses: invite.maxUses,
+    used_count: invite.usedCount,
+    email: invite.email,
+    vault_cap_bytes: invite.vaultCapBytes,
     expires_at: invite.expiresAt,
     used_at: invite.usedAt,
     redeemed_user_id: invite.redeemedUserId,
@@ -100,6 +137,10 @@ interface CreateInviteBody {
   provisionVault: boolean;
   defaultMirror: string | null;
   expiresInSeconds: number;
+  /** v15 — how many accounts the link may create (default 1 = single-use). */
+  maxUses: number;
+  /** v15 — per-vault storage cap (bytes) to stamp at provision, or null (uncapped). */
+  vaultCapBytes: number | null;
 }
 
 interface ParseErr {
@@ -283,9 +324,71 @@ async function parseCreateBody(
     expiresInSeconds = Math.floor(rawExpiry);
   }
 
+  // max_uses — v15. Default 1 (single-use, the legacy shape). A positive
+  // integer ≤ MAX_INVITE_USES. >1 = a multi-use public-signup link.
+  let maxUses = 1;
+  const rawMaxUses =
+    Object.hasOwn(obj, "max_uses") && obj.max_uses !== undefined
+      ? obj.max_uses
+      : Object.hasOwn(obj, "maxUses") && obj.maxUses !== undefined
+        ? obj.maxUses
+        : undefined;
+  if (rawMaxUses !== undefined && rawMaxUses !== null) {
+    if (
+      typeof rawMaxUses !== "number" ||
+      !Number.isInteger(rawMaxUses) ||
+      rawMaxUses < 1 ||
+      rawMaxUses > MAX_INVITE_USES
+    ) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: `"max_uses" must be an integer between 1 and ${MAX_INVITE_USES}`,
+      };
+    }
+    maxUses = rawMaxUses;
+  }
+
+  // vault_cap_bytes — v15, B4. Optional per-vault storage cap stamped at
+  // provision. null/omitted = uncapped (legacy). A positive integer
+  // ≤ MAX_VAULT_CAP_BYTES.
+  let vaultCapBytes: number | null = null;
+  const rawCap =
+    Object.hasOwn(obj, "vault_cap_bytes") && obj.vault_cap_bytes !== undefined
+      ? obj.vault_cap_bytes
+      : Object.hasOwn(obj, "vaultCapBytes") && obj.vaultCapBytes !== undefined
+        ? obj.vaultCapBytes
+        : undefined;
+  if (rawCap !== undefined && rawCap !== null) {
+    if (
+      typeof rawCap !== "number" ||
+      !Number.isInteger(rawCap) ||
+      rawCap < 1 ||
+      rawCap > MAX_VAULT_CAP_BYTES
+    ) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_request",
+        description: `"vault_cap_bytes" must be a positive integer ≤ ${MAX_VAULT_CAP_BYTES} (100 GiB)`,
+      };
+    }
+    vaultCapBytes = rawCap;
+  }
+
   return {
     ok: true,
-    body: { vaultName, username, role, provisionVault, defaultMirror, expiresInSeconds },
+    body: {
+      vaultName,
+      username,
+      role,
+      provisionVault,
+      defaultMirror,
+      expiresInSeconds,
+      maxUses,
+      vaultCapBytes,
+    },
   };
 }
 
@@ -303,8 +406,16 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
   }
   const parsed = await parseCreateBody(req);
   if (!parsed.ok) return jsonError(parsed.status, parsed.error, parsed.description);
-  const { vaultName, username, role, provisionVault, defaultMirror, expiresInSeconds } =
-    parsed.body;
+  const {
+    vaultName,
+    username,
+    role,
+    provisionVault,
+    defaultMirror,
+    expiresInSeconds,
+    maxUses,
+    vaultCapBytes,
+  } = parsed.body;
   const now = (deps.now ?? (() => new Date()))();
 
   // Shape gates over the three supported invite shapes:
@@ -328,6 +439,42 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
       400,
       "invalid_request",
       'a provisioned vault\'s sole user must hold write — use role "write", or share an existing vault (provision_vault=false + vault_name) for read-only access',
+    );
+  }
+
+  // Multi-use coherence gates (v15). A link that creates many accounts can't:
+  //   - pre-name a username (one name can't be reused across redeemers), or
+  //   - pin a single NEW vault name (every redeemer would collide on it —
+  //     the redeem path's freshly-created invariant rejects the 2nd onward).
+  // Either combination would make every seat past the first dead-on-arrival,
+  // so reject at mint. (A multi-use SHARED-vault invite — provision_vault=false
+  // + an existing vault_name — IS coherent: many users joining one vault; it's
+  // not blocked here.)
+  if (maxUses > 1) {
+    if (username !== null) {
+      return jsonError(
+        400,
+        "invalid_request",
+        "a multi-use link (max_uses > 1) can't pre-name a username — one username can't be shared across signups. Omit \"username\".",
+      );
+    }
+    if (provisionVault && vaultName !== null) {
+      return jsonError(
+        400,
+        "invalid_request",
+        'a multi-use provisioning link (max_uses > 1) can\'t pin a single vault name — every signup would collide on it. Omit "vault_name" so each signup names their own vault.',
+      );
+    }
+  }
+
+  // A per-vault cap only applies to a vault THIS link provisions. Pinning a
+  // cap on a non-provisioning invite (account-only or shared-existing-vault)
+  // has nothing to stamp — reject the contradiction at mint.
+  if (vaultCapBytes !== null && !provisionVault) {
+    return jsonError(
+      400,
+      "invalid_request",
+      '"vault_cap_bytes" only applies to a provisioning invite (provision_vault=true) — a non-provisioning link has no vault to cap',
     );
   }
   if (vaultName !== null && !provisionVault) {
@@ -358,6 +505,17 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
     }
   }
 
+  // Auto-apply the ~1 GB default cap to a PUBLIC-SIGNUP (multi-use,
+  // provisioning) link when the admin didn't set one explicitly — the
+  // DEMO-PREP decision is "1 GB per vault, configurable," so a multi-use
+  // signup link on a shared box should never provision UNcapped by omission.
+  // An explicit cap (any value, validated above) is honored as-is; a
+  // single-use friends link stays uncapped unless the admin opts in.
+  const effectiveVaultCapBytes =
+    vaultCapBytes === null && maxUses > 1 && provisionVault
+      ? DEFAULT_VAULT_CAP_BYTES
+      : vaultCapBytes;
+
   const issued = issueInvite(deps.db, {
     createdBy: authUserId,
     vaultName,
@@ -366,6 +524,8 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
     provisionVault,
     defaultMirror,
     expiresInSeconds,
+    maxUses,
+    vaultCapBytes: effectiveVaultCapBytes,
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
   const status = inviteStatus(issued.invite, now);

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -88,6 +88,8 @@ export interface UserWireShape {
   id: string;
   username: string;
   password_changed: boolean;
+  /** Contactable email captured at signup (v15, B2), or null. Visible to admin. */
+  email: string | null;
   assigned_vaults: string[];
   created_at: string;
 }
@@ -97,6 +99,7 @@ function toWire(u: User): UserWireShape {
     id: u.id,
     username: u.username,
     password_changed: u.passwordChanged,
+    email: u.email,
     assigned_vaults: [...u.assignedVaults],
     created_at: u.createdAt,
   };

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -4,7 +4,10 @@
  * issuer — signing keys (v1), users + opaque refresh tokens (v2), OAuth
  * clients + auth-codes + grants + browser sessions (v3), TOTP 2FA
  * enrollment on the users row (v11, hub#473), and one-time invite links
- * (v12, the `invites` table; v13 adds the pre-named `username` column).
+ * (v12, the `invites` table; v13 adds the pre-named `username` column;
+ * v14 adds refresh-token rotation grace; v15 generalizes invites into
+ * multi-use public-signup links + email-as-username + the `vault_caps`
+ * per-vault storage-cap table).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -472,6 +475,81 @@ const MIGRATIONS: readonly Migration[] = [
       -- older ancestor under burst issuance (ties), and the grace decision is
       -- security-load-bearing, so it must be exact, not heuristic.
       ALTER TABLE tokens ADD COLUMN rotated_to TEXT;
+    `,
+  },
+  {
+    version: 15,
+    sql: `
+      -- Multi-use public signup links + email-as-username + per-vault caps
+      -- (DEMO-PREP-2026-06-25 Workstream B: B1 multi-use invite, B2 email
+      -- capture, B4 public signup page; the cap value is persisted now so
+      -- B3's vault-side enforcement — a separate Phase-2 PR — can read it).
+      --
+      -- (1) FOUR columns on \`invites\` generalize the single-use link into a
+      --     multi-use, capped one. Backwards compatible: every pre-v15 invite
+      --     redeems exactly as before because the defaults reproduce the old
+      --     single-use semantics.
+      --
+      --   * max_uses (INTEGER NOT NULL DEFAULT 1) — how many accounts ONE link
+      --     may create. DEFAULT 1 = the historical single-use invite, so every
+      --     pre-v15 row and every default-shaped new row stays single-use. A
+      --     public signup link mints with a higher value (e.g. 25 demo seats).
+      --   * used_count (INTEGER NOT NULL DEFAULT 0) — how many accounts the link
+      --     HAS created. Redeem refuses once used_count >= max_uses. Replaces
+      --     the boolean used_at as the exhaustion signal for multi-use links;
+      --     used_at is RETAINED (stamped on the FIRST redeem) so legacy
+      --     single-use lookups + the admin list's "redeemed" status keep
+      --     working unchanged.
+      --   * email (TEXT, nullable) — the redeemer's email captured at signup
+      --     as the contactable identity (B2). NULL on every pre-v15 invite and
+      --     on admin-issued links that don't collect email; set per-redemption
+      --     for public-signup links. Stored so the operator can reach signups.
+      --     (One link → many signups means one invite row can't hold every
+      --     redeemer's email; this column holds the MOST-RECENT redeemer's
+      --     email for a single-use link, and the per-account email lives on the
+      --     users row — see (3). For multi-use the canonical per-user email is
+      --     users.email.)
+      --   * vault_cap_bytes (INTEGER, nullable) — the per-vault storage cap to
+      --     STAMP onto each vault this link provisions (B4). NULL on every
+      --     pre-v15 invite + admin-issued links that don't set a cap (those
+      --     provision uncapped, the historical behavior); set to ~1 GB on a
+      --     public-signup link so each provisioned vault gets a vault_caps row
+      --     for the Phase-2 enforcement PR to read. The cap travels on the
+      --     invite (not a server-wide default) so different links can carry
+      --     different caps.
+      --
+      -- (2) ONE column on \`users\`: email-as-contactable-identity (B2). The
+      --     username stays the login + URL identity ([a-z0-9_-]); email is the
+      --     separate contact field the operator sees + uses to reach a signup.
+      --     Nullable: every pre-v15 account (wizard admin, env-seeded admin,
+      --     pre-named friend invites) predates email capture and keeps NULL.
+      --     NOT UNIQUE — two people behind one shared mailbox, or an operator
+      --     re-using their address across test accounts, shouldn't be blocked
+      --     at the schema. Validation (format) happens at the API/redeem edge.
+      --
+      -- (3) NEW \`vault_caps\` table — the per-vault storage cap, persisted at
+      --     provision time (B4: "persist a per-vault cap value at provision
+      --     time EVEN THOUGH vault-side enforcement lands in a separate
+      --     Phase-2 PR — at minimum store the cap so the later PR can read +
+      --     enforce it"). Keyed by vault_name (the same instance-name space
+      --     used across services.json / user_vaults / invites.vault_name; no
+      --     FK — vault names resolve through services.json, not a DB row, the
+      --     established pattern). cap_bytes is the byte ceiling (default
+      --     ~1 GB stamped by the public-signup flow). No backfill — existing
+      --     vaults have no cap row, which the Phase-2 enforcement reads as
+      --     "uncapped" (only vaults provisioned through a capped signup get a
+      --     row).
+      ALTER TABLE invites ADD COLUMN max_uses INTEGER NOT NULL DEFAULT 1;
+      ALTER TABLE invites ADD COLUMN used_count INTEGER NOT NULL DEFAULT 0;
+      ALTER TABLE invites ADD COLUMN email TEXT;
+      ALTER TABLE invites ADD COLUMN vault_cap_bytes INTEGER;
+      ALTER TABLE users ADD COLUMN email TEXT;
+      CREATE TABLE vault_caps (
+        vault_name TEXT PRIMARY KEY,
+        cap_bytes INTEGER NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      );
     `,
   },
 ];

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -535,7 +535,9 @@ const MIGRATIONS: readonly Migration[] = [
       --     used across services.json / user_vaults / invites.vault_name; no
       --     FK — vault names resolve through services.json, not a DB row, the
       --     established pattern). cap_bytes is the byte ceiling (default
-      --     ~1 GB stamped by the public-signup flow). No backfill — existing
+      --     ~1 GB stamped by the public-signup flow), guarded by a
+      --     CHECK (cap_bytes > 0) so a direct DB write can't seed a 0/negative
+      --     cap the Phase-2 reader would misinterpret. No backfill — existing
       --     vaults have no cap row, which the Phase-2 enforcement reads as
       --     "uncapped" (only vaults provisioned through a capped signup get a
       --     row).
@@ -546,7 +548,11 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE users ADD COLUMN email TEXT;
       CREATE TABLE vault_caps (
         vault_name TEXT PRIMARY KEY,
-        cap_bytes INTEGER NOT NULL,
+        -- CHECK (cap_bytes > 0): guard against a 0/negative cap from a direct
+        -- DB write making the Phase-2 enforcement reader treat the vault as
+        -- "0-byte ceiling" (everything over cap) or nonsense. The mint + redeem
+        -- paths already validate positivity; this is the at-rest backstop.
+        cap_bytes INTEGER NOT NULL CHECK (cap_bytes > 0),
         created_at TEXT NOT NULL,
         updated_at TEXT NOT NULL
       );

--- a/src/invites.ts
+++ b/src/invites.ts
@@ -37,10 +37,23 @@
  * v13): the redemption form shows it read-only and the redeem handler
  * enforces it. NULL = redeemer picks their own.
  *
- * Single-use is enforced by stamping `used_at` on redemption — a replay
- * attempt sees the row with `used_at` set and `redeemInvite` throws
- * `InviteUsedError`. Revocation is a separate `revoked_at` stamp the admin
- * sets before redemption. Expiry is enforced at redeem-time.
+ * MULTI-USE (migration v15, DEMO-PREP-2026-06-25 Workstream B): an invite
+ * carries `max_uses` (how many accounts ONE link may create) + `used_count`
+ * (how many it has). A redeem is refused once `used_count >= max_uses`. A
+ * LEGACY single-use invite is exactly `max_uses = 1` (the column default), so
+ * pre-v15 invites and default-shaped new ones behave identically to before.
+ * `used_at` is RETAINED — stamped on the FIRST redeem — so the admin list's
+ * "redeemed" status and any single-use lookups keep reading the same signal.
+ * Exhaustion is enforced atomically in `recordInviteRedemption` (the
+ * `used_count < max_uses` guard in the UPDATE), so two concurrent redeems of
+ * the last remaining seat can't both succeed.
+ *
+ * Revocation is a separate `revoked_at` stamp the admin sets before
+ * redemption (terminal regardless of remaining uses). Expiry is enforced at
+ * redeem-time. A public-signup link also captures the redeemer's `email`
+ * (B2 — the contactable identity, also stored per-account on `users.email`)
+ * and may carry a `vault_cap_bytes` to stamp onto each provisioned vault (B4
+ * — persisted to `vault_caps` for the Phase-2 enforcement PR to read).
  */
 import type { Database } from "bun:sqlite";
 import { createHash, randomBytes } from "node:crypto";
@@ -70,6 +83,24 @@ export interface Invite {
   provisionVault: boolean;
   /** `'internal' | 'off'` mirror knob for the provisioned vault, or null. */
   defaultMirror: string | null;
+  /**
+   * How many accounts this link may create (v15). 1 = legacy single-use
+   * (the column default); >1 = a multi-use public-signup link.
+   */
+  maxUses: number;
+  /** How many accounts this link HAS created (v15). Redeem refused once == maxUses. */
+  usedCount: number;
+  /**
+   * Most-recent redeemer's email (v15, B2), or null. For a multi-use link
+   * the canonical per-account email lives on `users.email`; this column
+   * holds the latest redeemer's for the admin's at-a-glance audit.
+   */
+  email: string | null;
+  /**
+   * Per-vault storage cap (bytes) to stamp onto each provisioned vault
+   * (v15, B4), or null to provision uncapped (legacy behavior).
+   */
+  vaultCapBytes: number | null;
   expiresAt: string;
   usedAt: string | null;
   redeemedUserId: string | null;
@@ -98,6 +129,20 @@ export class InviteUsedError extends Error {
   }
 }
 
+/**
+ * A multi-use link whose seats are all taken (`used_count >= max_uses`). For
+ * a single-use (max_uses=1) link this is the same condition the legacy
+ * `InviteUsedError` named, but the redeem path throws `InviteUsedError` for a
+ * single-use link (familiar "already used" copy) and `InviteExhaustedError`
+ * for a multi-use one ("all signups taken") so the message can differ.
+ */
+export class InviteExhaustedError extends Error {
+  constructor() {
+    super("invite has reached its maximum number of signups");
+    this.name = "InviteExhaustedError";
+  }
+}
+
 export class InviteRevokedError extends Error {
   constructor() {
     super("invite has been revoked");
@@ -113,6 +158,10 @@ interface Row {
   role: string;
   provision_vault: number;
   default_mirror: string | null;
+  max_uses: number;
+  used_count: number;
+  email: string | null;
+  vault_cap_bytes: number | null;
   expires_at: string;
   used_at: string | null;
   redeemed_user_id: string | null;
@@ -129,6 +178,10 @@ function rowToInvite(r: Row): Invite {
     role: r.role,
     provisionVault: r.provision_vault === 1,
     defaultMirror: r.default_mirror,
+    maxUses: r.max_uses,
+    usedCount: r.used_count,
+    email: r.email,
+    vaultCapBytes: r.vault_cap_bytes,
     expiresAt: r.expires_at,
     usedAt: r.used_at,
     redeemedUserId: r.redeemed_user_id,
@@ -142,10 +195,19 @@ export function hashInviteToken(rawToken: string): string {
   return createHash("sha256").update(rawToken).digest("hex");
 }
 
-/** Derive an invite's status from its stamps + the current time. */
+/**
+ * Derive an invite's status from its stamps + the current time.
+ *
+ * Multi-use (v15): an invite is "redeemed" only once every seat is taken
+ * (`usedCount >= maxUses`). A partially-used multi-use link (some seats left,
+ * not expired/revoked) is still "pending" — it can take more signups. A
+ * legacy single-use link (maxUses=1) flips to "redeemed" on its first
+ * redeem, exactly as before, because 1 >= 1. Expired wins over a not-yet-
+ * exhausted link; revoked + exhausted are checked first (terminal).
+ */
 export function inviteStatus(invite: Invite, now: Date = new Date()): InviteStatus {
   if (invite.revokedAt) return "revoked";
-  if (invite.usedAt) return "redeemed";
+  if (invite.usedCount >= invite.maxUses) return "redeemed";
   if (now.getTime() > new Date(invite.expiresAt).getTime()) return "expired";
   return "pending";
 }
@@ -166,6 +228,16 @@ export interface IssueInviteOpts {
   provisionVault?: boolean;
   /** `'internal' | 'off'` mirror knob for the provisioned vault. */
   defaultMirror?: string | null;
+  /**
+   * How many accounts this link may create (v15). Default 1 (single-use,
+   * the legacy shape). Caller validates the upper bound.
+   */
+  maxUses?: number;
+  /**
+   * Per-vault storage cap (bytes) to stamp onto each provisioned vault
+   * (v15, B4). Omit/null = provision uncapped (legacy behavior).
+   */
+  vaultCapBytes?: number | null;
   /** Lifetime in seconds. Default {@link DEFAULT_INVITE_TTL_SECONDS} (7 days). */
   expiresInSeconds?: number;
   now?: () => Date;
@@ -198,12 +270,15 @@ export function issueInvite(db: Database, opts: IssueInviteOpts): IssuedInvite {
   const username = opts.username ?? null;
   const provisionVault = opts.provisionVault ?? true;
   const defaultMirror = opts.defaultMirror ?? null;
+  const maxUses = opts.maxUses ?? 1;
+  const vaultCapBytes = opts.vaultCapBytes ?? null;
 
   db.prepare(
     `INSERT INTO invites
        (token, created_by, vault_name, username, role, provision_vault, default_mirror,
+        max_uses, used_count, email, vault_cap_bytes,
         expires_at, used_at, redeemed_user_id, revoked_at, created_at)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, NULL, ?)`,
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, NULL, ?, ?, NULL, NULL, NULL, ?)`,
   ).run(
     tokenHash,
     opts.createdBy,
@@ -212,6 +287,8 @@ export function issueInvite(db: Database, opts: IssueInviteOpts): IssuedInvite {
     role,
     provisionVault ? 1 : 0,
     defaultMirror,
+    maxUses,
+    vaultCapBytes,
     expiresAt,
     createdAt,
   );
@@ -226,6 +303,10 @@ export function issueInvite(db: Database, opts: IssueInviteOpts): IssuedInvite {
       role,
       provisionVault,
       defaultMirror,
+      maxUses,
+      usedCount: 0,
+      email: null,
+      vaultCapBytes,
       expiresAt,
       usedAt: null,
       redeemedUserId: null,
@@ -275,7 +356,7 @@ export function usernameReservedByPendingInvite(
   const row = db
     .query<{ token: string }, [string, string]>(
       `SELECT token FROM invites
-       WHERE username = ? AND used_at IS NULL AND revoked_at IS NULL AND expires_at > ?
+       WHERE username = ? AND used_count < max_uses AND revoked_at IS NULL AND expires_at > ?
        LIMIT 1`,
     )
     .get(username, now.toISOString());
@@ -295,11 +376,13 @@ export function listInvites(
 }
 
 /**
- * Validate an invite for redemption WITHOUT consuming it. Throws on every
- * not-redeemable branch (not-found / expired / used / revoked). Returns the
- * invite when it's redeemable. The redemption handler calls this FIRST (so a
- * bad token is rejected before any account/vault work), then does
- * createUser, then `consumeInvite` AFTER the user row commits.
+ * Validate an invite for redemption WITHOUT recording one. Throws on every
+ * not-redeemable branch (not-found / expired / exhausted / revoked). Returns
+ * the invite when it's redeemable. The redemption handler calls this FIRST (so
+ * a bad token is rejected before any account/vault work), then does createUser,
+ * then `recordInviteRedemption` INSIDE the user-row transaction (the atomic
+ * seat-lock — the `< max_uses` UPDATE guard is what actually prevents an
+ * over-seat under concurrency; this early check is the fast-path rejection).
  */
 export function assertInviteRedeemable(
   db: Database,
@@ -308,10 +391,15 @@ export function assertInviteRedeemable(
 ): Invite {
   const invite = findInviteByRawToken(db, rawToken);
   if (!invite) throw new InviteNotFoundError();
-  // Revoked + used are terminal regardless of clock; check them before expiry
-  // so a revoked-then-expired invite reports the more specific reason.
+  // Revoked + exhausted are terminal regardless of clock; check them before
+  // expiry so a revoked-then-expired invite reports the more specific reason.
   if (invite.revokedAt) throw new InviteRevokedError();
-  if (invite.usedAt) throw new InviteUsedError();
+  // Exhaustion (v15): seats all taken. A single-use link (maxUses=1) throws
+  // the familiar InviteUsedError ("already used"); a multi-use one throws
+  // InviteExhaustedError ("all signups taken") so the copy can differ.
+  if (invite.usedCount >= invite.maxUses) {
+    throw invite.maxUses > 1 ? new InviteExhaustedError() : new InviteUsedError();
+  }
   if (now.getTime() > new Date(invite.expiresAt).getTime()) {
     throw new InviteExpiredError();
   }
@@ -319,15 +407,52 @@ export function assertInviteRedeemable(
 }
 
 /**
- * Mark an invite consumed — stamp `used_at` + `redeemed_user_id`. Called
- * Called within the account-creation transaction (or after a committed user
- * row). Single-use + not-revoked is enforced by the
- * `used_at IS NULL AND revoked_at IS NULL` guard in the UPDATE: a racing
- * second redeem — or a concurrent revoke — updates zero rows and the caller
- * treats that as already-consumed/revoked. Race-safe because sqlite
- * serializes writes.
+ * Record ONE redemption against an invite — the multi-use-aware consume
+ * (v15). Atomically:
+ *   - increments `used_count` by 1,
+ *   - stamps `used_at` on the FIRST redeem only (COALESCE keeps the original),
+ *   - records the redeemer's `email` (B2) + `redeemed_user_id` as the
+ *     MOST-RECENT redeemer (the canonical per-account email lives on
+ *     `users.email`; this is the admin's at-a-glance latest).
  *
- * Returns `true` if THIS call consumed the invite, `false` otherwise.
+ * Exhaustion + revocation are enforced by the `used_count < max_uses AND
+ * revoked_at IS NULL` guard in the UPDATE: a racing redeem that would take a
+ * seat past the cap — or one racing a revoke — updates zero rows, and the
+ * caller treats that as exhausted/revoked. Race-safe because sqlite
+ * serializes writes (a legacy single-use link is just the max_uses=1 case:
+ * the second concurrent redeem sees `used_count`=1, fails the `< max_uses`
+ * guard, and changes zero rows — exactly the old single-use behavior).
+ *
+ * Returns `true` if THIS call recorded a redemption, `false` otherwise.
+ */
+export function recordInviteRedemption(
+  db: Database,
+  tokenHash: string,
+  redeemedUserId: string,
+  email: string | null = null,
+  now: Date = new Date(),
+): boolean {
+  const stamp = now.toISOString();
+  const res = db
+    .prepare(
+      `UPDATE invites
+       SET used_count = used_count + 1,
+           used_at = COALESCE(used_at, ?),
+           redeemed_user_id = ?,
+           email = ?
+       WHERE token = ? AND used_count < max_uses AND revoked_at IS NULL`,
+    )
+    .run(stamp, redeemedUserId, email, tokenHash);
+  return res.changes > 0;
+}
+
+/**
+ * Legacy single-use consume — thin wrapper over {@link recordInviteRedemption}
+ * for callers that don't capture email. Retained for backwards compatibility;
+ * the redeem path uses `recordInviteRedemption` directly so it can record the
+ * email. Race-safe + exhaustion-aware via the underlying function.
+ *
+ * Returns `true` if THIS call recorded a redemption, `false` otherwise.
  */
 export function consumeInvite(
   db: Database,
@@ -335,23 +460,22 @@ export function consumeInvite(
   redeemedUserId: string,
   now: Date = new Date(),
 ): boolean {
-  const res = db
-    .prepare(
-      "UPDATE invites SET used_at = ?, redeemed_user_id = ? WHERE token = ? AND used_at IS NULL AND revoked_at IS NULL",
-    )
-    .run(now.toISOString(), redeemedUserId, tokenHash);
-  return res.changes > 0;
+  return recordInviteRedemption(db, tokenHash, redeemedUserId, null, now);
 }
 
 /**
  * Revoke a pending invite (admin DELETE). Stamps `revoked_at` only when the
- * invite isn't already used or revoked. Returns `true` if this call revoked
- * it, `false` if it was already consumed/revoked or not found.
+ * invite still has seats left (`used_count < max_uses`) and isn't already
+ * revoked. A multi-use link can be revoked mid-life to cut off its remaining
+ * seats; a fully-exhausted link is terminal and revoke is a no-op. (For a
+ * legacy single-use link `used_count < max_uses` is equivalent to the old
+ * `used_at IS NULL` guard.) Returns `true` if this call revoked it, `false`
+ * if it was already exhausted/revoked or not found.
  */
 export function revokeInvite(db: Database, tokenHash: string, now: Date = new Date()): boolean {
   const res = db
     .prepare(
-      "UPDATE invites SET revoked_at = ? WHERE token = ? AND used_at IS NULL AND revoked_at IS NULL",
+      "UPDATE invites SET revoked_at = ? WHERE token = ? AND used_count < max_uses AND revoked_at IS NULL",
     )
     .run(now.toISOString(), tokenHash);
   return res.changes > 0;
@@ -373,7 +497,7 @@ export function revokeInvitesForVault(
 ): number {
   const res = db
     .prepare(
-      "UPDATE invites SET revoked_at = ? WHERE vault_name = ? AND used_at IS NULL AND revoked_at IS NULL",
+      "UPDATE invites SET revoked_at = ? WHERE vault_name = ? AND used_count < max_uses AND revoked_at IS NULL",
     )
     .run(now.toISOString(), vaultName);
   return Number(res.changes);

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -1,7 +1,12 @@
 /**
  * Rate-limit primitives for hub auth-surface endpoints.
  *
- * Two limiters today (one floor each — neither is the primary defense):
+ * Each limiter is a floor, not the primary defense. Two are highlighted below
+ * for their contrasting threat models; the rest (`/login/2fa`, vault-token
+ * mint, public signup) are documented at their `export const` definitions.
+ * The public-signup limiter is the deliberate OUTLIER — generous, not tight —
+ * because its endpoint is meant to be redeemed by a room of people sharing one
+ * egress IP (see `SIGNUP_MAX_ATTEMPTS`).
  *
  *   - `/login` (per-IP, hub#187 / hub#188): 5 attempts / 15 min.
  *     Lands as a floor under brute-force after hub#187 collapsed the
@@ -109,6 +114,27 @@ export const VAULT_TOKEN_MINT_WINDOW_MS = 10 * 60 * 1000;
  * minutes is generous for a human and still chokes a stolen-cookie flood.
  */
 export const VAULT_TOKEN_MINT_MAX_ATTEMPTS = 10;
+/**
+ * `POST /account/setup/<token>` (public invite redemption / signup) window
+ * length: 15 minutes — same window as `/login`, but a MUCH larger cap (below)
+ * because the threat model is the opposite. A public multi-use signup link is
+ * meant to be redeemed by a ROOM OF PEOPLE, and a demo room shares ONE NAT'd
+ * egress IP — so a per-IP `/login`-sized cap (5/15min) would 429 the ~6th
+ * legitimate signer. This bucket is deliberately generous so a shared egress
+ * IP comfortably handles a cohort, while still being a floor against an
+ * attacker scripting account creation against an open link (the invite's
+ * own `max_uses` + expiry are the primary bound; this is the abuse floor).
+ * Separate bucket from `/login` so a signup flurry never burns the login
+ * window, and vice-versa.
+ */
+export const SIGNUP_WINDOW_MS = 15 * 60 * 1000;
+/**
+ * `POST /account/setup/<token>` attempts allowed per IP per window. 60 is
+ * comfortably above a single demo room behind one NAT (and well above any
+ * legitimate human's retries) while still capping a scripted-abuse rate to
+ * ~4/min sustained. The 61st attempt within the window is denied.
+ */
+export const SIGNUP_MAX_ATTEMPTS = 60;
 /** Sentinel for the IP-extraction priority chain when nothing parsed. */
 export const UNKNOWN_IP_SENTINEL = "unknown";
 
@@ -247,6 +273,16 @@ export const vaultTokenMintRateLimiter = new RateLimiter(
 );
 
 /**
+ * `POST /account/setup/<token>` rate limiter — per-IP, 60 attempts / 15 min
+ * (public invite redemption / signup). DELIBERATELY generous: a public
+ * multi-use signup link is redeemed by a room of people sharing one NAT'd
+ * egress IP, so a `/login`-sized cap would 429 legitimate signers mid-demo.
+ * Separate bucket from `/login` so the two never share a window. The invite's
+ * own `max_uses` + expiry are the primary bound; this is the abuse floor.
+ */
+export const signupRateLimiter = new RateLimiter(SIGNUP_MAX_ATTEMPTS, SIGNUP_WINDOW_MS);
+
+/**
  * Backwards-compat shim for hub#188's call sites: the original
  * top-level `checkAndRecord` was the login limiter. New code should
  * reach into `loginRateLimiter.checkAndRecord` directly.
@@ -266,6 +302,7 @@ export function __resetForTests(): void {
   changePasswordRateLimiter.reset();
   totpRateLimiter.reset();
   vaultTokenMintRateLimiter.reset();
+  signupRateLimiter.reset();
 }
 
 /**

--- a/src/users.ts
+++ b/src/users.ts
@@ -35,6 +35,15 @@ export interface User {
    */
   passwordChanged: boolean;
   /**
+   * Contactable email captured at signup (migration v15, B2). The username
+   * is the login + URL identity ([a-z0-9_-]); email is the SEPARATE contact
+   * field the operator sees + uses to reach a signup. `null` for every
+   * account created before email capture (wizard admin, env-seeded admin,
+   * pre-named friend invites that didn't collect one). Not unique at the
+   * schema level — see migration v15.
+   */
+  email: string | null;
+  /**
    * The vault instance names this user has access to (multi-user Phase 2
    * PR 2 — many-to-many via the `user_vaults` table; design
    * 2026-05-20-multi-user-phase-1.md §Phase 2). Empty `[]` means "no per-
@@ -81,6 +90,7 @@ interface Row {
   created_at: string;
   updated_at: string;
   password_changed: number;
+  email: string | null;
 }
 
 /**
@@ -126,6 +136,7 @@ function rowToUser(r: Row, assignedVaults: string[]): User {
     createdAt: r.created_at,
     updatedAt: r.updated_at,
     passwordChanged: r.password_changed === 1,
+    email: r.email ?? null,
     assignedVaults,
   };
 }
@@ -233,6 +244,15 @@ export interface CreateUserOpts {
    */
   assignedVaults?: string[];
   /**
+   * Contactable email to store on the new account (migration v15, B2).
+   * Default `null` — the wizard/env-seeded admin paths and pre-named
+   * friend invites that don't collect email omit it. The public-signup
+   * redeem path passes the validated email so the operator can reach the
+   * signup. Validation (format) is the caller's responsibility
+   * (`validateEmail`); this just persists what it's given.
+   */
+  email?: string | null;
+  /**
    * The `user_vaults.role` to write for every entry in `assignedVaults`.
    * Default `'write'` (= owner; `vaultVerbsForRole('write')` grants the
    * full read/write/admin triple). The invite-redeem path passes the
@@ -268,6 +288,7 @@ export async function createUser(
   const passwordHash = await argonHash(password);
   const stamp = (opts.now?.() ?? new Date()).toISOString();
   const passwordChanged = opts.passwordChanged === true ? 1 : 0;
+  const email = opts.email ?? null;
   // De-dupe + preserve insert order so the returned array matches what
   // `getUserById` would load right after (which sorts by created_at +
   // vault_name). Empty array is "no vaults" — admin posture or a non-
@@ -284,9 +305,9 @@ export async function createUser(
     db.transaction(() => {
       db.prepare(
         `INSERT INTO users
-           (id, username, password_hash, created_at, updated_at, password_changed)
-         VALUES (?, ?, ?, ?, ?, ?)`,
-      ).run(id, username, passwordHash, stamp, stamp, passwordChanged);
+           (id, username, password_hash, created_at, updated_at, password_changed, email)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(id, username, passwordHash, stamp, stamp, passwordChanged, email);
       if (assignedVaults.length > 0) {
         const role = opts.role ?? "write";
         const insertVault = db.prepare(
@@ -315,6 +336,7 @@ export async function createUser(
     createdAt: stamp,
     updatedAt: stamp,
     passwordChanged: passwordChanged === 1,
+    email,
     assignedVaults,
   };
 }
@@ -748,4 +770,41 @@ export function validatePassword(password: string): ValidatePasswordResult {
     return { valid: false, reason: "too_short" };
   }
   return { valid: true };
+}
+
+/**
+ * Email validation (migration v15, B2 — public-signup email capture).
+ *
+ * Deliberately PERMISSIVE: a single `local@domain.tld` shape check, not a
+ * full RFC 5322 parser. The goal is "the operator can plausibly reach this
+ * person," not RFC compliance — over-strict regexes reject valid real-world
+ * addresses (plus-tags, subdomains, long TLDs) and add no security. We require:
+ *   * exactly one `@`,
+ *   * a non-empty local part with no whitespace,
+ *   * a domain with at least one `.` and a 2+ char final label,
+ *   * no whitespace anywhere, and an overall length ceiling (254, the SMTP
+ *     practical max) so a megabyte string can't be stored.
+ *
+ * The address is lowercased + trimmed before the check and returned in that
+ * canonical form. Same discriminated-union shape as the other validators so
+ * the API/redeem edge can surface the reason.
+ */
+export const EMAIL_MAX_LEN = 254;
+
+// One @, no whitespace, a dotted domain ending in a 2+ char label.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@.]{2,}$/;
+
+export type ValidateEmailResult =
+  | { valid: true; email: string }
+  | { valid: false; reason: "format" | "length" };
+
+export function validateEmail(raw: string): ValidateEmailResult {
+  const email = raw.trim().toLowerCase();
+  if (email.length === 0 || email.length > EMAIL_MAX_LEN) {
+    return { valid: false, reason: "length" };
+  }
+  if (!EMAIL_REGEX.test(email)) {
+    return { valid: false, reason: "format" };
+  }
+  return { valid: true, email };
 }

--- a/src/vault-caps.ts
+++ b/src/vault-caps.ts
@@ -1,0 +1,109 @@
+/**
+ * Per-vault storage caps (migration v15, DEMO-PREP-2026-06-25 Workstream B,
+ * task B4). A vault provisioned through a capped signup link gets a row in
+ * the `vault_caps` table recording its byte ceiling. This module is the
+ * read/write seam over that table.
+ *
+ * Split of responsibility, on purpose:
+ *   - THIS PR (B1/B2/B4) PERSISTS the cap at provision time — nothing more.
+ *     The public-signup flow stamps a row here when it provisions a vault.
+ *   - A SEPARATE Phase-2 PR (B3, parachute-vault + hub wiring) READS this
+ *     row and ENFORCES it at upload time (4xx over cap). The brief is
+ *     explicit: "at minimum store the cap so the later PR can read + enforce
+ *     it." So `getVaultCapBytes` exists for that future reader; this PR only
+ *     calls `setVaultCap`.
+ *
+ * Keyed by `vault_name` — the same instance-name space used across
+ * services.json / `user_vaults` / `invites.vault_name`. No FK to a vaults
+ * table (there isn't one — vault names resolve through services.json, the
+ * established hub pattern). A vault with NO row is "uncapped," which is what
+ * the Phase-2 reader treats every pre-existing / admin-provisioned vault as.
+ */
+import type { Database } from "bun:sqlite";
+
+/**
+ * Default per-vault cap stamped by the public-signup flow when an invite
+ * carries no explicit cap but the flow wants one: ~1 GB (DEMO-PREP decision
+ * "1 GB per vault, configurable"). 1 GiB = 1024^3 bytes.
+ */
+export const DEFAULT_VAULT_CAP_BYTES = 1024 * 1024 * 1024;
+
+export interface VaultCap {
+  vaultName: string;
+  capBytes: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface Row {
+  vault_name: string;
+  cap_bytes: number;
+  created_at: string;
+  updated_at: string;
+}
+
+function rowToCap(r: Row): VaultCap {
+  return {
+    vaultName: r.vault_name,
+    capBytes: r.cap_bytes,
+    createdAt: r.created_at,
+    updatedAt: r.updated_at,
+  };
+}
+
+/**
+ * Persist (or update) a vault's storage cap. Upsert on `vault_name`: a
+ * re-provision (or a future admin edit) overwrites the cap and bumps
+ * `updated_at` while preserving the original `created_at`. `capBytes` must
+ * be a positive integer — callers validate before reaching here; this
+ * floors to an int defensively.
+ */
+export function setVaultCap(
+  db: Database,
+  vaultName: string,
+  capBytes: number,
+  now: Date = new Date(),
+): VaultCap {
+  const stamp = now.toISOString();
+  const bytes = Math.floor(capBytes);
+  db.prepare(
+    `INSERT INTO vault_caps (vault_name, cap_bytes, created_at, updated_at)
+     VALUES (?, ?, ?, ?)
+     ON CONFLICT(vault_name) DO UPDATE SET
+       cap_bytes = excluded.cap_bytes,
+       updated_at = excluded.updated_at`,
+  ).run(vaultName, bytes, stamp, stamp);
+  // Re-read so the returned createdAt reflects the preserved original on an
+  // update (excluded.created_at is NOT written on conflict).
+  const cap = getVaultCap(db, vaultName);
+  // The row was just written, so it always exists; the non-null assertion
+  // is safe but we fall back defensively rather than throw.
+  return cap ?? { vaultName, capBytes: bytes, createdAt: stamp, updatedAt: stamp };
+}
+
+/** Read a vault's cap, or `null` when the vault has no cap row (uncapped). */
+export function getVaultCap(db: Database, vaultName: string): VaultCap | null {
+  const row = db
+    .query<Row, [string]>("SELECT * FROM vault_caps WHERE vault_name = ?")
+    .get(vaultName);
+  return row ? rowToCap(row) : null;
+}
+
+/**
+ * Convenience for the Phase-2 enforcement reader: the cap in bytes, or
+ * `null` (uncapped) when no row exists. Thin wrapper over {@link getVaultCap}.
+ */
+export function getVaultCapBytes(db: Database, vaultName: string): number | null {
+  return getVaultCap(db, vaultName)?.capBytes ?? null;
+}
+
+/**
+ * Vault-delete cascade hook (parity with the other per-vault identity
+ * artifacts swept in admin-vaults.ts `handleDeleteVault`): drop the cap row
+ * when its vault is deleted so a re-created same-name vault doesn't inherit a
+ * stale cap. Exact `=` match, no pattern. Returns rows deleted (0 or 1).
+ */
+export function removeVaultCap(db: Database, vaultName: string): number {
+  const res = db.prepare("DELETE FROM vault_caps WHERE vault_name = ?").run(vaultName);
+  return Number(res.changes);
+}


### PR DESCRIPTION
## What

DEMO-PREP-2026-06-25 **Workstream B** (B1+B2+B4) in one PR: a shareable **public, multi-use** invite link lets someone Aaron knows less personally self-serve sign up (email + password → a capped vault), usable live in the demo room. Caps + max-uses + expiry protect the shared box.

Out of scope (separate Phase-2 hub PR): **B3** vault-side cap enforcement and **B5** admin user/vault visibility UI. This PR **persists** the cap now so B3 can read+enforce it.

## B1 — Multi-use invite link
- `invites.max_uses` (default 1) + `used_count` (default 0). Redeem refused once `used_count >= max_uses`.
- Exhaustion is **atomic / race-safe**: the `used_count < max_uses` guard lives in the `recordInviteRedemption` UPDATE, run inside `createUser`'s transaction (the `withinTx` hook). The loser of a concurrent last-seat race rolls back its user insert — no orphan account, no over-seat.
- **Backwards compatible**: a legacy single-use invite is exactly `max_uses=1`; every pre-v15 row redeems unchanged. Single-use throws the familiar `InviteUsedError`; multi-use throws `InviteExhaustedError` so copy can differ.
- Mint gates: a multi-use link can't pre-name a username or pin a single new vault name (every seat past the first would collide).

## B2 — Email-as-username signup
- `validateEmail` (permissive `local@domain.tld`, length-bounded ≤254, lowercased). Captured at signup, stored on **`users.email`** (visible to admin via `GET /api/users`) and on the invite (latest redeemer).
- Collected only for **public (multi-use)** links; the friends single-use flow stays no-email.

## B4 — Public signup page
- The existing `/account/setup/<token>` redeem flow **is** the public page; extended to multi-use + an email field (server-rendered, no-JS, reuses login chrome + CSRF + rate-limit).
- Per-vault storage cap (`invites.vault_cap_bytes`) **persisted to the new `vault_caps` table at provision time**, atomically inside the redeem transaction, so the Phase-2 enforcement PR can read it. `getVaultCapBytes()` is the reader seam for that PR; "no row = uncapped".
- A multi-use **provisioning** link auto-defaults to **~1 GB** when no explicit cap is set (DEMO decision: "1 GB per vault, configurable"); single-use links stay uncapped unless opted in.

## Migration v15 (append-only)
`invites.{max_uses,used_count,email,vault_cap_bytes}`, `users.email`, the `vault_caps` table. Safe defaults reproduce pre-v15 single-use semantics; no backfill. Vault-delete cascade drops the `vault_caps` row (parity with the other per-vault identity artifacts).

## API shape
- `POST /api/invites` accepts `max_uses` (1–1000) + `vault_cap_bytes` (1–100 GiB); `expires_in` already existed. Create/list wire shape gains `max_uses`, `used_count`, `email`, `vault_cap_bytes`.
- Public page: `GET|POST /account/setup/<token>` (unchanged route; multi-use-aware).

## Security
Public unauthenticated endpoint (the token *is* the credential). Reuses the `/login` CSRF + IP rate-limit gates. The freshly-created-vault cross-tenant invariant is preserved for multi-use. No existing auth weakened; `host:admin` remains unreachable via the invite path.

## Tests / gates
Scoped to avoid launchctl-booting the live hub. **typecheck clean.** Per-suite: public-signup **20**, vault-caps **5**, invites **13**, account-setup **30**, api-invites **14**, users **53**, hub-db **12**, admin-vaults **30** — all pass. Broader safe batch (1300+ tests across DB/API/UI/auth suites) green.

Reviewer-dispatched (LGTM-with-nits; nits folded inline: doc accuracy, auto-default cap made load-bearing, cap write moved into the atomic redeem tx, added uncapped-contract + auto-default tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)