### PR TITLE
fix(security): defense-in-depth at the public boundary — op-snapshot gate, DCR redirect_uri hygiene, Tier-1 proxy CSP (rc.4)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.3",
+  "version": "0.7.4-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/clients.test.ts
+++ b/src/__tests__/clients.test.ts
@@ -151,7 +151,10 @@ describe("expandRedirectUrisForHubOrigins (surface#118 cross-hub-origin DCR expa
   const hubOrigins = [LOOPBACK, "http://localhost:1939", PUBLIC];
 
   test("expands a loopback-rooted URI onto every other hub origin", () => {
-    const out = expandRedirectUrisForHubOrigins([`${LOOPBACK}/surface/notes/oauth/callback`], hubOrigins);
+    const out = expandRedirectUrisForHubOrigins(
+      [`${LOOPBACK}/surface/notes/oauth/callback`],
+      hubOrigins,
+    );
     // Original is preserved + the public + localhost variants are added.
     expect(out).toContain(`${LOOPBACK}/surface/notes/oauth/callback`);
     expect(out).toContain(`${PUBLIC}/surface/notes/oauth/callback`);
@@ -188,10 +191,7 @@ describe("expandRedirectUrisForHubOrigins (surface#118 cross-hub-origin DCR expa
   });
 
   test("single known hub origin → no expansion (submitted set returned as-is)", () => {
-    const out = expandRedirectUrisForHubOrigins(
-      [`${LOOPBACK}/surface/notes/`],
-      [LOOPBACK],
-    );
+    const out = expandRedirectUrisForHubOrigins([`${LOOPBACK}/surface/notes/`], [LOOPBACK]);
     expect(out).toEqual([`${LOOPBACK}/surface/notes/`]);
   });
 
@@ -222,9 +222,9 @@ describe("expandRedirectUrisForHubOrigins (surface#118 cross-hub-origin DCR expa
       const r = registerClient(db, { redirectUris: expanded });
       // The public-origin variant now matches exactly at authorize time — the
       // off-localhost sign-in that surface#118 broke.
-      expect(
-        requireRegisteredRedirectUri(r.client, `${PUBLIC}/surface/notes/oauth/callback`),
-      ).toBe(`${PUBLIC}/surface/notes/oauth/callback`);
+      expect(requireRegisteredRedirectUri(r.client, `${PUBLIC}/surface/notes/oauth/callback`)).toBe(
+        `${PUBLIC}/surface/notes/oauth/callback`,
+      );
       // A truly-unregistered URI is still rejected — strict match unchanged.
       expect(() =>
         requireRegisteredRedirectUri(r.client, "https://evil.example/surface/notes/oauth/callback"),
@@ -351,5 +351,25 @@ describe("isValidRedirectUri", () => {
     expect(isValidRedirectUri("data:text/html,x")).toBe(false);
     expect(isValidRedirectUri("/relative")).toBe(false);
     expect(isValidRedirectUri("not a url")).toBe(false);
+  });
+  // hub#663: spec-forbidden shapes that the protocol allowlist alone passed.
+  test("rejects userinfo-bearing redirect URIs (hub#663)", () => {
+    expect(isValidRedirectUri("https://x@evil.com/cb")).toBe(false);
+    expect(isValidRedirectUri("https://user:pass@evil.com/cb")).toBe(false);
+    expect(isValidRedirectUri("http://attacker@127.0.0.1:3000/cb")).toBe(false);
+  });
+  test("rejects control chars in the raw input (hub#663)", () => {
+    // Control chars must be caught on the RAW string — URL parsing would
+    // otherwise strip a trailing \r\n and the smuggled value would pass.
+    expect(isValidRedirectUri("https://example.com/cb\r\nSet-Cookie: x")).toBe(false);
+    expect(isValidRedirectUri("https://example.com/\x00cb")).toBe(false);
+    expect(isValidRedirectUri("https://example.com/cb\x7f")).toBe(false);
+  });
+  test("still accepts clean http(s) with ports, paths, and queries (regression guard)", () => {
+    // Legitimate clients (hub modules, self-built surfaces, Notes, Claude DCR)
+    // all register clean URIs — these must keep passing.
+    expect(isValidRedirectUri("https://claude.ai/api/mcp/auth_callback")).toBe(true);
+    expect(isValidRedirectUri("http://localhost:1939/admin/oauth/callback")).toBe(true);
+    expect(isValidRedirectUri("https://my-surface.github.io/cb?x=1")).toBe(true);
   });
 });

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -3,10 +3,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import {
-  _resetBootstrapTokenForTests,
-  generateBootstrapToken,
-} from "../bootstrap-token.ts";
+import { _resetBootstrapTokenForTests, generateBootstrapToken } from "../bootstrap-token.ts";
 import { buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
 import { createDbHolder } from "../hub-db-liveness.ts";
@@ -3715,7 +3712,9 @@ describe("layerOf — classify trust layer from proxy headers + peer (item E / #
   // flipped an empty XFF back to loopback would re-open the Caddy-direct leak.
   test("loopback peer + empty X-Forwarded-For → public (errs safe, not loopback) [#704]", () => {
     expect(layerOf(req("/", { headers: { "X-Forwarded-For": "" } }), "127.0.0.1")).toBe("public");
-    expect(layerOf(req("/", { headers: { "X-Forwarded-For": "   " } }), "127.0.0.1")).toBe("public");
+    expect(layerOf(req("/", { headers: { "X-Forwarded-For": "   " } }), "127.0.0.1")).toBe(
+      "public",
+    );
   });
 
   // The genuine on-box caller (CLI, health probe, init bootstrap-token loopback
@@ -6086,6 +6085,129 @@ describe("GET /admin/setup bootstrap-token probe — loopback-gated (hub#576 + C
       }
     } finally {
       _resetBootstrapTokenForTests();
+      h.cleanup();
+    }
+  });
+});
+
+// hub#643 (Tier-1): non-script security headers on proxied module/surface
+// text/html pages. The vault content proxy and the generic services-mount
+// proxy both flow through `decorateWithChrome`, so the headers land on both.
+// DELIBERATELY no `script-src` — a strict script-src would white-screen
+// self-built GitHub-hosted surfaces + inline-script module pages (that's the
+// deferred Tier-2). Header-only: non-HTML proxied responses are NOT decorated.
+describe("hubFetch proxied-page security headers (hub#643 Tier-1)", () => {
+  const TIER1_CSP = "frame-ancestors 'self'; object-src 'none'; base-uri 'self'";
+
+  // Live upstream that echoes a fixed content-type + body so the test can
+  // exercise both the text/html (decorated) and JSON (untouched) branches.
+  function startUpstream(contentType: string, body: string): { port: number; stop: () => void } {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () => new Response(body, { status: 200, headers: { "content-type": contentType } }),
+    });
+    return { port: server.port as number, stop: () => server.stop(true) };
+  }
+
+  test("decorates a proxied text/html generic-mount page with nosniff + the Tier-1 CSP", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream(
+      "text/html; charset=utf-8",
+      "<html><body><h1>my surface</h1></body></html>",
+    );
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-surface",
+              port: upstream.port,
+              paths: ["/surface"],
+              health: "/surface/health",
+              version: "0.2.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(req("/surface/foo"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      const csp = res.headers.get("content-security-policy");
+      expect(csp).toBe(TIER1_CSP);
+      // The critical Tier-1/Tier-2 boundary: NO script-src — self-built
+      // GitHub-hosted surfaces + inline-script module pages must stay
+      // unrestricted. A strict script-src is the deferred Tier-2.
+      expect(csp).not.toContain("script-src");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("decorates a proxied text/html per-vault page (the Notes-PWA path) with the same headers", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("text/html; charset=utf-8", "<html><body>notes</body></html>");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              port: upstream.port,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/vault/default/some-page"),
+      );
+      expect(res.status).toBe(200);
+      expect(res.headers.get("x-content-type-options")).toBe("nosniff");
+      expect(res.headers.get("content-security-policy")).toBe(TIER1_CSP);
+      expect(res.headers.get("content-security-policy")).not.toContain("script-src");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("leaves a proxied NON-HTML response (JSON) undecorated", async () => {
+    const h = makeHarness();
+    const upstream = startUpstream("application/json", JSON.stringify({ ok: true }));
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-surface",
+              port: upstream.port,
+              paths: ["/surface"],
+              health: "/surface/health",
+              version: "0.2.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(req("/surface/api/data"));
+      expect(res.status).toBe(200);
+      expect(res.headers.get("content-type")).toContain("application/json");
+      // No HTML CSP on a JSON API response (proves the header is gated on
+      // content-type, so a `.js` asset proxied through the same path is also
+      // left alone).
+      expect(res.headers.get("content-security-policy")).toBeNull();
+      expect(res.headers.get("x-content-type-options")).toBeNull();
+      const body = (await res.json()) as { ok: boolean };
+      expect(body.ok).toBe(true);
+    } finally {
+      upstream.stop();
       h.cleanup();
     }
   });

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -990,6 +990,123 @@ describe("handleSetupGet", () => {
       db.close();
     }
   });
