### PR TITLE
fix(deps): publish depcheck 0.1.1 + re-pin hub — fix fresh-install crash since rc.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.7",
+  "version": "0.7.4-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -40,7 +40,7 @@
   },
   "dependencies": {
     "@node-rs/argon2": "^2.0.2",
-    "@openparachute/depcheck": "0.1.0",
+    "@openparachute/depcheck": "0.1.1",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4"

--- a/packages/depcheck/package.json
+++ b/packages/depcheck/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/depcheck",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Canonical missing-dependency UX for Parachute modules: a dependency registry, a message formatter, and ENOENT spawn-error helpers shared across vault / scribe / runner / hub.",
   "license": "AGPL-3.0",
   "type": "module",


### PR DESCRIPTION
Fresh-install live-test (the #478 Part-2 droplet) caught `parachute init` crashing: `Export named 'NonExecutableError' not found in @openparachute/depcheck/dist/index.js`. hub#634 (rc.5) added the export to depcheck's source but never bumped/republished depcheck (still 0.1.0 on npm), while hub pins it exactly — so fresh npm installs get the stale depcheck. Local dev/CI masked it via the build:depcheck prepare hook. **@latest (0.7.3) unaffected** (predates the export); only @rc (rc.5–rc.7) broken on fresh install.\n\n**Fix:** depcheck 0.1.0→0.1.1 (source already exports NonExecutableError; prepublishOnly builds dist), hub dep re-pinned 0.1.1, hub rc.7→rc.8.\n\n**Publish order (manual tags):** `depcheck-v0.1.1` FIRST → wait for npm → `v0.7.4-rc.8`. Then re-run the fresh-install live-test (was blocked by this).\n\nFollow-up: the depcheck-source-in-hub-repo-but-separately-published model is drift-prone (the prepare hook hides published staleness) — file a hardening issue (bundle into hub, or a CI check that the pinned depcheck version is published with the symbols hub imports).