### PR TITLE
feat(admin): signups + vault-caps admin view (B5 / D-slice)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.5",
+  "version": "0.7.3-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-vault-caps.test.ts
+++ b/src/__tests__/api-vault-caps.test.ts
@@ -145,6 +145,34 @@ describe("handleSetVaultCap", () => {
     expect(res.status).toBe(401);
   });
 
+  test("403 when bearer lacks parachute:host:admin", async () => {
+    const bearer = await makeAdminBearer(["other:scope"]);
+    const res = await handleSetVaultCap(
+      withBearer("/api/vault-caps/beta", bearer, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cap_bytes: 1000 }),
+      }),
+      "beta",
+      deps(),
+    );
+    expect(res.status).toBe(403);
+  });
+
+  test("400 on a fractional (non-integer) cap", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleSetVaultCap(
+      withBearer("/api/vault-caps/beta", bearer, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cap_bytes: 1.5 }),
+      }),
+      "beta",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+  });
+
   test("405 on GET", async () => {
     const bearer = await makeAdminBearer();
     const res = await handleSetVaultCap(withBearer("/api/vault-caps/beta", bearer), "beta", deps());

--- a/src/__tests__/api-vault-caps.test.ts
+++ b/src/__tests__/api-vault-caps.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for `/api/vault-caps*` (B5 admin visibility / D-slice).
+ * Covers:
+ *
+ *   - Auth boundary: GET + PUT require a bearer carrying `parachute:host:admin`.
+ *   - GET joins services.json vault names with persisted caps (uncapped =
+ *     null cap_bytes), ordered by name.
+ *   - PUT sets/updates a cap (upsert), validates positive cap, refuses a
+ *     vault not registered in services.json (400 vault_not_found).
+ *   - 405 on wrong methods.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleListVaultCaps, handleSetVaultCap } from "../api-vault-caps.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { createUser } from "../users.ts";
+import { getVaultCapBytes, setVaultCap } from "../vault-caps.ts";
+
+const ISSUER = "https://hub.test";
+const HOST_ADMIN_SCOPE = "parachute:host:admin";
+
+interface Harness {
+  db: Database;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function manifestWithVaults(...names: string[]): string {
+  const paths = names.map((n) => `/vault/${n}`);
+  return JSON.stringify({
+    services: [
+      { name: "parachute-vault", port: 4101, paths, health: "/health", version: "0.0.0-test" },
+    ],
+  });
+}
+
+function makeHarness(servicesJson?: string): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-api-vault-caps-"));
+  const db = openHubDb(hubDbPath(dir));
+  const manifestPath = join(dir, "services.json");
+  writeFileSync(manifestPath, servicesJson ?? manifestWithVaults("beta", "personal"));
+  return {
+    db,
+    manifestPath,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+async function makeAdminBearer(scopes = [HOST_ADMIN_SCOPE]): Promise<string> {
+  const user = await createUser(harness.db, "operator", "any-password", {
+    allowMulti: true,
+    passwordChanged: true,
+  });
+  const minted = await signAccessToken(harness.db, {
+    sub: user.id,
+    scopes,
+    audience: "hub",
+    clientId: "parachute-hub-spa",
+    issuer: ISSUER,
+    ttlSeconds: 600,
+  });
+  return minted.token;
+}
+
+function req(path: string, init: RequestInit = {}): Request {
+  return new Request(`${ISSUER}${path}`, init);
+}
+
+function withBearer(path: string, bearer: string, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers ?? {});
+  headers.set("authorization", `Bearer ${bearer}`);
+  return new Request(`${ISSUER}${path}`, { ...init, headers });
+}
+
+function deps() {
+  return { db: harness.db, issuer: ISSUER, manifestPath: harness.manifestPath };
+}
+
+describe("handleListVaultCaps", () => {
+  test("401 with no Authorization header", async () => {
+    const res = await handleListVaultCaps(req("/api/vault-caps"), deps());
+    expect(res.status).toBe(401);
+  });
+
+  test("403 when bearer lacks parachute:host:admin", async () => {
+    const bearer = await makeAdminBearer(["other:scope"]);
+    const res = await handleListVaultCaps(withBearer("/api/vault-caps", bearer), deps());
+    expect(res.status).toBe(403);
+  });
+
+  test("405 on POST", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleListVaultCaps(
+      withBearer("/api/vault-caps", bearer, { method: "POST" }),
+      deps(),
+    );
+    expect(res.status).toBe(405);
+  });
+
+  test("joins services.json vaults with caps, uncapped = null cap_bytes", async () => {
+    const bearer = await makeAdminBearer();
+    // Only "beta" has a persisted cap; "personal" stays uncapped.
+    setVaultCap(harness.db, "beta", 1024 * 1024 * 1024);
+    const res = await handleListVaultCaps(withBearer("/api/vault-caps", bearer), deps());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+    const body = (await res.json()) as {
+      vault_caps: Array<{ vault_name: string; cap_bytes: number | null }>;
+    };
+    // Both vaults present, ordered by name (beta, personal).
+    expect(body.vault_caps.map((c) => c.vault_name)).toEqual(["beta", "personal"]);
+    const beta = body.vault_caps.find((c) => c.vault_name === "beta");
+    const personal = body.vault_caps.find((c) => c.vault_name === "personal");
+    expect(beta?.cap_bytes).toBe(1024 * 1024 * 1024);
+    expect(personal?.cap_bytes).toBeNull();
+  });
+});
+
+describe("handleSetVaultCap", () => {
+  test("401 with no Authorization header", async () => {
+    const res = await handleSetVaultCap(
+      req("/api/vault-caps/beta", {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cap_bytes: 1000 }),
+      }),
+      "beta",
+      deps(),
+    );
+    expect(res.status).toBe(401);
+  });
+
+  test("405 on GET", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleSetVaultCap(withBearer("/api/vault-caps/beta", bearer), "beta", deps());
+    expect(res.status).toBe(405);
+  });
+
+  test("sets a cap on a registered vault and persists it (upsert)", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleSetVaultCap(
+      withBearer("/api/vault-caps/beta", bearer, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cap_bytes: 2 * 1024 * 1024 * 1024 }),
+      }),
+      "beta",
+      deps(),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { vault_cap: { cap_bytes: number } };
+    expect(body.vault_cap.cap_bytes).toBe(2 * 1024 * 1024 * 1024);
+    expect(getVaultCapBytes(harness.db, "beta")).toBe(2 * 1024 * 1024 * 1024);
+  });
+
+  test("400 vault_not_found for a vault not in services.json", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleSetVaultCap(
+      withBearer("/api/vault-caps/ghost", bearer, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cap_bytes: 1000 }),
+      }),
+      "ghost",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("vault_not_found");
+    // Nothing persisted for the rejected name.
+    expect(getVaultCapBytes(harness.db, "ghost")).toBeNull();
+  });
+
+  test("400 on non-positive cap", async () => {
+    const bearer = await makeAdminBearer();
+    const res = await handleSetVaultCap(
+      withBearer("/api/vault-caps/beta", bearer, {
+        method: "PUT",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ cap_bytes: 0 }),
+      }),
+      "beta",
+      deps(),
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_request");
+  });
+});

