### PR TITLE
feat(origin): persist canonical hub origin from the CLI for Caddy-direct boxes (rc.10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.9",
+  "version": "0.7.3-rc.10",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -83,6 +83,26 @@ describe("cli", () => {
     expect(code).toBe(1);
     expect(stderr).toMatch(/unknown command/);
   });
+
+  // hub#693: --hub-origin is persisted to hub_settings.hub_origin and stamps the
+  // OAuth `iss` claim, so the CLI must validate it to the same shape as
+  // `hub set-origin` BEFORE it reaches init() / the DB. These reject at the arg
+  // layer (exit 1) before any daemon work runs.
+  test("init --hub-origin with a path component exits 1", async () => {
+    const { code, stderr } = await runCli([
+      "init",
+      "--hub-origin",
+      "https://host.example/some/path",
+    ]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/invalid --hub-origin/);
+  });
+
+  test("init --hub-origin with a non-http(s) scheme exits 1", async () => {
+    const { code, stderr } = await runCli(["init", "--hub-origin", "ftp://bad.example"]);
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/invalid --hub-origin/);
+  });
 });
 
 describe("cli per-subcommand help", () => {

--- a/src/__tests__/hub-command.test.ts
+++ b/src/__tests__/hub-command.test.ts
@@ -1,0 +1,136 @@
+/**
+ * `parachute hub set-origin <url>` (onboarding-streamline 2026-06-25,
+ * Caddy-direct zero-SSH path).
+ *
+ * The verb persists the operator's canonical public origin to
+ * `hub_settings.hub_origin` from the CLI — closing the "set the issuer without
+ * an admin browser session" gap on a headless reverse-proxy box. These tests
+ * pin: it writes the row, it validates + canonicalizes the URL (reusing the
+ * SPA's `validateHubOrigin`), and it warns-but-allows loopback.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hub, hubSetOrigin } from "../commands/hub.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { getHubOrigin } from "../hub-settings.ts";
+
+describe("parachute hub set-origin", () => {
+  let dir: string;
+  let log: string[];
+  const collect = (line: string) => log.push(line);
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hub-set-origin-"));
+    log = [];
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  /** Open the configDir's hub.db and read the persisted origin. */
+  function persisted(): string | null {
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      return getHubOrigin(db);
+    } finally {
+      db.close();
+    }
+  }
+
+  test("persists a valid public origin to hub_settings.hub_origin", async () => {
+    const code = await hubSetOrigin(["https://box.sslip.io"], { configDir: dir, log: collect });
+    expect(code).toBe(0);
+    expect(persisted()).toBe("https://box.sslip.io");
+  });
+
+  test("strips a trailing slash (canonical bare-origin form)", async () => {
+    const code = await hubSetOrigin(["https://box.example.com/"], { configDir: dir, log: collect });
+    expect(code).toBe(0);
+    expect(persisted()).toBe("https://box.example.com");
+  });
+
+  test("rejects a non-http(s) scheme without writing", async () => {
+    const code = await hubSetOrigin(["ftp://box.example.com"], { configDir: dir, log: collect });
+    expect(code).toBe(1);
+    expect(persisted()).toBeNull();
+  });
+
+  test("rejects a URL with a path without writing", async () => {
+    const code = await hubSetOrigin(["https://box.example.com/admin"], {
+      configDir: dir,
+      log: collect,
+    });
+    expect(code).toBe(1);
+    expect(persisted()).toBeNull();
+  });
+
+  test("rejects a bare hostname (no scheme) without writing", async () => {
+    const code = await hubSetOrigin(["box.example.com"], { configDir: dir, log: collect });
+    expect(code).toBe(1);
+    expect(persisted()).toBeNull();
+  });
+
+  test("missing the URL argument is a usage error, no write", async () => {
+    const code = await hubSetOrigin([], { configDir: dir, log: collect });
+    expect(code).toBe(1);
+    expect(persisted()).toBeNull();
+  });
+
+  test("warns but ALLOWS a loopback origin (dev/test escape hatch)", async () => {
+    const code = await hubSetOrigin(["http://127.0.0.1:1939"], { configDir: dir, log: collect });
+    expect(code).toBe(0);
+    expect(persisted()).toBe("http://127.0.0.1:1939");
+    expect(log.some((l) => l.toLowerCase().includes("loopback"))).toBe(true);
+  });
+
+  test("prints the restart note so the operator knows running modules need a restart", async () => {
+    await hubSetOrigin(["https://box.sslip.io"], { configDir: dir, log: collect });
+    const joined = log.join("\n");
+    expect(joined).toContain("parachute restart vault");
+  });
+
+  test("openDb seam is honored (no touch of the live ~/.parachute)", async () => {
+    // Point the seam at a SEPARATE on-disk DB so we can assert (a) the seam was
+    // consulted, and (b) the write landed in the seam's DB — never the
+    // configDir's default path. (A real Database can't be Proxy-wrapped: Bun's
+    // prepared-statement private fields break under a Proxy.)
+    const altDir = mkdtempSync(join(tmpdir(), "hub-set-origin-alt-"));
+    try {
+      let opened = 0;
+      const code = await hubSetOrigin(["https://box.sslip.io"], {
+        configDir: dir,
+        log: collect,
+        openDb: () => {
+          opened++;
+          return openHubDb(hubDbPath(altDir));
+        },
+      });
+      expect(code).toBe(0);
+      expect(opened).toBe(1);
+      // The write landed in the seam's DB, NOT the configDir's default DB.
+      const alt = openHubDb(hubDbPath(altDir));
+      try {
+        expect(getHubOrigin(alt)).toBe("https://box.sslip.io");
+      } finally {
+        alt.close();
+      }
+    } finally {
+      rmSync(altDir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("parachute hub dispatcher", () => {
+  test("no subcommand prints help, exits 0", async () => {
+    const code = await hub([]);
+    expect(code).toBe(0);
+  });
+
+  test("--help exits 0", async () => {
+    expect(await hub(["--help"])).toBe(0);
+  });
+
+  test("unknown subcommand exits 1", async () => {
+    expect(await hub(["frobnicate"])).toBe(1);
+  });
+});

--- a/src/__tests__/hub-origins-env-set.test.ts
+++ b/src/__tests__/hub-origins-env-set.test.ts
@@ -21,7 +21,10 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { resolveStartupIssuer } from "../commands/serve.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { parseHubOrigins, serializeHubOrigins } from "../hub-origin.ts";
+import { getHubOrigin, setHubOrigin } from "../hub-settings.ts";
 import { buildHubOriginsEnvValue } from "../vault-hub-origin-env.ts";
 
 describe("serializeHubOrigins / parseHubOrigins round-trip", () => {
@@ -195,5 +198,76 @@ describe("buildHubOriginsEnvValue — assembles the hub's legitimate-origin set"
       ]);
       for (const o of set) expect(sanctioned.has(o)).toBe(true);
     });
+  });
+});
+
+/**
+ * THE CRUX (onboarding-streamline 2026-06-25, Caddy-direct zero-SSH path):
+ * a box whose ONLY canonical-origin source is the DB row `hub_settings.hub_origin`
+ * (no PARACHUTE_HUB_ORIGIN env, no expose-state, no RENDER/FLY platform var —
+ * the bare-droplet-behind-Caddy shape) MUST inject that public origin into the
+ * supervised modules' PARACHUTE_HUB_ORIGINS. Otherwise vault/scribe accept only
+ * loopback `iss` and reject every token the hub mints under the public origin
+ * (which the per-request resolveIssuer DOES stamp from the DB).
+ *
+ * These tests prove the full boot chain: DB row → `resolveStartupIssuer`
+ * (boot-time issuer seed) → `buildHubOriginsEnvValue` (the env injected at
+ * child spawn) CONTAINS the public origin.
+ */
+describe("DB hub_origin flows into the injected PARACHUTE_HUB_ORIGINS (Caddy-direct boot chain)", () => {
+  let dir: string;
+  const noExpose = (): string | undefined => undefined;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hub-origins-db-"));
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("DB-persisted public origin lands in the assembled origin set", () => {
+    // Persist the Caddy public origin to the DB exactly as `hub set-origin` /
+    // `init --hub-origin` would.
+    const db = openHubDb(hubDbPath(dir));
+    setHubOrigin(db, "https://box.sslip.io");
+    db.close();
+
+    // Boot-time issuer resolution reads the DB row (passed as dbHubOrigin) —
+    // no env, no expose-state, no platform var (the bare-Caddy shape).
+    const dbOrigin = getHubOrigin(openHubDb(hubDbPath(dir))) ?? undefined;
+    const issuer = resolveStartupIssuer(
+      { ...(dbOrigin !== undefined ? { dbHubOrigin: dbOrigin } : {}) },
+      {},
+      noExpose,
+    );
+    expect(issuer).toBe("https://box.sslip.io");
+
+    // That issuer seeds the env injected into vault/scribe — the public origin
+    // MUST be in their accepted-`iss` set.
+    const set = parseHubOrigins(
+      buildHubOriginsEnvValue(dir, issuer, {}, join(dir, "expose-state.json")),
+    );
+    expect(set).toContain("https://box.sslip.io");
+    // Loopback aliases stay present (co-located CLI / loopback proxy path).
+    expect(set).toContain("http://127.0.0.1:1939");
+    expect(set).toContain("http://localhost:1939");
+  });
+
+  test("no DB origin AND nothing else → loopback-only (the regression this guards: no public origin would leak in)", () => {
+    // Fresh DB, no row, no env, no expose-state: the boot issuer is undefined
+    // and the set is loopback-only. Proves the fix doesn't fabricate an origin.
+    const dbOrigin = getHubOrigin(openHubDb(hubDbPath(dir))) ?? undefined;
+    const issuer = resolveStartupIssuer(
+      { ...(dbOrigin !== undefined ? { dbHubOrigin: dbOrigin } : {}) },
+      {},
+      noExpose,
+    );
+    expect(issuer).toBeUndefined();
+    const set = parseHubOrigins(
+      buildHubOriginsEnvValue(dir, issuer, {}, join(dir, "expose-state.json")),
+    );
+    // Loopback-only — no public origin fabricated. (Order is Set-insertion
+    // dependent; assert membership + size rather than a brittle exact array.)
+    expect(set).toContain("http://127.0.0.1:1939");
+    expect(set).toContain("http://localhost:1939");
+    expect(set).toHaveLength(2);
   });
 });

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -960,6 +960,154 @@ describe("hasNoDisplay heuristic (Fix 2 — headless browser-open guard)", () =>
   });
 });
 
