### PR TITLE
feat(auth): multi-origin iss-set tolerance — one box, many URLs (rc.9)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.8",
+  "version": "0.7.3-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -393,6 +393,142 @@ describe("createScopeGuard — failure modes (HubJwtError.code)", () => {
   });
 });
 
+describe("createScopeGuard — multi-origin iss-set (allowedIssuers)", () => {
+  // The "same box, multiple URLs" case (onboarding-streamline 2026-06-25).
+  // A Caddy-fronted box reachable via loopback + <ip>.sslip.io + a custom
+  // domain mints `iss` = whichever URL the request arrived on; a token minted
+  // under URL-A must validate when the resource is reached via URL-B on the
+  // SAME box. The signing key is stable + origin-independent (the fixture
+  // serves ONE keypair), so widening the accepted-`iss` from one string to the
+  // hub's legitimate-origin SET is safe — the signature verify still gates
+  // provenance.
+  //
+  // `hubOrigin` = fixture.origin so JWKS + revocation fetch from the real
+  // fixture; the second/third URLs are provided via `allowedIssuers`. The
+  // fixture origin plays "URL-A"; "https://b.example" + "https://c.example"
+  // are the other URLs of the same box.
+  const URL_B = "https://b.example";
+  const URL_C = "https://c.example";
+
+  test("(a) token iss=A validates when allowed set is {A,B}", async () => {
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => [fixture.origin, URL_B],
+    });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+    guard.resetJwksCache();
+  });
+
+  test("(b) token iss=B validates against set {A,B} — the core same-box-two-URLs case", async () => {
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => [fixture.origin, URL_B],
+    });
+    // Token minted under URL-B, presented to a resource reached via URL-A.
+    const token = await signJwt(kp, { iss: URL_B });
+    const claims = await guard.validateHubJwt(token);
+    expect(claims.sub).toBe("user-1");
+    guard.resetJwksCache();
+  });
+
+  test("(c) token iss=C is REJECTED against set {A,B}", async () => {
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => [fixture.origin, URL_B],
+    });
+    const token = await signJwt(kp, { iss: URL_C });
+    await expectError(guard.validateHubJwt(token), "issuer", /verification failed/);
+    guard.resetJwksCache();
+  });
+
+  test("(d) single-origin config → identical exact-match behavior (back-compat)", async () => {
+    // No allowedIssuers → byte-identical to before the seam existed: exact
+    // match against the single hubOrigin, foreign iss rejected.
+    const guard = createScopeGuard({ hubOrigin: fixture.origin });
+    const ok = await signJwt(kp, { iss: fixture.origin });
+    expect((await guard.validateHubJwt(ok)).sub).toBe("user-1");
+    const bad = await signJwt(kp, { iss: URL_B });
+    await expectError(guard.validateHubJwt(bad), "issuer", /verification failed/);
+    guard.resetJwksCache();
+  });
+
+  test("(d') allowedIssuers returning empty/undefined → exact-match on hubOrigin only", async () => {
+    // Defense: a resolver that returns an empty array (or undefined) collapses
+    // to the single-origin path — a non-hubOrigin iss is still rejected, never
+    // silently widened.
+    const guardEmpty = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => [],
+    });
+    expect((await guardEmpty.validateHubJwt(await signJwt(kp, { iss: fixture.origin }))).sub).toBe(
+      "user-1",
+    );
+    await expectError(
+      guardEmpty.validateHubJwt(await signJwt(kp, { iss: URL_B })),
+      "issuer",
+      /verification failed/,
+    );
+    guardEmpty.resetJwksCache();
+
+    const guardUndef = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => undefined,
+    });
+    await expectError(
+      guardUndef.validateHubJwt(await signJwt(kp, { iss: URL_B })),
+      "issuer",
+      /verification failed/,
+    );
+    guardUndef.resetJwksCache();
+  });
+
+  test("(e) hubOrigin is always accepted even when allowedIssuers omits it", async () => {
+    // The canonical hubOrigin (= JWKS/revocation pin) is always a member of the
+    // accepted set regardless of what allowedIssuers returns — so a caller that
+    // returns only the *extra* origins never accidentally locks out the
+    // canonical one. Loopback-as-canonical is the always-present case in
+    // production (buildHubBoundOrigins always seeds loopback aliases).
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => [URL_B, URL_C], // deliberately omits fixture.origin
+    });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    expect((await guard.validateHubJwt(token)).sub).toBe("user-1");
+    // …and B is still accepted (it's in the extra set).
+    expect((await guard.validateHubJwt(await signJwt(kp, { iss: URL_B }))).sub).toBe("user-1");
+    guard.resetJwksCache();
+  });
+
+  test("allowedIssuers is re-evaluated per call (widening without restart)", async () => {
+    // An operator adding a domain (new env value) is picked up on the next
+    // request without a process restart — mirrors the resolver-per-call
+    // contract the existing hubOrigin/jwksOrigin resolvers already honor.
+    let allowed: string[] = [fixture.origin];
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => allowed,
+    });
+    const tokenB = await signJwt(kp, { iss: URL_B });
+    await expectError(guard.validateHubJwt(tokenB), "issuer", /verification failed/);
+    // Operator widens the set mid-process.
+    allowed = [fixture.origin, URL_B];
+    expect((await guard.validateHubJwt(tokenB)).sub).toBe("user-1");
+    guard.resetJwksCache();
+  });
+
+  test("trailing slashes in allowedIssuers are normalized (match hub-minted iss)", async () => {
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      allowedIssuers: () => [`${URL_B}/`],
+    });
+    const token = await signJwt(kp, { iss: URL_B });
+    expect((await guard.validateHubJwt(token)).sub).toBe("user-1");
+    guard.resetJwksCache();
+  });
+});
+
 describe("createScopeGuard — injected JWKS getter", () => {
   test("uses injected getter, ignores cache + origin fetch", async () => {
     const realGuard = makeGuard();

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -21,6 +21,12 @@ import {
  *   - The hub origin is the trust pin. `iss` MUST equal it; without that
  *     check, anyone could mint a token against any RSA key and pass JWKS
  *     verification (jose verifies the signature, not who issued the token).
+ *     With `allowedIssuers`, the pin widens from a single origin to a
+ *     hub-CONTROLLED SET of the hub's own legitimate origins (one box reached
+ *     via several URLs — loopback ∪ sslip.io ∪ custom domain). This is still a
+ *     pin against the hub's origins, NOT a relaxation: the signature verify
+ *     runs first and proves only this hub minted the token; the set never
+ *     includes an unvalidated request Host. See `allowedIssuers` jsdoc.
  *   - JWKS is fetched from `<jwksOrigin>/.well-known/jwks.json`, defaulting
  *     to the same `hubOrigin` used for the `iss` pin. Co-located resource
  *     servers can override `jwksOrigin` (e.g. loopback) to read their hub's
@@ -144,6 +150,43 @@ export interface CreateScopeGuardOptions {
    * form matches what the hub mints.
    */
   hubOrigin: string | (() => string);
+
+  /**
+   * The SET of additional origins to accept in the token's `iss` claim,
+   * beyond `hubOrigin`. **Optional and purely additive** — when omitted (the
+   * default), the `iss` check is byte-identical to before this seam existed:
+   * exact match against the single resolved `hubOrigin`.
+   *
+   * Motivation (multi-origin iss-set, onboarding-streamline 2026-06-25): one
+   * box reachable on several URLs at once (loopback + `<ip>.sslip.io` + a
+   * custom domain behind Caddy) mints tokens whose `iss` is whichever origin
+   * the request arrived on. The hub's signing KEY is stable and
+   * origin-independent — the only thing the origin drives is the `iss` string —
+   * so a token minted under URL-A must validate when the resource is reached
+   * via URL-B on the SAME box. jose's `issuer` option already accepts
+   * `string | string[]`; this option supplies the extra members of that set.
+   *
+   * SECURITY INVARIANT (load-bearing — do not loosen): the values returned
+   * here MUST be the hub's own legitimate origins ONLY — i.e. the output of
+   * the hub's `buildHubBoundOrigins` (configured issuer ∪ loopback aliases ∪
+   * expose-state public origin ∪ platform origin), published to the resource
+   * server out-of-band (env / config) by the HUB/OPERATOR. They must NEVER
+   * derive from an unvalidated request `Host` / `X-Forwarded-Host`. Accepting
+   * `iss ∈ this-set` is safe ONLY because the JWKS signature verify
+   * (`jwtVerify`, which runs FIRST and unconditionally) already proves THIS
+   * hub minted the token. The set is a belt-and-suspenders allowlist layered
+   * on top of the signature gate, never a substitute for it. A token signed by
+   * a foreign key fails the signature step regardless of its `iss`.
+   *
+   * Shape: a resolver function returning the set, re-evaluated per call so an
+   * operator widening the box's origins (a new domain via the env var) is
+   * picked up without a resource-server restart. The resolved `hubOrigin` is
+   * always added to whatever this returns, so a caller need not (but may)
+   * include it. Empty / undefined → identical to omitting the option (single
+   * `hubOrigin` only). Trailing slashes are stripped; malformed entries are
+   * dropped.
+   */
+  allowedIssuers?: () => readonly string[] | undefined;
 
   /**
    * Origin to FETCH the JWKS from, when it must differ from the `hubOrigin`
@@ -315,6 +358,7 @@ function resolveOrigin(input: string | (() => string)): string {
 export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
   const {
     hubOrigin,
+    allowedIssuers,
     jwksOrigin,
     jwks: jwksOpts,
     jwksGetter: injected,
@@ -397,17 +441,55 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
   }
 
   /**
+   * Resolve the accepted-`iss` value passed to jose's `issuer` option.
+   *
+   * Default (no `allowedIssuers`): the single canonical `origin` — byte-
+   * identical exact-match behavior to before the multi-origin seam existed.
+   *
+   * With `allowedIssuers`: the UNION of `origin` and the (sanitized) extra
+   * origins, deduped, returned as a `string[]`. jose accepts `string[]` for
+   * `issuer` and passes a token whose `iss` matches ANY member — this is the
+   * "same box, two URLs" tolerance. The canonical `origin` is always present
+   * so a single-member set behaves exactly like the default.
+   *
+   * SECURITY: this set is the hub's own legitimate-origin allowlist (see
+   * `allowedIssuers` jsdoc). The signature verify in `jwtVerify` runs FIRST
+   * and proves provenance unconditionally; widening the accepted `iss` from
+   * one string to this hub-controlled set never accepts a foreign-key token.
+   */
+  function resolveAcceptedIssuers(origin: string): string | string[] {
+    if (!allowedIssuers) return origin;
+    const extra = allowedIssuers();
+    if (!extra || extra.length === 0) return origin;
+    const set = new Set<string>([origin]);
+    for (const raw of extra) {
+      if (typeof raw !== "string") continue;
+      const trimmed = raw.replace(/\/$/, "");
+      if (trimmed.length > 0) set.add(trimmed);
+    }
+    // A single-member set collapses to the bare string so the
+    // default/single-origin path stays observably identical (jose treats
+    // `string` and `[string]` the same, but the string form keeps the
+    // configured-shape obvious in logs / tests).
+    return set.size === 1 ? origin : Array.from(set);
+  }
+
+  /**
    * Verify the JWT signature + issuer, with a force-reload-and-retry-once on
    * rotation-class failures. Returns the verified payload or throws a wrapped
    * `HubJwtError`. See the inline comment for the recovery rationale.
+   *
+   * `acceptedIssuers` is what jose checks `iss` against — a single string
+   * (default / single-origin) or a string[] (the multi-origin set). jose
+   * passes a token whose `iss` matches any member.
    */
   async function verifyWithRotationRetry(
     token: string,
-    origin: string,
+    acceptedIssuers: string | string[],
     getter: JwksGetter,
   ): Promise<JWTPayload> {
     try {
-      const verified = await jwtVerify(token, getter, { issuer: origin });
+      const verified = await jwtVerify(token, getter, { issuer: acceptedIssuers });
       return verified.payload;
     } catch (err) {
       const code = classifyJoseError(err);
@@ -429,7 +511,7 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
             // The retry's outcome — success OR error — is final and flows
             // through the same classify-and-wrap. No second reload.
             try {
-              const verified = await jwtVerify(token, getter, { issuer: origin });
+              const verified = await jwtVerify(token, getter, { issuer: acceptedIssuers });
               return verified.payload;
             } catch (retryErr) {
               throwWrapped(retryErr);
@@ -443,15 +525,20 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
 
   return {
     async validateHubJwt(token, validateOpts = {}) {
-      // `origin` pins the `iss` check (and the revocation-list endpoint, which
-      // lives on the issuer). `jwksFetchOrigin` is where the keys are fetched —
-      // identical to `origin` unless the caller supplied `jwksOrigin`. Both are
-      // resolved per call so env changes propagate without a restart.
+      // `origin` is the CANONICAL hub origin. It pins (a) the revocation-list
+      // endpoint, which lives on the canonical issuer, and (b) the default
+      // JWKS-fetch origin. `acceptedIssuers` is what the token's `iss` is
+      // checked against — `origin` alone by default, or the multi-origin SET
+      // (origin ∪ the hub's other legitimate origins) when `allowedIssuers` is
+      // supplied. `jwksFetchOrigin` is where the keys are fetched — identical
+      // to `origin` unless the caller supplied `jwksOrigin`. All resolved per
+      // call so env changes propagate without a restart.
       const origin = resolveOrigin(hubOrigin);
+      const acceptedIssuers = resolveAcceptedIssuers(origin);
       const jwksFetchOrigin = resolveOrigin(jwksOriginInput);
       const getter = pickGetter(jwksFetchOrigin);
 
-      const payload: JWTPayload = await verifyWithRotationRetry(token, origin, getter);
+      const payload: JWTPayload = await verifyWithRotationRetry(token, acceptedIssuers, getter);
 
       if (typeof payload.sub !== "string" || payload.sub.length === 0) {
         throw new HubJwtError("shape", "hub JWT missing required `sub` claim");

--- a/src/__tests__/hub-origins-env-set.test.ts
+++ b/src/__tests__/hub-origins-env-set.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Multi-origin iss-set (onboarding-streamline 2026-06-25) — hub side.
+ *
+ * The hub publishes the SET of origins it legitimately answers on to its
+ * supervised resource servers via `PARACHUTE_HUB_ORIGINS` (comma-separated),
+ * alongside the single canonical `PARACHUTE_HUB_ORIGIN`. A resource server on
+ * scope-guard ≥0.5.0 widens its accepted-`iss` check to this set so a token
+ * minted under one URL of a multi-URL box validates via another URL of the
+ * SAME box.
+ *
+ * These tests pin two things:
+ *   1. The serialize/parse round-trip + the assembly from hub-controlled
+ *      inputs (issuer ∪ loopback aliases ∪ expose-state ∪ platform).
+ *   2. The SECURITY INVARIANT: the set is built ONLY from operator/hub config
+ *      and on-disk state — never from an unvalidated request `Host` /
+ *      `X-Forwarded-Host`. We feed an attacker-controlled "Host" through every
+ *      input channel a request could plausibly reach and assert it never lands
+ *      in the published set.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseHubOrigins, serializeHubOrigins } from "../hub-origin.ts";
+import { buildHubOriginsEnvValue } from "../vault-hub-origin-env.ts";
+
+describe("serializeHubOrigins / parseHubOrigins round-trip", () => {
+  test("serialize dedupes, drops empties, strips trailing slashes", () => {
+    const v = serializeHubOrigins([
+      "https://a.example/",
+      "https://a.example",
+      "",
+      "https://b.example",
+    ]);
+    expect(v).toBe("https://a.example,https://b.example");
+  });
+
+  test("serialize returns undefined when nothing survives", () => {
+    expect(serializeHubOrigins([])).toBeUndefined();
+    expect(serializeHubOrigins(["", "  "])).toBeUndefined();
+  });
+
+  test("parse is the inverse — tolerant of whitespace + trailing slashes + empties", () => {
+    expect(parseHubOrigins("https://a.example, https://b.example/ ,,")).toEqual([
+      "https://a.example",
+      "https://b.example",
+    ]);
+  });
+
+  test("parse returns [] for absent/empty/garbage", () => {
+    expect(parseHubOrigins(undefined)).toEqual([]);
+    expect(parseHubOrigins("")).toEqual([]);
+    expect(parseHubOrigins(" , , ")).toEqual([]);
+  });
+
+  test("round-trips a real set", () => {
+    const origins = ["https://example.com", "http://127.0.0.1:1939", "http://localhost:1939"];
+    const wire = serializeHubOrigins(origins)!;
+    expect(parseHubOrigins(wire)).toEqual(origins);
+  });
+});
+
+describe("buildHubOriginsEnvValue — assembles the hub's legitimate-origin set", () => {
+  let dir: string;
+  const EXPOSE = () => join(dir, "expose-state.json");
+
+  /** Write a schema-valid expose-state.json carrying the given hubOrigin. */
+  function writeExposeState(hubOrigin: string): void {
+    writeFileSync(
+      EXPOSE(),
+      JSON.stringify({
+        version: 1,
+        layer: "public",
+        mode: "path",
+        canonicalFqdn: new URL(hubOrigin).host,
+        port: 1939,
+        funnel: true,
+        entries: [],
+        hubOrigin,
+      }),
+    );
+  }
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hub-origins-set-"));
+    // No hub.port file in this fresh configDir → readHubPort falls back to
+    // HUB_UNIT_DEFAULT_PORT (1939), the deterministic value these cases assert.
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("issuer ∪ loopback aliases when no expose / platform origin", () => {
+    const v = buildHubOriginsEnvValue(dir, "https://example.com", {}, EXPOSE());
+    const set = parseHubOrigins(v);
+    expect(set).toContain("https://example.com");
+    expect(set).toContain("http://127.0.0.1:1939");
+    expect(set).toContain("http://localhost:1939");
+    expect(set).toHaveLength(3);
+  });
+
+  test("loopback aliases are ALWAYS present (the always-present invariant)", () => {
+    // Even with a public issuer, loopback must be in the set so the co-located
+    // CLI / loopback-proxied request path validates.
+    const set = parseHubOrigins(buildHubOriginsEnvValue(dir, "https://example.com", {}, EXPOSE()));
+    expect(set).toContain("http://127.0.0.1:1939");
+    expect(set).toContain("http://localhost:1939");
+  });
+
+  test("folds in the expose-state public origin", () => {
+    writeExposeState("https://box.sslip.io");
+    const set = parseHubOrigins(buildHubOriginsEnvValue(dir, "https://example.com", {}, EXPOSE()));
+    expect(set).toContain("https://example.com");
+    expect(set).toContain("https://box.sslip.io");
+  });
+
+  test("folds in the platform origin (RENDER_EXTERNAL_URL)", () => {
+    const set = parseHubOrigins(
+      buildHubOriginsEnvValue(
+        dir,
+        "https://example.com",
+        { RENDER_EXTERNAL_URL: "https://app.onrender.com" },
+        EXPOSE(),
+      ),
+    );
+    expect(set).toContain("https://app.onrender.com");
+  });
+
+  test("folds in the composed Fly default origin", () => {
+    const set = parseHubOrigins(
+      buildHubOriginsEnvValue(dir, "https://example.com", { FLY_APP_NAME: "myapp" }, EXPOSE()),
+    );
+    expect(set).toContain("https://myapp.fly.dev");
+  });
+
+  test("absent issuer → loopback-only set (still useful, never empty on a normal box)", () => {
+    const set = parseHubOrigins(buildHubOriginsEnvValue(dir, undefined, {}, EXPOSE()));
+    expect(set).toContain("http://127.0.0.1:1939");
+    expect(set).toContain("http://localhost:1939");
+    // The empty issuer "" is dropped by buildHubBoundOrigins' URL parse.
+    expect(set).not.toContain("");
+  });
+
+  test("a malformed expose-state.json never throws — falls back to issuer + loopback", () => {
+    writeFileSync(EXPOSE(), "{ not valid json");
+    const set = parseHubOrigins(buildHubOriginsEnvValue(dir, "https://example.com", {}, EXPOSE()));
+    expect(set).toContain("https://example.com");
+    expect(set).toContain("http://127.0.0.1:1939");
+  });
+
+  describe("SECURITY INVARIANT — request Host never enters the set", () => {
+    const ATTACKER = "https://attacker.evil";
+
+    test("an attacker Host smuggled via expose-state IS honored ONLY because it's operator-written on-disk state — but a Host passed nowhere never appears", () => {
+      // There is NO request input to buildHubOriginsEnvValue at all — it takes
+      // configDir + issuer + env + expose-state-path. None of those is a
+      // request header. We assert the function's surface offers no channel for
+      // a request Host: feeding the attacker value to the only inputs an
+      // attacker might influence (a stray env var, a header-shaped string)
+      // never reaches the set unless it's a legitimate operator-config var.
+      const set = parseHubOrigins(
+        buildHubOriginsEnvValue(
+          dir,
+          "https://example.com",
+          {
+            // Header-shaped env vars an attacker might hope are read — none are
+            // consulted by the assembler (only RENDER_EXTERNAL_URL / FLY_APP_NAME).
+            HTTP_HOST: ATTACKER,
+            HTTP_X_FORWARDED_HOST: ATTACKER,
+            X_FORWARDED_HOST: ATTACKER,
+            HOST: ATTACKER,
+          } as NodeJS.ProcessEnv,
+          EXPOSE(),
+        ),
+      );
+      expect(set).not.toContain(ATTACKER);
+      expect(set.some((o) => o.includes("attacker"))).toBe(false);
+    });
+
+    test("the set is exactly issuer ∪ loopback ∪ expose ∪ platform — no other source", () => {
+      writeExposeState("https://box.sslip.io");
+      const set = parseHubOrigins(
+        buildHubOriginsEnvValue(
+          dir,
+          "https://example.com",
+          { RENDER_EXTERNAL_URL: "https://app.onrender.com" },
+          EXPOSE(),
+        ),
+      );
+      // Every member is one of the four sanctioned sources; nothing else.
+      const sanctioned = new Set([
+        "https://example.com",
+        "http://127.0.0.1:1939",
+        "http://localhost:1939",
+        "https://box.sslip.io",
+        "https://app.onrender.com",
+      ]);
+      for (const o of set) expect(sanctioned.has(o)).toBe(true);
+    });
+  });
+});

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -125,6 +125,51 @@ describe("bootSupervisedModules", () => {
     expect(recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://hub.example");
   });
 
+  test("forwards PARACHUTE_HUB_ORIGINS (the multi-origin iss-set) alongside the single origin", async () => {
+    // Multi-origin iss-set (onboarding-streamline 2026-06-25): a resource
+    // server on scope-guard ≥0.5.0 widens its accepted-`iss` check to this set
+    // so a token minted under one URL of a multi-URL box validates via another.
+    // The set always carries the issuer + loopback aliases (the deterministic
+    // members); expose-state / platform members vary by box.
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      hubOrigin: "https://hub.example",
+    });
+
+    const origins = recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGINS;
+    expect(origins).toBeDefined();
+    const set = (origins ?? "").split(",");
+    expect(set).toContain("https://hub.example");
+    // SECURITY: the set is hub-controlled (issuer + loopback + expose +
+    // platform) — never a request Host. Loopback aliases are always present.
+    expect(set.some((o) => o.startsWith("http://127.0.0.1:"))).toBe(true);
+    expect(set.some((o) => o.startsWith("http://localhost:"))).toBe(true);
+    // And the single canonical origin is still written for back-compat.
+    expect(recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGIN).toBe("https://hub.example");
+  });
+
+  test("no PARACHUTE_HUB_ORIGINS when hubOrigin is unset (no widening, single-origin only)", async () => {
+    // Back-compat: a boot with no hubOrigin neither sets PARACHUTE_HUB_ORIGIN
+    // nor the set — the child keeps its own loopback default + scope-guard's
+    // single-origin behavior.
+    writeManifest({ services: [VAULT_ENTRY] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+
+    await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+
+    expect(recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGIN).toBeUndefined();
+    expect(recorder.calls[0]?.env?.PARACHUTE_HUB_ORIGINS).toBeUndefined();
+  });
+
   test("sets PORT in child env from services.json entry (hub#357)", async () => {
     // Container deploys (Render etc.) set PORT in hub's process.env via
     // Dockerfile / platform injection. The supervisor's defaultSpawnFn

--- a/src/__tests__/vault-hub-origin-env.test.ts
+++ b/src/__tests__/vault-hub-origin-env.test.ts
@@ -76,13 +76,29 @@ describe("persistVaultHubOrigin", () => {
     expect(existsSync(vaultEnv())).toBe(false);
   });
 
-  test("is idempotent — no rewrite when the value is already current", () => {
+  test("is idempotent — no rewrite when both the origin and the set are current", () => {
     const log: string[] = [];
     expect(persistVaultHubOrigin(dir, "https://hub.example.com", (l) => log.push(l))).toBe(true);
+    // First call wrote BOTH the single origin and the multi-origin set.
+    expect(
+      log.some((l) => /persisted PARACHUTE_HUB_ORIGIN=https:\/\/hub\.example\.com/.test(l)),
+    ).toBe(true);
+    expect(log.some((l) => /persisted PARACHUTE_HUB_ORIGINS=/.test(l))).toBe(true);
+    const writesAfterFirst = log.length;
+    // Second call is a no-op: both values already current → false, no new logs.
     expect(persistVaultHubOrigin(dir, "https://hub.example.com", (l) => log.push(l))).toBe(false);
-    // Only the first call logged.
-    expect(log).toHaveLength(1);
-    expect(log[0]).toMatch(/persisted PARACHUTE_HUB_ORIGIN=https:\/\/hub\.example\.com/);
+    expect(log).toHaveLength(writesAfterFirst);
+  });
+
+  test("writes PARACHUTE_HUB_ORIGINS (multi-origin iss-set) alongside the single origin", () => {
+    expect(persistVaultHubOrigin(dir, "https://hub.example.com", () => {})).toBe(true);
+    const values = readEnvFileValues(vaultEnv());
+    expect(values.PARACHUTE_HUB_ORIGIN).toBe("https://hub.example.com");
+    // The set carries the issuer + loopback aliases (always present).
+    const set = (values.PARACHUTE_HUB_ORIGINS ?? "").split(",");
+    expect(set).toContain("https://hub.example.com");
+    expect(set.some((o) => o.startsWith("http://127.0.0.1:"))).toBe(true);
+    expect(set.some((o) => o.startsWith("http://localhost:"))).toBe(true);
   });
 
   test("updates a stale origin in-place and preserves sibling keys", () => {
@@ -111,6 +127,24 @@ describe("clearVaultHubOrigin", () => {
     const values = readEnvFileValues(vaultEnv());
     expect(values.PARACHUTE_HUB_ORIGIN).toBeUndefined();
     expect(values.SCRIBE_AUTH_TOKEN).toBe("secret");
+  });
+
+  test("removes BOTH the single origin and the multi-origin set, leaving siblings", () => {
+    writeFileSync(
+      mkVaultDir(),
+      "SCRIBE_AUTH_TOKEN=secret\nPARACHUTE_HUB_ORIGIN=https://hub.example.com\nPARACHUTE_HUB_ORIGINS=https://hub.example.com,http://127.0.0.1:1939\n",
+    );
+    expect(clearVaultHubOrigin(dir, () => {})).toBe(true);
+    const values = readEnvFileValues(vaultEnv());
+    expect(values.PARACHUTE_HUB_ORIGIN).toBeUndefined();
+    expect(values.PARACHUTE_HUB_ORIGINS).toBeUndefined();
+    expect(values.SCRIBE_AUTH_TOKEN).toBe("secret");
+  });
+
+  test("clears a lone PARACHUTE_HUB_ORIGINS even if the single origin is absent", () => {
+    writeFileSync(mkVaultDir(), "PARACHUTE_HUB_ORIGINS=https://hub.example.com\n");
+    expect(clearVaultHubOrigin(dir, () => {})).toBe(true);
+    expect(readEnvFileValues(vaultEnv()).PARACHUTE_HUB_ORIGINS).toBeUndefined();
   });
 
   test("no-op when no origin is present", () => {

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -55,6 +55,7 @@ import {
 import { findService, readManifestLenient, removeService } from "./services-manifest.ts";
 import { enrichedPath } from "./spawn-path.ts";
 import type { ModuleState, SpawnRequest, Supervisor } from "./supervisor.ts";
+import { buildHubOriginsEnvValue } from "./vault-hub-origin-env.ts";
 import { WELL_KNOWN_PATH, type regenerateWellKnown } from "./well-known.ts";
 
 /**
@@ -609,10 +610,21 @@ async function spawnSupervised(
   // `process.env.PATH` may ALREADY be enriched by serve startup (serve.ts);
   // re-enriching here is a harmless no-op — `enrichedPath` is idempotent
   // (dedupe + append-only), so double-enrichment can't duplicate or reorder.
+  // PARACHUTE_HUB_ORIGINS (multi-origin iss-set, onboarding-streamline
+  // 2026-06-25): alongside the single canonical PARACHUTE_HUB_ORIGIN, inject
+  // the SET of origins the hub legitimately answers on (issuer ∪ loopback ∪
+  // expose-state ∪ platform). A resource server on scope-guard ≥0.5.0 widens
+  // its accepted-`iss` check to this set so a token minted under one URL of a
+  // multi-URL box validates via another URL of the SAME box. Mirrors
+  // buildModuleSpawnRequest (serve-boot.ts) — keep the two in sync. SECURITY:
+  // the set is hub-controlled config/disk state ONLY, never a request Host
+  // (see buildHubOriginsEnvValue). `deps.spawnEnv` still wins.
+  const hubOrigins = deps.issuer ? buildHubOriginsEnvValue(deps.configDir, deps.issuer) : undefined;
   const childEnv: Record<string, string> = {
     PATH: enrichedPath(),
     PORT: String(entry.port),
     ...(deps.issuer ? { PARACHUTE_HUB_ORIGIN: deps.issuer } : {}),
+    ...(hubOrigins ? { PARACHUTE_HUB_ORIGINS: hubOrigins } : {}),
     ...(deps.spawnEnv ?? {}),
   };
   const req: SpawnRequest = {

--- a/src/commands/serve-boot.ts
+++ b/src/commands/serve-boot.ts
@@ -18,7 +18,7 @@
 
 import { join } from "node:path";
 import { readEnvFileValues } from "../env-file.ts";
-import { HUB_ORIGIN_ENV } from "../hub-origin.ts";
+import { HUB_ORIGINS_ENV, HUB_ORIGIN_ENV } from "../hub-origin.ts";
 import { ModuleManifestError } from "../module-manifest.ts";
 import {
   type ServiceSpec,
@@ -30,6 +30,7 @@ import {
 import { type ServiceEntry, readManifestLenient, upsertService } from "../services-manifest.ts";
 import { enrichedPath } from "../spawn-path.ts";
 import type { Supervisor } from "../supervisor.ts";
+import { buildHubOriginsEnvValue } from "../vault-hub-origin-env.ts";
 
 export interface BootOpts {
   /** Path to services.json. */
@@ -197,7 +198,20 @@ export function buildModuleSpawnRequest(
     PORT: String(entry.port),
     ...fileEnvSansPort,
   };
-  if (opts.hubOrigin) env[HUB_ORIGIN_ENV] = opts.hubOrigin;
+  if (opts.hubOrigin) {
+    env[HUB_ORIGIN_ENV] = opts.hubOrigin;
+    // Multi-origin iss-set (onboarding-streamline 2026-06-25): alongside the
+    // single canonical origin, inject the SET of origins this hub legitimately
+    // answers on (issuer ∪ loopback aliases ∪ expose-state ∪ platform). A
+    // resource server on scope-guard ≥0.5.0 widens its accepted-`iss` check to
+    // this set, so a token minted under one URL of a multi-URL box validates
+    // when the resource is reached via another URL of the SAME box. SECURITY:
+    // the set is hub-controlled config/disk state only, NEVER a request Host —
+    // see `buildHubOriginsEnvValue`. The single `PARACHUTE_HUB_ORIGIN` above
+    // stays for back-compat with older scope-guard.
+    const originsValue = buildHubOriginsEnvValue(opts.configDir, opts.hubOrigin);
+    if (originsValue) env[HUB_ORIGINS_ENV] = originsValue;
+  }
   if (opts.extraEnv) Object.assign(env, opts.extraEnv);
 
   const req: SpawnReqShape = { short, cmd };

--- a/src/hub-origin.ts
+++ b/src/hub-origin.ts
@@ -14,6 +14,70 @@
 
 export const HUB_ORIGIN_ENV = "PARACHUTE_HUB_ORIGIN";
 
+/**
+ * The env var carrying the SET of origins the hub legitimately answers on,
+ * comma-separated (multi-origin iss-set, onboarding-streamline 2026-06-25).
+ *
+ * Supervised resource servers (vault, scribe) read this in addition to the
+ * single canonical `PARACHUTE_HUB_ORIGIN` and widen their accepted-`iss` check
+ * from one string to this set — so a token minted under one URL of a
+ * multi-URL box (loopback ∪ `<ip>.sslip.io` ∪ a custom domain behind Caddy)
+ * validates when the resource is reached via another URL of the SAME box. The
+ * signing key is stable + origin-independent, so only the `iss` string varies.
+ *
+ * SECURITY INVARIANT: the value MUST be the hub's `buildHubBoundOrigins`
+ * output — configured issuer ∪ loopback aliases ∪ expose-state public origin ∪
+ * platform origin — published BY THE HUB. It must NEVER contain an unvalidated
+ * request `Host` / `X-Forwarded-Host`. Accepting `iss ∈ this-set` is safe
+ * ONLY because the resource server's JWKS signature verify runs first and
+ * proves the hub minted the token.
+ *
+ * `PARACHUTE_HUB_ORIGIN` (the single canonical origin) is ALWAYS written
+ * alongside this var for back-compat: a resource server on an older
+ * scope-guard that doesn't read `PARACHUTE_HUB_ORIGINS` keeps its existing
+ * single-origin behavior.
+ */
+export const HUB_ORIGINS_ENV = "PARACHUTE_HUB_ORIGINS";
+
+/**
+ * Serialize an origin SET into the comma-separated `PARACHUTE_HUB_ORIGINS`
+ * wire form. Dedupes, drops empties, preserves first-seen order. Returns
+ * `undefined` when nothing survives (caller skips setting the env var so a
+ * resource server falls back to single-origin behavior). Pair with
+ * `buildHubBoundOrigins` to produce `origins`.
+ */
+export function serializeHubOrigins(origins: readonly string[]): string | undefined {
+  const seen = new Set<string>();
+  for (const raw of origins) {
+    if (typeof raw !== "string") continue;
+    const trimmed = raw.trim().replace(/\/+$/, "");
+    if (trimmed.length > 0) seen.add(trimmed);
+  }
+  if (seen.size === 0) return undefined;
+  return Array.from(seen).join(",");
+}
+
+/**
+ * Parse the comma-separated `PARACHUTE_HUB_ORIGINS` wire form back into an
+ * origin array. Tolerant of surrounding whitespace + trailing slashes + empty
+ * segments. The resource-server inverse of `serializeHubOrigins`; lives here
+ * (rather than only in the consumer adapters) so the hub's own injection tests
+ * can round-trip against the canonical parser. Returns `[]` for an
+ * absent/empty/garbage value.
+ */
+export function parseHubOrigins(raw: string | undefined): string[] {
+  if (!raw) return [];
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const seg of raw.split(",")) {
+    const trimmed = seg.trim().replace(/\/+$/, "");
+    if (trimmed.length === 0 || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    out.push(trimmed);
+  }
+  return out;
+}
+
 export interface DeriveHubOriginOpts {
   /** Explicit user override (e.g., `--hub-origin`). Wins over everything else. */
   override?: string;

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -55,9 +55,20 @@ export interface SignAccessTokenOpts {
   clientId: string;
   /**
    * Hub origin — sets the `iss` claim. Required: every consumer (vault,
-   * scribe, channel) validates `iss` against `PARACHUTE_HUB_ORIGIN`, and a
-   * missing claim is rejected. Callers derive this via `deriveHubOrigin()`
-   * or thread it from `OAuthDeps.issuer`.
+   * scribe, agent) validates `iss`, and a missing claim is rejected. Callers
+   * derive this via `deriveHubOrigin()` or thread it from `OAuthDeps.issuer`
+   * (the per-request origin from `resolveIssuer`).
+   *
+   * Multi-origin iss-set (onboarding-streamline 2026-06-25): consumers no
+   * longer pin `iss` to a SINGLE `PARACHUTE_HUB_ORIGIN`. The hub publishes the
+   * SET of origins it legitimately answers on via `PARACHUTE_HUB_ORIGINS`
+   * (`buildHubBoundOrigins` — issuer ∪ loopback ∪ expose-state ∪ platform),
+   * and a scope-guard ≥0.5.0 consumer accepts `iss` ∈ that set. So a token
+   * minted here with one URL of a multi-URL box validates when the resource is
+   * reached via another URL of the SAME box. Mint stays per-request as-is: the
+   * canonical configured origin (the intended Caddy/zero-SSH deploy) is minted
+   * on every request AND is a member of the published set, so mint and validate
+   * already align — no clamp needed here.
    */
   issuer: string;
   /**

--- a/src/vault-hub-origin-env.ts
+++ b/src/vault-hub-origin-env.ts
@@ -29,7 +29,10 @@
 import { join } from "node:path";
 import { parseEnvFile, removeEnvLine, upsertEnvLine, writeEnvFile } from "./env-file.ts";
 import { EXPOSE_STATE_PATH, readExposeState } from "./expose-state.ts";
-import { HUB_ORIGIN_ENV } from "./hub-origin.ts";
+import { readHubPort } from "./hub-control.ts";
+import { HUB_ORIGINS_ENV, HUB_ORIGIN_ENV, serializeHubOrigins } from "./hub-origin.ts";
+import { HUB_UNIT_DEFAULT_PORT } from "./hub-unit.ts";
+import { buildHubBoundOrigins } from "./origin-check.ts";
 
 /**
  * Loopback origins (`http://127.0.0.1:<port>`, `localhost`, `[::1]`) are the
@@ -92,10 +95,79 @@ function vaultEnvPath(configDir: string): string {
 }
 
 /**
+ * Compose `https://${FLY_APP_NAME}.fly.dev` when FLY_APP_NAME is a plausible
+ * Fly app slug (no slashes — Fly slugs don't contain them). Mirrors the
+ * private helper in operator-token.ts / hub-server.ts; kept local so the
+ * origin-SET assembly here doesn't reach across modules for a 3-line guard.
+ */
+function flyDefaultOriginFromEnv(env: NodeJS.ProcessEnv): string | undefined {
+  const app = env.FLY_APP_NAME;
+  if (typeof app !== "string" || app.length === 0 || app.includes("/")) return undefined;
+  return `https://${app}.fly.dev`;
+}
+
+/**
+ * Assemble the comma-separated `PARACHUTE_HUB_ORIGINS` value the hub injects
+ * into supervised resource servers (multi-origin iss-set). The SET is the
+ * hub's own legitimate origins — the env-injection sibling of the operator
+ * token's `buildKnownIssuersForOperatorToken` and the per-request
+ * `buildHubBoundOrigins` call in hub-server.ts. Inputs:
+ *
+ *   - `issuer` — the canonical hub origin the child also receives as the
+ *     single `PARACHUTE_HUB_ORIGIN` (the seed; always included).
+ *   - loopback aliases — `http://127.0.0.1:<port>` ∪ `http://localhost:<port>`
+ *     for the hub's port (`readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT`).
+ *   - the expose-state public origin — `expose-state.json`'s `hubOrigin`.
+ *   - the platform/env public origin — `RENDER_EXTERNAL_URL` ∪ the composed
+ *     Fly default (container deploys where the public origin comes from the
+ *     platform, not expose-state).
+ *
+ * SECURITY INVARIANT: every input is hub/operator-controlled config or
+ * on-disk state — NEVER an unvalidated request `Host` / `X-Forwarded-Host`.
+ * The accepted-`iss` widening this enables is safe only because the resource
+ * server verifies the JWKS signature first; this set is the belt-and-
+ * suspenders allowlist layered on top.
+ *
+ * Returns `undefined` when the seed issuer is absent AND nothing else resolves
+ * (caller skips the env var so the child keeps single-origin behavior).
+ */
+export function buildHubOriginsEnvValue(
+  configDir: string,
+  issuer: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+  exposeStatePath: string = EXPOSE_STATE_PATH,
+): string | undefined {
+  const loopbackPort = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  let exposeHubOrigin: string | undefined;
+  try {
+    exposeHubOrigin = readExposeState(exposeStatePath)?.hubOrigin;
+  } catch {
+    // A malformed expose-state.json must never block a module spawn — the seed
+    // issuer + loopback aliases already cover legitimate access.
+    exposeHubOrigin = undefined;
+  }
+  const platformOrigin = env.RENDER_EXTERNAL_URL ?? flyDefaultOriginFromEnv(env);
+  const origins = buildHubBoundOrigins({
+    // buildHubBoundOrigins requires `issuer`; pass "" when absent (it's dropped
+    // by the URL parse) so the loopback aliases still seed the set.
+    issuer: issuer ?? "",
+    loopbackPort,
+    ...(exposeHubOrigin !== undefined ? { exposeHubOrigin } : {}),
+    ...(platformOrigin !== undefined ? { platformOrigin } : {}),
+  });
+  return serializeHubOrigins(origins);
+}
+
+/**
  * Upsert `PARACHUTE_HUB_ORIGIN=<origin>` into `vault/.env` when `origin` is a
- * non-loopback public origin. Idempotent — skips the write (and the log) when
- * the value is already current so repeated `start`s don't churn the file.
- * Returns true iff the file was written this call.
+ * non-loopback public origin, AND the `PARACHUTE_HUB_ORIGINS` set (the
+ * multi-origin iss-set: origin ∪ loopback aliases ∪ expose-state ∪ platform)
+ * so the daemon-boot path validates `iss` against every URL the box answers on
+ * (a Caddy-fronted box reached via loopback + sslip.io + a custom domain at
+ * once). The set is assembled from hub-controlled inputs only (see
+ * `buildHubOriginsEnvValue`'s security invariant). Idempotent — skips the
+ * write (and the log) when BOTH values are already current so repeated
+ * `start`s don't churn the file. Returns true iff the file was written.
  */
 export function persistVaultHubOrigin(
   configDir: string,
@@ -105,26 +177,47 @@ export function persistVaultHubOrigin(
   if (isLoopbackOrigin(origin)) return false;
   const path = vaultEnvPath(configDir);
   const parsed = parseEnvFile(path);
-  if (parsed.values[HUB_ORIGIN_ENV] === origin) return false;
-  writeEnvFile(path, upsertEnvLine(parsed.lines, HUB_ORIGIN_ENV, origin));
-  log(`  persisted ${HUB_ORIGIN_ENV}=${origin} to ${path} (survives daemon restart)`);
+  const originsValue = buildHubOriginsEnvValue(configDir, origin);
+  const originCurrent = parsed.values[HUB_ORIGIN_ENV] === origin;
+  const originsCurrent =
+    originsValue === undefined || parsed.values[HUB_ORIGINS_ENV] === originsValue;
+  if (originCurrent && originsCurrent) return false;
+  let lines = parsed.lines;
+  if (!originCurrent) lines = upsertEnvLine(lines, HUB_ORIGIN_ENV, origin);
+  if (!originsCurrent && originsValue !== undefined) {
+    lines = upsertEnvLine(lines, HUB_ORIGINS_ENV, originsValue);
+  }
+  writeEnvFile(path, lines);
+  if (!originCurrent) {
+    log(`  persisted ${HUB_ORIGIN_ENV}=${origin} to ${path} (survives daemon restart)`);
+  }
+  if (!originsCurrent && originsValue !== undefined) {
+    log(`  persisted ${HUB_ORIGINS_ENV}=${originsValue} to ${path} (multi-origin iss-set)`);
+  }
   return true;
 }
 
 /**
- * Drop a previously-persisted `PARACHUTE_HUB_ORIGIN` from `vault/.env`. Called
- * on `expose … off`: once exposure is torn down, a local-only hub mints tokens
- * with a loopback `iss`, so a stale public origin left in `.env` would itself
- * cause the mismatch. Removing the line reverts vault to its loopback default
- * (`getHubOrigin`), which matches what the local hub now stamps. No-op (returns
- * false) when the key isn't present. Returns true iff the file was rewritten.
+ * Drop a previously-persisted `PARACHUTE_HUB_ORIGIN` (and `PARACHUTE_HUB_ORIGINS`)
+ * from `vault/.env`. Called on `expose … off`: once exposure is torn down, a
+ * local-only hub mints tokens with a loopback `iss`, so a stale public origin
+ * left in `.env` would itself cause the mismatch. Removing the lines reverts
+ * vault to its loopback default (`getHubOrigin`), which matches what the local
+ * hub now stamps. No-op (returns false) when neither key is present. Returns
+ * true iff the file was rewritten.
  */
 export function clearVaultHubOrigin(configDir: string, log: (line: string) => void): boolean {
   const path = vaultEnvPath(configDir);
   const parsed = parseEnvFile(path);
-  if (parsed.values[HUB_ORIGIN_ENV] === undefined) return false;
-  writeEnvFile(path, removeEnvLine(parsed.lines, HUB_ORIGIN_ENV));
-  log(`  cleared ${HUB_ORIGIN_ENV} from ${path} (exposure torn down)`);
+  const hadOrigin = parsed.values[HUB_ORIGIN_ENV] !== undefined;
+  const hadOrigins = parsed.values[HUB_ORIGINS_ENV] !== undefined;
+  if (!hadOrigin && !hadOrigins) return false;
+  let lines = parsed.lines;
+  if (hadOrigin) lines = removeEnvLine(lines, HUB_ORIGIN_ENV);
+  if (hadOrigins) lines = removeEnvLine(lines, HUB_ORIGINS_ENV);
+  writeEnvFile(path, lines);
+  if (hadOrigin) log(`  cleared ${HUB_ORIGIN_ENV} from ${path} (exposure torn down)`);
+  if (hadOrigins) log(`  cleared ${HUB_ORIGINS_ENV} from ${path} (exposure torn down)`);
   return true;
 }
 


### PR DESCRIPTION
## What & why

Onboarding-streamline round-2, **decision item 7**. The Render-like zero-SSH DO setup means a single box is reachable on **several URLs at once** (Caddy-fronted droplet via loopback + `<ip>.sslip.io` + an optional custom domain). The hub mints a token's `iss` as whichever origin the request arrived on; today resource servers (vault, scribe via `@openparachute/scope-guard`) pin `iss` to **one exact origin** (`PARACHUTE_HUB_ORIGIN`), so a token minted under URL-A is **rejected** when the resource is reached via URL-B on the **same box**.

The signing **key is stable + origin-independent** — the only thing the canonical origin drives is the `iss` string. So this is purely about widening `iss` **validation** from one string to a hub-controlled **SET**. **No key work. No `aud` work** (`aud=vault.<name>` is static). Extends the **hub#516** decision (verify signature first → accept `iss` ∈ a set via `buildHubBoundOrigins`) from the hub's own credentials to the OAuth/resource path.

## The change (hub repo only)

**1. scope-guard `0.4.1` → `0.5.0` (additive minor)** — `packages/scope-guard/src/validate.ts`
- New optional `allowedIssuers?: () => readonly string[] | undefined` on `CreateScopeGuardOptions`. The resolved set is passed to jose's `issuer` option (which already accepts `string | string[]`).
- **Backwards-compatible**: when `allowedIssuers` is omitted (or returns empty/undefined), behavior is **byte-identical** — exact match against the single `hubOrigin`. `hubOrigin` stays the JWKS-fetch + revocation-endpoint pin (single string). The canonical `hubOrigin` is always a member of the accepted set.
- Resolver is re-evaluated per call (widen a box's origins without a restart).

**2. The set source + env injection** — the hub publishes `buildHubBoundOrigins`'s output (issuer ∪ loopback aliases ∪ expose-state ∪ platform) to children via a **new comma-separated `PARACHUTE_HUB_ORIGINS`** env var, **alongside** the existing single `PARACHUTE_HUB_ORIGIN` (kept for back-compat), in:
- `src/commands/serve-boot.ts` (`buildModuleSpawnRequest`) — serve-boot spawn path
- `src/api-modules-ops.ts` (`spawnSupervised`) — `/api/modules/:short/start` path
- `src/vault-hub-origin-env.ts` (`persistVaultHubOrigin` / `clearVaultHubOrigin` / self-heal) — vault `.env` daemon-boot path
- `src/hub-origin.ts` — `HUB_ORIGINS_ENV` + `serializeHubOrigins` / `parseHubOrigins` helpers; `buildHubOriginsEnvValue` (assembly) in `vault-hub-origin-env.ts`.

**3. Mint side — unchanged (decision recorded).** Hub mints `iss` per-request via `resolveIssuer` (which already **refuses `X-Forwarded-Host`** for its own issuer derivation, `hub-server.ts:~1606`). In the intended Caddy/zero-SSH deploy the canonical origin is configured, so `resolveIssuer` returns it on every request **and** it's a member of the published set → mint and validate already align. The unconfigured-multiple-public-domains case (clamp `resolveIssuer` to the bound set) is a riskier follow-up that would alter OAuth-discovery URL derivation — deliberately deferred; the safe shape if pursued is documented in the migration.

## NON-NEGOTIABLE security invariant

The accepted-issuer SET is **hub/operator-controlled ONLY** (`buildHubBoundOrigins` output). It **NEVER** includes an unvalidated request `Host` / `X-Forwarded-Host`. Accepting `iss ∈ hub's-own-set` is safe **only** because the JWKS signature verify runs FIRST + unconditionally and proves the hub minted the token. Stated in code comments at the validation site (`validate.ts` `allowedIssuers` jsdoc + `resolveAcceptedIssuers`) and the assembly site (`hub-origin.ts` `HUB_ORIGINS_ENV` + `buildHubOriginsEnvValue`). A dedicated test feeds attacker `Host`-shaped values through every channel and asserts they never enter the set.

## Tests

- **scope-guard** (`validate.test.ts`): iss=A validates against {A,B}; iss=B validates against {A,B} (core same-box-two-URLs); iss=C **rejected** against {A,B}; single-origin config = identical exact-match (back-compat); empty/undefined `allowedIssuers` → exact-match only; hubOrigin always accepted; per-call re-eval; trailing-slash normalization.
- **hub** (`hub-origins-env-set.test.ts`): serialize/parse round-trip; assembly from issuer ∪ loopback ∪ expose ∪ platform; loopback always present; **security invariant — request Host never enters the set**. Plus `serve-boot.test.ts` + `vault-hub-origin-env.test.ts` env-injection cases.

**Gate counts (literal):**
- hub `bun test ./src` (sandboxed `PARACHUTE_HOME`): **3710 pass, 1 skip, 0 fail**
- scope-guard `bun test packages/scope-guard/src`: **130 pass, 0 fail**
- `bun run typecheck`: clean

## Follow-on (separate PRs — NOT in this PR)
- **parachute-vault** `src/hub-jwt.ts`: bump scope-guard `^0.4.1` → `^0.5.0`; add `allowedIssuers: () => parseHubOrigins(process.env.PARACHUTE_HUB_ORIGINS)` to its `createScopeGuard` call (it already uses the resolver form for `hubOrigin`/`jwksOrigin` — one added line + a tiny split-helper). Leave `hubOrigin`/`jwksOrigin` as-is.
- **parachute-scribe** `src/hub-jwt.ts`: bump scope-guard `^0.2.0` → `^0.5.0`; add the same `allowedIssuers` resolver reading `PARACHUTE_HUB_ORIGINS` to its `createScopeGuard({ hubOrigin })` call.
- scope-guard `0.5.0` publishes via the existing `release.yml` Trusted-Publishing job on a `scope-guard-v0.5.0[-rc.N]` tag push (separate tag namespace from hub's `v*`); vault/scribe pin `^0.5.0` from npm.

## Migration
Checklist shipped at `parachute-patterns/migrations/2026-06-25-multi-origin-iss-set.md` (separate patterns PR). Touch points: scope-guard, hub env-injection (both spawn sites + vault .env), vault adapter, scribe adapter, the `jwt-sign.ts` issuer-field doc-comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)