### PR TITLE
feat(oauth): owner-on-own-vault scope selector + sharper admin consent copy (rc.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.2",
+  "version": "0.7.4-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -9899,3 +9899,422 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
     }
   });
 });
+
+// ───────────────────────────────────────────────────────────────────────────
+// hub#689 — owner-on-own-vault VERB SELECTOR. The consent screen offers an
+// owner of the picked vault a read/write/admin selector (pre-selected to
+// admin) when the client requested an UNNAMED `vault:read`/`vault:write`. On
+// submit, the owner's selection widens the unnamed verb to the chosen level
+// on the picked vault — BEFORE `capScopesToUserAuthority`, which remains the
+// backstop. The selector value is an UNTRUSTED hint: the handler re-derives
+// ownership of the picked vault server-side, and the cap drops any verb the
+// user doesn't actually hold.
+// ───────────────────────────────────────────────────────────────────────────
+describe("hub#689 — owner-on-own-vault verb selector + widening", () => {
+  const TTL_S = Math.floor(SESSION_TTL_MS / 1000);
+  const SEL_MANIFEST: ServicesManifest = {
+    services: [
+      {
+        name: "parachute-vault",
+        port: 1940,
+        paths: ["/vault/work", "/vault/other"],
+        health: "/health",
+        version: "0.7.0",
+      },
+    ],
+  };
+  const selDeps = {
+    issuer: ISSUER,
+    loadServicesManifest: () => SEL_MANIFEST,
+    hubBoundOrigins: () => [ISSUER],
+  };
+
+  async function submitConsent(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    sessionId: string,
+    clientId: string,
+    scope: string,
+    challenge: string,
+    extra: Record<string, string> = {},
+  ): Promise<Response> {
+    const form = new URLSearchParams({
+      __action: "consent",
+      __csrf: TEST_CSRF,
+      approve: "yes",
+      client_id: clientId,
+      redirect_uri: "https://app.example/cb",
+      response_type: "code",
+      scope,
+      code_challenge: challenge,
+      code_challenge_method: "S256",
+      ...extra,
+    });
+    return handleAuthorizePost(
+      db,
+      new Request(`${ISSUER}/oauth/authorize`, {
+        method: "POST",
+        body: form,
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+          cookie: `${CSRF_COOKIE}; ${buildSessionCookie(sessionId, TTL_S)}`,
+        },
+      }),
+      selDeps,
+    );
+  }
+
+  async function redeemScope(
+    db: Awaited<ReturnType<typeof makeDb>>["db"],
+    code: string,
+    clientId: string,
+    verifier: string,
+  ): Promise<string> {
+    const tokenRes = await handleToken(
+      db,
+      new Request(`${ISSUER}/oauth/token`, {
+        method: "POST",
+        body: new URLSearchParams({
+          grant_type: "authorization_code",
+          code,
+          client_id: clientId,
+          redirect_uri: "https://app.example/cb",
+          code_verifier: verifier,
+        }),
+        headers: { "content-type": "application/x-www-form-urlencoded" },
+      }),
+      selDeps,
+    );
+    expect(tokenRes.status).toBe(200);
+    const body = (await tokenRes.json()) as { scope: string };
+    return body.scope;
+  }
+
+  // GET render: owner of the picked vault sees the selector. A non-admin
+  // assigned to exactly one vault gets the locked picker → the selector is
+  // offered (they hold admin on their assigned vault).
+  test("selector RENDERED for an owner (assigned user) of the picked vault", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw"); // consumes the admin slot
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]); // role=write → holds admin on "work"
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        selDeps,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain("Access level");
+      expect(html).toContain('name="verb_select"');
+      // Admin pre-selected, still visibly flagged.
+      expect(html).toMatch(/name="verb_select" value="admin"[^>]*checked/);
+      expect(html).toContain("badge-admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // GET render: a read-only-assigned user (role=read → holds read, NOT admin)
+  // does NOT see the selector — offering admin pre-selected would promise an
+  // upgrade the cap silently demotes. They hold the vault but not admin on it.
+  test("selector NOT rendered for a read-only-assigned user (holds read, not admin)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const reader = await createUser(db, "reader", "pw", { allowMulti: true });
+      // role=read directly (setUserVaults hardcodes write) → holds read only.
+      db.prepare(
+        "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, 'read', ?)",
+      ).run(reader.id, "work", new Date().toISOString());
+      const session = createSession(db, { userId: reader.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        selDeps,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("Access level");
+      expect(html).not.toContain('name="verb_select"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // GET render: a non-owner (non-admin with ZERO assigned vaults) does NOT
+  // see the selector — they can't authorize a vault scope at all.
+  test("selector NOT rendered for a non-owner (zero-vault non-admin)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const stranger = await createUser(db, "stranger", "pw", { allowMulti: true });
+      // No setUserVaults → zero assignments → not an owner of anything.
+      const session = createSession(db, { userId: stranger.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        selDeps,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("Access level");
+      expect(html).not.toContain('name="verb_select"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Submit: owner (first admin) + client requested unnamed vault:read + selects
+  // admin → minted vault:<picked>:admin. THE core bug fix.
+  test("owner selects admin on an unnamed vault:read → minted vault:work:admin", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw"); // first admin
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        {
+          vault_pick: "work",
+          verb_select: "admin",
+        },
+      );
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).toBe("vault:work:admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Submit: owner selects write → vault:<picked>:write.
+  test("owner selects write on an unnamed vault:read → minted vault:work:write", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        {
+          vault_pick: "work",
+          verb_select: "write",
+        },
+      );
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).toBe("vault:work:write");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Submit: owner DOWNGRADES — selects read on an unnamed vault:write → read.
+  test("owner selects read on an unnamed vault:write → minted vault:work:read (downgrade)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:write",
+        challenge,
+        {
+          vault_pick: "work",
+          verb_select: "read",
+        },
+      );
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).toBe("vault:work:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // SECURITY: a non-owner who holds only READ on the picked vault forges
+  // verb_select=admin → the server re-derives ownership (no admin held) and
+  // refuses to widen; the cap is the backstop. Minted scope is capped to
+  // their actual authority (read), NOT elevated to admin.
+  test("SECURITY: read-only-assigned non-owner forges verb_select=admin → minted vault:work:read, NOT admin", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw"); // first admin = owner
+      const reader = await createUser(db, "reader", "pw", { allowMulti: true });
+      // Assign "work" with role=read directly → holds read only (NOT admin).
+      // setUserVaults hardcodes role=write, so insert the read row by hand to
+      // construct the read-only-authority case the cap must defend.
+      db.prepare(
+        "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, 'read', ?)",
+      ).run(reader.id, "work", new Date().toISOString());
+      const session = createSession(db, { userId: reader.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        {
+          vault_pick: "work",
+          verb_select: "admin", // FORGED — reader holds read only
+        },
+      );
+      // Read survives (held); admin never rides along.
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).toBe("vault:work:read");
+      expect(scope).not.toContain("admin");
+      // And the recorded grant carries no admin verb either.
+      const grant = findGrant(db, reader.id, reg.client.clientId);
+      expect(grant?.scopes ?? []).not.toContain("vault:work:admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // SECURITY: a non-admin assigned to "work" picks/forges admin on "other"
+  // (a vault outside their assignment) — the assignment-mismatch gate refuses
+  // before widening ever runs. No token minted.
+  test("SECURITY: forged verb_select=admin against an UNASSIGNED vault → 400 (mismatch gate, no mint)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]); // assigned "work" only
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        {
+          vault_pick: "other", // NOT in friend's assignment
+          verb_select: "admin",
+        },
+      );
+      expect(res.status).toBe(400);
+      expect(findGrant(db, friend.id, reg.client.clientId)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  // Owner without a verb_select field (older form / JS-off) → unchanged
+  // behavior: the unnamed verb narrows as-requested (vault:read → work:read).
+  test("owner with NO verb_select → unchanged narrowing (vault:read → vault:work:read)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        {
+          vault_pick: "work",
+          // no verb_select
+        },
+      );
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).toBe("vault:work:read");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -116,7 +116,8 @@ describe("renderConsent", () => {
     expect(html).toContain("vault:admin");
     // Scope explanations from the registry
     expect(html).toContain("Read your notes");
-    expect(html).toContain("Full vault access");
+    // hub#689 Leg 1: the admin label now enumerates the concrete grants.
+    expect(html).toContain("Read and write everything, plus admin");
   });
 
   test("highlights admin scopes with a danger color and badge", () => {
@@ -251,6 +252,59 @@ describe("renderConsent", () => {
     });
     expect(html).not.toContain("You have no assigned vaults");
     expect(html).not.toContain('value="yes" class="btn btn-primary" disabled');
+  });
+
+  // hub#689 — owner-on-own-vault verb selector rendering.
+  test("renders the owner verb selector (read/write/admin), pre-selected to admin", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:read" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
+      ownerVerbSelector: { requestedVerbs: ["read"] },
+    });
+    expect(html).toContain("Access level");
+    expect(html).toContain('name="verb_select" value="read"');
+    expect(html).toContain('name="verb_select" value="write"');
+    expect(html).toContain('name="verb_select" value="admin"');
+    // Admin is the pre-selected (checked) option.
+    expect(html).toMatch(/name="verb_select" value="admin"[^>]*checked/);
+    // read/write are NOT pre-checked.
+    expect(html).not.toMatch(/name="verb_select" value="read"[^>]*checked/);
+    expect(html).not.toMatch(/name="verb_select" value="write"[^>]*checked/);
+  });
+
+  test("owner verb selector keeps the admin option visibly flagged (admin badge + red border)", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:read" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
+      ownerVerbSelector: { requestedVerbs: ["read"] },
+    });
+    // The .scope-admin red-border class + the admin badge ride on the admin
+    // radio option so a pre-selected admin grant stays transparent.
+    expect(html).toContain("verb-option-admin");
+    expect(html).toContain("scope-admin");
+    expect(html).toContain("badge-admin");
+  });
+
+  test("does NOT render the verb selector when ownerVerbSelector is absent (non-owner)", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:read" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
+      // ownerVerbSelector omitted → no selector
+    });
+    expect(html).not.toContain("Access level");
+    expect(html).not.toContain('name="verb_select"');
   });
 });
 

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -29,6 +29,25 @@ describe("SCOPE_EXPLANATIONS", () => {
     }
   });
 
