### PR TITLE
release: v0.7.3 — promote to @latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.3-rc.12",
+  "version": "0.7.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Promote the soaked rc chain to stable. Drops the `-rc` suffix on package.json (0.7.3-rc.12 → 0.7.3) — **same code, same patch number**, now shipped as `@latest`. On merge I push tag `v0.7.3` → CI publishes `@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)