+
+  // hub#618: gate the JSON `?op=` op-snapshot once setup is complete.
+  // Mid-setup it stays OPEN (the unauth CLI wizard + brand-new-operator
+  // browser both poll it before any session exists); post-complete it
+  // requires a session or loopback (it's a post-setup admin surface, and
+  // `/admin/setup` is always lockout-exempt so it's otherwise unauth-reachable).
+
+  test("mid-setup unauth ?op= still returns the op snapshot (hub#618 regression guard)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      // No admin yet → setup INCOMPLETE → the surface stays open.
+      const reg = getDefaultOperationsRegistry();
+      const op = reg.create("install", "vault");
+      reg.update(op.id, { status: "running" }, "running bun add -g @openparachute/vault@latest");
+      const res = handleSetupGet(
+        req(`/admin/setup?op=${op.id}`, { headers: { accept: "application/json" } }),
+        {
+          db,
+          manifestPath: h.manifestPath,
+          configDir: h.dir,
+          readExposeStateFn: h.readExposeStateFn,
+          issuer: "https://hub.example",
+          registry: reg,
+          // No loopback flag, no session — the unauth first-boot poll.
+        },
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        hasAdmin: boolean;
+        operation?: { id: string; status: string; log: readonly string[] };
+      };
+      expect(body.hasAdmin).toBe(false);
+      expect(body.operation).toBeDefined();
+      expect(body.operation?.id).toBe(op.id);
+      expect(body.operation?.status).toBe("running");
+    } finally {
+      db.close();
+    }
+  });
+
+  test("post-complete unauth ?op= omits the op snapshot; session OR loopback restores it (hub#618)", async () => {
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      // Drive state to COMPLETE: admin + vault + expose mode.
+      const user = await createUser(db, "owner", "pw");
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault",
+              version: "0.1.0",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      setSetting(db, "setup_expose_mode", "localhost");
+      const reg = getDefaultOperationsRegistry();
+      const op = reg.create("install", "vault");
+      reg.update(op.id, { status: "running" }, "still running");
+
+      const deps = {
+        db,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        readExposeStateFn: h.readExposeStateFn,
+        issuer: "https://hub.example",
+        registry: reg,
+      };
+
+      // (a) Unauth, non-loopback → operation omitted.
+      const unauth = handleSetupGet(
+        req(`/admin/setup?op=${op.id}`, { headers: { accept: "application/json" } }),
+        deps,
+      );
+      expect(unauth.status).toBe(200);
+      const unauthBody = (await unauth.json()) as {
+        hasAdmin: boolean;
+        hasVault: boolean;
+        hasExposeMode: boolean;
+        operation?: unknown;
+      };
+      // Confirm setup actually derived as complete (else the gate is vacuous).
+      expect(unauthBody.hasAdmin).toBe(true);
+      expect(unauthBody.hasVault).toBe(true);
+      expect(unauthBody.hasExposeMode).toBe(true);
+      expect(unauthBody.operation).toBeUndefined();
+
+      // (b) Valid session → operation restored.
+      const { createSession } = await import("../sessions.ts");
+      const session = createSession(db, { userId: user.id });
+      const authed = handleSetupGet(
+        req(`/admin/setup?op=${op.id}`, {
+          headers: {
+            accept: "application/json",
+            cookie: `${SESSION_COOKIE_NAME}=${session.id}`,
+          },
+        }),
+        deps,
+      );
+      const authedBody = (await authed.json()) as { operation?: { id: string } };
+      expect(authedBody.operation?.id).toBe(op.id);
+
+      // (c) Loopback (no session) → operation restored.
+      const loopback = handleSetupGet(
+        req(`/admin/setup?op=${op.id}`, { headers: { accept: "application/json" } }),
+        { ...deps, requestIsLoopback: true },
+      );
+      const loopbackBody = (await loopback.json()) as { operation?: { id: string } };
+      expect(loopbackBody.operation?.id).toBe(op.id);
+    } finally {
+      db.close();
+    }
+  });
 });
 
 // --- POST /admin/setup/account -------------------------------------------

