### PR TITLE
fix(vaults): skip empty-paths rows in well-known + consent — finish the #478 phantom-default contract

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.8",
+  "version": "0.7.4-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -2914,6 +2914,75 @@ describe("handleToken — full OAuth dance", () => {
         notes: { url: `${ISSUER}/notes`, version: "0.3.0" },
       });
     });
+
+    // closes #478 — an empty-paths vault row ("installed but no servable
+    // instance"; vault's self-register emits `paths: []` at zero vaults) must
+    // NOT synthesize a phantom `vault` / `vault:default` entry pointing at
+    // root in the /oauth/token services catalog. Pre-fix the `["/"]` fallback
+    // resolved `vaultInstanceNameFor(name, "/")` → "default" and advertised
+    // `${ISSUER}/` as the vault. Mirrors the skip in well-known.ts /
+    // admin-vaults.ts / vault-names.ts.
+    test("empty-paths vault row produces NO catalog entry — no phantom default (#478)", () => {
+      const emptyPathsManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: [],
+            health: "/vault/default/health",
+            version: "0.7.0",
+          },
+        ],
+      };
+      // Broad scope: would have leaked `vault` + `vault:default` at `/`.
+      expect(buildServicesCatalog(emptyPathsManifest, ISSUER, ["vault:read"])).toEqual({});
+      // Per-vault-narrowed scope for the phantom name: also nothing.
+      expect(buildServicesCatalog(emptyPathsManifest, ISSUER, ["vault:default:read"])).toEqual({});
+    });
+
+    test("positive control: a vault row WITH a path is still cataloged (#478)", () => {
+      const realManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/vault/default/health",
+            version: "0.7.0",
+          },
+        ],
+      };
+      expect(buildServicesCatalog(realManifest, ISSUER, ["vault:read"])).toEqual({
+        vault: { url: `${ISSUER}/vault/default`, version: "0.7.0" },
+      });
+    });
+
+    test("empty-paths vault row alongside a real vault: only the real one is cataloged (#478)", () => {
+      // A transitional manifest could carry both a path-less bare row and a
+      // real instance row. The empty-paths row must contribute nothing; the
+      // real vault is unaffected.
+      const mixedManifest: ServicesManifest = {
+        services: [
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: [],
+            health: "/vault/default/health",
+            version: "0.7.0",
+          },
+          {
+            name: "parachute-vault-work",
+            port: 1941,
+            paths: ["/vault/work"],
+            health: "/vault/work/health",
+            version: "0.7.0",
+          },
+        ],
+      };
+      expect(buildServicesCatalog(mixedManifest, ISSUER, ["vault:read"])).toEqual({
+        vault: { url: `${ISSUER}/vault/work`, version: "0.7.0" },
+      });
+    });
   });
 });
 

--- a/src/__tests__/well-known.test.ts
+++ b/src/__tests__/well-known.test.ts
@@ -472,13 +472,48 @@ describe("buildWellKnown", () => {
     );
   });
 
