### PR TITLE
fix(hub): skip wizard expose step + one-command Caddy domain change when origin configured (rc.12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.11",
+  "version": "0.7.3-rc.12",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-command.test.ts
+++ b/src/__tests__/hub-command.test.ts
@@ -9,12 +9,13 @@
  * SPA's `validateHubOrigin`), and it warns-but-allows loopback.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hub, hubSetOrigin } from "../commands/hub.ts";
+import { hub, hubSetOrigin, rewriteCaddyfileHost } from "../commands/hub.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { getHubOrigin } from "../hub-settings.ts";
+import type { CommandResult } from "../tailscale/run.ts";
 
 describe("parachute hub set-origin", () => {
   let dir: string;
@@ -27,6 +28,29 @@ describe("parachute hub set-origin", () => {
   });
   afterEach(() => rmSync(dir, { recursive: true, force: true }));
 
+  /**
+   * Hermetic seams for the non-DB side effects: point the Caddyfile at a
+   * non-existent path (→ "no managed Caddyfile" branch), and mock the reload
+   * Runner + module restart so NOTHING real reloads Caddy or drives the live
+   * supervisor. The DB write is the only real side effect (scoped to the temp
+   * configDir). Tests that exercise Caddy specifically override these.
+   */
+  function safeSeams(): {
+    configDir: string;
+    log: (line: string) => void;
+    caddyfilePath: string;
+    run: (cmd: readonly string[]) => Promise<{ code: number; stdout: string; stderr: string }>;
+    restartModules: () => Promise<number>;
+  } {
+    return {
+      configDir: dir,
+      log: collect,
+      caddyfilePath: join(dir, "no-caddyfile-here"),
+      run: async () => ({ code: 0, stdout: "", stderr: "" }),
+      restartModules: async () => 0,
+    };
+  }
+
   /** Open the configDir's hub.db and read the persisted origin. */
   function persisted(): string | null {
     const db = openHubDb(hubDbPath(dir));
@@ -38,55 +62,60 @@ describe("parachute hub set-origin", () => {
   }
 
   test("persists a valid public origin to hub_settings.hub_origin", async () => {
-    const code = await hubSetOrigin(["https://box.sslip.io"], { configDir: dir, log: collect });
+    const code = await hubSetOrigin(["https://box.sslip.io"], safeSeams());
     expect(code).toBe(0);
     expect(persisted()).toBe("https://box.sslip.io");
   });
 
   test("strips a trailing slash (canonical bare-origin form)", async () => {
-    const code = await hubSetOrigin(["https://box.example.com/"], { configDir: dir, log: collect });
+    const code = await hubSetOrigin(["https://box.example.com/"], safeSeams());
     expect(code).toBe(0);
     expect(persisted()).toBe("https://box.example.com");
   });
 
   test("rejects a non-http(s) scheme without writing", async () => {
-    const code = await hubSetOrigin(["ftp://box.example.com"], { configDir: dir, log: collect });
+    const code = await hubSetOrigin(["ftp://box.example.com"], safeSeams());
     expect(code).toBe(1);
     expect(persisted()).toBeNull();
   });
 
   test("rejects a URL with a path without writing", async () => {
-    const code = await hubSetOrigin(["https://box.example.com/admin"], {
-      configDir: dir,
-      log: collect,
-    });
+    const code = await hubSetOrigin(["https://box.example.com/admin"], safeSeams());
     expect(code).toBe(1);
     expect(persisted()).toBeNull();
   });
 
   test("rejects a bare hostname (no scheme) without writing", async () => {
-    const code = await hubSetOrigin(["box.example.com"], { configDir: dir, log: collect });
+    const code = await hubSetOrigin(["box.example.com"], safeSeams());
     expect(code).toBe(1);
     expect(persisted()).toBeNull();
   });
 
   test("missing the URL argument is a usage error, no write", async () => {
-    const code = await hubSetOrigin([], { configDir: dir, log: collect });
+    const code = await hubSetOrigin([], safeSeams());
     expect(code).toBe(1);
     expect(persisted()).toBeNull();
   });
 
   test("warns but ALLOWS a loopback origin (dev/test escape hatch)", async () => {
-    const code = await hubSetOrigin(["http://127.0.0.1:1939"], { configDir: dir, log: collect });
+    const code = await hubSetOrigin(["http://127.0.0.1:1939"], safeSeams());
     expect(code).toBe(0);
     expect(persisted()).toBe("http://127.0.0.1:1939");
     expect(log.some((l) => l.toLowerCase().includes("loopback"))).toBe(true);
   });
 
-  test("prints the restart note so the operator knows running modules need a restart", async () => {
-    await hubSetOrigin(["https://box.sslip.io"], { configDir: dir, log: collect });
+  test("prints a restart instruction when no managed Caddyfile is present", async () => {
+    let restartCalls = 0;
+    await hubSetOrigin(["https://box.sslip.io"], {
+      ...safeSeams(),
+      restartModules: async () => {
+        restartCalls++;
+        return 1; // simulate restart not landing → prints the manual hint
+      },
+    });
     const joined = log.join("\n");
-    expect(joined).toContain("parachute restart vault");
+    expect(restartCalls).toBe(1);
+    expect(joined).toContain("parachute restart");
   });
 
   test("openDb seam is honored (no touch of the live ~/.parachute)", async () => {
@@ -98,8 +127,7 @@ describe("parachute hub set-origin", () => {
     try {
       let opened = 0;
       const code = await hubSetOrigin(["https://box.sslip.io"], {
-        configDir: dir,
-        log: collect,
+        ...safeSeams(),
         openDb: () => {
           opened++;
           return openHubDb(hubDbPath(altDir));
@@ -132,5 +160,274 @@ describe("parachute hub dispatcher", () => {
 
   test("unknown subcommand exits 1", async () => {
     expect(await hub(["frobnicate"])).toBe(1);
+  });
+});
+
+// --- rewriteCaddyfileHost (pure) -----------------------------------------
+
+const MANAGED_CADDYFILE = `# Managed by Parachute install (install/digitalocean.sh). Re-run to refresh.
+old.example.com {
+    reverse_proxy 127.0.0.1:1939 {
+        # Strip client-supplied layer-spoofing trust signals — only a real
+        # Cloudflare / Tailscale edge may set these; this Caddy is the edge.
+        header_up -Cf-Ray
+        header_up -Cf-Connecting-Ip
+        header_up -Tailscale-Funnel-Request
+        header_up -Tailscale-User-Login
+    }
+}
+`;
+
+describe("rewriteCaddyfileHost", () => {
+  test("rewrites ONLY the site-address line, body + header strips intact", () => {
+    const r = rewriteCaddyfileHost(MANAGED_CADDYFILE, "new.example.com");
+    expect(r.kind).toBe("rewritten");
+    if (r.kind !== "rewritten") throw new Error("unreachable");
+    expect(r.content).toContain("new.example.com {");
+    expect(r.content).not.toContain("old.example.com");
+    // The reverse_proxy body + the security-load-bearing header strips survive.
+    expect(r.content).toContain("reverse_proxy 127.0.0.1:1939 {");
+    expect(r.content).toContain("header_up -Cf-Ray");
+    expect(r.content).toContain("header_up -Cf-Connecting-Ip");
+    expect(r.content).toContain("header_up -Tailscale-Funnel-Request");
+    expect(r.content).toContain("header_up -Tailscale-User-Login");
+    // Only one line changed (host line); everything else byte-identical.
+    const before = MANAGED_CADDYFILE.split("\n");
+    const after = r.content.split("\n");
+    const diff = before.filter((l, i) => l !== after[i]);
+    expect(diff).toEqual(["old.example.com {"]);
+  });
+
+  test("idempotent — host already matches → unchanged (no reload needed)", () => {
+    expect(rewriteCaddyfileHost(MANAGED_CADDYFILE, "old.example.com").kind).toBe("unchanged");
+  });
+
+  test("an unmanaged Caddyfile (no marker) → not-managed", () => {
+    const unmanaged = "example.com {\n    reverse_proxy 127.0.0.1:1939\n}\n";
+    expect(rewriteCaddyfileHost(unmanaged, "new.example.com").kind).toBe("not-managed");
+  });
+
+  test("marker present but no site-opener line (hand-edited) → customized", () => {
+    const odd = "# Managed by Parachute install (foo)\nreverse_proxy 127.0.0.1:1939\n";
+    expect(rewriteCaddyfileHost(odd, "new.example.com").kind).toBe("customized");
+  });
+
+  test("injection-shaped host can't break the rewrite (host comes from validated URL)", () => {
+    // The caller only ever passes `new URL(origin).host` from an already-validated
+    // origin, so a host with spaces / braces never reaches here — but even a weird
+    // token is written verbatim as the bare site address (no shell, plain file edit).
+    const r = rewriteCaddyfileHost(MANAGED_CADDYFILE, "weird.host:8443");
+    expect(r.kind).toBe("rewritten");
+    if (r.kind !== "rewritten") throw new Error("unreachable");
+    expect(r.content).toContain("weird.host:8443 {");
+    // The body is still intact — the regex only touched the site opener.
+    expect(r.content).toContain("header_up -Cf-Ray");
+  });
+});
+
+// --- set-origin Caddy rewrite + reload + restart -------------------------
+
+const okResult = (): CommandResult => ({ code: 0, stdout: "", stderr: "" });
+
+describe("parachute hub set-origin — Caddy automation", () => {
+  let dir: string;
+  let log: string[];
+  const collect = (line: string) => log.push(line);
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "hub-set-origin-caddy-"));
+    log = [];
+  });
+  afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+  function caddyFixture(): string {
+    const p = join(dir, "Caddyfile");
+    writeFileSync(p, MANAGED_CADDYFILE);
+    return p;
+  }
+
+  test("managed Caddyfile → host line rewritten, reload + restart invoked (mocked)", async () => {
+    const caddyfilePath = caddyFixture();
+    const runCalls: ReadonlyArray<string>[] = [];
+    let restartCalls = 0;
+    const code = await hubSetOrigin(["https://new.example.com"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath,
+      getuid: () => 0, // simulate root so the rewrite path runs
+      run: async (cmd) => {
+        runCalls.push(cmd);
+        return okResult();
+      },
+      restartModules: async () => {
+        restartCalls++;
+        return 0;
+      },
+    });
+    expect(code).toBe(0);
+    // DB origin persisted.
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      expect(getHubOrigin(db)).toBe("https://new.example.com");
+    } finally {
+      db.close();
+    }
+    // Host line rewritten on disk; body + header strips preserved.
+    const written = readFileSync(caddyfilePath, "utf8");
+    expect(written).toContain("new.example.com {");
+    expect(written).not.toContain("old.example.com");
+    expect(written).toContain("header_up -Cf-Connecting-Ip");
+    // Reload + restart both invoked.
+    expect(runCalls).toContainEqual(["systemctl", "reload", "caddy"]);
+    expect(restartCalls).toBe(1);
+  });
+
+  test("NO managed Caddyfile → origin persisted, manual steps printed, reload/restart NOT invoked", async () => {
+    const runCalls: ReadonlyArray<string>[] = [];
+    let restartCalls = 0;
+    const code = await hubSetOrigin(["https://new.example.com"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath: join(dir, "does-not-exist"),
+      getuid: () => 0,
+      run: async (cmd) => {
+        runCalls.push(cmd);
+        return okResult();
+      },
+      restartModules: async () => {
+        restartCalls++;
+        return 0;
+      },
+    });
+    expect(code).toBe(0);
+    const db = openHubDb(hubDbPath(dir));
+    try {
+      expect(getHubOrigin(db)).toBe("https://new.example.com");
+    } finally {
+      db.close();
+    }
+    // No managed Caddyfile → reload never runs. (restart still runs by design;
+    // it's the module-propagation step, independent of Caddy.)
+    expect(runCalls).toEqual([]);
+    expect(restartCalls).toBe(1);
+    expect(log.join("\n")).toContain("No Parachute-managed Caddyfile");
+  });
+
+  test("--no-caddy → Caddy untouched (no read/write/reload), restart still runs", async () => {
+    const caddyfilePath = caddyFixture();
+    const runCalls: ReadonlyArray<string>[] = [];
+    let restartCalls = 0;
+    const code = await hubSetOrigin(["https://new.example.com", "--no-caddy"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath,
+      getuid: () => 0,
+      run: async (cmd) => {
+        runCalls.push(cmd);
+        return okResult();
+      },
+      restartModules: async () => {
+        restartCalls++;
+        return 0;
+      },
+    });
+    expect(code).toBe(0);
+    // Caddyfile left byte-identical (not rewritten).
+    expect(readFileSync(caddyfilePath, "utf8")).toBe(MANAGED_CADDYFILE);
+    expect(runCalls).toEqual([]);
+    expect(restartCalls).toBe(1);
+    expect(log.join("\n")).toContain("--no-caddy");
+  });
+
+  test("--no-restart → modules not restarted", async () => {
+    const caddyfilePath = caddyFixture();
+    let restartCalls = 0;
+    const code = await hubSetOrigin(["https://new.example.com", "--no-restart"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath,
+      getuid: () => 0,
+      run: async () => okResult(),
+      restartModules: async () => {
+        restartCalls++;
+        return 0;
+      },
+    });
+    expect(code).toBe(0);
+    expect(restartCalls).toBe(0);
+    expect(log.join("\n")).toContain("--no-restart");
+  });
+
+  test("non-root with a managed Caddyfile → graceful, non-fatal, NOT rewritten/reloaded", async () => {
+    const caddyfilePath = caddyFixture();
+    const runCalls: ReadonlyArray<string>[] = [];
+    const code = await hubSetOrigin(["https://new.example.com"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath,
+      getuid: () => 1000, // non-root
+      run: async (cmd) => {
+        runCalls.push(cmd);
+        return okResult();
+      },
+      restartModules: async () => 0,
+    });
+    expect(code).toBe(0); // non-fatal: origin still persisted
+    // File untouched, reload never attempted.
+    expect(readFileSync(caddyfilePath, "utf8")).toBe(MANAGED_CADDYFILE);
+    expect(runCalls).toEqual([]);
+    expect(log.join("\n").toLowerCase()).toContain("not running as root");
+  });
+
+  test("reload fails → graceful, non-fatal, file still rewritten, manual reload hinted", async () => {
+    const caddyfilePath = caddyFixture();
+    const code = await hubSetOrigin(["https://new.example.com"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath,
+      getuid: () => 0,
+      run: async () => ({ code: 1, stdout: "", stderr: "caddy: config error" }),
+      restartModules: async () => 0,
+    });
+    expect(code).toBe(0); // non-fatal
+    expect(readFileSync(caddyfilePath, "utf8")).toContain("new.example.com {");
+    const joined = log.join("\n");
+    expect(joined).toContain("reload");
+    expect(joined).toContain("caddy: config error");
+  });
+
+  test("restart fails → graceful, non-fatal, prints the manual restart hint", async () => {
+    const caddyfilePath = caddyFixture();
+    const code = await hubSetOrigin(["https://new.example.com"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath,
+      getuid: () => 0,
+      run: async () => okResult(),
+      restartModules: async () => 1, // restart reports failure
+    });
+    expect(code).toBe(0); // non-fatal — origin persisted, Caddy reloaded
+    expect(log.join("\n")).toContain("parachute restart");
+  });
+
+  test("a managed Caddyfile already on the new host → unchanged, reload skipped", async () => {
+    const caddyfilePath = caddyFixture();
+    const runCalls: ReadonlyArray<string>[] = [];
+    // Set origin to the host already in the fixture (old.example.com).
+    const code = await hubSetOrigin(["https://old.example.com"], {
+      configDir: dir,
+      log: collect,
+      caddyfilePath,
+      getuid: () => 0,
+      run: async (cmd) => {
+        runCalls.push(cmd);
+        return okResult();
+      },
+      restartModules: async () => 0,
+    });
+    expect(code).toBe(0);
+    // Host already matched → no reload.
+    expect(runCalls).toEqual([]);
+    expect(log.join("\n")).toContain("already points at old.example.com");
   });
 });

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -26,7 +26,7 @@ import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
 import { type ExposeState, readExposeState, writeExposeState } from "../expose-state.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { hubFetch } from "../hub-server.ts";
-import { getSetting, setSetting } from "../hub-settings.ts";
+import { getSetting, setHubOrigin, setSetting } from "../hub-settings.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
 import {
   OPERATOR_TOKEN_SCOPE_SET_CLAIM,
@@ -533,6 +533,126 @@ describe("deriveWizardState", () => {
       expect(s.hasAdmin).toBe(true);
       expect(s.hasVault).toBe(true);
       expect(s.hasExposeMode).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  // --- Caddy-direct: a configured public origin already answers "how reached?"
+  // Seed a real vault row so the only step left to decide is expose.
+  const seedAdminAndVault = async (db: ReturnType<typeof openHubDb>) => {
+    await createUser(db, "owner", "pw");
+    writeManifest(
+      {
+        services: [
+          {
+            name: "parachute-vault",
+            version: "0.1.0",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+          },
+        ],
+      },
+      h.manifestPath,
+    );
+  };
+
+  test("auto-skips expose when a public hub_origin is configured (Caddy-direct / init --hub-origin)", async () => {
+    // Caddy-direct box: `parachute init --hub-origin https://host` persisted a
+    // real public origin to hub_settings.hub_origin BEFORE the wizard opened.
+    // No Render/Fly env var, no live tailscale exposure. That origin already
+    // answers "how will this hub be reached?" — the wizard must skip the expose
+    // step (account → vault → done) rather than re-asking.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await seedAdminAndVault(db);
+      setHubOrigin(db, "https://box.example.com");
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("done");
+      expect(s.hasExposeMode).toBe(true);
+      // Seeded "public" (not localhost/tailnet) — a Caddy-fronted box is public.
+      expect(getSetting(db, "setup_expose_mode")).toBe("public");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("auto-skips expose when PARACHUTE_HUB_ORIGIN env is a public origin (env-var Caddy box)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await seedAdminAndVault(db);
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: { PARACHUTE_HUB_ORIGIN: "https://box.example.com" },
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("done");
+      expect(s.hasExposeMode).toBe(true);
+      expect(getSetting(db, "setup_expose_mode")).toBe("public");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("does NOT skip expose when hub_origin is loopback (laptop / dev box still asks)", async () => {
+    // A loopback hub_origin must NOT count as "reached publicly" —
+    // sanitizePublicOrigin rejects 127.0.0.1/localhost/::1/0.0.0.0, so the
+    // expose step still renders and the operator chooses.
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await seedAdminAndVault(db);
+      setHubOrigin(db, "http://127.0.0.1:1939");
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("expose");
+      expect(s.hasExposeMode).toBe(false);
+      expect(getSetting(db, "setup_expose_mode")).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("does NOT skip expose when no origin is configured (unset → still asks)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await seedAdminAndVault(db);
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: {},
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("expose");
+      expect(s.hasExposeMode).toBe(false);
+      expect(getSetting(db, "setup_expose_mode")).toBeUndefined();
+    } finally {
+      db.close();
+    }
+  });
+
+  test("does NOT skip expose when PARACHUTE_HUB_ORIGIN env is loopback", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await seedAdminAndVault(db);
+      const s = deriveWizardState({
+        db,
+        manifestPath: h.manifestPath,
+        env: { PARACHUTE_HUB_ORIGIN: "http://localhost:1939" },
+        readExposeStateFn: h.readExposeStateFn,
+      });
+      expect(s.step).toBe("expose");
+      expect(s.hasExposeMode).toBe(false);
     } finally {
       db.close();
     }

--- a/src/commands/hub.ts
+++ b/src/commands/hub.ts
@@ -289,7 +289,17 @@ export async function hubSetOrigin(
         log(`  Update its site address to "${host}" by hand, then: sudo systemctl reload caddy`);
       }
       if (wrote) {
-        const reload = await runCaddyReload(run);
+        // `runCaddyReload` → defaultRunner pre-flights `systemctl` and THROWS
+        // (friendly missing-dep error) on a non-systemd box, before its own
+        // try/catch. Wrap it so a throw degrades to the manual-reload hint
+        // instead of escaping past the module restart below — the origin is
+        // already persisted, so the restart must still run.
+        let reload: CommandResult;
+        try {
+          reload = await runCaddyReload(run);
+        } catch (e) {
+          reload = { code: 1, stdout: "", stderr: e instanceof Error ? e.message : String(e) };
+        }
         if (reload.code === 0) {
           log("");
           log(`✓ Rewrote ${caddyfilePath} → ${host}, reloaded Caddy.`);

--- a/src/commands/hub.ts
+++ b/src/commands/hub.ts
@@ -27,11 +27,25 @@
  */
 
 import type { Database } from "bun:sqlite";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import { validateHubOrigin } from "../api-settings-hub-origin.ts";
+import { restart } from "../commands/lifecycle.ts";
 import { CONFIG_DIR } from "../config.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { setHubOrigin } from "../hub-settings.ts";
+import { type CommandResult, type Runner, defaultRunner } from "../tailscale/run.ts";
 import { isLoopbackOrigin } from "../vault-hub-origin-env.ts";
+
+/** Default path to the Parachute-managed Caddyfile (install/digitalocean.sh). */
+const DEFAULT_CADDYFILE_PATH = "/etc/caddy/Caddyfile";
+
+/**
+ * Stable prefix of the marker comment the install script writes as line 1 of a
+ * Parachute-managed Caddyfile (`# Managed by Parachute install …`). We match a
+ * prefix, not the whole line, so a future heredoc tweak to the trailing text
+ * doesn't break detection.
+ */
+const CADDY_MARKER_PREFIX = "# Managed by Parachute install";
 
 export interface HubCommandDeps {
   configDir?: string;
@@ -42,14 +56,97 @@ export interface HubCommandDeps {
    * write is exercised without touching the operator's live `~/.parachute`.
    */
   openDb?: (configDir: string) => Database;
+  /**
+   * Path to the Parachute-managed Caddyfile. Defaults to the install script's
+   * hardcoded `/etc/caddy/Caddyfile`. Tests point it at a temp fixture.
+   */
+  caddyfilePath?: string;
+  /** fs read seam (default `node:fs`). Returns undefined when the file is absent. */
+  readFile?: (path: string) => string | undefined;
+  /** fs write seam (default `node:fs`). */
+  writeFile?: (path: string, content: string) => void;
+  /** fs existence seam (default `node:fs`). */
+  exists?: (path: string) => boolean;
+  /**
+   * Runner for `systemctl reload caddy` + the module restart fan-out. Canonical
+   * {@link Runner} seam (the same one `expose.ts` injects). Tests mock it so
+   * nothing real reloads.
+   */
+  run?: Runner;
+  /** Effective uid (default `process.getuid`). Non-root → skip the write/reload. */
+  getuid?: () => number | undefined;
+  /**
+   * Restart supervised modules so `PARACHUTE_HUB_ORIGINS` re-injects with the
+   * fresh origin. Defaults to `restart(undefined, …)` (restarts the hub unit,
+   * re-booting all modules). Tests mock it so the live supervisor isn't driven.
+   */
+  restartModules?: (configDir: string) => Promise<number>;
+}
+
+/** Outcome of an attempted in-place Caddyfile hostname rewrite. */
+type CaddyRewriteResult =
+  | { kind: "rewritten"; content: string; host: string }
+  | { kind: "unchanged" } // host already matches — idempotent, no reload needed
+  | { kind: "not-managed" } // no file, or no `# Managed by Parachute install` marker
+  | { kind: "customized" }; // marker present but the site-address line shape is unrecognized
+
+/**
+ * Rewrite ONLY the site-address (hostname) line of a Parachute-managed Caddyfile
+ * to `host`, leaving the `reverse_proxy` body + the security-load-bearing
+ * `header_up -…` trust-signal strips byte-intact.
+ *
+ * The managed shape (install/digitalocean.sh write_caddyfile) is:
+ *
+ *   # Managed by Parachute install (install/digitalocean.sh). Re-run to refresh.
+ *   <hostname> {
+ *       reverse_proxy 127.0.0.1:<port> {
+ *           header_up -Cf-Ray
+ *           …
+ *       }
+ *   }
+ *
+ * Strategy: confirm the first non-empty line carries the marker prefix; then
+ * find the first top-level site-opener line (`<token> {`) that is NOT the
+ * `reverse_proxy …` line and replace its host token with `host`, preserving
+ * indentation + the trailing ` {`. If the marker is present but no such line
+ * matches (operator hand-edited), return `customized` and let the caller fall
+ * back to manual steps rather than guess.
+ */
+export function rewriteCaddyfileHost(content: string, host: string): CaddyRewriteResult {
+  const lines = content.split("\n");
+  const firstNonEmpty = lines.find((l) => l.trim().length > 0);
+  if (firstNonEmpty === undefined || !firstNonEmpty.trim().startsWith(CADDY_MARKER_PREFIX)) {
+    return { kind: "not-managed" };
+  }
+  // The site-address opener is the first `<token> {`-terminated line that is NOT
+  // the `reverse_proxy …` line. A bare host token: no whitespace, no scheme.
+  const siteOpener = /^(\s*)(\S+)(\s*\{\s*)$/;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (line === undefined) continue;
+    const trimmed = line.trim();
+    if (trimmed.startsWith("#") || trimmed.length === 0) continue;
+    if (trimmed.startsWith("reverse_proxy")) continue;
+    const m = line.match(siteOpener);
+    if (!m) continue;
+    const [, indent, token, brace] = m;
+    if (indent === undefined || token === undefined || brace === undefined) continue;
+    if (token === host) return { kind: "unchanged" };
+    lines[i] = `${indent}${host}${brace}`;
+    return { kind: "rewritten", content: lines.join("\n"), host };
+  }
+  return { kind: "customized" };
 }
 
 /**
  * `parachute hub set-origin <url>`. Validates + canonicalizes the URL, persists
- * it to `hub_settings.hub_origin`, and prints the restart note (already-running
- * supervised modules pick up the widened `PARACHUTE_HUB_ORIGINS` set only on
- * their next `parachute restart`, because that set is injected at child-spawn
- * time). Returns 0 on success, 1 on a validation / write failure.
+ * it to `hub_settings.hub_origin`, then — on a Parachute-managed Caddy-direct
+ * box — rewrites the Caddyfile hostname, reloads Caddy, and restarts the
+ * supervised modules so they re-pick the origin. Every post-DB step is
+ * best-effort: on any miss (no managed Caddyfile, `--no-caddy`, non-root, a
+ * failed reload/restart) the origin still persisted and the manual steps are
+ * printed. Returns 0 on success (incl. soft Caddy/restart misses), 1 only on a
+ * validation / DB-write failure.
  */
 export async function hubSetOrigin(
   args: readonly string[],
@@ -59,7 +156,20 @@ export async function hubSetOrigin(
   const log = deps.log ?? ((line) => console.log(line));
   const err = (line: string) => console.error(line);
   const openDb = deps.openDb ?? ((dir: string) => openHubDb(hubDbPath(dir)));
+  const caddyfilePath = deps.caddyfilePath ?? DEFAULT_CADDYFILE_PATH;
+  const exists = deps.exists ?? ((path: string) => existsSync(path));
+  const readFile = deps.readFile ?? ((path: string) => readFileSync(path, "utf8"));
+  const writeFile =
+    deps.writeFile ?? ((path: string, content: string) => writeFileSync(path, content));
+  const run = deps.run ?? defaultRunner;
+  const getuid =
+    deps.getuid ?? (() => (typeof process.getuid === "function" ? process.getuid() : undefined));
+  const restartModules =
+    deps.restartModules ??
+    ((dir: string) => restart(undefined, { configDir: dir, supervisor: {} }));
 
+  const noCaddy = args.includes("--no-caddy");
+  const noRestart = args.includes("--no-restart");
   const positional = args.filter((a) => !a.startsWith("-"));
   const raw = positional[0];
   if (raw === undefined) {
@@ -114,12 +224,117 @@ export async function hubSetOrigin(
   log(`✓ Canonical hub origin set to ${origin}.`);
   log("  Stored in hub_settings — the OAuth issuer (`iss`) hub stamps on every token,");
   log("  and the origin set injected into supervised modules so they accept it.");
-  log("");
-  log("Already-running modules (vault, scribe) pick up the widened origin set only on");
-  log("their next restart (it's injected at spawn time). Restart them to apply now:");
-  log("  parachute restart vault");
-  log("  parachute restart scribe   # if installed");
+
+  // The DB write is the load-bearing contract; everything below is best-effort
+  // automation of the manual restart/rewrite steps. Any miss falls back to
+  // printing the manual instructions and still returns 0.
+  //
+  // The Caddy site address is a BARE host (Caddy auto-TLS on HTTPS-default),
+  // taken from the ALREADY-VALIDATED URL — `new URL(origin).host` (no scheme),
+  // never a raw arg, so there's nothing to inject (the rewrite is a file edit,
+  // the reload/restart are argv-form Bun.spawn, no shell).
+  const host = new URL(origin).host;
+
+  if (noCaddy) {
+    log("");
+    log("(--no-caddy) Skipping the Caddyfile rewrite + reload.");
+  } else if (!exists(caddyfilePath)) {
+    // Tailscale / Cloudflare / manual-proxy box — no managed Caddyfile to touch.
+    log("");
+    log(
+      `No Parachute-managed Caddyfile at ${caddyfilePath} — origin set; restart modules to apply.`,
+    );
+  } else {
+    let content: string | undefined;
+    try {
+      content = readFile(caddyfilePath);
+    } catch {
+      content = undefined;
+    }
+    const rewrite =
+      content === undefined
+        ? ({ kind: "not-managed" } as const)
+        : rewriteCaddyfileHost(content, host);
+    if (rewrite.kind === "not-managed") {
+      log("");
+      log(
+        `No Parachute-managed Caddyfile at ${caddyfilePath} — origin set; restart modules to apply.`,
+      );
+    } else if (rewrite.kind === "customized") {
+      log("");
+      log(`The Caddyfile at ${caddyfilePath} looks customized — not rewriting its host line.`);
+      log(`  Update the site address to "${host}" by hand, then: sudo systemctl reload caddy`);
+    } else if (rewrite.kind === "unchanged") {
+      // Host already matches — nothing to write or reload.
+      log("");
+      log(`Caddyfile already points at ${host} — no change needed.`);
+    } else if (getuid() !== undefined && getuid() !== 0) {
+      // Writing /etc/caddy/Caddyfile + `systemctl reload` need root; the hub
+      // never shells `sudo` itself. Persist + print the manual steps.
+      log("");
+      log(`Not running as root — can't rewrite ${caddyfilePath} or reload Caddy.`);
+      log(
+        `  As root: set the Caddyfile site address to "${host}", then: sudo systemctl reload caddy`,
+      );
+    } else {
+      // Root + managed file + host changed → rewrite, then (only if the write
+      // landed) reload.
+      let wrote = false;
+      try {
+        writeFile(caddyfilePath, rewrite.content);
+        wrote = true;
+      } catch (e) {
+        log("");
+        log(`Could not write ${caddyfilePath}: ${e instanceof Error ? e.message : String(e)}`);
+        log(`  Update its site address to "${host}" by hand, then: sudo systemctl reload caddy`);
+      }
+      if (wrote) {
+        const reload = await runCaddyReload(run);
+        if (reload.code === 0) {
+          log("");
+          log(`✓ Rewrote ${caddyfilePath} → ${host}, reloaded Caddy.`);
+        } else {
+          log("");
+          log(`✓ Rewrote ${caddyfilePath} → ${host}, but Caddy reload reported an error:`);
+          if (reload.stderr.trim().length > 0) log(`  ${reload.stderr.trim()}`);
+          log("  Reload it manually: sudo systemctl reload caddy");
+        }
+      }
+    }
+  }
+
+  // Restart supervised modules so they re-pick the origin via PARACHUTE_HUB_ORIGINS
+  // (injected at child-spawn time). One hub-unit restart re-boots all modules —
+  // strictly better than the old "restart vault / restart scribe" two-step.
+  if (noRestart) {
+    log("");
+    log("(--no-restart) Skipping the module restart. Apply with: parachute restart");
+  } else {
+    let restarted = false;
+    try {
+      restarted = (await restartModules(configDir)) === 0;
+    } catch {
+      restarted = false;
+    }
+    if (restarted) {
+      log("✓ Restarted modules (vault, scribe) so they accept the new origin.");
+    } else {
+      log("");
+      log("Restart already-running modules so they pick up the new origin:");
+      log("  parachute restart");
+    }
+  }
+
   return 0;
+}
+
+/**
+ * `systemctl reload caddy` through the injected Runner. Kept tiny so the call
+ * site reads as one step; the Runner default (`defaultRunner`) env-inherits +
+ * pre-flights the binary, and tests mock it.
+ */
+async function runCaddyReload(run: Runner): Promise<CommandResult> {
+  return run(["systemctl", "reload", "caddy"]);
 }
 
 /**
@@ -152,7 +367,7 @@ export function hubHelp(): string {
   return `parachute hub — hub-local configuration
 
 Usage:
-  parachute hub set-origin <url>    set the canonical public hub origin
+  parachute hub set-origin <url> [--no-caddy] [--no-restart]
 
 Subcommands:
   set-origin <url>    Persist the canonical public origin (OAuth issuer) to the
@@ -163,11 +378,22 @@ Subcommands:
                       over a public HTTPS URL — no admin browser session needed.
 
                       The URL must be http(s), with a hostname and no trailing
-                      slash / path / query. After it's set, restart already-running
-                      modules so they pick up the widened origin set.
+                      slash / path / query.
+
+                      On a Parachute-managed Caddy-direct box (a
+                      /etc/caddy/Caddyfile written by the install script), this
+                      ALSO rewrites the Caddyfile's hostname line to the new
+                      origin (the reverse_proxy body + trust-signal header strips
+                      are left intact), reloads Caddy, and restarts the modules so
+                      the new origin propagates — a one-command domain change. If
+                      no managed Caddyfile is present, the rewrite is skipped and
+                      the manual steps are printed. Pass --no-caddy to skip the
+                      Caddyfile rewrite + reload, or --no-restart to skip the
+                      module restart.
 
 Examples:
   parachute hub set-origin https://box.sslip.io
   parachute hub set-origin https://parachute.example.com
+  parachute hub set-origin https://parachute.example.com --no-caddy
 `;
 }

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -60,6 +60,7 @@ import {
   SETUP_EXPOSE_MODES,
   type SetupExposeMode,
   deleteSetting,
+  getHubOrigin,
   getSetting,
   isSetupExposeMode,
   openFirstClientAutoApproveWindow,
@@ -89,6 +90,7 @@ import {
 } from "./sessions.ts";
 import type { Supervisor } from "./supervisor.ts";
 import { createUser, userCount } from "./users.ts";
+import { sanitizePublicOrigin } from "./vault-hub-origin-env.ts";
 import { DEFAULT_VAULT_NAME, validateVaultName } from "./vault-name.ts";
 
 // --- shared chrome --------------------------------------------------------
@@ -350,6 +352,24 @@ export function deriveWizardState(deps: {
     const seeded = exposeModeFromLiveState(deps.readExposeStateFn ?? readExposeState);
     if (seeded !== undefined) {
       setSetting(deps.db, "setup_expose_mode", seeded);
+    }
+  }
+  // hub Caddy-direct case: a reverse-proxy box (`parachute init --hub-origin
+  // https://<host>`, or `parachute hub set-origin`) persists a real public
+  // origin to `hub_settings.hub_origin` (also honored from PARACHUTE_HUB_ORIGIN).
+  // That origin already answers "how is this hub reached?" — Caddy/Let's-Encrypt
+  // fronts the loopback hub, no `parachute expose` and no Render/Fly env var.
+  // Auto-seed `setup_expose_mode = "public"` so the wizard skips the expose step
+  // exactly as the Render/Fly + live-tailscale branches do. `sanitizePublicOrigin`
+  // (the SAME guard `resolveIssuer`/`exposeIssuerOrigin` use) requires an absolute
+  // http(s) URL and REJECTS loopback/0.0.0.0 — so a laptop/loopback/unset origin
+  // returns undefined and the expose step still renders (the operator chooses).
+  if (getSetting(deps.db, "setup_expose_mode") === undefined) {
+    const configured =
+      sanitizePublicOrigin(getHubOrigin(deps.db) ?? undefined) ??
+      sanitizePublicOrigin(deps.env?.PARACHUTE_HUB_ORIGIN ?? process.env.PARACHUTE_HUB_ORIGIN);
+    if (configured !== undefined) {
+      setSetting(deps.db, "setup_expose_mode", "public");
     }
   }
   const hasExposeMode = getSetting(deps.db, "setup_expose_mode") !== undefined;


### PR DESCRIPTION
Two related fixes for the **Caddy-direct / reverse-proxy install path**, where the hub binds loopback and a public origin is configured out-of-band. Bumps `0.7.3-rc.11` → `0.7.3-rc.12`.

## FIX 1 — setup wizard skips the expose step when an origin is already configured
`src/setup-wizard.ts` · `deriveWizardState`

A Caddy-direct box persists its public origin to `hub_settings.hub_origin` (`parachute init --hub-origin https://host` or `parachute hub set-origin`) — which already answers "how is this hub reached?". Yet the wizard re-asked the expose step (localhost / tailnet / public radios, none of which describe a Caddy-fronted box).

A new auto-seed branch (mirroring the existing Render/Fly + live-tailscale branches) seeds `setup_expose_mode = "public"` from a configured **non-loopback https** origin — DB `hub_origin` first, then `PARACHUTE_HUB_ORIGIN` env. The guard is `sanitizePublicOrigin`, the **same** loopback / non-http(s) reject `resolveIssuer` / `exposeIssuerOrigin` use, so:

- Caddy-direct (`https://host` configured) → expose step **skipped**, wizard goes account → vault → done.
- Laptop / loopback / unset origin → `sanitizePublicOrigin` returns undefined → expose step **still rendered** (operator chooses).
- Render / Fly / live-tailscale auto-skip unchanged.

## FIX 2 — `parachute hub set-origin` is now a one-command domain change
`src/commands/hub.ts` · `hubSetOrigin`

After persisting the DB origin (unchanged), on a **Parachute-managed Caddyfile** (`/etc/caddy/Caddyfile` with the `# Managed by Parachute install` marker) it ALSO:

1. Rewrites **only** the site-address (hostname) line to the new origin's host — the `reverse_proxy` body + the security-load-bearing `header_up -…` trust-signal strips are left **byte-intact**.
2. Reloads Caddy (`systemctl reload caddy` via the injectable Runner seam).
3. Restarts the modules (one hub-unit restart re-boots all) so `PARACHUTE_HUB_ORIGINS` re-injects with the fresh origin.

The host is `new URL(origin).host` from the already-validated URL — no shell, argv-form spawn, safe file edit, nothing to inject. Every post-DB step is **best-effort + non-fatal**: no managed Caddyfile / `--no-caddy` / non-root / failed reload or restart → persist the origin and print the manual steps, still exit 0. Only validation/DB-write failure returns 1 (unchanged). New `--no-caddy` / `--no-restart` flags + updated `--help`.

## Tests (hermetic — injected Runner + temp Caddyfile fixtures)
- **Wizard**: configured public origin (DB + env) → step `done`, expose skipped; loopback (DB + env) / unset → step `expose` still rendered; Render/Fly/tailscale unchanged.
- **set-origin**: managed Caddyfile → host line rewritten (body + header strips preserved) + mocked reload + restart invoked; no managed Caddyfile → persisted + manual steps, reload/restart **not** invoked; `--no-caddy` → Caddy untouched; `--no-restart` → no restart; non-root / reload-fail / restart-fail → graceful non-fatal; injection-shaped host can't break the rewrite; idempotent (host already matches → no reload).
- All seams (Runner / fs / getuid / restartModules) injected so nothing real reloads or drives the live supervisor.

## Gates
- `bun run typecheck` — clean
- `bun test ./src` — **3768 pass, 1 skip (pre-existing), 0 fail**
- `bunx biome check` — clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)