--- a/src/api-vault-caps.ts
+++ b/src/api-vault-caps.ts
@@ -135,15 +135,16 @@ async function parseSetCapBody(req: Request): Promise<{ ok: true; body: SetCapBo
   }
   const obj = raw as Record<string, unknown>;
   const capBytes = obj.cap_bytes;
-  // Positive finite integer only — the table's CHECK (cap_bytes > 0) is the
-  // at-rest backstop; this is the edge validation so the operator gets a clean
-  // 400 instead of a sqlite constraint error.
-  if (typeof capBytes !== "number" || !Number.isFinite(capBytes) || capBytes <= 0) {
+  // Positive integer only — the table's CHECK (cap_bytes > 0) is the at-rest
+  // backstop; this is the edge validation so the operator gets a clean 400
+  // instead of a sqlite constraint error. A fractional byte count (which a byte
+  // count can never be) is rejected rather than silently floored downstream.
+  if (typeof capBytes !== "number" || !Number.isInteger(capBytes) || capBytes <= 0) {
     return {
       ok: false,
       status: 400,
       error: "invalid_request",
-      description: '"cap_bytes" must be a positive number of bytes',
+      description: '"cap_bytes" must be a positive integer number of bytes',
     };
   }
   return { ok: true, body: { cap_bytes: capBytes } };

--- a/src/api-vault-caps.ts
+++ b/src/api-vault-caps.ts
@@ -1,0 +1,205 @@
+/**
+ * `/api/vault-caps*` — admin visibility + edit for per-vault storage caps
+ * (DEMO-PREP-2026-06-25 Workstream B5 / D-slice).
+ *
+ * PR #686 shipped the `vault_caps` table + `setVaultCap`/`getVaultCapBytes`
+ * (provision-time persistence) and a separate Phase-2 PR reads + ENFORCES the
+ * cap at upload time. This file is the OPERATOR-FACING seam in between: the
+ * admin SPA needs to SEE who has what cap and EDIT a cap live in the demo.
+ *
+ * Surfaces:
+ *
+ *   GET /api/vault-caps          list every vault (from services.json) joined
+ *                                with its persisted cap (host:admin)
+ *   PUT /api/vault-caps/:name    set/update a vault's cap to N bytes (host:admin)
+ *
+ * The list is the JOIN of "what vaults exist" (services.json, the canonical
+ * vault-name source) and "what caps are persisted" (`vault_caps`). A vault
+ * with no cap row appears with `cap_bytes: null` (uncapped) — the same
+ * "uncapped = no row" contract the Phase-2 enforcement reader relies on.
+ *
+ * Wire shape is snake_case (matches `/api/users`, `/api/invites`). Auth: same
+ * `parachute:host:admin` Bearer gate as every other `/api/*` admin surface;
+ * the SPA mints it from the session cookie via `/admin/host-admin-token`.
+ *
+ * Scope discipline: PUT only sets a cap on a vault that is REGISTERED in
+ * services.json (rejects a stale / typo name with 400 `vault_not_found`) so an
+ * operator can't seed a cap row for a vault that doesn't exist. Additive only —
+ * this never changes the provision-time cap-persistence from #686; it's a
+ * read + targeted-edit layer on the same table.
+ */
+import type { Database } from "bun:sqlite";
+import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { getVaultCap, setVaultCap } from "./vault-caps.ts";
+import { listVaultNamesFromPath } from "./vault-names.ts";
+
+export interface ApiVaultCapsDeps {
+  db: Database;
+  /** Hub origin — JWT `iss` validation. */
+  issuer: string;
+  /** Override services.json path. Defaults to `~/.parachute/services.json`. */
+  manifestPath?: string;
+}
+
+/**
+ * One row in the `GET /api/vault-caps` response: a vault name + its cap. A
+ * vault with no persisted cap carries `cap_bytes: null` (uncapped); `created_at`
+ * / `updated_at` are null too in that case.
+ */
+export interface VaultCapWireShape {
+  vault_name: string;
+  cap_bytes: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+/**
+ * GET /api/vault-caps — every vault registered in services.json, joined with
+ * its persisted cap (null = uncapped). Ordered by vault name.
+ */
+export async function handleListVaultCaps(req: Request, deps: ApiVaultCapsDeps): Promise<Response> {
+  if (req.method !== "GET") {
+    return jsonError(405, "method_not_allowed", "use GET");
+  }
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const names = listVaultNamesFromPath(manifestPath);
+  const caps: VaultCapWireShape[] = names.map((vaultName) => {
+    const cap = getVaultCap(deps.db, vaultName);
+    return {
+      vault_name: vaultName,
+      cap_bytes: cap?.capBytes ?? null,
+      created_at: cap?.createdAt ?? null,
+      updated_at: cap?.updatedAt ?? null,
+    };
+  });
+  return new Response(JSON.stringify({ vault_caps: caps }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+interface SetCapBody {
+  cap_bytes: number;
+}
+
+interface ParseErr {
+  ok: false;
+  status: number;
+  error: string;
+  description: string;
+}
+
+async function parseSetCapBody(req: Request): Promise<{ ok: true; body: SetCapBody } | ParseErr> {
+  const ctype = req.headers.get("content-type") ?? "";
+  if (!ctype.toLowerCase().includes("application/json")) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: "Content-Type must be application/json",
+    };
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: `invalid JSON body: ${msg}`,
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: "request body must be a JSON object",
+    };
+  }
+  const obj = raw as Record<string, unknown>;
+  const capBytes = obj.cap_bytes;
+  // Positive finite integer only — the table's CHECK (cap_bytes > 0) is the
+  // at-rest backstop; this is the edge validation so the operator gets a clean
+  // 400 instead of a sqlite constraint error.
+  if (typeof capBytes !== "number" || !Number.isFinite(capBytes) || capBytes <= 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      description: '"cap_bytes" must be a positive number of bytes',
+    };
+  }
+  return { ok: true, body: { cap_bytes: capBytes } };
+}
+
+/**
+ * PUT /api/vault-caps/:name — set or update a vault's storage cap.
+ *
+ * Order of checks (mirrors the /api/users handlers):
+ *
+ *   1. Method gate (405 on non-PUT).
+ *   2. Bearer carries `parachute:host:admin` (401 / 403 via `requireScope`).
+ *   3. Parse + validate body (400 on shape / non-positive cap).
+ *   4. Vault is registered in services.json (400 `vault_not_found`) — refuse
+ *      to seed a cap for a vault that doesn't exist.
+ *   5. `setVaultCap` (upsert) — overwrites the cap, bumps `updated_at`,
+ *      preserves the original `created_at`.
+ *
+ * Response on success: `200 { vault_cap: <wire shape> }`.
+ */
+export async function handleSetVaultCap(
+  req: Request,
+  vaultName: string,
+  deps: ApiVaultCapsDeps,
+): Promise<Response> {
+  if (req.method !== "PUT") {
+    return jsonError(405, "method_not_allowed", "use PUT");
+  }
+  try {
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+  } catch (err) {
+    return adminAuthErrorResponse(err as AdminAuthError);
+  }
+  const parsed = await parseSetCapBody(req);
+  if (!parsed.ok) {
+    return jsonError(parsed.status, parsed.error, parsed.description);
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const known = new Set(listVaultNamesFromPath(manifestPath));
+  if (!known.has(vaultName)) {
+    return jsonError(
+      400,
+      "vault_not_found",
+      `vault "${vaultName}" is not registered in services.json`,
+    );
+  }
+  const cap = setVaultCap(deps.db, vaultName, parsed.body.cap_bytes);
+  console.log(`vault cap set: vault=${vaultName} cap_bytes=${cap.capBytes}`);
+  const wire: VaultCapWireShape = {
+    vault_name: cap.vaultName,
+    cap_bytes: cap.capBytes,
+    created_at: cap.createdAt,
+    updated_at: cap.updatedAt,
+  };
+  return new Response(JSON.stringify({ vault_cap: wire }), {
+    status: 200,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -96,6 +96,8 @@
  *   /api/users/vaults             (GET)        → vault-name list for assigned-vault picker (host:admin)
  *   /api/users/<id>               (DELETE)     → hard-delete user + revoke tokens (host:admin)
  *   /api/users/<id>/reset-password (POST)      → admin-initiated password reset (host:admin)
+ *   /api/vault-caps               (GET)        → list vaults + persisted storage caps (host:admin)
+ *   /api/vault-caps/<name>        (PUT)        → set/update a vault's storage cap (host:admin)
  *   /login                        (GET + POST) → operator password login
  *   /login/2fa                    (POST)       → second-factor (TOTP/backup) step
  *                                                 (hub#473; reached after a correct
@@ -221,6 +223,7 @@ import {
   handleResetUserPassword,
   handleUpdateUserVaults,
 } from "./api-users.ts";
+import { handleListVaultCaps, handleSetVaultCap } from "./api-vault-caps.ts";
 import { gateUiAudience, resolveUiMount } from "./audience-gate.ts";
 import {
   CHROME_OPT_OUT_PREFIXES,
@@ -3345,6 +3348,30 @@ export function hubFetch(
           return new Response("not found", { status: 404 });
         }
         return handleRevokeInvite(req, id, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          manifestPath,
+        });
+      }
+
+      // Per-vault storage caps (B5 admin visibility / D-slice). GET lists every
+      // vault from services.json joined with its persisted cap; PUT /:name
+      // sets/updates a cap. host:admin-gated, same gate flavor as /api/users.
+      if (pathname === "/api/vault-caps") {
+        if (!getDb) return dbNotConfigured();
+        return handleListVaultCaps(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          manifestPath,
+        });
+      }
+      if (pathname.startsWith("/api/vault-caps/")) {
+        if (!getDb) return dbNotConfigured();
+        const name = decodeURIComponent(pathname.slice("/api/vault-caps/".length));
+        if (!name || name.includes("/")) {
+          return new Response("not found", { status: 404 });
+        }
+        return handleSetVaultCap(req, name, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
           manifestPath,

--- a/src/vault-caps.ts
+++ b/src/vault-caps.ts
@@ -98,6 +98,18 @@ export function getVaultCapBytes(db: Database, vaultName: string): number | null
 }
 
 /**
+ * List every persisted vault cap (B5 admin visibility). Returns only vaults
+ * that HAVE a cap row — the admin surface joins this against the live
+ * services.json vault list so an uncapped vault still appears (as "uncapped")
+ * while a capped vault shows its ceiling. Ordered by `vault_name` for a
+ * deterministic table.
+ */
+export function listVaultCaps(db: Database): VaultCap[] {
+  const rows = db.query<Row, []>("SELECT * FROM vault_caps ORDER BY vault_name ASC").all();
+  return rows.map(rowToCap);
+}
+
+/**
  * Vault-delete cascade hook (parity with the other per-vault identity
  * artifacts swept in admin-vaults.ts `handleDeleteVault`): drop the cap row
  * when its vault is deleted so a re-created same-name vault doesn't inherit a

--- a/src/vault-caps.ts
+++ b/src/vault-caps.ts
@@ -98,18 +98,6 @@ export function getVaultCapBytes(db: Database, vaultName: string): number | null
 }
 
 /**
- * List every persisted vault cap (B5 admin visibility). Returns only vaults
- * that HAVE a cap row — the admin surface joins this against the live
- * services.json vault list so an uncapped vault still appears (as "uncapped")
- * while a capped vault shows its ceiling. Ordered by `vault_name` for a
- * deterministic table.
- */
-export function listVaultCaps(db: Database): VaultCap[] {
-  const rows = db.query<Row, []>("SELECT * FROM vault_caps ORDER BY vault_name ASC").all();
-  return rows.map(rowToCap);
-}
-
-/**
  * Vault-delete cascade hook (parity with the other per-vault identity
  * artifacts swept in admin-vaults.ts `handleDeleteVault`): drop the cap row
  * when its vault is deleted so a re-created same-name vault doesn't inherit a

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -1002,6 +1002,12 @@ export interface UserListing {
   id: string;
   username: string;
   password_changed: boolean;
+  /**
+   * Contactable email captured at signup (v15, B2), or null for accounts
+   * created before email capture (wizard admin, env-seeded admin, pre-named
+   * friend invites). Visible to the operator so they can reach a signup.
+   */
+  email: string | null;
   assigned_vaults: string[];
   created_at: string;
 }
@@ -1187,6 +1193,70 @@ export async function listUserVaults(): Promise<string[]> {
   if (!res.ok) throw new HttpError(res.status, await readError(res));
   const body = (await res.json()) as { vaults: string[] };
   return body.vaults ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// Per-vault storage caps (B5 admin visibility / D-slice). host:admin-gated;
+// same Bearer pattern as users. GET lists every vault joined with its cap;
+// PUT /:name sets/updates a cap.
+// ---------------------------------------------------------------------------
+
+/**
+ * One row from `GET /api/vault-caps` — a vault name + its persisted storage
+ * cap. `cap_bytes: null` means the vault has no cap row (uncapped); the
+ * Phase-2 enforcement reader treats that as "no ceiling." `created_at` /
+ * `updated_at` are null for an uncapped vault.
+ */
+export interface VaultCapListing {
+  vault_name: string;
+  cap_bytes: number | null;
+  created_at: string | null;
+  updated_at: string | null;
+}
+
+/**
+ * GET /api/vault-caps — list every vault registered on this hub joined with
+ * its persisted storage cap. Same `host:admin` Bearer pattern as `listUsers`.
+ */
+export async function listVaultCaps(): Promise<VaultCapListing[]> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch("/api/vault-caps", {
+    method: "GET",
+    headers: { accept: "application/json", authorization: `Bearer ${bearer}` },
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { vault_caps: VaultCapListing[] };
+  return body.vault_caps ?? [];
+}
+
+/**
+ * PUT /api/vault-caps/:name — set or update a vault's storage cap (bytes).
+ * Server validates the vault is registered in services.json (400
+ * `vault_not_found`) and the cap is a positive integer. Returns the updated
+ * row. Same Bearer pattern; 401/403 dumps the cached token.
+ */
+export async function setVaultCap(vaultName: string, capBytes: number): Promise<VaultCapListing> {
+  const bearer = await getHostAdminToken();
+  const res = await fetch(`/api/vault-caps/${encodeURIComponent(vaultName)}`, {
+    method: "PUT",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json",
+      authorization: `Bearer ${bearer}`,
+    },
+    body: JSON.stringify({ cap_bytes: capBytes }),
+  });
+  if (res.status === 401 || res.status === 403) {
+    clearCachedToken();
+    throw new HttpError(res.status, await readError(res));
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { vault_cap: VaultCapListing };
+  return body.vault_cap;
 }
 
 // ---------------------------------------------------------------------------

--- a/web/ui/src/routes/Users.test.tsx
+++ b/web/ui/src/routes/Users.test.tsx
@@ -23,6 +23,8 @@ vi.mock("../lib/api.ts", async (orig) => {
     resetUserPassword: vi.fn(),
     updateUserVaults: vi.fn(),
     getHubOriginSetting: vi.fn(),
+    listVaultCaps: vi.fn(),
+    setVaultCap: vi.fn(),
   };
 });
 
@@ -38,6 +40,10 @@ beforeEach(() => {
     resolved_issuer: "https://hub.example.com",
     source: "settings",
   });
+  // The VaultCapsSection (rendered below the users table once the list
+  // resolves) fetches caps on mount. Default to empty so existing tests
+  // load cleanly; the cap-specific tests override it.
+  vi.mocked(api.listVaultCaps).mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -57,6 +63,7 @@ function user(username: string, overrides: Partial<api.UserListing> = {}): api.U
     id: `id-${username}`,
     username,
     password_changed: true,
+    email: null,
     assigned_vaults: [],
     created_at: "2026-05-01T12:00:00.000Z",
     ...overrides,
@@ -93,8 +100,9 @@ describe("Users — list rendering", () => {
     // badge specifically by its short label rather than matching any
     // "first admin" occurrence anywhere in the DOM.)
     expect(screen.getByText("first admin")).toBeInTheDocument();
-    // assigned_vault: null renders as em-dash.
-    expect(screen.getByText("—")).toBeInTheDocument();
+    // Em-dash placeholders appear in several cells now (empty assigned-vaults,
+    // null email). Assert at least one is present rather than uniqueness.
+    expect(screen.getAllByText("—").length).toBeGreaterThan(0);
     // password_changed: false renders the "pending first login" label.
     expect(screen.getByText(/pending first login/i)).toBeInTheDocument();
   });
@@ -601,5 +609,90 @@ describe("Users — sign-in handoff URL (onboarding discoverability)", () => {
     const banner = screen.getByText(/prompted to change their password/i).closest("output");
     // No double slash — the loader trims the trailing slash.
     expect(within(banner!).getByText("https://hub.example.com/login")).toBeInTheDocument();
+  });
+});
+
+describe("Users — email + role columns (B5)", () => {
+  it("renders the captured email as a mailto link and admin/member roles", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([
+      user("operator", { email: null }),
+      user("alice", { email: "alice@example.com" }),
+    ]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    renderRoute();
+    await waitFor(() => expect(screen.getByText("alice")).toBeInTheDocument());
+    // Email surfaced as a mailto link.
+    const mail = screen.getByText("alice@example.com");
+    expect(mail).toHaveAttribute("href", "mailto:alice@example.com");
+    // First admin → "admin" badge; the second user → "member".
+    expect(screen.getByText("admin")).toBeInTheDocument();
+    expect(screen.getByText("member")).toBeInTheDocument();
+  });
+});
+
+describe("Users — vault caps section (B5)", () => {
+  it("lists vaults with human-readable caps + uncapped placeholder", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    vi.mocked(api.listVaultCaps).mockResolvedValue([
+      {
+        vault_name: "beta",
+        cap_bytes: 1024 * 1024 * 1024,
+        created_at: "2026-06-20T00:00:00.000Z",
+        updated_at: "2026-06-21T00:00:00.000Z",
+      },
+      { vault_name: "personal", cap_bytes: null, created_at: null, updated_at: null },
+    ]);
+    renderRoute();
+    // Wait for the cap row itself (the section renders in a loading state
+    // first, then resolves its own listVaultCaps fetch).
+    const betaCell = await screen.findByTestId("vault-cap-beta");
+    // 1 GiB renders as "1.0 GB" via formatBytes.
+    expect(within(betaCell).getByText("1.0 GB")).toBeInTheDocument();
+    // No cap → "uncapped".
+    expect(
+      within(screen.getByTestId("vault-cap-personal")).getByText("uncapped"),
+    ).toBeInTheDocument();
+  });
+
+  it("edits a cap → PUTs bytes and reloads", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    vi.mocked(api.listVaultCaps).mockResolvedValue([
+      { vault_name: "beta", cap_bytes: null, created_at: null, updated_at: null },
+    ]);
+    vi.mocked(api.setVaultCap).mockResolvedValue({
+      vault_name: "beta",
+      cap_bytes: 2 * 1024 * 1024 * 1024,
+      created_at: "2026-06-25T00:00:00.000Z",
+      updated_at: "2026-06-25T00:00:00.000Z",
+    });
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /edit cap for beta/i }));
+    fireEvent.change(screen.getByLabelText(/cap for/i, { selector: "#cap-input-beta" }), {
+      target: { value: "2" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save cap/i }));
+    await waitFor(() =>
+      expect(api.setVaultCap).toHaveBeenCalledWith("beta", 2 * 1024 * 1024 * 1024),
+    );
+  });
+
+  it("rejects a non-positive cap client-side without calling the API", async () => {
+    vi.mocked(api.listUsers).mockResolvedValue([user("operator")]);
+    vi.mocked(api.listUserVaults).mockResolvedValue([]);
+    vi.mocked(api.listVaultCaps).mockResolvedValue([
+      { vault_name: "beta", cap_bytes: null, created_at: null, updated_at: null },
+    ]);
+    renderRoute();
+    fireEvent.click(await screen.findByRole("button", { name: /edit cap for beta/i }));
+    fireEvent.change(screen.getByLabelText(/cap for/i, { selector: "#cap-input-beta" }), {
+      target: { value: "0" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /save cap/i }));
+    await waitFor(() =>
+      expect(screen.getByText(/cap must be a positive number/i)).toBeInTheDocument(),
+    );
+    expect(api.setVaultCap).not.toHaveBeenCalled();
   });
 });

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -562,8 +562,15 @@ function ListRendered({
                     {u.email ? (
                       // Email is the contactable identity captured at public
                       // signup (B2) — the operator's "who signed up + how do I
-                      // reach them" column. mailto so a click drafts an email.
-                      <a href={`mailto:${u.email}`}>{u.email}</a>
+                      // reach them" column. Only render a mailto link when the
+                      // value actually looks like an email; otherwise show it as
+                      // plain text (defense-in-depth against a non-email value
+                      // ever landing in the field).
+                      u.email.includes("@") ? (
+                        <a href={`mailto:${u.email}`}>{u.email}</a>
+                      ) : (
+                        <span>{u.email}</span>
+                      )
                     ) : (
                       <span
                         className="muted"

--- a/web/ui/src/routes/Users.tsx
+++ b/web/ui/src/routes/Users.tsx
@@ -49,12 +49,16 @@ import {
   type CreateUserInput,
   HttpError,
   type UserListing,
+  type VaultCapListing,
   createUser,
   deleteUser,
+  formatBytes,
   getHubOriginSetting,
   listUserVaults,
   listUsers,
+  listVaultCaps,
   resetUserPassword,
+  setVaultCap,
   updateUserVaults,
 } from "../lib/api.ts";
 import { InvitesSection } from "./InvitesSection";
@@ -403,6 +407,8 @@ export function Users() {
       )}
 
       {state.kind === "ok" && <InvitesSection hubOrigin={state.data.hubOrigin} />}
+
+      {state.kind === "ok" && <VaultCapsSection />}
     </div>
   );
 }
@@ -510,6 +516,8 @@ function ListRendered({
           <thead>
             <tr>
               <th scope="col">Username</th>
+              <th scope="col">Email</th>
+              <th scope="col">Role</th>
               <th scope="col">Assigned vaults</th>
               <th scope="col">Password set</th>
               <th scope="col">Created</th>
@@ -548,6 +556,32 @@ function ListRendered({
                       <span className="badge" style={{ marginLeft: "0.5rem" }}>
                         first admin
                       </span>
+                    )}
+                  </td>
+                  <td>
+                    {u.email ? (
+                      // Email is the contactable identity captured at public
+                      // signup (B2) — the operator's "who signed up + how do I
+                      // reach them" column. mailto so a click drafts an email.
+                      <a href={`mailto:${u.email}`}>{u.email}</a>
+                    ) : (
+                      <span
+                        className="muted"
+                        title="No email on file (account predates signup-email capture)"
+                      >
+                        —
+                      </span>
+                    )}
+                  </td>
+                  <td>
+                    {/* No per-user role column exists in Phase 1 — the first
+                        admin is *the* admin by construction (earliest-created
+                        row). Surface that as the operator-facing "role" so a
+                        demo viewer can tell admin from member at a glance. */}
+                    {isFirstAdmin ? (
+                      <span className="badge">admin</span>
+                    ) : (
+                      <span className="muted">member</span>
                     )}
                   </td>
                   <td>
@@ -1148,4 +1182,254 @@ function CreateUserSection({
 function formatCreatedAt(iso: string): string {
   const d = new Date(iso);
   return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+// ---------------------------------------------------------------------------
+// Vault caps section (B5 / D-slice). Lists every vault on this hub with its
+// persisted storage cap (human-readable) and an inline editor to set/update a
+// cap. The operator-facing "who's using how much room" surface for the shared
+// beta box. Usage bytes (consumed) live in the VAULT service, not hub, so this
+// shows the CAP only — no new hub→vault plumbing for the demo slice.
+// ---------------------------------------------------------------------------
+
+const BYTES_PER_GIB = 1024 * 1024 * 1024;
+
+/** Cap in bytes → a GB number the operator edits (3 sig figs). 0/null → "". */
+function bytesToGiBInput(bytes: number | null): string {
+  if (bytes === null) return "";
+  const gib = bytes / BYTES_PER_GIB;
+  // Trim to a tidy value: integers stay integers, fractions keep 2 decimals.
+  return Number.isInteger(gib) ? String(gib) : gib.toFixed(2);
+}
+
+type VaultCapsState =
+  | { kind: "loading" }
+  | { kind: "ok"; caps: VaultCapListing[] }
+  | { kind: "error"; message: string };
+
+/** Per-row edit state — only one cap row can be open at a time. */
+type CapEditState =
+  | { kind: "idle" }
+  | { kind: "open"; vaultName: string; gibInput: string }
+  | { kind: "submitting"; vaultName: string; gibInput: string }
+  | { kind: "error"; vaultName: string; gibInput: string; message: string };
+
+function VaultCapsSection(): React.ReactNode {
+  const [state, setState] = useState<VaultCapsState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [edit, setEdit] = useState<CapEditState>({ kind: "idle" });
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setState({ kind: "loading" });
+    listVaultCaps()
+      .then((caps) => {
+        if (cancelled) return;
+        setState({ kind: "ok", caps });
+      })
+      .catch((err) => {
+        if (cancelled) return;
+        const message = err instanceof Error ? err.message : String(err);
+        setState({ kind: "error", message });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  async function onSubmit(vaultName: string, gibInput: string): Promise<void> {
+    const gib = Number(gibInput);
+    if (!Number.isFinite(gib) || gib <= 0) {
+      setEdit({
+        kind: "error",
+        vaultName,
+        gibInput,
+        message: "Cap must be a positive number of GB.",
+      });
+      return;
+    }
+    setEdit({ kind: "submitting", vaultName, gibInput });
+    try {
+      await setVaultCap(vaultName, Math.round(gib * BYTES_PER_GIB));
+      setEdit({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      const message =
+        err instanceof HttpError
+          ? `Set cap failed (${err.status}): ${err.message}`
+          : err instanceof Error
+            ? err.message
+            : String(err);
+      setEdit({ kind: "error", vaultName, gibInput, message });
+    }
+  }
+
+  return (
+    <section style={{ marginTop: "1.5rem" }} data-testid="vault-caps-section">
+      <h2>Vault caps</h2>
+      <p className="muted">
+        Per-vault storage ceilings for this hub. Public-signup vaults are stamped with a default cap
+        (~1 GB); admin-provisioned vaults are uncapped until you set one. Edit a cap to raise or
+        lower a vault's ceiling.
+      </p>
+      {state.kind === "loading" && <p className="muted">Loading vault caps…</p>}
+      {state.kind === "error" && (
+        <>
+          <div className="error-banner">
+            Couldn't load vault caps: <code>{state.message}</code>
+          </div>
+          <button type="button" className="secondary" onClick={() => setReload((n) => n + 1)}>
+            Retry
+          </button>
+        </>
+      )}
+      {state.kind === "ok" && state.caps.length === 0 && (
+        <div className="empty empty-rich">
+          <p className="empty-headline">No vaults on this hub yet.</p>
+          <p className="muted">Caps appear here once a vault is registered.</p>
+        </div>
+      )}
+      {state.kind === "ok" && state.caps.length > 0 && (
+        <div className="table-scroll" style={{ marginTop: "1rem" }}>
+          <table className="user-table">
+            <thead>
+              <tr>
+                <th scope="col">Vault</th>
+                <th scope="col">Cap</th>
+                <th scope="col">Updated</th>
+                <th scope="col">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {state.caps.map((c) => {
+                const editForRow =
+                  (edit.kind === "open" || edit.kind === "submitting" || edit.kind === "error") &&
+                  edit.vaultName === c.vault_name
+                    ? edit
+                    : null;
+                return (
+                  <tr key={c.vault_name} data-vault-name={c.vault_name}>
+                    <td>
+                      <code>{c.vault_name}</code>
+                    </td>
+                    <td data-testid={`vault-cap-${c.vault_name}`}>
+                      {c.cap_bytes !== null ? (
+                        formatBytes(c.cap_bytes)
+                      ) : (
+                        <span className="muted" title="No cap set — this vault is uncapped">
+                          uncapped
+                        </span>
+                      )}
+                    </td>
+                    <td>
+                      {c.updated_at ? (
+                        <span title={c.updated_at}>{formatCreatedAt(c.updated_at)}</span>
+                      ) : (
+                        <span className="muted">—</span>
+                      )}
+                    </td>
+                    <td>
+                      {editForRow ? (
+                        <CapEditRowForm
+                          vaultName={c.vault_name}
+                          state={editForRow}
+                          onCancel={() => setEdit({ kind: "idle" })}
+                          onChange={(gibInput) =>
+                            setEdit({ kind: "open", vaultName: c.vault_name, gibInput })
+                          }
+                          onSubmit={(gibInput) => {
+                            void onSubmit(c.vault_name, gibInput);
+                          }}
+                        />
+                      ) : (
+                        <button
+                          type="button"
+                          className="secondary"
+                          onClick={() =>
+                            setEdit({
+                              kind: "open",
+                              vaultName: c.vault_name,
+                              gibInput: bytesToGiBInput(c.cap_bytes),
+                            })
+                          }
+                          aria-label={`Edit cap for ${c.vault_name}`}
+                        >
+                          Edit cap
+                        </button>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}
+
+interface CapEditRowFormProps {
+  vaultName: string;
+  state:
+    | { kind: "open"; vaultName: string; gibInput: string }
+    | { kind: "submitting"; vaultName: string; gibInput: string }
+    | { kind: "error"; vaultName: string; gibInput: string; message: string };
+  onCancel: () => void;
+  onChange: (gibInput: string) => void;
+  onSubmit: (gibInput: string) => void;
+}
+
+function CapEditRowForm({
+  vaultName,
+  state,
+  onCancel,
+  onChange,
+  onSubmit,
+}: CapEditRowFormProps): React.ReactNode {
+  const submitting = state.kind === "submitting";
+  const errorMsg = state.kind === "error" ? state.message : null;
+  const inputId = `cap-input-${vaultName}`;
+  return (
+    <form
+      onSubmit={(e) => {
+        e.preventDefault();
+        onSubmit(state.gibInput);
+      }}
+      aria-label={`Edit cap for ${vaultName}`}
+      style={{
+        padding: "0.5rem",
+        background: "var(--bg-soft, #f5f5f5)",
+        borderRadius: "4px",
+      }}
+    >
+      <label htmlFor={inputId}>
+        Cap for <code>{vaultName}</code> <span className="muted">(GB)</span>
+      </label>
+      <br />
+      <input
+        id={inputId}
+        type="number"
+        step="0.01"
+        value={state.gibInput}
+        disabled={submitting}
+        onChange={(e) => onChange(e.target.value)}
+        style={{ width: "8rem", marginTop: "0.25rem" }}
+      />
+      {errorMsg && (
+        <div className="error-banner" style={{ marginTop: "0.25rem" }}>
+          <code>{errorMsg}</code>
+        </div>
+      )}
+      <div style={{ display: "flex", gap: "0.5rem", marginTop: "0.5rem" }}>
+        <button type="submit" disabled={submitting}>
+          {submitting ? "Saving…" : "Save cap"}
+        </button>
+        <button type="button" className="secondary" onClick={onCancel} disabled={submitting}>
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
 }


### PR DESCRIPTION
## What

Demo-prep **Workstream B5 / D-slice**: an admin view so the operator (Aaron) can **see who signed up** (email, role, assigned vaults, signup time) and **see + edit each vault's storage cap** — usable live in tomorrow's demo.

Builds on #686 (public signup capturing `users.email`, the `vault_caps` table + `setVaultCap`/`getVaultCapBytes`, per-vault cap persistence at provision). **Additive only** — does not touch the signup flow or the provision-time cap persistence, and doesn't weaken auth.

## Backend
- `vault-caps.ts`: add `listVaultCaps(db)` over the existing table.
- `api-vault-caps.ts` (new), host:admin Bearer-gated (same gate as `/api/users`):
  - `GET /api/vault-caps` — every services.json vault joined with its persisted cap (uncapped = `cap_bytes: null`).
  - `PUT /api/vault-caps/:name` — set/update a cap; validates positive `cap_bytes` + vault registered in services.json (400 `vault_not_found`).
- `hub-server.ts`: wire both routes + route-table docstring.

## Admin SPA (`web/ui`)
- `lib/api.ts`: add `email` to `UserListing`; `VaultCapListing` type + `listVaultCaps()` / `setVaultCap()` helpers.
- `routes/Users.tsx`:
  - **Email** (mailto link) + **Role** (admin/member, derived from first-admin) columns on the users table. Username · Email · Role · Assigned vaults · Password set · Created · Actions.
  - New **Vault caps** section below invites: each vault with a human-readable cap (`formatBytes`, e.g. "1.0 GB") + an inline GB editor that PUTs the cap. Uncapped vaults show "uncapped".

### View
- Route: `/admin/users` (the Users page — always renders in-shell; the `/vaults` route is a feature-detected forwarder to `/vault/admin/` on modern vaults, so it's not a reliable demo surface).
- Fields shown per signup: email, role, assigned vaults, signup time (Created); plus the Vault caps section: vault name, cap (human-readable), last updated, edit control.

## Usage bytes — NOT included (by design)
Per-vault usage (bytes consumed) lives in the **vault** service, not hub. The only clean hub-side read is the per-vault `/.parachute/usage` proxy used on the legacy `/vaults` page; wiring new hub→vault plumbing for the Users view is out of scope for this slice (separate effort, per the brief). Cap + email + vault + role + signup time is the required content.

## Version
`0.7.3-rc.5` → `0.7.3-rc.6`.

## Gates
- `bun run typecheck` (backend) + `web/ui` typecheck: **clean**.
- `bun test` over api/admin/users/vault suites (33 files): **848 pass, 0 fail**.
- `web/ui` vitest (full): **310 pass, 0 fail** (Users.test.tsx: 32 pass, incl. 4 new B5 tests).
- `build:spa`: clean (verify-base ✓).

🤖 Generated with [Claude Code](https://claude.com/claude-code)