### PR TITLE
fix(hub-server): Caddy/nginx-direct requests classify as public, not loopback (#704) [security]

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.10",
+  "version": "0.7.3-rc.11",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -3707,6 +3707,17 @@ describe("layerOf — classify trust layer from proxy headers + peer (item E / #
     expect(layerOf(r, "::ffff:127.0.0.1")).toBe("public");
   });
 
+  // Security edge: an EMPTY / whitespace-only forwarding header (a misconfigured
+  // or stripped-but-present proxy header) must still err toward "public", never
+  // back to "loopback". `layerOf` uses a presence check (`!== null`), not a
+  // trim — keep it that way: the safe direction for a trust classifier is to
+  // DOWNGRADE on ambiguity. A future "tidy up with .trim()" refactor that
+  // flipped an empty XFF back to loopback would re-open the Caddy-direct leak.
+  test("loopback peer + empty X-Forwarded-For → public (errs safe, not loopback) [#704]", () => {
+    expect(layerOf(req("/", { headers: { "X-Forwarded-For": "" } }), "127.0.0.1")).toBe("public");
+    expect(layerOf(req("/", { headers: { "X-Forwarded-For": "   " } }), "127.0.0.1")).toBe("public");
+  });
+
   // The genuine on-box caller (CLI, health probe, init bootstrap-token loopback
   // probe `curl 127.0.0.1/admin/setup`, hub self-requests) sets NO forwarding
   // header and MUST stay loopback. This is the not-broken half of the fix.

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -3,6 +3,10 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import {
+  _resetBootstrapTokenForTests,
+  generateBootstrapToken,
+} from "../bootstrap-token.ts";
 import { buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
 import { createDbHolder } from "../hub-db-liveness.ts";
@@ -3676,6 +3680,63 @@ describe("layerOf — classify trust layer from proxy headers + peer (item E / #
     });
     expect(layerOf(r)).toBe("public");
   });