--- a/src/clients.ts
+++ b/src/clients.ts
@@ -323,9 +323,23 @@ function timingSafeEqualHex(a: string, b: string): boolean {
  * URIs). Doesn't try to match a registered URI; that's `requireRegisteredRedirectUri`.
  */
 export function isValidRedirectUri(uri: string): boolean {
+  // hub#663: reject control chars (C0 0x00-0x1f + DEL 0x7f) in the RAW input
+  // BEFORE URL parsing normalizes/strips them. A `\r`/`\n`/NUL smuggled into a
+  // redirect_uri is a header/log-injection vector even though our exact-match +
+  // verbatim foreign-storage neutralize it downstream — spec-forbidden hygiene.
+  // (Charcode scan rather than a control-char regex literal, which biome's
+  // noControlCharactersInRegex rightly flags as an easy footgun.)
+  for (let i = 0; i < uri.length; i++) {
+    const c = uri.charCodeAt(i);
+    if (c <= 0x1f || c === 0x7f) return false;
+  }
   try {
     const u = new URL(uri);
     if (u.protocol === "javascript:" || u.protocol === "data:") return false;
+    // hub#663: reject userinfo (`https://x@evil.com/cb`). A redirect target
+    // carrying credentials is spec-forbidden and an open-redirect / phishing
+    // shape; the protocol allowlist alone let it through.
+    if (u.username !== "" || u.password !== "") return false;
     return u.protocol === "http:" || u.protocol === "https:";
   } catch {
     return false;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -3824,13 +3824,57 @@ async function decorateWithChrome(
   if (setCookie && out !== res) {
     const headers = new Headers(out.headers);
     headers.append("set-cookie", setCookie);
-    return new Response(out.body, {
-      status: out.status,
-      statusText: out.statusText,
-      headers,
-    });
+    return withProxySecurityHeaders(
+      new Response(out.body, {
+        status: out.status,
+        statusText: out.statusText,
+        headers,
+      }),
+    );
   }
-  return out;
+  // hub#643: every exit runs through the security-header step, which self-
+  // gates on content-type — so a non-HTML pass-through (`out === res`, e.g. a
+  // 502 proxy error or a JSON/asset body) is returned unchanged, preserving
+  // the pre-existing behavior for those responses.
+  return withProxySecurityHeaders(out);
+}
+
+/**
+ * hub#643 (Tier-1): stamp non-script security headers on proxied `text/html`
+ * pages — the per-vault `/vault/<name>/*` proxy and the generic
+ * services-mount `/<mount>/*` proxy both flow through `decorateWithChrome`,
+ * so this is the single chokepoint that covers a module / surface page.
+ *
+ *   - `X-Content-Type-Options: nosniff` — stops content-type sniffing.
+ *   - `Content-Security-Policy: frame-ancestors 'self'; object-src 'none';
+ *     base-uri 'self'` — clickjacking (external framing) + plugin + base-tag
+ *     hardening.
+ *
+ * Deliberately NO `script-src`: a strict script-src would white-screen
+ * self-built GitHub-hosted surfaces (the primary surface story) and
+ * inline-script module pages. The opt-in strict script-src CSP is Tier-2,
+ * explicitly deferred (hub#643 stays open).
+ *
+ * Header-only: we never buffer the body. Only `text/html` responses are
+ * decorated, so JSON / `.js` / CSS / image assets proxied through the same
+ * path are left untouched. Existing headers are preserved (a fresh Headers
+ * copy is mutated); we set (not append) so a re-decorated response can't
+ * accumulate duplicates.
+ */
+function withProxySecurityHeaders(res: Response): Response {
+  const contentType = res.headers.get("content-type") ?? "";
+  if (!contentType.toLowerCase().includes("text/html")) return res;
+  const headers = new Headers(res.headers);
+  headers.set("x-content-type-options", "nosniff");
+  headers.set(
+    "content-security-policy",
+    "frame-ancestors 'self'; object-src 'none'; base-uri 'self'",
+  );
+  return new Response(res.body, {
+    status: res.status,
+    statusText: res.statusText,
+    headers,
+  });
 }
 
 if (import.meta.main) {

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1592,14 +1592,33 @@ export function handleSetupGet(req: Request, deps: SetupWizardDeps): Response {
     // poll on the auth the wizard already carries.
     const opId = url.searchParams.get("op");
     if (opId) {
-      const op = deps.registry?.get(opId);
-      if (op) {
-        envelope.operation = {
-          id: op.id,
-          status: op.status,
-          log: op.log,
-          ...(op.error !== undefined ? { error: op.error } : {}),
-        };
+      // hub#618: post-setup this JSON `?op=` surface is unauth-reachable —
+      // `/admin/setup` is always lockout-exempt (the dispatcher's
+      // `shouldGateForSetup` lets it through so a stale bookmark resolves), and
+      // the snapshot is read BEFORE any session check. The leak is small (an
+      // in-memory op's status + install-progress log lines, behind an
+      // unguessable UUID), but it's still a post-setup admin surface, so gate
+      // it once setup is COMPLETE. During setup (no admin yet) the surface
+      // stays OPEN: the unauth CLI wizard (`parachute init`) AND the brand-new-
+      // operator browser both poll this `?op=` snapshot mid-setup before any
+      // session exists — gating then would break first-boot vault
+      // provisioning. Loopback always passes (same on-box trust as the
+      // `bootstrapToken` branch below); a valid session also passes.
+      const setupComplete = state.hasAdmin && state.hasVault && state.hasExposeMode;
+      const opSnapshotAllowed =
+        !setupComplete ||
+        deps.requestIsLoopback === true ||
+        findActiveSession(deps.db, req) !== null;
+      if (opSnapshotAllowed) {
+        const op = deps.registry?.get(opId);
+        if (op) {
+          envelope.operation = {
+            id: op.id,
+            status: op.status,
+            log: op.log,
+            ...(op.error !== undefined ? { error: op.error } : {}),
+          };
+        }
       }
     }
     // hub#576: hand the actual token to a LOOPBACK caller only. The on-box


### PR DESCRIPTION
Three independent defense-in-depth fixes for the public boundary, one commit each. All low-regression — the regression guards are the load-bearing part. rc track (rc.3 → rc.4), no @latest.

## Commit 1 — `fix(setup): gate post-setup op-snapshot from unauth callers` (Closes #618)
`GET /admin/setup` with `Accept: application/json` returns an op-snapshot (status + install-progress log) BEFORE any session check, and `/admin/setup` is always lockout-exempt — so post-setup the JSON `?op=` surface is unauth-reachable. Low severity (leaks only install-progress strings behind an unguessable in-memory UUID).

**Fix:** in `handleSetupGet`'s JSON branch, once `deriveWizardState` reports setup COMPLETE (`hasAdmin && hasVault && hasExposeMode`), populate `envelope.operation` only when `findActiveSession(deps.db, req)` succeeds OR the request is loopback (same on-box trust as the existing `bootstrapToken` branch).

**Regression guard:** during setup (no admin yet) the surface stays OPEN — the unauth CLI wizard (`parachute init`) and the brand-new-operator browser both poll this `?op=` snapshot mid-setup before any session exists; gating then would break first-boot vault provisioning. The gate engages ONLY once setup is complete and still allows loopback.

## Commit 2 — `fix(oauth): reject malformed redirect_uris at DCR` (Closes #663)
`isValidRedirectUri` checked only the protocol, so userinfo-bearing (`https://x@evil.com/cb`) and control-char redirect_uris registered cleanly. Low severity — exact-match + verbatim foreign-storage neutralize them today — but spec-forbidden and a header/log-injection + phishing shape.

**Fix:** after parsing, also reject (a) userinfo (`u.username !== "" || u.password !== ""`); (b) control chars (C0 `0x00–0x1f` + DEL `0x7f`) scanned on the RAW input string BEFORE URL normalization strips a trailing CRLF (charcode scan rather than a control-char regex literal, which biome's `noControlCharactersInRegex` rightly flags). Protocol allowlist unchanged; enforced at both DCR (`oauth-handlers`) and `registerClient`.

**Regression guard:** clean http(s) URIs (hub modules, self-built surfaces, Notes, Claude DCR) keep registering — covered by an explicit accept-case test.

## Commit 3 — `feat(proxy): non-script security headers on proxied module/surface pages` (Addresses #643 — Tier-1 only — Tier-2 opt-in strict script-src CSP deferred pending sign-off)
Add to proxied **text/html** responses (the per-vault `/vault/<name>/*` proxy AND the generic services-mount `/<mount>/*` proxy): `X-Content-Type-Options: nosniff` and `Content-Security-Policy: frame-ancestors 'self'; object-src 'none'; base-uri 'self'`.

**Fix:** a new header-only `withProxySecurityHeaders` step at the tail of `decorateWithChrome` — the single chokepoint that already wraps both proxies. Gated on `text/html` content-type, no body buffering. Set (not append) so a re-decorated response can't accumulate duplicates.

**Regression guard:** NO `script-src` directive — a strict script-src would white-screen self-built GitHub-hosted surfaces (the primary surface story) and inline-script module pages (that's Tier-2, deferred — #643 stays open). None of the three directives touch script execution, so the admin SPA (served via `serveSpa`, out of this path), the Notes PWA (chrome-opt-out but still text/html → gets the headers), and a self-built surface all still load. The CSP-no-`script-src` boundary is asserted in the test as a load-bearing negative.

## Gates
- `bun test ./src` — **3810 pass, 1 skip, 0 fail** (3811 ran across 146 files)
- `bun run typecheck` — clean
- `bunx biome check` — all changed files clean (the pre-existing repo-wide `package.json`/string-concat error on main is untouched)

## Tests added
- `setup-wizard.test.ts`: mid-setup unauth `?op=` still returns the snapshot; post-complete unauth `?op=` omits `operation`, while a valid session OR loopback restores it.
- `clients.test.ts`: userinfo URIs rejected; control-char URIs rejected; clean http(s) still accepted.
- `hub-server.test.ts`: proxied text/html (generic mount + per-vault) carries `nosniff` + the Tier-1 CSP and NO `script-src`; a proxied JSON response is left undecorated.

Reviewed by an independent reviewer subagent (LGTM with optional nits; nit #1 applied as a clarifying comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)