### PR TITLE
fix(rate-limit): shared-egress-IP login pooling — per-(ip,identity) floor + per-IP ceiling, across both password doors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.4",
+  "version": "0.7.3-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1391,6 +1391,7 @@ describe("handleAuthorizePost — vault picker", () => {
 
 describe("handleAuthorizePost — login submit", () => {
   test("sets session cookie and redirects to GET on valid credentials", async () => {
+    resetRateLimit();
     const { db, cleanup } = await makeDb();
     try {
       await createUser(db, "owner", "hunter2");
@@ -1428,6 +1429,7 @@ describe("handleAuthorizePost — login submit", () => {
   });
 
   test("rejects bad password with 401, no cookie", async () => {
+    resetRateLimit();
     const { db, cleanup } = await makeDb();
     try {
       await createUser(db, "owner", "hunter2");

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -3,7 +3,7 @@ import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { handleAdminLoginTotpPost } from "../admin-handlers.ts";
+import { handleAdminLoginPost, handleAdminLoginTotpPost } from "../admin-handlers.ts";
 import { approveClient, getClient, registerClient } from "../clients.ts";
 import { CSRF_COOKIE_NAME } from "../csrf.ts";
 import { findGrant, recordGrant } from "../grants.ts";
@@ -1455,6 +1455,125 @@ describe("handleAuthorizePost — login submit", () => {
       const res = await handleAuthorizePost(db, req, { issuer: ISSUER });
       expect(res.status).toBe(401);
       expect(res.headers.get("set-cookie")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+// --- Shared per-account login bucket across BOTH password doors -------------
+//
+// The shared-egress-IP fix re-keyed the login floor to (ip,username) AND wired
+// the same `loginRateLimiter` instance into the previously-ungated
+// `/oauth/authorize` password door. Both doors must share ONE per-account
+// bucket, so an attacker can't get 5 tries at `/login` PLUS another 5 at
+// `/oauth/authorize` for the same (ip,username).
+describe("login floor is shared across /login and /oauth/authorize (same per-account bucket)", () => {
+  const ATTACK_IP = "203.0.113.200";
+
+  function adminLoginReq(username: string, password: string): Request {
+    const body = new URLSearchParams({
+      __csrf: TEST_CSRF,
+      username,
+      password,
+      next: "/admin/vaults",
+    });
+    return new Request("http://hub.test/login", {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        cookie: CSRF_COOKIE,
+        "cf-connecting-ip": ATTACK_IP,
+      },
+      body,
+    });
+  }
+
+  function oauthLoginReq(
+    username: string,
+    password: string,
+    clientId: string,
+    challenge: string,
+  ): Request {
+    const body = new URLSearchParams({
+      __action: "login",
+      __csrf: TEST_CSRF,
+      username,
+      password,
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope: "vault:read",
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+    });
+    return new Request(`${ISSUER}/oauth/authorize`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        cookie: CSRF_COOKIE,
+        "cf-connecting-ip": ATTACK_IP,
+      },
+      body,
+    });
+  }
+
+  // (e) 5 at /login + 1 at /oauth/authorize for the same (ip,username) → the
+  // 6th (the /oauth/authorize attempt) is denied regardless of which door it
+  // came through.
+  test("(e) 5 /login attempts then 1 /oauth/authorize attempt → the 6th door is 429", async () => {
+    const { db, cleanup } = await makeDb();
+    resetRateLimit();
+    try {
+      await createUser(db, "owner", "hunter2", { passwordChanged: true });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      // Burn the full 5-slot floor at the /login door (wrong password → 401).
+      for (let i = 0; i < 5; i++) {
+        const r = await handleAdminLoginPost(db, adminLoginReq("owner", "wrong"));
+        expect(r.status).toBe(401);
+      }
+      // 6th attempt — at the OTHER door (/oauth/authorize). Must be denied
+      // because both doors share ONE (ip,username) bucket.
+      const denied = await handleAuthorizePost(
+        db,
+        oauthLoginReq("owner", "hunter2", reg.client.clientId, challenge),
+        { issuer: ISSUER },
+      );
+      expect(denied.status).toBe(429);
+      expect(denied.headers.get("retry-after")).not.toBeNull();
+      // No session minted even though the password was correct — the floor
+      // fired before the credential check.
+      expect(cookieValueFrom(denied, "parachute_hub_session")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("the shared bucket is per-account: a DIFFERENT username at /oauth/authorize is unaffected", async () => {
+    const { db, cleanup } = await makeDb();
+    resetRateLimit();
+    try {
+      await createUser(db, "alice", "alice-pw", { passwordChanged: true });
+      await createUser(db, "bob", "bob-pw", { passwordChanged: true, allowMulti: true });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { challenge } = makePkce();
+
+      // Exhaust alice's floor at /login.
+      for (let i = 0; i < 5; i++) {
+        await handleAdminLoginPost(db, adminLoginReq("alice", "wrong"));
+      }
+      expect((await handleAdminLoginPost(db, adminLoginReq("alice", "wrong"))).status).toBe(429);
+
+      // bob (same IP, different username) still signs in at /oauth/authorize.
+      const bobRes = await handleAuthorizePost(
+        db,
+        oauthLoginReq("bob", "bob-pw", reg.client.clientId, challenge),
+        { issuer: ISSUER },
+      );
+      expect(bobRes.status).toBe(302);
+      expect(bobRes.headers.get("location")).toContain("/oauth/authorize?");
     } finally {
       cleanup();
     }

--- a/src/__tests__/rate-limit.test.ts
+++ b/src/__tests__/rate-limit.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  AUTH_IP_CEILING_MAX_ATTEMPTS,
   CHANGE_PASSWORD_MAX_ATTEMPTS,
   CHANGE_PASSWORD_WINDOW_MS,
   MAX_ATTEMPTS,
@@ -7,9 +8,12 @@ import {
   UNKNOWN_IP_SENTINEL,
   WINDOW_MS,
   __resetForTests,
+  authIpCeilingRateLimiter,
   changePasswordRateLimiter,
   checkAndRecord,
   clientIpFromRequest,
+  compositeKey,
+  loginRateLimiter,
 } from "../rate-limit.ts";
 
 afterEach(() => {
@@ -300,5 +304,87 @@ describe("changePasswordRateLimiter — tighter floor for /account/change-passwo
     expect(changePasswordRateLimiter.checkAndRecord("user-a", now).allowed).toBe(false);
     __resetForTests();
     expect(changePasswordRateLimiter.checkAndRecord("user-a", now).allowed).toBe(true);
+  });
+});
+
+// The shared-egress-IP fix: the per-account FLOOR is now keyed by
+// `compositeKey(ip, identity)` so a room of users behind ONE NAT'd /
+// Cloudflare egress IP doesn't pool into one 5-slot bucket. A coarse per-IP
+// CEILING (60/15min) backstops username-rotation across the floors.
+describe("compositeKey + shared-egress-IP login floor", () => {
+  test("normalizes identity: trims + lowercases so casing/whitespace share a bucket", () => {
+    expect(compositeKey("1.2.3.4", "Alice")).toBe("1.2.3.4|alice");
+    expect(compositeKey("1.2.3.4", "  ALICE  ")).toBe("1.2.3.4|alice");
+    // Case-flip evasion is closed: 'Alice' and 'alice' resolve to one key.
+    expect(compositeKey("1.2.3.4", "Alice")).toBe(compositeKey("1.2.3.4", "alice"));
+  });
+
+  // (a) REGRESSION: two distinct usernames from the SAME ip each get a full
+  // independent 5/15min floor (the shared-wifi bug). Before the fix both would
+  // have pooled into one per-IP bucket and the second user's 1st attempt would
+  // have been the 6th overall → 429.
+  test("(a) two usernames from the same IP each get an independent 5/15min floor", () => {
+    const ip = "203.0.113.7";
+    const now = new Date("2026-06-25T12:00:00Z");
+    // Alice exhausts her floor.
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      expect(loginRateLimiter.checkAndRecord(compositeKey(ip, "alice"), now).allowed).toBe(true);
+    }
+    expect(loginRateLimiter.checkAndRecord(compositeKey(ip, "alice"), now).allowed).toBe(false);
+    // Bob (same IP, different username) still has a fresh full floor.
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      expect(loginRateLimiter.checkAndRecord(compositeKey(ip, "bob"), now).allowed).toBe(true);
+    }
+    expect(loginRateLimiter.checkAndRecord(compositeKey(ip, "bob"), now).allowed).toBe(false);
+  });
+
+  // (b) a single (ip,username) still denies on the 6th attempt.
+  test("(b) a single (ip,username) still denies on the 6th attempt", () => {
+    const ip = "203.0.113.7";
+    const now = new Date("2026-06-25T12:00:00Z");
+    for (let i = 0; i < MAX_ATTEMPTS; i++) {
+      expect(loginRateLimiter.checkAndRecord(compositeKey(ip, "alice"), now).allowed).toBe(true);
+    }
+    const denied = loginRateLimiter.checkAndRecord(compositeKey(ip, "alice"), now);
+    expect(denied.allowed).toBe(false);
+    expect(denied.retryAfterSeconds).toBe(WINDOW_MS / 1000);
+  });
+
+  // (c) the per-IP ceiling denies on the 61st attempt from one IP even across
+  // rotated usernames (each username's own floor never trips because each only
+  // sees one attempt, but the coarse ceiling caps total per-IP volume).
+  test("(c) per-IP ceiling denies the 61st attempt across rotated usernames", () => {
+    const ip = "203.0.113.7";
+    const now = new Date("2026-06-25T12:00:00Z");
+    for (let i = 0; i < AUTH_IP_CEILING_MAX_ATTEMPTS; i++) {
+      // Rotate a fresh username every attempt so no per-account floor ever fills.
+      expect(loginRateLimiter.checkAndRecord(compositeKey(ip, `u${i}`), now).allowed).toBe(true);
+      expect(authIpCeilingRateLimiter.checkAndRecord(ip, now).allowed).toBe(true);
+    }
+    // 61st attempt: a brand-new username (floor is fresh) but the ceiling is full.
+    expect(loginRateLimiter.checkAndRecord(compositeKey(ip, "u60"), now).allowed).toBe(true);
+    const ceilingDenied = authIpCeilingRateLimiter.checkAndRecord(ip, now);
+    expect(ceilingDenied.allowed).toBe(false);
+    expect(ceilingDenied.retryAfterSeconds).toBe(WINDOW_MS / 1000);
+  });
+
+  test("the ceiling is per-IP: a different IP is unaffected by another's full ceiling", () => {
+    const now = new Date("2026-06-25T12:00:00Z");
+    for (let i = 0; i < AUTH_IP_CEILING_MAX_ATTEMPTS; i++) {
+      authIpCeilingRateLimiter.checkAndRecord("203.0.113.7", now);
+    }
+    expect(authIpCeilingRateLimiter.checkAndRecord("203.0.113.7", now).allowed).toBe(false);
+    expect(authIpCeilingRateLimiter.checkAndRecord("198.51.100.99", now).allowed).toBe(true);
+  });
+
+  test("ceiling matches the signup precedent (60) and `__resetForTests` clears it", () => {
+    expect(AUTH_IP_CEILING_MAX_ATTEMPTS).toBe(60);
+    const now = new Date("2026-06-25T12:00:00Z");
+    for (let i = 0; i < AUTH_IP_CEILING_MAX_ATTEMPTS; i++) {
+      authIpCeilingRateLimiter.checkAndRecord("203.0.113.7", now);
+    }
+    expect(authIpCeilingRateLimiter.checkAndRecord("203.0.113.7", now).allowed).toBe(false);
+    __resetForTests();
+    expect(authIpCeilingRateLimiter.checkAndRecord("203.0.113.7", now).allowed).toBe(true);
   });
 });

--- a/src/__tests__/two-factor-flow.test.ts
+++ b/src/__tests__/two-factor-flow.test.ts
@@ -332,6 +332,72 @@ describe("login two-step (TOTP) — hub#473", () => {
     expect(denied.status).toBe(429);
     expect(denied.headers.get("retry-after")).not.toBeNull();
   });
+
+  // (d) The 2FA floor is keyed by (ip,userId), NOT the rotating pendingToken.
+  // Re-POSTing /login mints a FRESH pendingToken for the SAME user — that must
+  // NOT reset the per-account TOTP floor (otherwise an attacker grinds TOTP
+  // forever by re-doing the password step between every 5 code attempts).
+  test("(d) re-POSTing /login (new pendingToken) does NOT reset the per-account TOTP floor", async () => {
+    const u = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    await persistEnrollment(harness.db, u.id, generateTotpSecret("owner").secret);
+    const ATTACK_IP = "203.0.113.66";
+
+    const passwordPost = async (): Promise<string> => {
+      const pw = formBody({
+        [CSRF_FIELD_NAME]: TEST_CSRF,
+        username: "owner",
+        password: "owner-password-123",
+        next: "/admin/vaults",
+      });
+      const res = await handleAdminLoginPost(
+        harness.db,
+        new Request("http://hub.test/login", {
+          method: "POST",
+          headers: { ...pw.headers, cookie: CSRF_COOKIE, "cf-connecting-ip": ATTACK_IP },
+          body: pw.body,
+        }),
+      );
+      const token = cookieFrom(res, PENDING_LOGIN_COOKIE_NAME);
+      expect(token).toBeTruthy();
+      return token!;
+    };
+
+    const wrongTotp = (pendingToken: string): Request => {
+      const tf = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, code: "000000", next: "/admin/vaults" });
+      return new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: {
+          ...tf.headers,
+          cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${pendingToken}`,
+          "cf-connecting-ip": ATTACK_IP,
+        },
+        body: tf.body,
+      });
+    };
+
+    // First password step → pendingToken1.
+    const token1 = await passwordPost();
+    // 4 wrong TOTP attempts against pendingToken1 (all 401, all count toward
+    // the (ip,userId) bucket).
+    for (let i = 0; i < 4; i++) {
+      expect((await handleAdminLoginTotpPost(harness.db, wrongTotp(token1))).status).toBe(401);
+    }
+
+    // Re-do the password step → a BRAND-NEW pendingToken2 (same userId).
+    const token2 = await passwordPost();
+    expect(token2).not.toBe(token1);
+
+    // 5th wrong TOTP — under pendingToken2 but the SAME (ip,userId) bucket →
+    // still the 5th attempt → allowed (401), not reset to fresh.
+    expect((await handleAdminLoginTotpPost(harness.db, wrongTotp(token2))).status).toBe(401);
+    // 6th wrong TOTP → floor full → 429. If the floor were keyed by the
+    // pendingToken, token2 would have a fresh bucket and this would be a 401.
+    const denied = await handleAdminLoginTotpPost(harness.db, wrongTotp(token2));
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("retry-after")).not.toBeNull();
+  });
 });
 
 describe("/account/2fa handlers — hub#473", () => {

--- a/src/__tests__/two-factor-flow.test.ts
+++ b/src/__tests__/two-factor-flow.test.ts
@@ -333,6 +333,34 @@ describe("login two-step (TOTP) — hub#473", () => {
     expect(denied.headers.get("retry-after")).not.toBeNull();
   });
 
+  // Fallback path: when the pending login can't be resolved (bad/expired
+  // token), the floor keys by IP ALONE — NOT the (rotating) pendingToken.
+  // Proven here by sending a DIFFERENT bogus pending cookie on every attempt
+  // from one IP: if the floor keyed by the token each would get a fresh bucket
+  // and never 429; keying by IP, the 6th still trips.
+  test("2FA floor with unresolvable pending tokens keys by IP, not the token", async () => {
+    const buildReq = (bogusToken: string) => {
+      const tf = formBody({ [CSRF_FIELD_NAME]: TEST_CSRF, code: "000000", next: "/admin/vaults" });
+      return new Request("http://hub.test/login/2fa", {
+        method: "POST",
+        headers: {
+          ...tf.headers,
+          cookie: `${CSRF_COOKIE}; ${PENDING_LOGIN_COOKIE_NAME}=${bogusToken}`,
+          "cf-connecting-ip": "203.0.113.77",
+        },
+        body: tf.body,
+      });
+    };
+    for (let i = 0; i < 5; i++) {
+      // A unique bogus token per attempt → never resolves to a pending login.
+      const r = await handleAdminLoginTotpPost(harness.db, buildReq(`bogus-${i}`));
+      expect(r.status).toBe(401); // no pending login → 401, counts toward the IP floor
+    }
+    const denied = await handleAdminLoginTotpPost(harness.db, buildReq("bogus-final"));
+    expect(denied.status).toBe(429);
+    expect(denied.headers.get("retry-after")).not.toBeNull();
+  });
+
   // (d) The 2FA floor is keyed by (ip,userId), NOT the rotating pendingToken.
   // Re-POSTing /login mints a FRESH pendingToken for the SAME user — that must
   // NOT reset the per-account TOTP floor (otherwise an attacker grinds TOTP

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -189,6 +189,10 @@ export async function handleAdminLoginPost(
   const username = String(form.get("username") ?? "");
   const clientIp = clientIpFromRequest(req);
   const now = deps.now ? deps.now() : new Date();
+  // Both checks always run (no short-circuit): a denied `checkAndRecord` does
+  // NOT append a timestamp, so running the floor after a denied ceiling never
+  // double-counts. We need both recorded so each independently tracks its own
+  // bucket (the floor still gates per-account even when the ceiling is fine).
   const ceiling = authIpCeilingRateLimiter.checkAndRecord(clientIp, now);
   const floor = loginRateLimiter.checkAndRecord(compositeKey(clientIp, username), now);
   if (!ceiling.allowed || !floor.allowed) {

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -21,7 +21,13 @@ import {
   getPendingLogin,
   parsePendingLoginCookie,
 } from "./pending-login.ts";
-import { checkAndRecord, clientIpFromRequest, totpRateLimiter } from "./rate-limit.ts";
+import {
+  authIpCeilingRateLimiter,
+  clientIpFromRequest,
+  compositeKey,
+  loginRateLimiter,
+  totpRateLimiter,
+} from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import {
   SESSION_TTL_MS,
@@ -167,24 +173,38 @@ export async function handleAdminLoginPost(
     );
   }
   // Rate-limit gate fires *after* CSRF (so a junk cross-site POST doesn't
-  // burn a bucket slot for the victim's IP) but *before* credential check.
+  // burn a bucket slot for the victim) but *before* credential check.
   // Every legitimate login attempt — wrong password, missing user, eventually
-  // failed-2FA (#186) — counts toward the same bucket so an attacker can't
-  // partition the cooldown across stages.
+  // failed-2FA — counts toward the same bucket so an attacker can't partition
+  // the cooldown across stages.
+  //
+  // Two tiers (the shared-egress-IP fix): a coarse per-IP CEILING (60/15min)
+  // backstops username-rotation, then a per-(ip,username) FLOOR (5/15min) so
+  // each account behind a shared NAT / Cloudflare egress IP gets its own
+  // bucket instead of the whole room pooling into one 5-slot per-IP bucket.
+  // `username` is hoisted above the gate because the floor keys on it. The same
+  // `loginRateLimiter` + `compositeKey(ip, username)` scheme backs the
+  // `/oauth/authorize` password door, so both doors share ONE per-account
+  // bucket.
+  const username = String(form.get("username") ?? "");
   const clientIp = clientIpFromRequest(req);
   const now = deps.now ? deps.now() : new Date();
-  const gate = checkAndRecord(clientIp, now);
-  if (!gate.allowed) {
+  const ceiling = authIpCeilingRateLimiter.checkAndRecord(clientIp, now);
+  const floor = loginRateLimiter.checkAndRecord(compositeKey(clientIp, username), now);
+  if (!ceiling.allowed || !floor.allowed) {
+    const retryAfterSeconds = Math.max(
+      ceiling.allowed ? 0 : (ceiling.retryAfterSeconds ?? 1),
+      floor.allowed ? 0 : (floor.retryAfterSeconds ?? 1),
+    );
     return htmlResponse(
       renderAdminError({
         title: "Too many login attempts",
-        message: `Too many login attempts from this IP. Try again in ${gate.retryAfterSeconds ?? 1} seconds.`,
+        message: `Too many login attempts. Try again in ${retryAfterSeconds} seconds.`,
       }),
       429,
-      { "retry-after": String(gate.retryAfterSeconds ?? 1) },
+      { "retry-after": String(retryAfterSeconds) },
     );
   }
-  const username = String(form.get("username") ?? "");
   const password = String(form.get("password") ?? "");
   const next = safeNext(String(form.get("next") ?? ""));
   const csrfToken = typeof formCsrf === "string" ? formCsrf : "";
@@ -314,23 +334,36 @@ export async function handleAdminLoginTotpPost(
   const next = safeNext(String(form.get("next") ?? ""));
   const code = String(form.get("code") ?? "");
 
-  // Rate-limit BEFORE resolving the pending login or verifying the factor.
+  // Rate-limit BEFORE verifying the factor. Resolve the pending login FIRST so
+  // the per-account floor can key on the STABLE userId (NOT the pendingToken,
+  // which a fresh /login success rotates and would reset the bucket). Resolving
+  // here also lets a bad/expired pending token fall back to keying the floor by
+  // IP alone — never by the rotating pendingToken.
   const clientIp = clientIpFromRequest(req);
   const now = deps.now ? deps.now() : new Date();
-  const gate = totpRateLimiter.checkAndRecord(clientIp, now);
-  if (!gate.allowed) {
+  const pendingToken = parsePendingLoginCookie(req.headers.get("cookie"));
+  const pending = getPendingLogin(pendingToken, () => now);
+  // Two tiers (the shared-egress-IP fix): coarse per-IP CEILING (60/15min) +
+  // per-(ip,userId) FLOOR (5/15min). When userId can't be resolved (bad/expired
+  // pending token), key the floor by IP alone — do NOT key by the pendingToken.
+  const ceiling = authIpCeilingRateLimiter.checkAndRecord(clientIp, now);
+  const floorKey = pending ? compositeKey(clientIp, pending.userId) : clientIp;
+  const floor = totpRateLimiter.checkAndRecord(floorKey, now);
+  if (!ceiling.allowed || !floor.allowed) {
+    const retryAfterSeconds = Math.max(
+      ceiling.allowed ? 0 : (ceiling.retryAfterSeconds ?? 1),
+      floor.allowed ? 0 : (floor.retryAfterSeconds ?? 1),
+    );
     return htmlResponse(
       renderAdminError({
         title: "Too many attempts",
-        message: `Too many verification attempts from this IP. Try again in ${gate.retryAfterSeconds ?? 1} seconds.`,
+        message: `Too many verification attempts. Try again in ${retryAfterSeconds} seconds.`,
       }),
       429,
-      { "retry-after": String(gate.retryAfterSeconds ?? 1) },
+      { "retry-after": String(retryAfterSeconds) },
     );
   }
 
-  const pendingToken = parsePendingLoginCookie(req.headers.get("cookie"));
-  const pending = getPendingLogin(pendingToken, () => now);
   if (!pending) {
     // No live pending login — expired, missing, or tampered. Send the user
     // back to the start; clear any stale pending cookie.

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -72,6 +72,12 @@ import {
 } from "./oauth-ui.ts";
 import { isSameOriginRequest } from "./origin-check.ts";
 import { buildPendingLoginCookie, createPendingLogin } from "./pending-login.ts";
+import {
+  authIpCeilingRateLimiter,
+  clientIpFromRequest,
+  compositeKey,
+  loginRateLimiter,
+} from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { narrowResourceVaultScopes, resolveResourceVault } from "./resource-binding.ts";
 import { isNonRequestableScope, isRequestableScope, scopeIsAdmin } from "./scope-explanations.ts";
@@ -1386,12 +1392,40 @@ async function handleLoginSubmit(
   db: Database,
   req: Request,
   form: Awaited<ReturnType<Request["formData"]>>,
-  _deps: OAuthDeps,
+  deps: OAuthDeps,
   csrfToken: string,
 ): Promise<Response> {
   const username = String(form.get("username") ?? "");
   const password = String(form.get("password") ?? "");
   const params = paramsFromForm(form);
+  // Rate-limit gate — AFTER CSRF (verified by the `handleAuthorizePost` caller)
+  // and BEFORE the credential check. This `/oauth/authorize` password door had
+  // NO rate-limit before; without it an attacker got an unbounded brute-force
+  // channel that bypassed `/login`'s floor entirely. Two tiers, reusing the
+  // SAME `loginRateLimiter` instance + the SAME `compositeKey(ip, username)`
+  // scheme as `/login`, so the two password doors share ONE per-account bucket
+  // (an attacker can't get 5 tries at `/login` PLUS another 5 here). The coarse
+  // per-IP CEILING backstops username-rotation; the per-(ip,username) FLOOR is
+  // the brute-force floor.
+  const clientIp = clientIpFromRequest(req);
+  const now = deps.now ? deps.now() : new Date();
+  const ceiling = authIpCeilingRateLimiter.checkAndRecord(clientIp, now);
+  const floor = loginRateLimiter.checkAndRecord(compositeKey(clientIp, username), now);
+  if (!ceiling.allowed || !floor.allowed) {
+    const retryAfterSeconds = Math.max(
+      ceiling.allowed ? 0 : (ceiling.retryAfterSeconds ?? 1),
+      floor.allowed ? 0 : (floor.retryAfterSeconds ?? 1),
+    );
+    return htmlResponse(
+      renderLogin({
+        params,
+        csrfToken,
+        errorMessage: `Too many login attempts. Try again in ${retryAfterSeconds} seconds.`,
+      }),
+      429,
+      { "retry-after": String(retryAfterSeconds) },
+    );
+  }
   if (!username || !password) {
     return htmlResponse(
       renderLogin({ params, csrfToken, errorMessage: "Username and password are required." }),

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -8,15 +8,16 @@
  * because its endpoint is meant to be redeemed by a room of people sharing one
  * egress IP (see `SIGNUP_MAX_ATTEMPTS`).
  *
- *   - `/login` (per-IP, hub#187 / hub#188): 5 attempts / 15 min.
- *     Lands as a floor under brute-force after hub#187 collapsed the
- *     public-reach matrix: with a cloudflare tunnel up, `/login` is now
- *     reachable from the open internet, and 2FA (#186) is the next PR
- *     rather than this one. A 5-attempts-per-15-minute bucket per IP is
- *     the standard login-form floor; it's not the primary defense, just
- *     the one that turns "infinite credential grinding" into "rotate IPs".
- *     (Endpoint was `/admin/login` pre-rename; bucket logic is path-
- *     agnostic so the rename was a comment-only change here.)
+ *   - `/login` (per-account floor + per-IP ceiling): the FLOOR is keyed by
+ *     `compositeKey(ip, username)` at 5 attempts / 15 min, shared with the
+ *     `/oauth/authorize` password door so both doors feed ONE per-account
+ *     bucket; the CEILING is `authIpCeilingRateLimiter` at 60 / 15 min keyed
+ *     by IP alone. Re-keyed from pure per-IP so a room of users behind one
+ *     NAT'd egress IP (shared wifi / cloudflare tunnel) no longer pool into a
+ *     single 5-slot bucket — the per-account floor still turns "infinite
+ *     credential grinding" into "rotate IPs", while the IP ceiling backstops
+ *     username-rotation. (Endpoint was `/admin/login` pre-rename; bucket
+ *     logic is path-agnostic so the rename was a comment-only change here.)
  *
  *   - `/account/change-password` (per-user, hub#282): 3 attempts / 5 min.
  *     The endpoint is session-gated, so the threat model isn't open-

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -99,6 +99,18 @@ export const TOTP_WINDOW_MS = 15 * 60 * 1000;
 /** `/login/2fa` attempts allowed per window. 6th within the window is denied. */
 export const TOTP_MAX_ATTEMPTS = 5;
 /**
+ * Coarse per-IP CEILING shared by all interactive auth doors (`/login`, the
+ * `/oauth/authorize` password door, `/login/2fa`). 60 attempts / 15 min — the
+ * same generous cap as public signup (`SIGNUP_MAX_ATTEMPTS`), chosen so a
+ * ~20-person demo room behind ONE NAT'd / Cloudflare egress IP clears it
+ * comfortably. It exists ONLY as a backstop against username-rotation: the
+ * per-(ip,identity) FLOORs stay tight at 5/15min, but an attacker who rotates
+ * usernames against one IP would otherwise get a fresh 5-slot floor per name.
+ * This ceiling caps total per-IP auth volume regardless of identity. Reuses the
+ * 15-min `WINDOW_MS`.
+ */
+export const AUTH_IP_CEILING_MAX_ATTEMPTS = 60;
+/**
  * `POST /account/vault-token/<name>` window length: 10 minutes. The endpoint
  * is session-gated and assignment-capped (a friend can only mint
  * `vault:<assigned>:read|write`), so this limiter isn't the primary defense —
@@ -235,9 +247,19 @@ export class RateLimiter {
 }
 
 /**
- * `/login` rate limiter — per-IP, 5 attempts / 15 min. Exported as a
- * singleton so all callers share one bucket map (rotating IPs across the
- * test suite or across a real attack must hit the same backing store).
+ * `/login` (+ the `/oauth/authorize` password door) rate limiter — per-
+ * account/per-half-login floor, keyed (ip,identity), 5 attempts / 15 min.
+ * RE-KEYED from per-IP to `compositeKey(ip, username)` (the shared-egress-IP
+ * fix): behind NAT / Cloudflare every user in a room presents one
+ * CF-Connecting-IP, so a per-IP-only key pooled the whole room into one 5-slot
+ * bucket and 429'd the 6th legitimate sign-in. Keyed by (ip,username) instead,
+ * each account gets its own floor while still pinning the floor to the IP so a
+ * single attacker can't grind one account from one box past 5 tries. BOTH
+ * password doors (`/login` and `/oauth/authorize` `__action=login`) share this
+ * ONE instance + the SAME key scheme, so an attacker can't get 5 tries per door
+ * against the same account. Exported as a singleton so all callers share one
+ * bucket map. The coarse per-IP `authIpCeilingRateLimiter` backstops
+ * username-rotation across this floor.
  */
 export const loginRateLimiter = new RateLimiter(MAX_ATTEMPTS, WINDOW_MS);
 
@@ -252,13 +274,29 @@ export const changePasswordRateLimiter = new RateLimiter(
 );
 
 /**
- * `/login/2fa` rate limiter — per-IP, 5 attempts / 15 min (hub#473). Bounds
- * second-factor grinding by an attacker who already has the password. Separate
+ * `/login/2fa` rate limiter — per-account/per-half-login floor, keyed
+ * (ip,identity), 5 attempts / 15 min (hub#473). Bounds second-factor grinding
+ * by an attacker who already has the password. RE-KEYED from per-IP to
+ * `compositeKey(ip, userId)` (the shared-egress-IP fix): keyed by the STABLE
+ * userId resolved from the pending-login (NOT the pendingToken, which rotates
+ * on every /login success and would reset the bucket). Behind NAT every 2FA-
+ * enrolled user in a room would otherwise pool into one per-IP bucket. Separate
  * bucket from `/login` so a password failure and a TOTP failure don't share a
- * window — but both are per-IP so rotating egress IPs is the only escape, same
- * as the password floor.
+ * window. The coarse per-IP `authIpCeilingRateLimiter` backstops this floor.
  */
 export const totpRateLimiter = new RateLimiter(TOTP_MAX_ATTEMPTS, TOTP_WINDOW_MS);
+
+/**
+ * Coarse per-IP CEILING rate limiter — 60 attempts / 15 min, keyed by client
+ * IP ONLY. Shared by all interactive auth doors (`/login`, the
+ * `/oauth/authorize` password door, `/login/2fa`) as a backstop against
+ * username-rotation: the per-(ip,identity) floors above stay tight, but an
+ * attacker rotating usernames against one IP would otherwise get a fresh floor
+ * per name. This ceiling caps total per-IP auth volume regardless of identity.
+ * Deliberately generous (matches the signup precedent) so a demo room sharing
+ * one egress IP clears it.
+ */
+export const authIpCeilingRateLimiter = new RateLimiter(AUTH_IP_CEILING_MAX_ATTEMPTS, WINDOW_MS);
 
 /**
  * `POST /account/vault-token/<name>` rate limiter — per-user, 10 attempts /
@@ -303,6 +341,19 @@ export function __resetForTests(): void {
   totpRateLimiter.reset();
   vaultTokenMintRateLimiter.reset();
   signupRateLimiter.reset();
+  authIpCeilingRateLimiter.reset();
+}
+
+/**
+ * Compose a per-(ip,identity) rate-limit key. Used by the per-account auth
+ * FLOORs (`/login` + `/oauth/authorize` keyed by username; `/login/2fa` keyed
+ * by userId) so each account behind a shared egress IP gets its own bucket
+ * while the floor still pins to the IP. The identity is trimmed + lowercased so
+ * `'Alice'` and `'alice'` share one bucket — otherwise an attacker could
+ * case-flip a username to mint a fresh 5-slot floor per casing.
+ */
+export function compositeKey(ip: string, id: string): string {
+  return `${ip}|${id.trim().toLowerCase()}`;
 }
 
 /**

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -91,9 +91,11 @@ export const CHANGE_PASSWORD_MAX_ATTEMPTS = 3;
  * factor step (hub#473) sits behind a verified password + a short-lived
  * pending-login token, so the threat model is "attacker who already has the
  * password grinding 6-digit codes / backup codes." A 5-attempt / 15-min
- * bucket per IP turns 10^6-space TOTP grinding into "rotate IPs," same floor
- * as `/login`. Keyed by IP (the pending-login token is short-lived and an
- * attacker could mint many, so IP is the stable actor key here).
+ * floor turns 10^6-space TOTP grinding into "rotate IPs," same floor as
+ * `/login`. Keyed by `compositeKey(ip, userId)` (the shared-egress-IP fix) so
+ * each 2FA-enrolled user behind one NAT'd / Cloudflare egress IP gets their own
+ * floor — the STABLE userId from the pending-login, NOT the rotating pending
+ * token. The coarse per-IP `authIpCeilingRateLimiter` backstops it.
  */
 export const TOTP_WINDOW_MS = 15 * 60 * 1000;
 /** `/login/2fa` attempts allowed per window. 6th within the window is denied. */


### PR DESCRIPTION
## Problem

The hub's interactive auth rate limiters keyed **solely by client IP** at 5 attempts/15min. Behind NAT / Cloudflare every user presents one `CF-Connecting-IP`, so a whole room pooled into one 5-slot bucket — and successful logins burned slots too. **Real incident: 4 friends on one wifi kept getting 429'd just logging in.** A separate gap: the `/oauth/authorize` password door (`__action=login`) had **no rate-limit gate at all**.

## Fix (one PR, two-tier, both password doors + 2FA)

1. **`src/rate-limit.ts`**
   - New `compositeKey(ip, id)` → `` `${ip}|${id.trim().toLowerCase()}` `` (lowercased/trimmed → no `Alice`/`alice` case-flip evasion).
   - Per-account **FLOOR** limiters keep their caps (5/15min) but are now *called with* composite keys: `loginRateLimiter` ← `(ip, username)`, `totpRateLimiter` ← `(ip, userId)`. (Instances unchanged; only call-site keys + docstrings changed.)
   - New coarse per-IP **CEILING**: `authIpCeilingRateLimiter` = 60/15min (`AUTH_IP_CEILING_MAX_ATTEMPTS`, matching the signup precedent — clears a ~20-person demo room on one IP), keyed by IP only. Backstops username-rotation. Added to `__resetForTests()`.

2. **`src/admin-handlers.ts`**
   - `handleAdminLoginPost`: hoist `username` above the gate; two checks (ceiling then `(ip,username)` floor), after CSRF / before credential check; either denies → 429 + the larger Retry-After.
   - `handleAdminLoginTotpPost`: resolve the pending-login → **stable `userId`** *before* the gate; floor keyed `(ip, userId)` (**not** the rotating `pendingToken`). Bad/expired pending token → floor falls back to IP-only (never the pendingToken).

3. **`src/oauth-handlers.ts` — closes the missed hole**
   - `handleLoginSubmit` (`POST /oauth/authorize __action=login`): added the same two-tier gate after CSRF, before `verifyPassword`, reusing the **SAME `loginRateLimiter` instance + SAME `compositeKey(ip, username)`** so the two password doors share **ONE** per-account bucket (no 5-at-/login PLUS-5-at-/oauth/authorize).

## Security posture (preserved)

- Per-account brute-force floor stays **exactly 5/15min**, now per-`(ip,username)` across **both** password doors.
- 2FA stays **5/15min** per `(ip,userId)`.
- Coarse per-IP ceiling **60/15min** backstops username-rotation.
- **CSRF-before-rate-limit** ordering preserved everywhere.
- `signup` / `change-password` / `vault-token-mint` limiters untouched.

## Tests

New cases: (a) two usernames / one IP → independent 5/15min floors (the bug); (b) single `(ip,username)` denies on the 6th; (c) per-IP ceiling denies the 61st across rotated usernames; (d) `/login/2fa` keyed by userId — re-POSTing `/login` (new pendingToken) does NOT reset the TOTP floor; (e) `/login` + `/oauth/authorize` share ONE per-account bucket (5 at one door + 1 at the other → the 6th 429s regardless of door).

## Gates (literal, hub-only)

- `bun run typecheck` — clean (`tsc --noEmit`)
- rate-limit + two-factor-flow + oauth-handlers + admin-handlers: **313 pass / 0 fail**
- adjacent auth (two-factor, admin-csrf-belt, admin-auth, auth): **130 pass / 0 fail**
- remaining importers (account-setup, account-vault-token, admin-lock, api-account, api-mint-token, public-signup, vault-names): **197 pass / 0 fail**
- Destructive lifecycle/launchctl/migrate/expose/install/serve suites intentionally **not** run (live-daemon bootout risk).

Version: `0.7.3-rc.4` → `0.7.3-rc.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)