+describe("init --hub-origin (Caddy-direct zero-SSH boot, onboarding-streamline 2026-06-25)", () => {
+  test("persists the origin BEFORE ensureHub so modules spawn with it in one pass", async () => {
+    const h = makeHarness();
+    try {
+      const order: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        ensureHubVersion: async () => ({
+          outcome: "match" as const,
+          installedVersion: "test",
+          messages: [],
+        }),
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        hubOrigin: "https://box.sslip.io",
+        // The load-bearing ordering assertion: the origin write MUST happen
+        // before the hub unit starts (which boots + spawns vault/scribe), so
+        // the boot-time issuer + child env pick it up without a restart.
+        setHubOriginImpl: (_dir, origin) => {
+          order.push(`set-origin:${origin}`);
+        },
+        ensureHub: async () => {
+          order.push("ensureHub");
+          writeHubPort(1939, h.configDir);
+          return { pid: 5555, port: 1939, started: true };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      expect(order).toEqual(["set-origin:https://box.sslip.io", "ensureHub"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("default impl writes hub_settings.hub_origin to the real DB", async () => {
+    const h = makeHarness();
+    try {
+      const code = await init({
+        configDir: h.configDir,
+        ensureHubVersion: async () => ({
+          outcome: "match" as const,
+          installedVersion: "test",
+          messages: [],
+        }),
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        hubOrigin: "https://box.sslip.io",
+        // No setHubOriginImpl override → exercise the production default
+        // (openHubDb + setHubOrigin) against the harness's temp configDir.
+        ensureHub: async () => {
+          writeHubPort(1939, h.configDir);
+          return { pid: 5555, port: 1939, started: true };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      const { hubDbPath, openHubDb } = await import("../hub-db.ts");
+      const { getHubOrigin } = await import("../hub-settings.ts");
+      const db = openHubDb(hubDbPath(h.configDir));
+      try {
+        expect(getHubOrigin(db)).toBe("https://box.sslip.io");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no --hub-origin → no persistence call (laptop/loopback path unchanged)", async () => {
+    const h = makeHarness();
+    try {
+      let setCalls = 0;
+      const code = await init({
+        configDir: h.configDir,
+        ensureHubVersion: async () => ({
+          outcome: "match" as const,
+          installedVersion: "test",
+          messages: [],
+        }),
+        manifestPath: h.manifestPath,
+        log: () => {},
+        alive: () => false,
+        setHubOriginImpl: () => {
+          setCalls++;
+        },
+        ensureHub: async () => {
+          writeHubPort(1939, h.configDir);
+          return { pid: 5555, port: 1939, started: true };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      expect(setCalls).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a persistence failure is non-fatal — init still reaches the wizard", async () => {
+    const h = makeHarness();
+    try {
+      const logs: string[] = [];
+      const code = await init({
+        configDir: h.configDir,
+        ensureHubVersion: async () => ({
+          outcome: "match" as const,
+          installedVersion: "test",
+          messages: [],
+        }),
+        manifestPath: h.manifestPath,
+        log: (l) => logs.push(l),
+        alive: () => false,
+        hubOrigin: "https://box.sslip.io",
+        setHubOriginImpl: () => {
+          throw new Error("disk full");
+        },
+        ensureHub: async () => {
+          writeHubPort(1939, h.configDir);
+          return { pid: 5555, port: 1939, started: true };
+        },
+        readExposeStateFn: () => undefined,
+        isTty: false,
+        platform: "linux",
+        installVaultModuleImpl: noopVaultInstall,
+      });
+      expect(code).toBe(0);
+      const joined = logs.join("\n");
+      expect(joined).toContain("Couldn't persist the hub origin");
+      expect(joined).toContain("http://127.0.0.1:1939/admin/");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
 describe("init exposure chain", () => {
   test("TTY + no exposure + no flags → prompt is shown", async () => {
     const h = makeHarness();

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -21,7 +21,9 @@ describe("hubServeOptions — the production listener wires the WS bridge", () =
   // upgrades (the channel in-page terminal) 500'd through the hub
   // ("set the websocket object in Bun.serve({})"). The listener MUST declare a
   // websocket handler or `server.upgrade()` throws.
-  const fakeFetch = (() => new Response("ok")) as unknown as Parameters<typeof hubServeOptions>[0]["fetch"];
+  const fakeFetch = (() => new Response("ok")) as unknown as Parameters<
+    typeof hubServeOptions
+  >[0]["fetch"];
 
   test("declares a websocket handler set (open/message/close)", () => {
     const o = hubServeOptions({ port: 0, hostname: "127.0.0.1", fetch: fakeFetch });
@@ -403,6 +405,70 @@ describe("resolveStartupIssuer — precedence chain (hub#365)", () => {
 
   test("FLY_APP_NAME empty string → no fallback", () => {
     expect(resolveStartupIssuer({}, { FLY_APP_NAME: "" }, noExpose)).toBeUndefined();
+  });
+
+  // onboarding-streamline 2026-06-25 — the Caddy-direct zero-SSH boot-issuer
+  // fix. The operator-set `hub_settings.hub_origin` (tier-1 in resolveIssuer)
+  // MUST also drive the boot-time issuer, else a box whose ONLY canonical-
+  // origin source is the DB row boots without an issuer and injects only
+  // loopback into supervised children's PARACHUTE_HUB_ORIGINS.
+  describe("dbHubOrigin tier (DB hub_settings.hub_origin)", () => {
+    test("dbHubOrigin wins over env/platform/expose (mirrors resolveIssuer tier-1)", () => {
+      const got = resolveStartupIssuer(
+        { dbHubOrigin: "https://box.sslip.io" },
+        {
+          PARACHUTE_HUB_ORIGIN: "https://env.example",
+          RENDER_EXTERNAL_URL: "https://render.example.onrender.com",
+        },
+        () => "https://exposed.example",
+      );
+      expect(got).toBe("https://box.sslip.io");
+    });
+
+    test("dbHubOrigin even wins over explicit opts.issuer (DB is the operator's deliberate canonical)", () => {
+      const got = resolveStartupIssuer(
+        { issuer: "https://flag.example", dbHubOrigin: "https://box.sslip.io" },
+        {},
+        noExpose,
+      );
+      expect(got).toBe("https://box.sslip.io");
+    });
+
+    test("dbHubOrigin trailing slash is stripped", () => {
+      expect(resolveStartupIssuer({ dbHubOrigin: "https://box.sslip.io/" }, {}, noExpose)).toBe(
+        "https://box.sslip.io",
+      );
+    });
+
+    test("a loopback dbHubOrigin is rejected (sanitized) → falls through to next tier", () => {
+      // A stray loopback value in the DB must NOT pin the issuer to a non-
+      // public origin; fall through to env so the box keeps a usable issuer.
+      const got = resolveStartupIssuer(
+        { dbHubOrigin: "http://127.0.0.1:1939" },
+        { PARACHUTE_HUB_ORIGIN: "https://env.example" },
+        noExpose,
+      );
+      expect(got).toBe("https://env.example");
+    });
+
+    test("a non-http(s) dbHubOrigin is rejected → falls through", () => {
+      const got = resolveStartupIssuer(
+        { dbHubOrigin: "ftp://box.example" },
+        {},
+        () => "https://exposed.example",
+      );
+      expect(got).toBe("https://exposed.example");
+    });
+
+    test("undefined dbHubOrigin is a no-op (unchanged precedence)", () => {
+      expect(
+        resolveStartupIssuer(
+          { dbHubOrigin: undefined },
+          { PARACHUTE_HUB_ORIGIN: "https://e.x" },
+          noExpose,
+        ),
+      ).toBe("https://e.x");
+    });
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -360,7 +360,12 @@ async function main(argv: string[]): Promise<number> {
         console.log(initHelp());
         return 0;
       }
-      const exposeExtract = extractNamedFlag(rest, "--expose");
+      const originExtract = extractHubOrigin(rest);
+      if (originExtract.error) {
+        console.error(`parachute init: ${originExtract.error}`);
+        return 1;
+      }
+      const exposeExtract = extractNamedFlag(originExtract.rest, "--expose");
       if (exposeExtract.error) {
         console.error(`parachute init: ${exposeExtract.error}`);
         return 1;
@@ -392,6 +397,7 @@ async function main(argv: string[]): Promise<number> {
         console.error(
           "usage: parachute init [--no-browser] [--no-expose-prompt]\n" +
             "                     [--expose none|tailnet|cloudflare]\n" +
+            "                     [--hub-origin <url>]\n" +
             "                     [--cli-wizard | --browser-wizard]",
         );
         return 1;
@@ -403,6 +409,7 @@ async function main(argv: string[]): Promise<number> {
       const initOpts: Parameters<typeof init>[0] = {};
       if (noBrowser) initOpts.noBrowser = true;
       if (noExposePrompt) initOpts.noExposePrompt = true;
+      if (originExtract.hubOrigin) initOpts.hubOrigin = originExtract.hubOrigin;
       if (exposeExtract.value) {
         initOpts.exposeChoice = exposeExtract.value as "none" | "tailnet" | "cloudflare";
       }
@@ -929,6 +936,12 @@ async function main(argv: string[]): Promise<number> {
       const mod = await loadCommand("auth", () => import("./commands/auth.ts"));
       if (!mod) return 1;
       return await mod.auth(rest);
+    }
+
+    case "hub": {
+      const mod = await loadCommand("hub", () => import("./commands/hub.ts"));
+      if (!mod) return 1;
+      return await mod.hub(rest);
     }
 
     case "vault": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,7 @@
 
 import { MissingDependencyError } from "@openparachute/depcheck";
 import pkg from "../package.json" with { type: "json" };
+import { validateHubOrigin } from "./api-settings-hub-origin.ts";
 import { CloudflaredStateError } from "./cloudflare/state.ts";
 // Command-implementation modules are loaded LAZILY inside their switch arms (see
 // `loadCommand` + each `case`), so a module that throws at eval-time is isolated
@@ -365,6 +366,26 @@ async function main(argv: string[]): Promise<number> {
         console.error(`parachute init: ${originExtract.error}`);
         return 1;
       }
+      // Validate --hub-origin to the SAME shape `hub set-origin` enforces — the
+      // value is persisted to hub_settings.hub_origin and stamps the OAuth `iss`
+      // claim on every minted token, so a malformed path/scheme/credential must
+      // never reach the DB. Strip a trailing slash first (browser copy-paste
+      // ergonomics), then validate; pass the normalized form downstream.
+      let validatedHubOrigin: string | undefined;
+      if (originExtract.hubOrigin !== undefined) {
+        const result = validateHubOrigin(originExtract.hubOrigin.replace(/\/+$/, ""));
+        if (!result.ok) {
+          console.error(`parachute init: invalid --hub-origin: ${result.description}`);
+          return 1;
+        }
+        if (result.normalized === null) {
+          console.error(
+            "parachute init: invalid --hub-origin: an empty value is not a valid public origin.",
+          );
+          return 1;
+        }
+        validatedHubOrigin = result.normalized;
+      }
       const exposeExtract = extractNamedFlag(originExtract.rest, "--expose");
       if (exposeExtract.error) {
         console.error(`parachute init: ${exposeExtract.error}`);
@@ -409,7 +430,7 @@ async function main(argv: string[]): Promise<number> {
       const initOpts: Parameters<typeof init>[0] = {};
       if (noBrowser) initOpts.noBrowser = true;
       if (noExposePrompt) initOpts.noExposePrompt = true;
-      if (originExtract.hubOrigin) initOpts.hubOrigin = originExtract.hubOrigin;
+      if (validatedHubOrigin) initOpts.hubOrigin = validatedHubOrigin;
       if (exposeExtract.value) {
         initOpts.exposeChoice = exposeExtract.value as "none" | "tailnet" | "cloudflare";
       }

--- a/src/commands/hub.ts
+++ b/src/commands/hub.ts
@@ -1,0 +1,173 @@
+/**
+ * `parachute hub <subcommand>` — hub-local configuration verbs that write
+ * `~/.parachute/hub.db`.
+ *
+ * Subcommands:
+ *   - `set-origin <url>` — persist the operator's canonical public hub origin
+ *     into `hub_settings.hub_origin`. That row is tier-1 in `resolveIssuer`
+ *     (hub-server.ts) — the OAuth `iss` claim hub stamps into every JWT — and,
+ *     since the onboarding-streamline 2026-06-25 boot-issuer fix, also seeds the
+ *     `PARACHUTE_HUB_ORIGINS` set hub injects into supervised modules
+ *     (vault/scribe) so they accept tokens minted under the public origin.
+ *
+ * The headline use case is the zero-SSH Caddy-direct DigitalOcean path: a bare
+ * droplet runs Caddy (Let's Encrypt TLS terminator + reverse proxy to the
+ * loopback hub), and the hub never does TLS. The hub binds loopback and reads
+ * its public origin from the DB. Before this verb the only way to set
+ * `hub_origin` was the admin SPA's `PUT /api/settings/hub-origin` — which needs
+ * a browser session you don't have on a freshly-provisioned headless box. The
+ * CLI verb closes that gap so a cloud-init script (or an operator over the DO
+ * console) can record the public origin without SSHing into the admin UI.
+ *
+ * Validation reuses `validateHubOrigin` (api-settings-hub-origin.ts) so the CLI
+ * and the SPA enforce the EXACT same shape: http(s) scheme, a hostname, no
+ * trailing slash / path / query / fragment / credentials. A loopback value is
+ * allowed (a dev/test box may legitimately set one) but warned about, since a
+ * loopback `hub_origin` would advertise a non-public issuer.
+ */
+
+import type { Database } from "bun:sqlite";
+import { validateHubOrigin } from "../api-settings-hub-origin.ts";
+import { CONFIG_DIR } from "../config.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { setHubOrigin } from "../hub-settings.ts";
+import { isLoopbackOrigin } from "../vault-hub-origin-env.ts";
+
+export interface HubCommandDeps {
+  configDir?: string;
+  log?: (line: string) => void;
+  /**
+   * Test seam: open the hub DB. Production opens `hub.db` under the resolved
+   * `configDir` (running migrations). Tests pass an in-memory / temp DB so the
+   * write is exercised without touching the operator's live `~/.parachute`.
+   */
+  openDb?: (configDir: string) => Database;
+}
+
+/**
+ * `parachute hub set-origin <url>`. Validates + canonicalizes the URL, persists
+ * it to `hub_settings.hub_origin`, and prints the restart note (already-running
+ * supervised modules pick up the widened `PARACHUTE_HUB_ORIGINS` set only on
+ * their next `parachute restart`, because that set is injected at child-spawn
+ * time). Returns 0 on success, 1 on a validation / write failure.
+ */
+export async function hubSetOrigin(
+  args: readonly string[],
+  deps: HubCommandDeps = {},
+): Promise<number> {
+  const configDir = deps.configDir ?? CONFIG_DIR;
+  const log = deps.log ?? ((line) => console.log(line));
+  const err = (line: string) => console.error(line);
+  const openDb = deps.openDb ?? ((dir: string) => openHubDb(hubDbPath(dir)));
+
+  const positional = args.filter((a) => !a.startsWith("-"));
+  const raw = positional[0];
+  if (raw === undefined) {
+    err("usage: parachute hub set-origin <url>");
+    err("example: parachute hub set-origin https://box.sslip.io");
+    return 1;
+  }
+  if (positional.length > 1) {
+    err(`parachute hub set-origin: unexpected argument "${positional[1]}"`);
+    err("usage: parachute hub set-origin <url>");
+    return 1;
+  }
+
+  // Strip a trailing slash up front so the convenient `https://host/` form is
+  // accepted (the operator copy-pastes a browser URL). `validateHubOrigin`
+  // itself REJECTS a trailing slash (it's the SPA's PUT body validator, where a
+  // strict shape is wanted) — we canonicalize here, then validate the rest of
+  // the shape (scheme / hostname / no-path / no-credentials) through the shared
+  // validator so the CLI and SPA agree on everything else.
+  const trimmed = raw.replace(/\/+$/, "");
+  const result = validateHubOrigin(trimmed);
+  if (!result.ok) {
+    err(`parachute hub set-origin: ${result.description}`);
+    return 1;
+  }
+  // `validateHubOrigin` maps empty / null to `normalized: null` (clear the row).
+  // `set-origin` with an explicit non-empty arg should never land there — a
+  // present positional that normalizes to null means the operator passed an
+  // empty string, which is not a valid public origin for this verb.
+  if (result.normalized === null) {
+    err("parachute hub set-origin: a non-empty origin URL is required");
+    err("usage: parachute hub set-origin <url>");
+    return 1;
+  }
+  const origin = result.normalized;
+
+  // Loopback is allowed (a dev/test box may set one deliberately) but warned —
+  // a loopback hub_origin advertises a non-public issuer, so remote devices
+  // and supervised resource servers reached over a public URL would reject it.
+  if (isLoopbackOrigin(origin)) {
+    log(`⚠ ${origin} is a loopback origin — it won't be reachable from other devices.`);
+    log("  Set the box's PUBLIC URL (e.g. https://<droplet-ip>.sslip.io) for a real deploy.");
+  }
+
+  const db = openDb(configDir);
+  try {
+    setHubOrigin(db, origin);
+  } finally {
+    db.close();
+  }
+
+  log(`✓ Canonical hub origin set to ${origin}.`);
+  log("  Stored in hub_settings — the OAuth issuer (`iss`) hub stamps on every token,");
+  log("  and the origin set injected into supervised modules so they accept it.");
+  log("");
+  log("Already-running modules (vault, scribe) pick up the widened origin set only on");
+  log("their next restart (it's injected at spawn time). Restart them to apply now:");
+  log("  parachute restart vault");
+  log("  parachute restart scribe   # if installed");
+  return 0;
+}
+
+/**
+ * `parachute hub <subcommand>` dispatcher. Mirrors `auth`'s shape (a thin
+ * router over subcommand handlers, each catching its own errors).
+ */
+export async function hub(args: readonly string[], deps: HubCommandDeps = {}): Promise<number> {
+  const sub = args[0];
+  if (sub === undefined || sub === "--help" || sub === "-h" || sub === "help") {
+    console.log(hubHelp());
+    return 0;
+  }
+  if (sub === "set-origin") {
+    try {
+      return await hubSetOrigin(args.slice(1), deps);
+    } catch (err) {
+      console.error(
+        `parachute hub set-origin: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 1;
+    }
+  }
+  console.error(`parachute hub: unknown subcommand "${sub}"`);
+  console.error("");
+  console.error(hubHelp());
+  return 1;
+}
+
+export function hubHelp(): string {
+  return `parachute hub — hub-local configuration
+
+Usage:
+  parachute hub set-origin <url>    set the canonical public hub origin
+
+Subcommands:
+  set-origin <url>    Persist the canonical public origin (OAuth issuer) to the
+                      hub DB. This is the URL the hub stamps as the \`iss\` claim
+                      on every token AND the origin it tells supervised modules
+                      (vault, scribe) to accept. Use it on a reverse-proxy /
+                      Caddy-direct box where the hub binds loopback but is reached
+                      over a public HTTPS URL — no admin browser session needed.
+
+                      The URL must be http(s), with a hostname and no trailing
+                      slash / path / query. After it's set, restart already-running
+                      modules so they pick up the widened origin set.
+
+Examples:
+  parachute hub set-origin https://box.sslip.io
+  parachute hub set-origin https://parachute.example.com
+`;
+}

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -41,6 +41,7 @@ import { type ExposeState, readExposeState } from "../expose-state.ts";
 import { type EnsureHubOpts, HUB_DEFAULT_PORT, HUB_SVC, readHubPort } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { deriveHubOrigin } from "../hub-origin.ts";
+import { setHubOrigin } from "../hub-settings.ts";
 import {
   type EnsureHubVersionMatchesResult,
   ensureHubUnit,
@@ -184,6 +185,27 @@ export interface InitOpts {
    * already known so there's no question to ask).
    */
   noWizardPrompt?: boolean;
+  /**
+   * Canonical public hub origin (the OAuth issuer / `iss` claim). Persisted to
+   * `hub_settings.hub_origin` BEFORE the hub unit starts + modules spawn, so
+   * supervised vault/scribe come up with the public origin already in their
+   * `PARACHUTE_HUB_ORIGINS` set in ONE pass — no restart needed. The headline
+   * use case is the zero-SSH Caddy-direct path: a cloud-init script passes
+   * `--hub-origin https://<droplet-ip>.sslip.io` so a reverse-proxied box
+   * records its public origin without an admin browser session. Validated +
+   * canonicalized by the CLI before it reaches here; persisted via the
+   * `setHubOriginImpl` seam. Loopback / non-http(s) values never reach this far
+   * (the CLI rejects them via `validateHubOrigin`). Absent → no-op (the laptop /
+   * loopback path is unchanged).
+   */
+  hubOrigin?: string;
+  /**
+   * Test seam: persist the canonical hub origin to `hub_settings.hub_origin`.
+   * Production opens `hub.db` (running migrations) and calls `setHubOrigin`.
+   * Tests pass a stub to assert the write happens BEFORE `ensureHub` without
+   * touching the operator's live DB. Receives the resolved configDir + origin.
+   */
+  setHubOriginImpl?: (configDir: string, origin: string) => void;
   /**
    * Test seam: probe the running hub for its first-claim bootstrap token
    * (hub#576). Production hits `GET http://127.0.0.1:<port>/admin/setup` with
@@ -389,6 +411,25 @@ async function defaultEnsureHubViaUnit(opts: EnsureHubOpts): Promise<{
   // no-manager / timeout / start-failed → actionable error. The init caller
   // catches this and prints the message + `parachute logs hub` hint.
   throw new Error(result.messages.join("\n") || `hub unit bringup failed (${result.outcome}).`);
+}
+
+/**
+ * Default impl for the `--hub-origin` persistence step. Opens `hub.db` (running
+ * migrations on a fresh box) and writes `hub_settings.hub_origin`. Runs BEFORE
+ * the hub unit starts so the boot-time issuer resolution + child-spawn env
+ * (`PARACHUTE_HUB_ORIGINS`) pick up the public origin in one pass. The DB is an
+ * on-disk SQLite file shared with the (not-yet-started) serve process, so a
+ * write here is visible to the unit when it boots. The CLI has already
+ * validated + canonicalized the URL via `validateHubOrigin`, so this trusts the
+ * input (mirrors `setHubOrigin`'s typed-callsite contract).
+ */
+function defaultSetHubOrigin(configDir: string, origin: string): void {
+  const db = openHubDb(hubDbPath(configDir));
+  try {
+    setHubOrigin(db, origin);
+  } finally {
+    db.close();
+  }
 }
 
 /**
@@ -629,9 +670,31 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   const installVaultModuleImpl = opts.installVaultModuleImpl ?? defaultInstallVaultModule;
   const runCliWizardImpl = opts.runCliWizardImpl ?? defaultRunCliWizard;
   const fetchBootstrapTokenImpl = opts.fetchBootstrapTokenImpl ?? defaultFetchBootstrapToken;
+  const setHubOriginImpl = opts.setHubOriginImpl ?? defaultSetHubOrigin;
 
   log("Parachute init — getting your hub set up.");
   log("");
+
+  // Step 0: persist `--hub-origin` BEFORE the hub unit starts (below). The
+  // boot-time issuer resolution + child-spawn env (`PARACHUTE_HUB_ORIGINS`)
+  // both read `hub_settings.hub_origin`, so writing it now means vault/scribe
+  // come up with the public origin already in their accepted-`iss` set in ONE
+  // pass — no restart needed (the Caddy-direct zero-SSH path). A failure here
+  // is non-fatal: warn + continue (the operator can re-run `parachute hub
+  // set-origin` later), since init's contract is hub up → wizard regardless.
+  if (opts.hubOrigin) {
+    try {
+      setHubOriginImpl(configDir, opts.hubOrigin);
+      log(`✓ Canonical hub origin set to ${opts.hubOrigin} (OAuth issuer).`);
+      log("");
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      log(
+        `⚠ Couldn't persist the hub origin (${detail}); set it later with \`parachute hub set-origin <url>\`.`,
+      );
+      log("");
+    }
+  }
 
   // Step 1: hub running?
   // NB: under the Phase 3a unit-managed hub there is no pidfile, so

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -37,13 +37,14 @@ import { readExposeState } from "../expose-state.ts";
 import { createDbHolder, defaultStatInode, startDbPathLivenessTimer } from "../hub-db-liveness.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
+import { getHubOrigin } from "../hub-settings.ts";
 import { writeHubFile } from "../hub.ts";
-import { createWsBridgeHandlers } from "../ws-bridge.ts";
 import { enrichedPath } from "../spawn-path.ts";
 import { Supervisor } from "../supervisor.ts";
 import { createUser, userCount } from "../users.ts";
 import { sanitizePublicOrigin } from "../vault-hub-origin-env.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
+import { createWsBridgeHandlers } from "../ws-bridge.ts";
 import { bootSupervisedModules } from "./serve-boot.ts";
 
 /**
@@ -217,12 +218,30 @@ function parsePort(raw: string | undefined): number | undefined {
  * remaining gap (rebuild the live spawn-env on `supervisor.restart` so the
  * first exposure propagates to already-running children without a manual
  * restart) is the deferred #532 follow-up; not implemented in this PR.
+ *
+ * DB ORIGIN, highest precedence (onboarding-streamline 2026-06-25, Caddy-direct
+ * zero-SSH path): the operator-set `hub_settings.hub_origin` is the tier-1 layer
+ * in the per-request `resolveIssuer` (hub-server.ts). The boot path MUST honor
+ * it too — otherwise a Caddy-fronted box whose ONLY canonical-origin source is
+ * the DB row (no `PARACHUTE_HUB_ORIGIN` env, no expose-state, no platform var)
+ * boots `serve` with no issuer, injects only loopback aliases into supervised
+ * children's `PARACHUTE_HUB_ORIGINS`, and vault/scribe then reject every token
+ * the hub mints under the public origin (which per-request `resolveIssuer` DOES
+ * stamp from the DB). Threading the DB origin in as the top input keeps the
+ * boot-time seed in lockstep with `resolveIssuer`'s tier-1. `serve()` reads the
+ * row off the opened hub DB and passes it as `dbHubOrigin`; tests pass it
+ * directly. It is sanitized like any other public-origin input (a stray
+ * loopback / non-http(s) DB value never pins the issuer).
  */
 export function resolveStartupIssuer(
-  opts: { issuer?: string },
+  opts: { issuer?: string; dbHubOrigin?: string },
   env: NodeJS.ProcessEnv,
   readExpose: () => string | undefined = defaultReadExposeHubOrigin,
 ): string | undefined {
+  // DB row first — mirrors `resolveIssuer`'s tier-1 (hub_settings.hub_origin).
+  // Sanitized so a stray loopback / non-http(s) value never pins the issuer.
+  const dbOrigin = sanitizePublicOrigin(opts.dbHubOrigin);
+  if (dbOrigin) return dbOrigin;
   const flyOrigin = flyDefaultOriginFromEnv(env);
   const explicit = (
     opts.issuer ??
@@ -435,7 +454,6 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 
   const envPort = parsePort(env.PORT);
   const port = opts.port ?? envPort ?? DEFAULT_PORT;
-  const issuer = resolveStartupIssuer(opts, env);
   // Containers default to 0.0.0.0 so the platform's HTTP forwarder can
   // reach us; the `--hostname` flag / PARACHUTE_BIND_HOST is the escape
   // hatch for setups that want loopback-only inside a sidecar.
@@ -461,6 +479,24 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   const dbPath = hubDbPath();
   // Self-heal-or-die DB holder (#594) + proactive ghost-fd watchdog (#610/#619).
   const { dbHolder, livenessTimer } = armServeDbWatchdog(dbPath, { log });
+  // Resolve the boot-time issuer AFTER the DB is open so the operator-set
+  // `hub_settings.hub_origin` (tier-1 in `resolveIssuer`) seeds the value the
+  // hub mints with AND the `PARACHUTE_HUB_ORIGINS` set injected into supervised
+  // children. This is what makes a Caddy-fronted, zero-SSH box (whose only
+  // canonical-origin source is the DB row) inject the public origin into
+  // vault/scribe so they accept hub-minted tokens. Pass it as `dbHubOrigin`;
+  // a malformed read can't crash startup — `getHubOrigin` is a plain SELECT
+  // and `resolveStartupIssuer` sanitizes the value.
+  let dbHubOrigin: string | undefined;
+  try {
+    dbHubOrigin = getHubOrigin(dbHolder.get()) ?? undefined;
+  } catch {
+    dbHubOrigin = undefined;
+  }
+  const issuer = resolveStartupIssuer(
+    { ...opts, ...(dbHubOrigin !== undefined ? { dbHubOrigin } : {}) },
+    env,
+  );
   const adminBootstrap = await seedInitialAdminIfNeeded(dbHolder.get(), env, log);
 
   if (adminBootstrap === "needs-setup") {

--- a/src/help.ts
+++ b/src/help.ts
@@ -28,6 +28,8 @@ Usage:
   parachute migrate --to-supervised move a legacy detached install to the managed hub
   parachute migrate [--dry-run]     archive legacy files at ecosystem root
   parachute auth <cmd>              identity (set password, manage 2FA)
+  parachute hub set-origin <url>    set the canonical public hub origin (OAuth issuer)
+                                    — for reverse-proxy / Caddy-direct boxes
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
                                     etc.) — forwards to parachute-vault.
                                     For lifecycle, use \`parachute start|stop|restart|logs vault\`.
@@ -130,6 +132,7 @@ export function initHelp(): string {
 Usage:
   parachute init [--no-browser] [--no-expose-prompt]
                  [--expose none|tailnet|cloudflare]
+                 [--hub-origin <url>]
                  [--cli-wizard | --browser-wizard]
 
 What it does:
@@ -165,6 +168,11 @@ Flags:
                               none       — stay loopback-only
                               tailnet    — set up Tailscale serve (private to your tailnet)
                               cloudflare — set up Cloudflare Tunnel (your own domain)
+  --hub-origin <url>        set the canonical public origin (OAuth issuer) BEFORE
+                            the hub + modules start, so vault/scribe come up
+                            accepting it in one pass. For reverse-proxy /
+                            Caddy-direct boxes that bind loopback but are reached
+                            over a public HTTPS URL (e.g. https://<ip>.sslip.io).
   --cli-wizard              skip the "browser or CLI?" prompt and walk the wizard
                             in this terminal (hub#168 Cut 4)
   --browser-wizard          skip the prompt and open the browser wizard directly


### PR DESCRIPTION
## What

Unblocks the **Render-like zero-SSH DigitalOcean setup** (Caddy-direct ingress) from the [onboarding-streamline arc](../ONBOARDING-STREAMLINE-2026-06-25.md). A bare droplet runs Caddy (Let's Encrypt TLS terminator + reverse proxy to the loopback hub); the hub binds loopback and reads its public origin from the DB. The whole request stack already works behind Caddy — the one gap was getting the public origin into the reboot-persistent `serve` process + its supervised children **without an admin browser session**.

Tightly scoped to that gap. Does NOT touch the bigger guided-init driver, expose-refuse hardening, or the managed-unit env passthrough (the DB-persist path is the chosen approach).

## Three pieces

1. **`parachute hub set-origin <url>`** — new CLI verb persisting the canonical public origin to `hub_settings.hub_origin` (the OAuth `iss` row, tier-1 in `resolveIssuer`). Validates via the shared `validateHubOrigin` (http(s), hostname, no path/query/credentials), strips a trailing slash, warns-but-allows loopback. Prints the restart note (running modules pick up the widened origin set on their next `parachute restart`, since `PARACHUTE_HUB_ORIGINS` is injected at child-spawn time).

2. **`parachute init --hub-origin <url>`** — flag (previously rejected at the init arg parser) that persists the origin to the DB **early**, before the hub unit starts + modules spawn, so vault/scribe come up accepting it in **one pass** (no restart needed). Non-fatal on failure (warn + continue to the wizard — init's contract is hub up → wizard regardless).

3. **THE CRUX (boot-issuer fix).** The serve **boot** path didn't read the DB origin. `resolveStartupIssuer` resolved only flag/env/platform/expose-state — so a Caddy box whose *only* canonical-origin source is the DB row booted with no issuer and injected only loopback aliases into children's `PARACHUTE_HUB_ORIGINS`, making vault/scribe reject every token minted under the public origin (which per-request `resolveIssuer` DOES stamp from the DB). Fixed by threading the DB `hub_settings.hub_origin` in as the top-precedence boot-issuer tier (now mirrors `resolveIssuer`). `buildHubOriginsEnvValue`/`buildHubBoundOrigins` already fold the issuer seed into the set, so the DB origin now flows into the injected `PARACHUTE_HUB_ORIGINS`.

### buildHubBoundOrigins / DB-origin finding
`buildHubBoundOrigins`/`buildHubOriginsEnvValue` already include their `issuer` seed in the assembled set — they did **not** need changing. The real omission was upstream: the boot-time `issuer` SEED itself (`resolveStartupIssuer`) never read the DB. Fixing the seed makes the DB origin flow through the existing assembly. (The `parachute restart` spawn path already got the DB origin, because it seeds `buildHubOriginsEnvValue` from the per-request `resolveIssuer`, which is DB tier-1.)

### Running-hub re-injection decision
Restart-note, not auto-restart. `set-origin` is a config write; restarting supervised modules from inside a config verb is out of scope and racy against a concurrent operator. The verb prints the exact `parachute restart vault` / `restart scribe` lines. The `init --hub-origin` path needs no restart at all — it persists before the first spawn.

## Tests (PARACHUTE_HOME-sandboxed)
- `hub set-origin`: persists to DB hub_settings; trailing-slash strip; scheme/path/bare-hostname rejection (no write); loopback warn-but-allow; openDb seam.
- `init --hub-origin`: persists **before** `ensureHub` (ordering assertion); real-DB write via the production default; no-flag no-op; non-fatal on failure.
- `resolveStartupIssuer`: dbHubOrigin precedence (wins over env/platform/expose AND explicit flag), trailing-slash strip, loopback/non-http(s) sanitization fall-through.
- **The crux**: DB origin → `resolveStartupIssuer` boot seed → assembled `PARACHUTE_HUB_ORIGINS` **contains** the public origin (proves vault/scribe will accept it); plus the negative control (no DB origin → loopback-only, nothing fabricated).

## Gates
- `bun test ./src` — **3734 pass / 1 skip / 0 fail**
- `bun run typecheck` — clean
- `bunx biome check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)