+  // hub#689 Leg 1: the vault:admin consent copy must enumerate what
+  // admin actually grants (config/settings, triggers/automation, GitHub
+  // backup, token minting) on top of read/write — so the consent screen
+  // is honest about the admin blast radius, not a vague "configuration
+  // changes" hand-wave.
+  test("vault:admin label enumerates the concrete admin grants (hub#689 Leg 1)", () => {
+    const label = SCOPE_EXPLANATIONS["vault:admin"]?.label ?? "";
+    const lower = label.toLowerCase();
+    expect(SCOPE_EXPLANATIONS["vault:admin"]?.level).toBe("admin");
+    // Read + write are still part of what admin grants.
+    expect(lower).toContain("read");
+    expect(lower).toContain("write");
+    // The four enumerated admin powers.
+    expect(lower).toContain("config");
+    expect(lower).toContain("trigger");
+    expect(lower).toContain("github");
+    expect(lower).toContain("token");
+  });
+
   test("FIRST_PARTY_SCOPES is sorted and matches the keys of SCOPE_EXPLANATIONS", () => {
     expect(FIRST_PARTY_SCOPES).toEqual([...FIRST_PARTY_SCOPES].sort());
     expect(new Set(FIRST_PARTY_SCOPES)).toEqual(new Set(Object.keys(SCOPE_EXPLANATIONS)));

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1209,9 +1209,31 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     return issueAuthCodeRedirect(db, parsed, requestedScopes, session.userId, deps);
   }
 
+  // hub#689 — does the user hold ADMIN on every vault they could pick? Admin
+  // (isFirstAdmin) owns the whole hub. A non-admin owns a vault only if their
+  // `user_vaults` role grants admin there (today role=write does; a role=read
+  // assignment would NOT). Re-derived from the DB so the owner-verb-selector
+  // is offered only to a genuine owner — the submit path re-checks the PICKED
+  // vault and the cap is the backstop, but rendering it precisely avoids
+  // promising an admin upgrade the cap would silently demote.
+  const userHoldsAdminOnPickable =
+    userIsAdmin ||
+    (assignedVaults.length > 0 &&
+      assignedVaults.every((v) =>
+        (vaultVerbsForUserVault(db, session.userId, v) ?? []).includes("admin"),
+      ));
+
   return htmlResponse(
     renderConsent(
-      consentProps(client, parsed, vaultNames, csrf.token, assignedVaults, userIsAdmin),
+      consentProps(
+        client,
+        parsed,
+        vaultNames,
+        csrf.token,
+        assignedVaults,
+        userIsAdmin,
+        userHoldsAdminOnPickable,
+      ),
     ),
     200,
     extra,
@@ -1681,6 +1703,44 @@ async function handleConsentSubmit(
         `vault_scope_mismatch: the picked vault "${pickedVault}" is not in your vault assignment. Ask the hub admin to update your assignment, or pick a vault shown on the consent screen.`,
         400,
       );
+    }
+    // hub#689 — owner-on-own-vault verb widening. The consent screen offers
+    // owners a read/write/admin selector (pre-selected to admin) for an
+    // unnamed `vault:read`/`vault:write` request, so an owner whose AI client
+    // asked for read-only can grant the level it actually needs in-flow. The
+    // submitted `verb_select` is an UNTRUSTED hint — we re-derive ownership of
+    // the PICKED vault server-side here, and `capScopesToUserAuthority` (inside
+    // issueAuthCodeRedirect) is the backstop that drops any verb the user
+    // doesn't actually hold. This only ever rewrites the unnamed read/write
+    // verb(s) to the selected level on the picked vault; named scopes and every
+    // other scope are untouched. A forged `verb_select=admin` from a user who
+    // doesn't own the picked vault gets capped back to what they hold (or, for
+    // a vault outside a pinned user's assignment, never reaches here — the
+    // mismatch checks above already 400'd it).
+    const selectedVerb = String(form.get("verb_select") ?? "").trim();
+    if (selectedVerb === "read" || selectedVerb === "write" || selectedVerb === "admin") {
+      // Re-derive, server-side, whether THIS user owns (holds admin on) the
+      // PICKED vault. Owner === first admin (holds admin everywhere) OR an
+      // assigned user whose role grants admin on this vault. Never trust the
+      // client-submitted selector to establish authority.
+      const heldOnPicked = vaultVerbsForUserVault(db, session.userId, pickedVault);
+      const ownsPicked = userIsAdmin || (heldOnPicked?.includes("admin") ?? false);
+      if (ownsPicked) {
+        scopes = scopes.map((s) => {
+          const parts = s.split(":");
+          // Only widen the unnamed read/write verbs the selector was offered
+          // for — leave an unnamed `vault:admin`, named scopes, and non-vault
+          // scopes exactly as requested.
+          if (
+            parts.length === 2 &&
+            parts[0] === "vault" &&
+            (parts[1] === "read" || parts[1] === "write")
+          ) {
+            return `vault:${selectedVerb}`;
+          }
+          return s;
+        });
+      }
     }
     scopes = narrowVaultScopes(scopes, pickedVault);
   }