+
+  // Caddy/nginx-direct deploy (hub#704). A same-box reverse proxy dials
+  // loopback (peer 127.0.0.1) and stamps NO cf/tailscale header — but it DOES
+  // set a standard reverse-proxy forwarding header. That header is the
+  // discriminator: a loopback peer carrying one is a proxied PUBLIC request and
+  // must NOT be "loopback" (which would leak the bootstrap token + drop the
+  // loopback-exposure cloak for every public visitor on a Caddy-direct box).
+  test("loopback peer + X-Forwarded-For → public (Caddy-direct, NOT loopback) [#704]", () => {
+    const r = req("/", { headers: { "X-Forwarded-For": "203.0.113.7" } });
+    expect(layerOf(r, "127.0.0.1")).toBe("public");
+  });
+
+  test("loopback peer + X-Forwarded-Host → public (Caddy-direct) [#704]", () => {
+    const r = req("/", { headers: { "X-Forwarded-Host": "hub.example.com" } });
+    expect(layerOf(r, "127.0.0.1")).toBe("public");
+  });
+
+  test("loopback peer + Forwarded (RFC 7239) → public (Caddy-direct) [#704]", () => {
+    const r = req("/", { headers: { Forwarded: "for=203.0.113.7;host=hub.example.com" } });
+    expect(layerOf(r, "127.0.0.1")).toBe("public");
+  });
+
+  test("IPv6-mapped loopback peer + X-Forwarded-For → public (Caddy-direct) [#704]", () => {
+    const r = req("/", { headers: { "X-Forwarded-For": "203.0.113.7" } });
+    expect(layerOf(r, "::ffff:127.0.0.1")).toBe("public");
+  });
+
+  // The genuine on-box caller (CLI, health probe, init bootstrap-token loopback
+  // probe `curl 127.0.0.1/admin/setup`, hub self-requests) sets NO forwarding
+  // header and MUST stay loopback. This is the not-broken half of the fix.
+  test("loopback peer + NO forwarding header → loopback (genuine on-box caller) [#704]", () => {
+    expect(layerOf(req("/"), "127.0.0.1")).toBe("loopback");
+    expect(layerOf(req("/"), "::1")).toBe("loopback");
+  });
+
+  // No spoof vector: forwarding headers can only DOWNGRADE a loopback caller.
+  // A NON-loopback peer is already "public" regardless of headers, so adding
+  // X-Forwarded-* never upgrades a network peer to a more-trusted layer.
+  test("non-loopback peer + X-Forwarded-For → public (no upgrade; spoof-proof) [#704]", () => {
+    const r = req("/", { headers: { "X-Forwarded-For": "127.0.0.1" } });
+    expect(layerOf(r, "203.0.113.7")).toBe("public");
+  });
+
+  // CF/TS header checks run FIRST — a Caddy-style forwarding header alongside a
+  // cf/tailscale header doesn't change those (still public/tailnet). Order
+  // preserved.
+  test("CF-Ray + X-Forwarded-For from loopback peer → public (CF check wins, order preserved)", () => {
+    const r = req("/", { headers: { "CF-Ray": "abc123-DEN", "X-Forwarded-For": "203.0.113.7" } });
+    expect(layerOf(r, "127.0.0.1")).toBe("public");
+  });
+
+  test("Tailscale-User-Login + X-Forwarded-For from loopback peer → tailnet (TS check wins)", () => {
+    const r = req("/", {
+      headers: { "Tailscale-User-Login": "alice@example.com", "X-Forwarded-For": "100.64.0.1" },
+    });
+    expect(layerOf(r, "127.0.0.1")).toBe("tailnet");
+  });
 });
 
 describe("hubFetch publicExposure layer-gate (proxyToService)", () => {
@@ -3817,6 +3878,74 @@ describe("hubFetch publicExposure layer-gate (proxyToService)", () => {
       const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
       const res = await fetcher(req("/loopback-only/health"), fakeServer("203.0.113.9"));
       expect(res.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  // hub#704 — Caddy/nginx-direct. A same-box reverse proxy dials loopback
+  // (peer 127.0.0.1) and stamps NO cf/tailscale header, but DOES set
+  // X-Forwarded-For. That request is a PUBLIC visitor proxied to the box and
+  // must hit the loopback-exposure cloak (404) — otherwise a Caddy-direct box
+  // leaks every loopback-only service/vault to the network.
+  test("publicExposure: loopback + X-Forwarded-For + loopback peer → 404 (Caddy-direct cloak fires) [#704]", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("loopback-only");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "loopback-only",
+              port: upstream.port,
+              paths: ["/loopback-only"],
+              health: "/loopback-only/health",
+              version: "0.1.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      // Caddy: peer is 127.0.0.1 (reverse_proxy 127.0.0.1:1939) but the request
+      // carries X-Forwarded-For for the real public client.
+      const r = req("/loopback-only/health", { headers: { "X-Forwarded-For": "203.0.113.7" } });
+      const res = await fetcher(r, fakeServer("127.0.0.1"));
+      expect(res.status).toBe(404);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  // The not-broken half: a header-less loopback peer (genuine on-box caller)
+  // still reaches the loopback-only service through the cloak.
+  test("publicExposure: loopback + NO forwarding header + loopback peer → reaches upstream [#704]", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("loopback-only");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "loopback-only",
+              port: upstream.port,
+              paths: ["/loopback-only"],
+              health: "/loopback-only/health",
+              version: "0.1.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/loopback-only/health"), fakeServer("127.0.0.1"));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { tag: string };
+      expect(body.tag).toBe("loopback-only");
     } finally {
       upstream.stop();
       h.cleanup();
@@ -5848,5 +5977,105 @@ describe("resolveClientIp (H2)", () => {
   test("whitespace-only header values are treated as absent", () => {
     const r = req("/", { headers: { "x-forwarded-for": "   " } });
     expect(resolveClientIp(r, null)).toBeNull();
+  });
+});
+
+describe("GET /admin/setup bootstrap-token probe — loopback-gated (hub#576 + Caddy-direct #704)", () => {
+  // The hub#576 token probe: a LOOPBACK caller (the on-box operator's own
+  // shell / `parachute init`) reading GET /admin/setup with Accept:
+  // application/json gets the actual bootstrap token in the JSON envelope; a
+  // public/tailnet caller does not. The hub derives requestIsLoopback from
+  // `layerOf(req, peerAddr) === "loopback"` (hub-server.ts ~2296), so the
+  // Caddy-direct fix (#704) flows straight through: a same-box reverse proxy
+  // carrying X-Forwarded-For now classifies "public" and the token is withheld
+  // even though the peer is 127.0.0.1.
+
+  // Fake Bun Server handle (mirrors the cloak suite) so the fetch fn resolves
+  // the peer address. The on-box operator connects from 127.0.0.1; Caddy
+  // reverse_proxy also dials 127.0.0.1 but stamps X-Forwarded-For.
+  const fakeServer = (address: string) => ({ requestIP: () => ({ address }) });
+
+  test("loopback peer + NO forwarding header → bootstrapToken present (on-box operator) [#576]", async () => {
+    const h = makeHarness();
+    _resetBootstrapTokenForTests();
+    const token = generateBootstrapToken();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        // No admin row → wizard mode → GET /admin/setup JSON probe is live.
+        const res = await hubFetch(h.dir, { getDb: () => db })(
+          req("/admin/setup", { headers: { accept: "application/json" } }),
+          fakeServer("127.0.0.1"),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          requireBootstrapToken?: boolean;
+          bootstrapToken?: string;
+        };
+        expect(body.requireBootstrapToken).toBe(true);
+        expect(body.bootstrapToken).toBe(token);
+      } finally {
+        db.close();
+      }
+    } finally {
+      _resetBootstrapTokenForTests();
+      h.cleanup();
+    }
+  });
+
+  test("loopback peer + X-Forwarded-For → bootstrapToken WITHHELD (Caddy-direct public visitor) [#704]", async () => {
+    const h = makeHarness();
+    _resetBootstrapTokenForTests();
+    generateBootstrapToken();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        // Caddy: peer 127.0.0.1, but the request carries the public client's
+        // X-Forwarded-For. Pre-fix this leaked the token to any public visitor.
+        const res = await hubFetch(h.dir, { getDb: () => db })(
+          req("/admin/setup", {
+            headers: { accept: "application/json", "x-forwarded-for": "203.0.113.7" },
+          }),
+          fakeServer("127.0.0.1"),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as {
+          requireBootstrapToken?: boolean;
+          bootstrapToken?: string;
+        };
+        // The gate still SAYS a token is required (so the form renders the
+        // field) — it just doesn't hand the value to the public caller.
+        expect(body.requireBootstrapToken).toBe(true);
+        expect(body.bootstrapToken).toBeUndefined();
+      } finally {
+        db.close();
+      }
+    } finally {
+      _resetBootstrapTokenForTests();
+      h.cleanup();
+    }
+  });
+
+  test("non-loopback peer → bootstrapToken WITHHELD (direct public/tailnet)", async () => {
+    const h = makeHarness();
+    _resetBootstrapTokenForTests();
+    generateBootstrapToken();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        const res = await hubFetch(h.dir, { getDb: () => db })(
+          req("/admin/setup", { headers: { accept: "application/json" } }),
+          fakeServer("203.0.113.9"),
+        );
+        expect(res.status).toBe(200);
+        const body = (await res.json()) as { bootstrapToken?: string };
+        expect(body.bootstrapToken).toBeUndefined();
+      } finally {
+        db.close();
+      }
+    } finally {
+      _resetBootstrapTokenForTests();
+      h.cleanup();
+    }
   });
 });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -578,6 +578,16 @@ export type RequestLayer = "loopback" | "tailnet" | "public";
  * the cloak fires. When `peerAddr` is unknown (null/undefined — no Server
  * threaded, e.g. a unit test calling `layerOf(req)` directly), we fail CLOSED
  * to `public` rather than open to `loopback`.