-  test("falls back to / for empty paths", () => {
+  test("an empty-paths VAULT row is skipped entirely — no phantom default (#478)", () => {
+    // A vault services row with `paths: []` means "module installed but no
+    // servable vault instance" (vault's self-register emits this at zero
+    // vaults). It must NOT fabricate a vault entry at root in either the
+    // `vaults` array or the flat `services` catalog. Mirrors the empty-paths
+    // skip in admin-vaults.ts / vault-names.ts / oauth-handlers.ts.
     const entry: ServiceEntry = { ...vault, paths: [] };
     const doc = buildWellKnown({
       services: [entry],
       canonicalOrigin: "https://x.example",
     });
-    expect(doc.vaults[0]?.url).toBe("https://x.example/");
+    expect(doc.vaults).toEqual([]);
+    // The row contributes nothing to the flat services list either — no
+    // phantom `/` mount advertised.
+    expect(doc.services).toEqual([]);
+  });
+
+  test("positive control: a vault row WITH a path still emits its vault + services entries (#478)", () => {
+    const doc = buildWellKnown({
+      services: [{ ...vault, paths: ["/vault/default"] }],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.vaults).toEqual([
+      {
+        name: "default",
+        url: "https://x.example/vault/default",
+        version: "0.2.4",
+      },
+    ]);
+    expect(doc.services.map((s) => s.name)).toEqual(["parachute-vault"]);
+  });
+
+  test("a NON-vault row with empty paths still falls back to / (#478 scope guard)", () => {
+    // The empty-paths skip is vault-only. A non-vault service legitimately
+    // mounts at root when path-less — that behavior is unchanged.
+    const entry: ServiceEntry = { ...notes, paths: [] };
+    const doc = buildWellKnown({
+      services: [entry],
+      canonicalOrigin: "https://x.example",
+    });
+    expect(doc.services.map((s) => s.path)).toEqual(["/"]);
+    expect(doc.notes).toEqual([{ url: "https://x.example/", version: "0.0.1" }]);
   });
 
   // Hierarchical sub-units (hub#313 — parachute-app design doc §12). Each

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -294,8 +294,11 @@ export function buildServicesCatalog(
   if (audiences.has("vault")) {
     for (const entry of manifest.services) {
       if (!isVaultEntry(entry)) continue;
-      const paths = entry.paths.length > 0 ? entry.paths : ["/"];
-      for (const path of paths) {
+      // #478: an empty-paths vault row is "installed but no servable instance"
+      // — skip it so it never counts toward (or, below, fabricates) a phantom
+      // vault. Mirrors the continue in well-known.ts / admin-vaults.ts.
+      if (entry.paths.length === 0) continue;
+      for (const path of entry.paths) {
         const instance = vaultInstanceNameFor(entry.name, path);
         if (broadVaultScope || namedVaults.has(instance)) admittedVaultPathCount++;
       }
@@ -308,12 +311,16 @@ export function buildServicesCatalog(
   for (const entry of manifest.services) {
     if (isVaultEntry(entry)) {
       if (!audiences.has("vault")) continue;
+      // #478: an empty-paths vault row is "installed but no servable instance"
+      // — skip it so the catalog never offers a phantom `vault` / `vault:default`
+      // entry pointing at root before any vault exists. Mirrors well-known.ts /
+      // admin-vaults.ts / vault-names.ts.
+      if (entry.paths.length === 0) continue;
       // Walk every path the row exposes. Real multi-vault on the hub is a
       // single `parachute-vault` row with N paths (one per vault instance);
       // legacy per-vault rows (`parachute-vault-<name>`) are handled by the
       // same loop because each contributes one path.
-      const paths = entry.paths.length > 0 ? entry.paths : ["/"];
-      for (const path of paths) {
+      for (const path of entry.paths) {
         const instance = vaultInstanceNameFor(entry.name, path);
         const admit = broadVaultScope || namedVaults.has(instance);
         if (!admit) continue;

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -247,7 +247,16 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
     // multi-path on those is treated as aliases rather than separate
     // installs.
     const isVault = isVaultEntry(s);
-    const pathsToEmit = isVault && s.paths.length > 0 ? s.paths : [s.paths[0] ?? "/"];
+    // #478: an empty-paths VAULT row means "installed but no servable vault
+    // instance" — vault's self-register emits `paths: []` at zero vaults.
+    // Skip it entirely: emitting `["/"]` here would fabricate a phantom vault
+    // entry at root in both the `services` catalog and the `vaults` array.
+    // This mirrors the empty-paths `continue` in admin-vaults.ts / vault-names.ts
+    // so every read path agrees: a vault instance exists only by a real
+    // `/vault/<name>` mount path. Non-vault services keep the `paths[0] ?? "/"`
+    // fallback (a path-less non-vault row legitimately mounts at root).
+    if (isVault && s.paths.length === 0) continue;
+    const pathsToEmit = isVault ? s.paths : [s.paths[0] ?? "/"];
     for (const path of pathsToEmit) {
       const url = new URL(path, `${base}/`).toString();
       const infoUrl = new URL(joinInfoPath(path), `${base}/`).toString();


### PR DESCRIPTION
Completes the **#478 empty-paths contract** — the two remaining read paths that still synthesized a phantom "default" vault from an empty-paths row.

A vault services row with `paths.length === 0` means **"module installed but no servable vault instance"** (vault's `self-register` emits `paths: []` at zero vaults). The contract: SKIP such rows; never synthesize a phantom "default". #707 applied this to `admin-vaults.ts` + `vault-names.ts`; two spots still violated it — caught by a fresh-install live-test where a zero-vault box's `.well-known/parachute.json` advertised a nonexistent `"default"` vault.

## Fixes — well-known catalog + consent picker

1. **`src/well-known.ts` (`buildWellKnown`)** — an empty-paths VAULT row previously fell to `[s.paths[0] ?? "/"]` → `["/"]`, fabricating a phantom vault entry at root in **both** the flat `services` catalog and the `vaults[]` array. Now skipped. Non-vault path-less rows still fall back to `/`; vaults WITH paths and the `SEED_VERSION` guard (hub#577) are unchanged.

2. **`src/oauth-handlers.ts` (`buildServicesCatalog`, both loops)** — the same `entry.paths.length > 0 ? entry.paths : ["/"]` fallback fabricated a phantom `vault` / `vault:default` entry pointing at root in the `/oauth/token` services catalog (the consent picker / named-scope path). Both the `admittedVaultPathCount` counter loop and the catalog-building loop now skip empty-paths vault rows, so the consent/token path never offers or accepts a phantom "default".

Mirrors the `if (paths.length === 0) continue` pattern established in #707, so **all four read paths now agree**: a vault instance exists only by a real `/vault/<name>` mount path.

## Tests
- empty-paths vault row → **absent** from the well-known catalog + the token services catalog (negative)
- positive controls — a vault WITH paths IS present in both
- a non-vault empty-paths row still falls back to `/` (scope guard — the skip is vault-only)
- mixed manifest (empty-paths row alongside a real vault) cataloged correctly

## Self-register health residue (assessed, not changed)
`parachute-vault/src/self-register.ts:181` derives `health = "${paths[0] ?? "/vault/default"}/health"` → `/vault/default/health` at zero vaults. The **only** hub consumer that HTTP-probes `entry.health` is the `defaultProbeModuleHealth` **degraded fallback** in `status.ts` (`hubHealthy && !states` — fires only when the supervisor run-state can't be read, e.g. missing/expired operator token). The normal supervised path checks **port-binding only** and never hits the health URL. So the 404→"inactive" is NOT surfaced on a healthy fresh box; left for a separate vault-side PR (fix the derivation at source) rather than a speculative hub workaround that could mask a genuinely-down vault.

## Gates
- `bun test ./src`: **3833 pass / 1 skip / 0 fail**
- `bun run typecheck`: clean
- `bunx biome check`: clean on the changed files (pre-existing repo-wide errors left as-is per the doc-only/pre-existing exemption)
- `package.json`: `0.7.4-rc.8` → `0.7.4-rc.9`

🤖 Generated with [Claude Code](https://claude.com/claude-code)