@@ -2746,6 +2806,10 @@ function consentProps(
   csrfToken: string,
   assignedVaults: readonly string[],
   userIsAdmin: boolean,
+  // hub#689 — true when the user holds admin on every vault they could pick
+  // (admin owns the hub; an assigned non-admin only if their role grants admin
+  // on each assigned vault). Gates whether the owner-verb-selector renders.
+  userHoldsAdminOnPickable = userIsAdmin,
 ) {
   const scopes = params.scope.split(" ").filter((s) => s.length > 0);
   const unnamedVerbs = unnamedVaultVerbs(scopes);
@@ -2875,6 +2939,25 @@ function consentProps(
     const only = vaultNames[0];
     if (only) displayVault = only;
   }
+  // hub#689 — owner-on-own-vault verb selector. The client requested an
+  // unnamed `vault:read`/`vault:write` verb, and the consenting user owns
+  // (holds admin on) every vault they could pick — first admin owns the whole
+  // hub; an assigned non-admin holds admin on each of their assigned vaults
+  // (vaultVerbsForRole('write') → [read,write,admin]). Offer the selector so
+  // they can grant the level their client actually needs (or downgrade), with
+  // admin pre-selected. Suppressed when the request can't be authorized (zero-
+  // vault non-admin) or the assignment is stale (no valid vault to own).
+  //
+  // SECURITY: this only DECIDES WHETHER TO RENDER. The actual widening is
+  // re-derived server-side in `handleConsentSubmit` against the *picked* vault
+  // and capped by `capScopesToUserAuthority`. The selector value is a hint.
+  const upgradeableUnnamedVerbs = unnamedVerbs.filter((v) => v === "read" || v === "write");
+  const userOwnsEveryPickableVault =
+    !hasStaleAssignment && userCanAuthorizeRequest && userHoldsAdminOnPickable;
+  const ownerVerbSelector =
+    upgradeableUnnamedVerbs.length > 0 && userOwnsEveryPickableVault
+      ? { requestedVerbs: upgradeableUnnamedVerbs }
+      : undefined;
   return {
     params,
     clientId: client.clientId,
@@ -2883,6 +2966,7 @@ function consentProps(
     csrfToken,
     vaultPicker,
     displayVault,
+    ownerVerbSelector,
     staleAssignedVault,
     // Approve stays enabled for non-vault scopes even when assigned_vault
     // is stale — the user can still consent to e.g. `scribe:transcribe`

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1292,7 +1292,8 @@ function capScopesToUserAuthority(
     if (name === undefined || verb === undefined || !VAULT_VERBS.has(verb)) return true;
     // Named vault verb requested by a non-owner: admit only if the user holds
     // it. `vaultVerbsForUserVault` returns null for an unassigned vault (drop)
-    // or the held verb list (today read/write only — never admin).
+    // or the held verb list — a `write` role holds [read, write, admin], a
+    // `read` role holds [read] (see `vaultVerbsForRole`).
     const held = vaultVerbsForUserVault(db, userId, name);
     return held !== null && (held as readonly string[]).includes(verb);
   });

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -147,6 +147,31 @@ export interface ConsentViewProps {
    * the user on an error page. Defaults to authorizable when omitted.
    */
   userCanAuthorizeRequest?: boolean;
+  /**
+   * hub#689 — owner-on-own-vault verb selector. Set when the consenting user
+   * OWNS (holds admin on) every vault they could pick AND the client requested
+   * an unnamed `vault:read`/`vault:write` verb. Renders a read/write/admin
+   * radio group, pre-selected to admin, so the owner can grant the level their
+   * AI client actually needs in-flow (the requested-scope shape was the
+   * blocker, not the user's authority) — or transparently downgrade.
+   *
+   * The submitted `verb_select` is an UNTRUSTED hint: the consent-submit
+   * handler re-derives, server-side, whether the user actually owns the picked
+   * vault before widening, and `capScopesToUserAuthority` remains the backstop
+   * that drops any verb the user doesn't hold. The selector only ever WIDENS
+   * the unnamed verb(s) on the picked vault; it never touches any other scope.
+   */
+  ownerVerbSelector?: OwnerVerbSelector;
+}
+
+export interface OwnerVerbSelector {
+  /**
+   * The unnamed read/write verb(s) the client requested. Only `read`/`write`
+   * are upgradeable here — an unnamed `vault:admin` request already renders
+   * with the admin badge and needs no selector. Used to word the selector
+   * help text ("the app asked for write access").
+   */
+  requestedVerbs: string[];
 }
 
 export interface VaultPicker {
@@ -328,6 +353,7 @@ export function renderConsent(props: ConsentViewProps): string {
     staleAssignedVault,
     blockApproveForStaleAssignment,
     userCanAuthorizeRequest,
+    ownerVerbSelector,
   } = props;
   // Substitute unnamed `vault:<verb>` rows with the resolved named form so
   // the operator sees the scope shape that will appear in the token. Raw
@@ -339,6 +365,7 @@ export function renderConsent(props: ConsentViewProps): string {
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
       : displayedScopes.map(renderScopeRow).join("\n");
   const pickerSection = vaultPicker ? renderVaultPicker(vaultPicker) : "";
+  const verbSelectorSection = ownerVerbSelector ? renderOwnerVerbSelector(ownerVerbSelector) : "";
   // Approve is disabled when the picker can't yield a valid vault. The
   // empty-vault branch (no vaults registered) is the original case. A
   // locked-vault picker (multi-user Phase 1) always has a valid value via
@@ -418,6 +445,7 @@ export function renderConsent(props: ConsentViewProps): string {
         ${renderCsrfHiddenInput(csrfToken)}
         ${renderHiddenInputs(params)}
         ${pickerSection}
+        ${verbSelectorSection}
         <div class="button-row">
           <button type="submit" name="approve" value="yes" class="btn btn-primary"${approveDisabled}>Approve</button>
           <button type="submit" name="approve" value="no" class="btn btn-secondary">Deny</button>
@@ -488,6 +516,60 @@ function renderVaultPicker(picker: VaultPicker): string {
             ${verbList} apply to the vault you select below.
           </p>
           <div class="vault-options">${options}
+          </div>
+        </section>`;
+}
+
+/**
+ * hub#689 — owner-on-own-vault verb selector. Rendered only when the
+ * consenting user owns (holds admin on) every vault they could pick and the
+ * client requested an unnamed `vault:read`/`vault:write` verb. Three radios
+ * (read / write / admin), pre-selected to **admin** so the common case (the
+ * owner's own AI client that needs full access) is one click — but the owner
+ * sees and submits the choice, and can downgrade.
+ *
+ * The `admin` option keeps the `.scope-admin` red border + admin badge so an
+ * admin grant stays visibly flagged even when pre-selected. The submitted
+ * `verb_select` is an untrusted hint re-checked server-side (ownership
+ * re-derivation in `handleConsentSubmit` + `capScopesToUserAuthority` backstop);
+ * this template only renders the choice.
+ */
+function renderOwnerVerbSelector(selector: OwnerVerbSelector): string {
+  const requested = selector.requestedVerbs.map((v) => `<code>vault:${escapeHtml(v)}</code>`);
+  const requestedList =
+    requested.length === 1
+      ? requested[0]
+      : `${requested.slice(0, -1).join(", ")} and ${requested.at(-1)}`;
+  const option = (
+    verb: "read" | "write" | "admin",
+    title: string,
+    desc: string,
+    checked: boolean,
+  ): string => {
+    const isAdmin = verb === "admin";
+    const cls = `verb-option${isAdmin ? " verb-option-admin scope-admin" : ""}`;
+    const badge = isAdmin ? `<span class="badge badge-admin">admin</span>` : "";
+    return `
+            <label class="${cls}">
+              <input type="radio" name="verb_select" value="${verb}"${checked ? " checked" : ""} />
+              <span class="verb-option-body">
+                <span class="verb-option-head">
+                  <span class="verb-option-title">${escapeHtml(title)}</span>
+                  ${badge}
+                </span>
+                <span class="verb-option-desc">${escapeHtml(desc)}</span>
+              </span>
+            </label>`;
+  };
+  return `
+        <section class="verb-selector">
+          <h2 class="scopes-title">Access level</h2>
+          <p class="picker-help">
+            This app asked for ${requestedList} access to your vault. Because you own
+            this vault, you can grant a different level — admin is selected so your app
+            can do everything it might need; lower it if you'd rather not.
+          </p>
+          <div class="verb-options">${option("read", "Read only", "View notes, tags, attachments, and config.", false)}${option("write", "Read & write", "Create, edit, and delete notes, tags, and attachments.", false)}${option("admin", "Admin", "Full access plus config, triggers/automation, GitHub backup, and minting tokens.", true)}
           </div>
         </section>`;
 }
@@ -1282,6 +1364,47 @@ const STYLES = `
     font-size: 0.88rem;
     color: ${PALETTE.fg};
   }
+  /* hub#689 — owner-on-own-vault verb selector. Same card shell as the
+     vault picker; the admin option carries the .scope-admin red border so an
+     admin grant stays visibly flagged even when pre-selected. */
+  .verb-selector {
+    margin: 0 0 1.25rem;
+    padding: 0.75rem 0.85rem;
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 6px;
+    background: ${PALETTE.bgSoft};
+  }
+  .verb-selector .scopes-title { margin-bottom: 0.4rem; }
+  .verb-options {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+  .verb-option {
+    display: flex;
+    align-items: flex-start;
+    gap: 0.5rem;
+    padding: 0.5rem 0.65rem;
+    border: 1px solid ${PALETTE.border};
+    border-radius: 6px;
+    background: ${PALETTE.cardBg};
+    cursor: pointer;
+    transition: border-color 0.15s ease, background 0.15s ease;
+  }
+  .verb-option:hover { border-color: ${PALETTE.accent}; }
+  .verb-option input[type=radio] { margin-top: 0.25rem; }
+  .verb-option input[type=radio]:focus { outline: 2px solid ${PALETTE.accent}; outline-offset: 2px; }
+  .verb-option-body { display: flex; flex-direction: column; gap: 0.1rem; }
+  .verb-option-head {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    flex-wrap: wrap;
+  }
+  .verb-option-title { font-weight: 500; color: ${PALETTE.fg}; font-size: 0.9rem; }
+  .verb-option-desc { font-size: 0.82rem; color: ${PALETTE.fgMuted}; }
+  .verb-option-admin .verb-option-title { color: ${PALETTE.danger}; }
+
   .vault-picker-empty .picker-help { color: ${PALETTE.danger}; }
   .vault-picker-empty .picker-help code { color: ${PALETTE.fg}; }
   .vault-picker-locked .picker-help { color: ${PALETTE.fgMuted}; }

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -42,7 +42,8 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
     level: "write",
   },
   "vault:admin": {
-    label: "Full vault access plus configuration changes (rotate tokens, change settings).",
+    label:
+      "Read and write everything, plus admin: config & settings, triggers & automation, GitHub backup, and minting access tokens.",
     level: "admin",
   },
   // Optional-module scopes (scribe / agent). These are in FIRST_PARTY_SCOPES


### PR DESCRIPTION
Closes #689. Two legs in one PR; both ship on the `rc` track (no `@latest`).

## Leg 1 — sharper admin-scope consent copy (no behavior change)
The `vault:admin` entry in `SCOPE_EXPLANATIONS` (`src/scope-explanations.ts`) now enumerates what admin actually grants so the consent screen is honest about the blast radius:

> Read and write everything, plus admin: config & settings, triggers & automation, GitHub backup, and minting access tokens.

(was the vague "Full vault access plus configuration changes…"). Updated the label/level assertions in `scope-explanations.test.ts` and the one literal-label assertion in `oauth-ui.test.ts`.

## Leg 2 — owner-on-own-vault verb selector (the real fix)
**The bug:** the hub minted exactly the scope the client requested, and the consent screen had only a vault picker — no verb selector. So an owner whose AI client requested an unnamed `vault:read` was minted read-only and failed on first write ("didn't have update-tag") with no in-flow upgrade, even though the owner already *holds* admin. The blocker was purely the requested-scope shape.

**The fix:** the consent screen now renders a read/write/admin selector (`name="verb_select"`), **pre-selected to admin**, whenever the consenting user owns (holds admin on) every vault they could pick. On submit, the selected level widens the unnamed verb on the **picked** vault — applied **before** `narrowVaultScopes`, and before `capScopesToUserAuthority` (which is left untouched). The owner can downgrade; the admin option keeps the `.scope-admin` red border + `badge-admin`.

- UI: `src/oauth-ui.ts` — new `OwnerVerbSelector` prop on `ConsentViewProps`, `renderOwnerVerbSelector()`, CSS, threaded through `renderConsent`.
- Submit + render decision: `src/oauth-handlers.ts` — widening in `handleConsentSubmit`; `consentProps` gated by a server-derived "holds admin on every pickable vault" boolean.

## Security invariants (this is scope elevation — enforced + tested)
- **`verb_select` is an UNTRUSTED hint.** `handleConsentSubmit` re-derives ownership of the **picked** vault server-side (`vaultVerbsForUserVault(db, session.userId, pickedVault)` must include `admin`) before honoring it — the client field never grants authority.
- **`capScopesToUserAuthority` stays the backstop** on every mint path (`issueAuthCodeRedirect`), unchanged. A forged `verb_select=admin` from a non-owner / read-only-assigned user is capped to their real authority, NOT elevated. A forged pick of an **unassigned** vault is refused 400 by the existing assignment-mismatch gate before widening runs.
- **Widening is scoped:** only unnamed `vault:read`/`vault:write` on the picked vault are rewritten — named scopes and every other scope pass through untouched.
- **Transparent:** an admin grant still renders the admin badge / red border even when pre-selected.

The GET-render decision re-derives admin-holding per assigned vault so the selector is offered only to a genuine owner (a `role=read` user sees no selector — render-side precision; the submit path + cap are the authority).

## Tests (full matrix)
- Leg 1: admin label enumerates the new items.
- owner + unnamed `vault:read` + selects admin → minted `vault:<picked>:admin`; selects write → `:write`; selects read (downgrade on an unnamed `vault:write`) → `:read`.
- selector RENDERED for an owner of the picked vault; NOT rendered for a non-owner (zero-vault non-admin) or a read-only-assigned user.
- **security:** read-only-assigned non-owner forges `verb_select=admin` → minted `vault:work:read`, not admin (cap is the backstop; grant row carries no admin); forged admin against an unassigned vault → 400, no mint.
- admin selection still renders the admin badge / red border; no-`verb_select` form → unchanged narrowing.

## Gates
- `bun test ./src` → **3802 pass / 1 skip / 0 fail**
- `bun run typecheck` → **clean**
- `bunx biome check` → **clean on all changed files** (the pre-existing repo-wide string-concat lint at the `same-origin check failed` log line in `oauth-handlers.ts` is outside this diff and left as-is, per scope).

## Version
`0.7.4-rc.2` → `0.7.4-rc.3` (rc track, no `@latest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)