+ *
+ * Caddy/nginx-direct (hub#704): a SAME-BOX reverse proxy dials loopback (peer
+ * is 127.0.0.1) but, unlike cloudflared/tailscale, sets NO cf/tailscale header
+ * — so a header-only-or-peer-only classifier would call every public request
+ * through it "loopback" (most-trusted). The discriminator is the standard
+ * reverse-proxy forwarding headers (X-Forwarded-For / X-Forwarded-Host /
+ * Forwarded): a loopback peer that carries one is a proxied PUBLIC request →
+ * `public`; a header-less loopback peer (direct on-box caller — CLI, probes,
+ * the init bootstrap-token loopback probe) stays `loopback`. See the inline
+ * comment in the function for the full rationale + spoof analysis.
  */
 export function layerOf(req: Request, peerAddr?: string | null): RequestLayer {
   const h = req.headers;
@@ -590,6 +600,37 @@ export function layerOf(req: Request, peerAddr?: string | null): RequestLayer {
   // value to compare against, hence the presence-check above.
   if (h.get("tailscale-funnel-request") === "?1") return "public";
   if (h.get("tailscale-user-login") !== null) return "tailnet";
+  // Caddy/nginx-direct deploy (hub#704): a same-box reverse proxy terminates
+  // TLS and `reverse_proxy 127.0.0.1:1939` — so it dials loopback (peer is
+  // 127.0.0.1) and, unlike cloudflared/tailscale, stamps NO cf/tailscale
+  // header. Without this branch every PUBLIC request through such a proxy
+  // would classify "loopback" (the MOST-trusted layer): the GET /admin/setup
+  // bootstrap-token JSON probe would hand the token to any public visitor, and
+  // the publicExposure:"loopback" 404-cloak would stop hiding loopback-only
+  // services/vaults from the network.
+  //
+  // The discriminator is the standard reverse-proxy forwarding headers. A
+  // same-box proxy carrying a PUBLIC request sets X-Forwarded-For /
+  // X-Forwarded-Host / Forwarded; a direct on-box caller (the CLI, health
+  // probes, the init bootstrap-token loopback probe `curl 127.0.0.1/admin/setup`,
+  // the hub's own loopback self-requests) sets none of them — the hub never
+  // injects X-Forwarded-* on the INBOUND request it classifies (it only stamps
+  // X-Forwarded-Host/Proto on OUTBOUND proxy requests to modules). So a
+  // loopback peer that ALSO carries a forwarding header is a proxied public
+  // request → "public"; a header-less loopback peer stays "loopback".
+  //
+  // No spoof vector: a NON-loopback peer is already "public" regardless of
+  // headers (the branch below), so adding these headers can only DOWNGRADE a
+  // loopback caller (the on-box operator hurting only their own request) —
+  // never upgrade a network peer to "loopback".
+  if (
+    isLoopbackPeer(peerAddr) &&
+    (h.get("x-forwarded-for") !== null ||
+      h.get("x-forwarded-host") !== null ||
+      h.get("forwarded") !== null)
+  ) {
+    return "public";
+  }
   // No proxy headers — classify by peer address, failing closed when unknown.
   return isLoopbackPeer(peerAddr) ? "loopback" : "public";
 }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -623,6 +623,11 @@ export function layerOf(req: Request, peerAddr?: string | null): RequestLayer {
   // headers (the branch below), so adding these headers can only DOWNGRADE a
   // loopback caller (the on-box operator hurting only their own request) —
   // never upgrade a network peer to "loopback".
+  //
+  // Presence check (`!== null`), NOT a trim: an empty/whitespace forwarding
+  // header still means "a proxy is in front" → err to public. Downgrading on
+  // ambiguity is the safe direction for a trust classifier; a future ".trim()
+  // tidy-up" that let an empty XFF fall back to loopback would re-open the leak.
   if (
     isLoopbackPeer(peerAddr) &&
     (h.get("x-forwarded-for") !== null ||


### PR DESCRIPTION
## Security fix

`layerOf(req, peerAddr)` classified **every public request through a same-box reverse proxy as `loopback`** — the most-trusted layer.

A **Caddy-direct** deploy (Caddy terminates TLS and `reverse_proxy 127.0.0.1:1939`) proxies from `127.0.0.1` and sets **no** cf/tailscale trust header. So the hub saw `peerAddr=127.0.0.1`, fell to `isLoopbackPeer ? "loopback" : "public"`, and treated public visitors as on-box operators.

### Blast radius (all in `hub-server.ts`, all route through `layerOf`)
- **`GET /admin/setup` bootstrap-token probe** (hub#576, ~L2296) → returned the first-boot token to any public visitor.
- **`publicExposure:"loopback"` 404-cloak** (proxyToService / proxyToVault / proxyToVaultAdmin / WS-upgrade gate) → loopback-only services/vaults became publicly reachable.

## The fix (surgical, in `layerOf`)

AFTER the cf/tailscale header checks (order preserved), BEFORE the `isLoopbackPeer ? "loopback" : "public"` fallback:

```ts
if (
  isLoopbackPeer(peerAddr) &&
  (h.get("x-forwarded-for") !== null ||
    h.get("x-forwarded-host") !== null ||
    h.get("forwarded") !== null)
) {
  return "public";
}
```

A loopback peer that **also** carries a standard reverse-proxy forwarding header is a same-box proxy carrying a PUBLIC request → `public`. A header-less loopback peer (CLI, health probes, the init bootstrap-token loopback probe, the hub's own loopback self-requests) stays `loopback`. Single fix; all blast-radius sites derive from `layerOf`.

## Genuine-on-box-loopback NOT broken
- The init bootstrap-token probe (`src/commands/init.ts:555`) does `fetch(.../admin/setup, { headers: { accept: "application/json" } })` — **no X-Forwarded-* header** → still classifies `loopback`, still gets the token.
- The hub **never injects X-Forwarded-* on the INBOUND request it classifies**. Grep confirms the only X-Forwarded sets in `src/` are `x-forwarded-host`/`x-forwarded-proto` in `proxyRequest` (~L816-823) — those are on **OUTBOUND** proxy requests to modules, not on inbound classification. The hub sets **X-Forwarded-For nowhere** (only reads it).

## No spoof vector
A non-loopback peer is **already** `public` regardless of headers (the unchanged fallback). Adding X-Forwarded-* can only **downgrade** a loopback caller (the on-box operator hurting only their own request) — never upgrade a network peer to `loopback`. CF/TS checks run first.

## Gates
- `bun run typecheck` — clean.
- `bun test ./src` (PARACHUTE_HOME=/tmp fresh) — **3749 pass, 1 skip, 0 fail** (38018 expect() calls, 146 files).
- rc bump `0.7.3-rc.10` → `0.7.3-rc.11`.

## Tests added (`src/__tests__/hub-server.test.ts`)
- **layerOf**: loopback + XFF/XFH/Forwarded → public; loopback + no header → loopback; CF-Ray & TS-funnel/TS-login still win (order preserved); non-loopback peer never upgrades.
- **publicExposure:loopback cloak**: Caddy-direct (loopback peer + XFF) → 404; header-less loopback → reaches service (200).
- **/admin/setup token probe**: loopback → `bootstrapToken` present; Caddy XFF → withheld (`requireBootstrapToken` still true so the form field renders); non-loopback → withheld.

---

## Migration checklist — trust-model shift (2026-06-26 layerOf-proxy-loopback)

> Included inline (rather than as a separate `parachute-patterns/migrations/` commit) to keep this a single-repo security fix. Promote to a patterns file if further propagation is needed.

**Context:** `layerOf` now recognizes same-box reverse proxies (Caddy/nginx-direct) via X-Forwarded-* and classifies them `public`. The new Caddy-direct deploy shape is now safe; previously it leaked the bootstrap token and dropped the loopback cloak.

**Code references**
- [x] `parachute-hub:src/hub-server.ts` — `layerOf` forwarding-header branch (this PR)
- [x] `parachute-hub:src/__tests__/hub-server.test.ts` — layerOf + cloak + token-probe tests (this PR)
- [x] Audited: no other repo (surface/vault/scribe/agent) classifies trust by cf/tailscale/loopback headers — modules consume the hub-stamped `X-Parachute-Layer`, the hub is the single classification point. No propagation needed.

**Doc references**
- [x] `parachute-patterns:patterns/hub-module-boundary.md` (L20) names `layerOf`/`publicExposure` as hub-owned transport — statement stays accurate (the fix keeps the responsibility in hub; the boundary is unchanged). No edit needed.
- [ ] If a Caddy-direct deploy guide ships on `parachute.computer`, note that Caddy must pass `X-Forwarded-For` (it does by default with `reverse_proxy`) so loopback-only cloaking holds.

**Operator-facing references**
- [ ] None today (no published Caddy-direct guide yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)