### PR TITLE
feat(account): in-SPA account settings — password + 2FA management (#85)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.9",
+  "version": "0.7.4-rc.10",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-account-2fa.test.ts
+++ b/src/__tests__/api-account-2fa.test.ts
@@ -1,0 +1,381 @@
+/**
+ * `/api/account/*` JSON self-service endpoints (hub#85): password change +
+ * 2FA start/confirm/disable. Plus `/api/me`'s `two_factor_enabled` field.
+ *
+ * Coverage:
+ *   - auth: no session → 401; wrong CSRF → 403; self-only (keyed off session)
+ *   - password: happy path (hash rotated + tokens revoked); wrong current →
+ *     401; too short → 400; mismatch handled client-side (not here); new ===
+ *     current → 400; too long → 413
+ *   - 2fa start → secret + qr; already-enrolled → 409
+ *   - 2fa confirm: round-trip with a live code persists + returns backup codes;
+ *     bad code → 400; malformed secret → 400
+ *   - 2fa disable: password-gated (wrong → 401), clears enrollment; idempotent
+ *   - /api/me reflects two_factor_enabled
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import * as OTPAuth from "otpauth";
+import { handleApiAccount } from "../api-account-2fa.ts";
+import { handleApiMe } from "../api-me.ts";
+import { CSRF_COOKIE_NAME } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { recordTokenMint } from "../jwt-sign.ts";
+import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { _resetTotpReplayCache, generateTotpSecret } from "../totp.ts";
+import { isTotpEnrolled, persistEnrollment } from "../two-factor-store.ts";
+import { createUser, verifyPassword } from "../users.ts";
+
+const TEST_CSRF = "csrf-account-2fa-token";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
+
+interface Harness {
+  db: Database;
+  configDir: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const configDir = mkdtempSync(join(tmpdir(), "phub-api-account-2fa-"));
+  const db = openHubDb(hubDbPath(configDir));
+  return {
+    db,
+    configDir,
+    cleanup: () => {
+      db.close();
+      rmSync(configDir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function userWithSession(
+  db: Database,
+  username: string,
+  password: string,
+): Promise<{ userId: string; cookie: string }> {
+  const user = await createUser(db, username, password, { passwordChanged: true });
+  const session = createSession(db, { userId: user.id });
+  const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
+  return { userId: user.id, cookie };
+}
+
+function post(
+  subpath: string,
+  cookie: string | null,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const headers: Record<string, string> = { "content-type": "application/json" };
+  if (cookie) headers.cookie = cookie;
+  return handleApiAccount(
+    new Request(`http://hub.test/api/account${subpath}`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    }),
+    subpath,
+    { db: harness.db },
+  );
+}
+
+function liveCode(secretBase32: string, label = "owner"): string {
+  return new OTPAuth.TOTP({
+    issuer: "Parachute Hub",
+    label,
+    algorithm: "SHA1",
+    digits: 6,
+    period: 30,
+    secret: OTPAuth.Secret.fromBase32(secretBase32),
+  }).generate();
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+  resetRateLimit();
+  _resetTotpReplayCache();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+describe("/api/account/* — auth posture", () => {
+  test("no session → 401", async () => {
+    const res = await post("/password", null, {
+      __csrf: TEST_CSRF,
+      current_password: "x",
+      new_password: "y",
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("wrong CSRF → 403", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/password", cookie, {
+      __csrf: "not-the-token",
+      current_password: "owner-password-123",
+      new_password: "brand-new-passphrase",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  test("unknown subpath → 404", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/bogus", cookie, { __csrf: TEST_CSRF });
+    expect(res.status).toBe(404);
+  });
+
+  test("GET → 405", async () => {
+    const res = await handleApiAccount(
+      new Request("http://hub.test/api/account/password", { method: "GET" }),
+      "/password",
+      { db: harness.db },
+    );
+    expect(res.status).toBe(405);
+  });
+});
+
+describe("/api/account/password", () => {
+  test("happy path rotates the hash + revokes active tokens", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    // Seed an active token for this user — it should be revoked.
+    recordTokenMint(harness.db, {
+      jti: "tok-1",
+      userId,
+      subject: userId,
+      clientId: "cli",
+      scopes: ["vault:default:read"],
+      expiresAt: new Date(Date.now() + 3600_000).toISOString(),
+      createdVia: "cli_mint",
+    });
+
+    const res = await post("/password", cookie, {
+      __csrf: TEST_CSRF,
+      current_password: "owner-password-123",
+      new_password: "brand-new-passphrase",
+    });
+    expect(res.status).toBe(200);
+
+    // New password verifies; old does not.
+    const row = harness.db
+      .query<{ password_hash: string }, [string]>("SELECT password_hash FROM users WHERE id = ?")
+      .get(userId);
+    expect(row).not.toBeNull();
+    const fakeUser = { passwordHash: row!.password_hash } as Parameters<typeof verifyPassword>[0];
+    expect(await verifyPassword(fakeUser, "brand-new-passphrase")).toBe(true);
+    expect(await verifyPassword(fakeUser, "owner-password-123")).toBe(false);
+
+    // Token revoked.
+    const tok = harness.db
+      .query<{ revoked_at: string | null }, [string]>("SELECT revoked_at FROM tokens WHERE jti = ?")
+      .get("tok-1");
+    expect(tok?.revoked_at).not.toBeNull();
+  });
+
+  test("wrong current password → 401 invalid_credentials", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/password", cookie, {
+      __csrf: TEST_CSRF,
+      current_password: "WRONG",
+      new_password: "brand-new-passphrase",
+    });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_credentials");
+  });
+
+  test("new password too short → 400 invalid_password", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/password", cookie, {
+      __csrf: TEST_CSRF,
+      current_password: "owner-password-123",
+      new_password: "short",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_password");
+  });
+
+  test("new === current → 400 password_unchanged", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/password", cookie, {
+      __csrf: TEST_CSRF,
+      current_password: "owner-password-123",
+      new_password: "owner-password-123",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("password_unchanged");
+  });
+
+  test("missing fields → 400", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/password", cookie, { __csrf: TEST_CSRF });
+    expect(res.status).toBe(400);
+  });
+
+  test("new password over PASSWORD_MAX_LEN → 413 (before argon2id hash)", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/password", cookie, {
+      __csrf: TEST_CSRF,
+      current_password: "owner-password-123",
+      new_password: "x".repeat(257),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  test("rate-limited after repeated wrong-current attempts → 429", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    // Bucket is 3 attempts / 5 min (CHANGE_PASSWORD_*). Burn 3 wrong-current
+    // attempts (each 401), then the 4th is rejected at 429 BEFORE the verify.
+    for (let i = 0; i < 3; i++) {
+      const r = await post("/password", cookie, {
+        __csrf: TEST_CSRF,
+        current_password: "WRONG",
+        new_password: "brand-new-passphrase",
+      });
+      expect(r.status).toBe(401);
+    }
+    const limited = await post("/password", cookie, {
+      __csrf: TEST_CSRF,
+      current_password: "WRONG",
+      new_password: "brand-new-passphrase",
+    });
+    expect(limited.status).toBe(429);
+    expect(limited.headers.get("retry-after")).not.toBeNull();
+  });
+});
+
+describe("/api/account/2fa start + confirm", () => {
+  test("start returns a secret + otpauth_url + qr_data_url", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      secret: string;
+      otpauth_url: string;
+      qr_data_url: string;
+    };
+    expect(body.secret).toMatch(/^[A-Z2-7]+$/);
+    expect(body.otpauth_url.startsWith("otpauth://totp/")).toBe(true);
+    expect(body.qr_data_url.startsWith("data:image/png;base64,")).toBe(true);
+  });
+
+  test("start refuses (409) when already enrolled", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    await persistEnrollment(harness.db, userId, generateTotpSecret("owner").secret);
+    const res = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });
+    expect(res.status).toBe(409);
+  });
+
+  test("confirm with a live code persists enrollment + returns backup codes", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const startRes = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });
+    const { secret } = (await startRes.json()) as { secret: string };
+
+    const confirmRes = await post("/2fa/confirm", cookie, {
+      __csrf: TEST_CSRF,
+      secret,
+      code: liveCode(secret),
+    });
+    expect(confirmRes.status).toBe(200);
+    const body = (await confirmRes.json()) as { enrolled: boolean; backup_codes: string[] };
+    expect(body.enrolled).toBe(true);
+    expect(body.backup_codes.length).toBe(10);
+    expect(isTotpEnrolled(harness.db, userId)).toBe(true);
+  });
+
+  test("confirm with a wrong code → 400 invalid_code (not persisted)", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const startRes = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });
+    const { secret } = (await startRes.json()) as { secret: string };
+    const res = await post("/2fa/confirm", cookie, {
+      __csrf: TEST_CSRF,
+      secret,
+      code: "000000",
+    });
+    expect(res.status).toBe(400);
+    expect(isTotpEnrolled(harness.db, userId)).toBe(false);
+  });
+
+  test("confirm with a malformed secret → 400 setup_expired", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/2fa/confirm", cookie, {
+      __csrf: TEST_CSRF,
+      secret: "not-base32!!",
+      code: "123456",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("setup_expired");
+  });
+});
+
+describe("/api/account/2fa/disable", () => {
+  test("password-gated: wrong password → 401, enrollment intact", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    await persistEnrollment(harness.db, userId, generateTotpSecret("owner").secret);
+    const res = await post("/2fa/disable", cookie, {
+      __csrf: TEST_CSRF,
+      password: "WRONG",
+    });
+    expect(res.status).toBe(401);
+    expect(isTotpEnrolled(harness.db, userId)).toBe(true);
+  });
+
+  test("correct password clears enrollment", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    await persistEnrollment(harness.db, userId, generateTotpSecret("owner").secret);
+    const res = await post("/2fa/disable", cookie, {
+      __csrf: TEST_CSRF,
+      password: "owner-password-123",
+    });
+    expect(res.status).toBe(200);
+    expect(isTotpEnrolled(harness.db, userId)).toBe(false);
+  });
+
+  test("idempotent when already off", async () => {
+    const { cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const res = await post("/2fa/disable", cookie, {
+      __csrf: TEST_CSRF,
+      password: "owner-password-123",
+    });
+    expect(res.status).toBe(200);
+  });
+
+  test("missing password → 400", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    await persistEnrollment(harness.db, userId, generateTotpSecret("owner").secret);
+    const res = await post("/2fa/disable", cookie, { __csrf: TEST_CSRF });
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("/api/me — two_factor_enabled", () => {
+  test("false when not enrolled, true after enrollment", async () => {
+    const user = await createUser(harness.db, "owner", "owner-password-123", {
+      passwordChanged: true,
+    });
+    const session = createSession(harness.db, { userId: user.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+
+    const before = await handleApiMe(
+      new Request("http://hub.test/api/me", { headers: { cookie } }),
+      { db: harness.db },
+    );
+    const beforeBody = (await before.json()) as { two_factor_enabled?: boolean };
+    expect(beforeBody.two_factor_enabled).toBe(false);
+
+    await persistEnrollment(harness.db, user.id, generateTotpSecret("owner").secret);
+
+    const after = await handleApiMe(
+      new Request("http://hub.test/api/me", { headers: { cookie } }),
+      { db: harness.db },
+    );
+    const afterBody = (await after.json()) as { two_factor_enabled?: boolean };
+    expect(afterBody.two_factor_enabled).toBe(true);
+  });
+});

--- a/src/api-account-2fa.ts
+++ b/src/api-account-2fa.ts
@@ -1,0 +1,373 @@
+/**
+ * `/api/account/*` — JSON self-service account surfaces for the admin SPA
+ * (hub#85). The server-rendered `/account/2fa` + `/account/change-password`
+ * pages stay (they work without JS, the friend-facing path); these are the
+ * JSON twins the in-`/admin` SPA "My account" page drives.
+ *
+ *   POST /api/account/2fa/start    → mint a fresh secret + QR + otpauth URL
+ *                                     (NOT persisted — confirm seals it)
+ *   POST /api/account/2fa/confirm  → verify a live code vs the in-flight
+ *                                     secret, persist enrollment, return the
+ *                                     backup codes ONCE
+ *   POST /api/account/2fa/disable  → verify current password, clear 2FA
+ *   POST /api/account/password     → verify current, set new (+ revoke the
+ *                                     user's still-active tokens)
+ *
+ * Auth posture: every endpoint is **self-service** — it acts on the
+ * SIGNED-IN user's OWN account (`session.userId`), never a client-supplied
+ * user id. ANY authenticated user reaches them (the owner / first-admin is
+ * NOT special — same path, no privilege bypass). This is deliberately the
+ * `/api/admin-lock` cookie+CSRF posture, NOT the host-admin Bearer posture:
+ * a user managing their own credentials shouldn't need (or have) the
+ * `parachute:host:admin` scope. Order on every POST:
+ *
+ *   1. Session cookie (else 401).
+ *   2. CSRF double-submit `__csrf` in the JSON body (else 403). Same-origin
+ *      belt is applied by the hub-server dispatcher before this runs.
+ *   3. Per-action validation.
+ *
+ * The crypto + persistence is REUSED, never duplicated: secret generation +
+ * code verification live in `totp.ts`; enrollment storage lives in
+ * `two-factor-store.ts`; password validation + hashing live in `users.ts`.
+ * This file is the JSON wire layer only.
+ *
+ * In-flight-secret model (mirrors the server-rendered flow): `start` returns
+ * the secret, the SPA holds it client-side, and `confirm` sends it back with
+ * the live code. Nothing is persisted until `confirm` verifies — an abandoned
+ * setup leaves zero state.
+ */
+import type { Database } from "bun:sqlite";
+import { hash as argonHash } from "@node-rs/argon2";
+import QRCode from "qrcode";
+import { verifyCsrfToken } from "./csrf.ts";
+import { changePasswordRateLimiter } from "./rate-limit.ts";
+import { findActiveSession } from "./sessions.ts";
+import { generateTotpSecret, otpauthUrlFor, verifyTotpCode } from "./totp.ts";
+import {
+  clearEnrollment,
+  getTotpState,
+  isTotpEnrolled,
+  persistEnrollment,
+} from "./two-factor-store.ts";
+import {
+  PASSWORD_MAX_LEN,
+  type User,
+  UserNotFoundError,
+  getUserById,
+  validatePassword,
+  verifyPassword,
+} from "./users.ts";
+
+export interface ApiAccount2faDeps {
+  db: Database;
+  /** Test seam — defaults to the real clock. */
+  now?: () => Date;
+}
+
+function json(status: number, body: unknown, extra: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store", ...extra },
+  });
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return json(status, { error, error_description: description });
+}
+
+/** Resolve the signed-in user, or an error Response (401). Self-only — no id from the client. */
+function requireUser(
+  db: Database,
+  req: Request,
+): { ok: true; user: User } | { ok: false; res: Response } {
+  const session = findActiveSession(db, req);
+  if (!session) {
+    return {
+      ok: false,
+      res: jsonError(401, "unauthenticated", "no session — sign in at /login first"),
+    };
+  }
+  const user = getUserById(db, session.userId);
+  if (!user) {
+    return {
+      ok: false,
+      res: jsonError(401, "unauthenticated", "signed-in account no longer exists"),
+    };
+  }
+  return { ok: true, user };
+}
+
+async function readJsonBody(req: Request): Promise<Record<string, unknown>> {
+  try {
+    const body = (await req.json()) as unknown;
+    return body && typeof body === "object" ? (body as Record<string, unknown>) : {};
+  } catch {
+    return {};
+  }
+}
+
+function checkCsrf(req: Request, body: Record<string, unknown>): boolean {
+  const token = typeof body.__csrf === "string" ? body.__csrf : null;
+  return verifyCsrfToken(req, token);
+}
+
+/**
+ * Gate the password-verifying endpoints (`/password`, `/2fa/disable`) before the
+ * argon2id `verifyPassword` call — a session-hijack attacker shouldn't get an
+ * unbounded grind window against the hash. Keyed by `user.id` (identity is
+ * already established by the session) and shares the `changePasswordRateLimiter`
+ * bucket (3 attempts / 5 min) with the server-rendered change-password POST, so
+ * a single user's argon2id budget is uniform across both surfaces. Returns a 429
+ * Response when the bucket is exhausted, else null. Fires AFTER CSRF so a junk
+ * cross-site POST can't burn the victim's bucket slot.
+ */
+function passwordRateLimit(userId: string, now: () => Date): Response | null {
+  const gate = changePasswordRateLimiter.checkAndRecord(userId, now());
+  if (gate.allowed) return null;
+  const retryAfter = gate.retryAfterSeconds ?? 1;
+  return json(
+    429,
+    {
+      error: "too_many_attempts",
+      error_description: `Too many attempts. Try again in ${retryAfter} seconds.`,
+    },
+    { "retry-after": String(retryAfter) },
+  );
+}
+
+/**
+ * Router for `/api/account/*`. `subpath` is the path AFTER `/api/account`
+ * (e.g. "/2fa/start", "/password"). The hub-server dispatcher slices it.
+ *
+ * Every route here is a POST (state-changing); the read-side 2FA status the
+ * SPA renders comes from `/api/me`'s `two_factor_enabled` field, so there's
+ * no GET on this surface.
+ */
+export async function handleApiAccount(
+  req: Request,
+  subpath: string,
+  deps: ApiAccount2faDeps,
+): Promise<Response> {
+  if (req.method !== "POST") return jsonError(405, "method_not_allowed", "use POST");
+
+  const gate = requireUser(deps.db, req);
+  if (!gate.ok) return gate.res;
+  const user = gate.user;
+
+  const body = await readJsonBody(req);
+  if (!checkCsrf(req, body)) {
+    return jsonError(403, "csrf_failed", "missing or invalid CSRF token");
+  }
+
+  switch (subpath) {
+    case "/2fa/start":
+      return handleStart(deps.db, user);
+    case "/2fa/confirm":
+      return handleConfirm(deps, user, body);
+    case "/2fa/disable":
+      return handleDisable(deps, user, body);
+    case "/password":
+      return handlePassword(deps, user, body);
+    default:
+      return jsonError(404, "not_found", `no account route at /api/account${subpath}`);
+  }
+}
+
+/**
+ * POST /api/account/2fa/start — mint a fresh secret + provisioning artifacts.
+ * Refuses if already enrolled (disable first to re-enroll) — same guard as
+ * the server-rendered `start`. The secret is NOT persisted; the SPA holds it
+ * and round-trips it back on confirm.
+ */
+async function handleStart(db: Database, user: User): Promise<Response> {
+  if (isTotpEnrolled(db, user.id)) {
+    return jsonError(
+      409,
+      "already_enrolled",
+      "Two-factor is already enabled. Turn it off first to re-enroll.",
+    );
+  }
+  const { secret, otpauthUrl } = generateTotpSecret(user.username);
+  // PNG data-URL QR (margin:1 for scanner-friendly quiet zone). The repo
+  // already depends on `qrcode`; returning a data-URL lets the SPA render a
+  // plain <img> with no new client dependency, and the otpauth URL is
+  // returned alongside for manual-entry / copy affordances.
+  const qrDataUrl = await QRCode.toDataURL(otpauthUrl, { margin: 1, errorCorrectionLevel: "M" });
+  return json(200, { secret, otpauth_url: otpauthUrl, qr_data_url: qrDataUrl });
+}
+
+/** base32 alphabet (A–Z, 2–7) + optional `=` padding, ≥16 chars. Same N1 guard as the HTML flow. */
+function isPlausibleBase32Secret(secret: string): boolean {
+  return /^[A-Z2-7]+=*$/i.test(secret) && secret.length >= 16;
+}
+
+/**
+ * POST /api/account/2fa/confirm {secret, code} — verify the live code vs the
+ * in-flight secret, persist enrollment, return the backup codes ONCE.
+ */
+async function handleConfirm(
+  deps: ApiAccount2faDeps,
+  user: User,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const secret = typeof body.secret === "string" ? body.secret : "";
+  const code = typeof body.code === "string" ? body.code : "";
+
+  if (!secret || !isPlausibleBase32Secret(secret)) {
+    return jsonError(400, "setup_expired", "Setup expired or malformed. Start again.");
+  }
+  // Defensive — a confirm POST against an already-enrolled account.
+  if (isTotpEnrolled(deps.db, user.id)) {
+    return jsonError(409, "already_enrolled", "Two-factor is already enabled.");
+  }
+  if (!verifyTotpCode(secret, code)) {
+    return jsonError(
+      400,
+      "invalid_code",
+      "That code didn't match. Check your device clock and try the current code.",
+    );
+  }
+  const result = await persistEnrollment(deps.db, user.id, secret, deps.now ?? (() => new Date()));
+  // Backup codes are shown ONCE — no-store so the response is never cached.
+  return json(200, {
+    enrolled: true,
+    enrolled_at: result.enrolledAt,
+    backup_codes: result.backupCodes,
+  });
+}
+
+/**
+ * POST /api/account/2fa/disable {password} — verify the current password,
+ * clear 2FA. Password-gated (same safety as the HTML flow): disabling a
+ * second factor with only a session cookie would let a hijacked session
+ * strip the very protection that defends the account.
+ */
+async function handleDisable(
+  deps: ApiAccount2faDeps,
+  user: User,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const db = deps.db;
+  if (!isTotpEnrolled(db, user.id)) {
+    // Idempotent — already off.
+    return json(200, { enrolled: false });
+  }
+  const password = typeof body.password === "string" ? body.password : "";
+  if (!password) {
+    return jsonError(
+      400,
+      "password_required",
+      "Enter your current password to turn off two-factor.",
+    );
+  }
+  // Cap before argon2id verify (CPU-DoS guard — same posture as /login).
+  if (password.length > PASSWORD_MAX_LEN) {
+    return jsonError(
+      413,
+      "password_too_long",
+      `Password must be ≤ ${PASSWORD_MAX_LEN} characters.`,
+    );
+  }
+  // Rate-limit before the argon2id verify (a stolen session shouldn't grind).
+  const limited = passwordRateLimit(user.id, deps.now ?? (() => new Date()));
+  if (limited) return limited;
+  const ok = await verifyPassword(user, password);
+  if (!ok) {
+    return jsonError(401, "invalid_credentials", "That password is incorrect.");
+  }
+  clearEnrollment(db, user.id);
+  return json(200, { enrolled: false });
+}
+
+/**
+ * POST /api/account/password {current_password, new_password} — JSON twin of
+ * the server-rendered `/account/change-password` POST. Same validation +
+ * atomic hash-write-and-revoke-tokens as `api-account.ts`, reusing the same
+ * `users.ts` validators. Self-only (the signed-in user's own hash).
+ *
+ * Check order mirrors the HTML handler:
+ *   1. fields present (400)
+ *   2. current too long → 413 (before argon2id verify)
+ *   3. new too long → 413 (before argon2id hash)
+ *   4. validatePassword(new) → 400
+ *   5. rate-limit (429, before the argon2id verify — same as the HTML twin)
+ *   6. verifyPassword(current) → 401
+ *   7. new === current → 400 (after verify — see api-account.ts rationale)
+ *   8. hash new + UPDATE + revoke tokens (one tx)
+ */
+async function handlePassword(
+  deps: ApiAccount2faDeps,
+  user: User,
+  body: Record<string, unknown>,
+): Promise<Response> {
+  const currentPassword = typeof body.current_password === "string" ? body.current_password : "";
+  const newPassword = typeof body.new_password === "string" ? body.new_password : "";
+
+  if (!currentPassword || !newPassword) {
+    return jsonError(400, "missing_fields", "current_password and new_password are required.");
+  }
+  if (currentPassword.length > PASSWORD_MAX_LEN) {
+    return jsonError(
+      413,
+      "password_too_long",
+      `Current password must be ≤ ${PASSWORD_MAX_LEN} characters.`,
+    );
+  }
+  if (newPassword.length > PASSWORD_MAX_LEN) {
+    return jsonError(
+      413,
+      "password_too_long",
+      `New password must be ≤ ${PASSWORD_MAX_LEN} characters.`,
+    );
+  }
+  if (!validatePassword(newPassword).valid) {
+    return jsonError(
+      400,
+      "invalid_password",
+      "New password must be at least 12 characters (a passphrase is fine).",
+    );
+  }
+  // Rate-limit before the argon2id verify (a stolen session shouldn't grind
+  // the current-password check). Shares the bucket with the HTML twin + the
+  // disable endpoint — uniform per-user argon2id budget.
+  const limited = passwordRateLimit(user.id, deps.now ?? (() => new Date()));
+  if (limited) return limited;
+  const currentOk = await verifyPassword(user, currentPassword);
+  if (!currentOk) {
+    return jsonError(401, "invalid_credentials", "Current password is incorrect.");
+  }
+  if (newPassword === currentPassword) {
+    return jsonError(
+      400,
+      "password_unchanged",
+      "New password must differ from your current password.",
+    );
+  }
+
+  // Hash OUTSIDE the transaction — argon2id is async and bun:sqlite's
+  // `db.transaction()` is sync; an async closure silently breaks atomicity
+  // (same constraint api-account.ts documents). Then write the hash, flip
+  // `password_changed`, and revoke the user's still-active tokens in one tx.
+  const now = deps.now ?? (() => new Date());
+  const passwordHash = await argonHash(newPassword);
+  const stamp = now().toISOString();
+  try {
+    deps.db.transaction(() => {
+      const result = deps.db
+        .prepare(
+          "UPDATE users SET password_hash = ?, password_changed = 1, updated_at = ? WHERE id = ?",
+        )
+        .run(passwordHash, stamp, user.id);
+      if (result.changes === 0) throw new UserNotFoundError(user.id);
+      deps.db
+        .prepare("UPDATE tokens SET revoked_at = ? WHERE user_id = ? AND revoked_at IS NULL")
+        .run(stamp, user.id);
+    })();
+  } catch (err) {
+    if (err instanceof UserNotFoundError) {
+      return jsonError(401, "unauthenticated", "The signed-in account no longer exists.");
+    }
+    throw err;
+  }
+  return json(200, { ok: true });
+}

--- a/src/api-me.ts
+++ b/src/api-me.ts
@@ -14,7 +14,12 @@
  * Response shape:
  *
  *   { hasSession: false }
- *   { hasSession: true, user: { id, displayName }, csrf: "<token>" }
+ *   { hasSession: true, user: { id, displayName }, csrf: "<token>",
+ *     two_factor_enabled: boolean }
+ *
+ * `two_factor_enabled` (hub#85) lets the SPA's "My account" page render the
+ * 2FA status without a separate read. It reflects `users.totp_secret` being
+ * set for the signed-in user.
  *
  * `displayName` is the user's `username` today — there's no separate
  * display-name field on the User shape. Surfaced under a different key
@@ -39,6 +44,7 @@
 import type { Database } from "bun:sqlite";
 import { ensureCsrfToken } from "./csrf.ts";
 import { findActiveSession } from "./sessions.ts";
+import { isTotpEnrolled } from "./two-factor-store.ts";
 import { getUserById } from "./users.ts";
 
 export interface ApiMeDeps {
@@ -59,7 +65,9 @@ interface SignedInUser {
  * that mixes states — e.g. `{ hasSession: false, user: staleUser }`
  * fails at the type-check, not just at code-review.
  */
-type ApiMeResponse = { hasSession: false } | { hasSession: true; user: SignedInUser; csrf: string };
+type ApiMeResponse =
+  | { hasSession: false }
+  | { hasSession: true; user: SignedInUser; csrf: string; two_factor_enabled: boolean };
 
 export function handleApiMe(req: Request, deps: ApiMeDeps): Response {
   if (req.method !== "GET") {
@@ -99,6 +107,7 @@ export function handleApiMe(req: Request, deps: ApiMeDeps): Response {
       displayName: user.username,
     },
     csrf: csrf.token,
+    two_factor_enabled: isTotpEnrolled(deps.db, user.id),
   };
   return new Response(JSON.stringify(body), { status: 200, headers });
 }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -69,9 +69,11 @@
  *   # "CSRF-belted" = strict same-origin Origin check on cookie-authed
  *   # mutations (hub#632, boundary C1) — origin-check.ts
  *   # `assertSameOriginForCookieMutation` carries the canonical enumeration.
- *   /api/me                       (GET)        → who-am-I (session+CSRF or hasSession:false)
+ *   /api/me                       (GET)        → who-am-I (session+CSRF+two_factor_enabled or hasSession:false)
  *   /api/admin-lock               (GET)        → screen-lock status (cookie-gated; first-admin)
  *   /api/admin-lock/{set,change,remove,unlock,lock,heartbeat} (POST) → manage the optional admin idle PIN lock (cookie-gated; CSRF)
+ *   /api/account/2fa/{start,confirm,disable} (POST) → self-service 2FA for the SPA (cookie-gated; CSRF; self-only) — hub#85
+ *   /api/account/password         (POST)       → self-service password change for the SPA (cookie-gated; CSRF; self-only) — hub#85
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
  *   /api/hub/upgrade/status       (GET)        → poll the on-disk hub-upgrade status (host:admin)
@@ -186,6 +188,7 @@ import { handleHostAdminToken } from "./admin-host-admin-token.ts";
 import { handleModuleToken } from "./admin-module-token.ts";
 import { handleVaultAdminToken } from "./admin-vault-admin-token.ts";
 import { handleCreateVault, handleDeleteVault } from "./admin-vaults.ts";
+import { handleApiAccount } from "./api-account-2fa.ts";
 import {
   handleAccountChangePasswordGet,
   handleAccountChangePasswordPost,
@@ -3042,6 +3045,24 @@ export function hubFetch(
         }
         const subpath = pathname.slice("/api/admin-lock".length);
         return handleAdminLock(req, subpath, { db: getDb() });
+      }
+
+      // JSON self-service account surfaces for the admin SPA "My account" page
+      // (hub#85): password change + 2FA enroll/confirm/disable. Self-only
+      // (acts on `session.userId`, never a client-supplied id) — ANY signed-in
+      // user, not just the first admin. Same cookie + CSRF + same-origin
+      // posture as /api/admin-lock above (NOT the host-admin Bearer posture —
+      // a user managing their own credentials needs no admin scope). The
+      // server-rendered /account/2fa + /account/change-password pages stay for
+      // the no-JS / friend-facing path; these are the JSON twins.
+      if (pathname.startsWith("/api/account/")) {
+        if (!getDb) return dbNotConfigured();
+        {
+          const rejected = assertSameOriginForCookieMutation(req, oauthDeps(req).hubBoundOrigins());
+          if (rejected) return rejected;
+        }
+        const subpath = pathname.slice("/api/account".length);
+        return handleApiAccount(req, subpath, { db: getDb() });
       }
 
       // SPA-driven hub self-upgrade (design 2026-06-01 §5.3 / D4). Dedicated

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -104,7 +104,7 @@ describe("App — brand subtitle (route-derived)", () => {
 });
 
 describe("App — nav structure", () => {
-  it("renders all hub-native nav links in order: brand, Home, Connections, Modules, Users, Tokens, Permissions, Settings, Discovery (signed-out)", async () => {
+  it("renders all hub-native nav links in order: brand, Home, Connections, Modules, Users, Tokens, Permissions, Settings, My account, Discovery (signed-out)", async () => {
     renderAt("/vaults");
     // Wait for /api/me to resolve so AuthIndicator's "Sign in" link
     // appears in the nav before we snapshot the link order.
@@ -133,6 +133,7 @@ describe("App — nav structure", () => {
       "Tokens",
       "Permissions",
       "Settings",
+      "My account",
       // Past the divider: the off-shell Discovery escape hatch.
       "Discovery",
     ]);
@@ -162,6 +163,7 @@ describe("App — nav structure", () => {
       "Tokens",
       "Permissions",
       "Settings",
+      "My account",
     ]) {
       expect(
         within(nav).getByRole("link", { name: new RegExp(`^${label}$`, "i") }),
@@ -285,6 +287,7 @@ describe("App — auth indicator (rc.13)", () => {
       hasSession: true,
       user: { id: "u1", displayName: "aaron" },
       csrf: "csrf-token-abc",
+      two_factor_enabled: false,
     });
     renderAt("/vaults");
     await waitFor(() => expect(screen.getByText(/signed in as/i)).toBeInTheDocument());
@@ -299,6 +302,7 @@ describe("App — auth indicator (rc.13)", () => {
       hasSession: true,
       user: { id: "u1", displayName: "aaron" },
       csrf: "csrf-token-abc",
+      two_factor_enabled: false,
     });
     vi.mocked(api.signOut).mockResolvedValue();
     // Stub window.location so we can observe the navigation without
@@ -327,6 +331,7 @@ describe("App — auth indicator (rc.13)", () => {
       hasSession: true,
       user: { id: "u1", displayName: "aaron" },
       csrf: "csrf-token-abc",
+      two_factor_enabled: false,
     });
     let resolveSignOut: () => void = () => {};
     vi.mocked(api.signOut).mockReturnValue(
@@ -351,6 +356,7 @@ describe("App — installed-services dropdown (hub#342)", () => {
       hasSession: true,
       user: { id: "u1", displayName: "aaron" },
       csrf: "csrf",
+      two_factor_enabled: false,
     });
     vi.mocked(api.listModules).mockResolvedValue({
       modules: [],
@@ -367,6 +373,7 @@ describe("App — installed-services dropdown (hub#342)", () => {
       hasSession: true,
       user: { id: "u1", displayName: "aaron" },
       csrf: "csrf",
+      two_factor_enabled: false,
     });
     vi.mocked(api.listModules).mockResolvedValue({
       modules: [
@@ -479,6 +486,7 @@ describe("App — admin screen lock", () => {
       hasSession: true,
       user: { id: "u1", displayName: "Op" },
       csrf: "csrf-1",
+      two_factor_enabled: false,
     });
     vi.mocked(api.getAdminLockStatus).mockResolvedValue({
       configured: true,
@@ -497,6 +505,7 @@ describe("App — admin screen lock", () => {
       hasSession: true,
       user: { id: "u1", displayName: "Op" },
       csrf: "csrf-1",
+      two_factor_enabled: false,
     });
     vi.mocked(api.getAdminLockStatus).mockResolvedValue({
       configured: true,
@@ -515,6 +524,7 @@ describe("App — admin screen lock", () => {
       hasSession: true,
       user: { id: "u1", displayName: "Op" },
       csrf: "csrf-1",
+      two_factor_enabled: false,
     });
     vi.mocked(api.getAdminLockStatus).mockResolvedValue({
       configured: false,
@@ -532,6 +542,7 @@ describe("App — admin screen lock", () => {
       hasSession: true,
       user: { id: "u1", displayName: "Op" },
       csrf: "csrf-1",
+      two_factor_enabled: false,
     });
     // First call: locked. After unlock, refresh() re-reads → unlocked.
     vi.mocked(api.getAdminLockStatus)

--- a/web/ui/src/App.tsx
+++ b/web/ui/src/App.tsx
@@ -42,6 +42,7 @@ import {
 } from "./lib/api.ts";
 import { clearCachedToken } from "./lib/auth.ts";
 import { useAdminLock } from "./lib/useAdminLock.ts";
+import { Account } from "./routes/Account.tsx";
 import { ApproveClient } from "./routes/ApproveClient.tsx";
 import { Connections } from "./routes/Connections.tsx";
 import { Grants } from "./routes/Grants.tsx";
@@ -79,6 +80,9 @@ function subtitleFor(pathname: string): string {
   }
   if (pathname === "/settings" || pathname.startsWith("/settings/")) {
     return "settings";
+  }
+  if (pathname === "/account" || pathname.startsWith("/account/")) {
+    return "my account";
   }
   if (pathname.startsWith("/approve-client/")) {
     return "approve app";
@@ -258,6 +262,7 @@ export function App() {
         <NavSection to="/tokens" label="Tokens" />
         <NavSection to="/permissions" label="Permissions" />
         <NavSection to="/settings" label="Settings" />
+        <NavSection to="/account" label="My account" />
         {/* Boundary: everything past here is module-owned / off-shell. */}
         <span className="nav-divider" aria-hidden="true" />
         <InstalledServicesDropdown services={installedServices} />
@@ -286,6 +291,7 @@ export function App() {
         <Route path="/permissions" element={<Permissions />} />
         <Route path="/tokens" element={<Tokens />} />
         <Route path="/settings" element={<Settings />} />
+        <Route path="/account" element={<Account />} />
         <Route path="/approve-client/:clientId" element={<ApproveClient />} />
         <Route
           path="*"

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -290,6 +290,8 @@ export interface MeSignedIn {
   user: { id: string; displayName: string };
   /** Per-session CSRF token; submit as `__csrf` against /logout etc. */
   csrf: string;
+  /** Whether the signed-in user has TOTP 2FA enrolled (hub#85). Drives the My-account page status. */
+  two_factor_enabled: boolean;
 }
 export interface MeSignedOut {
   hasSession: false;
@@ -1927,6 +1929,105 @@ export async function revokeAgentGrant(id: string): Promise<void> {
   if (res.status === 401) {
     await redirectToLoginAndHang<void>();
     return;
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+// ===========================================================================
+// Self-service account (hub#85) — /api/account/*
+//
+// These talk to the hub with the SESSION COOKIE directly (NOT the host-admin
+// Bearer): a user managing their OWN password / 2FA needs no admin scope, and
+// the endpoints key everything off `session.userId`. Same cookie + CSRF
+// posture as the admin-lock helpers above — the POST body carries the `__csrf`
+// token from `/api/me`; the browser adds the Origin header for the server's
+// same-origin belt. 401 means the session is gone → bounce to /login.
+// ===========================================================================
+
+async function postAccount(
+  subpath: string,
+  csrf: string,
+  body: Record<string, unknown> = {},
+): Promise<Response> {
+  return await fetch(`/api/account${subpath}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json" },
+    credentials: "same-origin",
+    body: JSON.stringify({ __csrf: csrf, ...body }),
+  });
+}
+
+/** Response from `POST /api/account/2fa/start` — the in-flight enroll artifacts. */
+export interface TwoFactorStart {
+  /** Base32 secret — the SPA holds this and sends it back on confirm. Show for manual entry. */
+  secret: string;
+  /** `otpauth://` provisioning URI (manual-entry / copy affordance). */
+  otpauth_url: string;
+  /** PNG data-URL QR for the otpauth URI — render in an <img src>. */
+  qr_data_url: string;
+}
+
+/** POST /api/account/2fa/start — mint a fresh secret + QR. Refuses (409) if already enrolled. */
+export async function startTwoFactor(csrf: string): Promise<TwoFactorStart> {
+  const res = await postAccount("/2fa/start", csrf);
+  if (res.status === 401) return redirectToLoginAndHang<TwoFactorStart>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as TwoFactorStart;
+}
+
+/** Response from `POST /api/account/2fa/confirm` — backup codes shown ONCE. */
+export interface TwoFactorConfirmed {
+  enrolled: true;
+  enrolled_at: string;
+  /** Single-use backup codes — display once; never retrievable again. */
+  backup_codes: string[];
+}
+
+/**
+ * POST /api/account/2fa/confirm {secret, code} — verify the live code against
+ * the in-flight secret + persist enrollment. Returns the backup codes once.
+ */
+export async function confirmTwoFactor(
+  csrf: string,
+  secret: string,
+  code: string,
+): Promise<TwoFactorConfirmed> {
+  const res = await postAccount("/2fa/confirm", csrf, { secret, code });
+  if (res.status === 401) return redirectToLoginAndHang<TwoFactorConfirmed>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as TwoFactorConfirmed;
+}
+
+/** POST /api/account/2fa/disable {password} — password-gated; clears 2FA. */
+export async function disableTwoFactor(csrf: string, password: string): Promise<void> {
+  const res = await postAccount("/2fa/disable", csrf, { password });
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/**
+ * POST /api/account/password {current_password, new_password} — change the
+ * signed-in user's own password. Verifies the current password server-side;
+ * revokes the user's still-active tokens on success.
+ */
+export async function changeAccountPassword(
+  csrf: string,
+  currentPassword: string,
+  newPassword: string,
+): Promise<void> {
+  const res = await postAccount("/password", csrf, {
+    current_password: currentPassword,
+    new_password: newPassword,
+  });
+  if (res.status === 401) {
+    // 401 here is ambiguous: a gone session OR a wrong current password.
+    // The server distinguishes them by `error` — wrong-password carries
+    // `invalid_credentials`, gone-session carries `unauthenticated`. Surface
+    // the server message rather than bouncing to /login on a typo'd password.
+    throw new HttpError(res.status, await readError(res));
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
 }

--- a/web/ui/src/routes/Account.test.tsx
+++ b/web/ui/src/routes/Account.test.tsx
@@ -1,0 +1,254 @@
+/**
+ * Account route tests (hub#85): My account page — password change + 2FA
+ * status / enroll flow / disable. The `lib/api.ts` HTTP helpers are mocked;
+ * these assert the page renders status, drives the enroll flow, and gates
+ * disable on a password.
+ */
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import * as api from "../lib/api.ts";
+import { Account } from "./Account.tsx";
+
+vi.mock("../lib/api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    getMe: vi.fn(),
+    changeAccountPassword: vi.fn(),
+    startTwoFactor: vi.fn(),
+    confirmTwoFactor: vi.fn(),
+    disableTwoFactor: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function renderRoute() {
+  return render(
+    <MemoryRouter>
+      <Account />
+    </MemoryRouter>,
+  );
+}
+
+function meSignedIn(twoFactorEnabled: boolean) {
+  return {
+    hasSession: true as const,
+    user: { id: "u1", displayName: "aaron" },
+    csrf: "csrf-abc",
+    two_factor_enabled: twoFactorEnabled,
+  };
+}
+
+describe("Account — render + status", () => {
+  it("shows loading on first paint", () => {
+    vi.mocked(api.getMe).mockImplementation(() => new Promise(() => {}));
+    renderRoute();
+    expect(screen.getByText(/loading account/i)).toBeInTheDocument();
+  });
+
+  it("renders a sign-in prompt when no session", async () => {
+    vi.mocked(api.getMe).mockResolvedValue({ hasSession: false });
+    renderRoute();
+    await waitFor(() => expect(screen.getByText(/you're not signed in/i)).toBeInTheDocument());
+  });
+
+  it("renders 2FA status Off when not enrolled", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    await waitFor(() => expect(screen.getByTestId("account-2fa-status")).toHaveTextContent(/off/i));
+    // Off → the "Set up two-factor" CTA shows.
+    expect(screen.getByTestId("account-2fa-enroll")).toBeInTheDocument();
+    // The password form is present.
+    expect(screen.getByTestId("account-current-password")).toBeInTheDocument();
+  });
+
+  it("renders 2FA status Enabled + disable form when enrolled", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(true));
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByTestId("account-2fa-status")).toHaveTextContent(/enabled/i),
+    );
+    expect(screen.getByTestId("account-2fa-disable")).toBeInTheDocument();
+    expect(screen.getByTestId("account-2fa-disable-password")).toBeInTheDocument();
+  });
+});
+
+describe("Account — password change", () => {
+  it("POSTs current + new on submit and shows a notice", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.changeAccountPassword).mockResolvedValue();
+    renderRoute();
+    await screen.findByTestId("account-current-password");
+
+    fireEvent.change(screen.getByTestId("account-current-password"), {
+      target: { value: "old-password-123" },
+    });
+    fireEvent.change(screen.getByTestId("account-new-password"), {
+      target: { value: "brand-new-passphrase" },
+    });
+    fireEvent.change(screen.getByTestId("account-confirm-password"), {
+      target: { value: "brand-new-passphrase" },
+    });
+    fireEvent.click(screen.getByTestId("account-change-password"));
+
+    await waitFor(() =>
+      expect(api.changeAccountPassword).toHaveBeenCalledWith(
+        "csrf-abc",
+        "old-password-123",
+        "brand-new-passphrase",
+      ),
+    );
+    await waitFor(() =>
+      expect(screen.getByTestId("account-password-notice")).toHaveTextContent(/password changed/i),
+    );
+  });
+
+  it("blocks a too-short new password client-side (no POST)", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    await screen.findByTestId("account-current-password");
+
+    fireEvent.change(screen.getByTestId("account-current-password"), {
+      target: { value: "old-password-123" },
+    });
+    fireEvent.change(screen.getByTestId("account-new-password"), { target: { value: "short" } });
+    fireEvent.change(screen.getByTestId("account-confirm-password"), {
+      target: { value: "short" },
+    });
+    fireEvent.click(screen.getByTestId("account-change-password"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("account-password-error")).toHaveTextContent(/at least 12/i),
+    );
+    expect(api.changeAccountPassword).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server's wrong-current-password error", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.changeAccountPassword).mockRejectedValue(
+      new api.HttpError(401, "Current password is incorrect."),
+    );
+    renderRoute();
+    await screen.findByTestId("account-current-password");
+
+    fireEvent.change(screen.getByTestId("account-current-password"), {
+      target: { value: "wrong-password" },
+    });
+    fireEvent.change(screen.getByTestId("account-new-password"), {
+      target: { value: "brand-new-passphrase" },
+    });
+    fireEvent.change(screen.getByTestId("account-confirm-password"), {
+      target: { value: "brand-new-passphrase" },
+    });
+    fireEvent.click(screen.getByTestId("account-change-password"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("account-password-error")).toHaveTextContent(/incorrect/i),
+    );
+  });
+});
+
+describe("Account — 2FA enroll flow", () => {
+  it("start → shows QR + secret, confirm → shows backup codes once", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startTwoFactor).mockResolvedValue({
+      secret: "JBSWY3DPEHPK3PXP",
+      otpauth_url: "otpauth://totp/aaron?secret=JBSWY3DPEHPK3PXP",
+      qr_data_url: "data:image/png;base64,AAAA",
+    });
+    vi.mocked(api.confirmTwoFactor).mockResolvedValue({
+      enrolled: true,
+      enrolled_at: "2026-06-27T00:00:00.000Z",
+      backup_codes: ["abcde-fghij", "klmno-pqrst"],
+    });
+    renderRoute();
+    await screen.findByTestId("account-2fa-enroll");
+
+    fireEvent.click(screen.getByTestId("account-2fa-enroll"));
+    await waitFor(() => expect(api.startTwoFactor).toHaveBeenCalledWith("csrf-abc"));
+
+    // QR + manual secret render.
+    expect(await screen.findByTestId("account-2fa-qr")).toHaveAttribute(
+      "src",
+      "data:image/png;base64,AAAA",
+    );
+    expect(screen.getByTestId("account-2fa-secret")).toHaveTextContent("JBSWY3DPEHPK3PXP");
+
+    // Enter a code + confirm.
+    fireEvent.change(screen.getByTestId("account-2fa-code"), { target: { value: "123456" } });
+    fireEvent.click(screen.getByTestId("account-2fa-confirm"));
+
+    await waitFor(() =>
+      expect(api.confirmTwoFactor).toHaveBeenCalledWith("csrf-abc", "JBSWY3DPEHPK3PXP", "123456"),
+    );
+    // Backup codes shown once.
+    await waitFor(() => expect(screen.getByTestId("account-2fa-backup-codes")).toBeInTheDocument());
+    expect(screen.getByText("abcde-fghij")).toBeInTheDocument();
+    expect(screen.getByText("klmno-pqrst")).toBeInTheDocument();
+  });
+
+  it("blocks a non-6-digit code client-side (no confirm POST)", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startTwoFactor).mockResolvedValue({
+      secret: "JBSWY3DPEHPK3PXP",
+      otpauth_url: "otpauth://totp/aaron?secret=JBSWY3DPEHPK3PXP",
+      qr_data_url: "data:image/png;base64,AAAA",
+    });
+    renderRoute();
+    await screen.findByTestId("account-2fa-enroll");
+    fireEvent.click(screen.getByTestId("account-2fa-enroll"));
+    await screen.findByTestId("account-2fa-code");
+
+    fireEvent.change(screen.getByTestId("account-2fa-code"), { target: { value: "12" } });
+    fireEvent.click(screen.getByTestId("account-2fa-confirm"));
+
+    await waitFor(() =>
+      expect(screen.getByTestId("account-2fa-error")).toHaveTextContent(/6-digit/i),
+    );
+    expect(api.confirmTwoFactor).not.toHaveBeenCalled();
+  });
+});
+
+describe("Account — 2FA disable", () => {
+  it("POSTs the password and refreshes status", async () => {
+    // First /api/me → enrolled; after disable → refetch returns not-enrolled.
+    vi.mocked(api.getMe)
+      .mockResolvedValueOnce(meSignedIn(true))
+      .mockResolvedValueOnce(meSignedIn(false));
+    vi.mocked(api.disableTwoFactor).mockResolvedValue();
+    renderRoute();
+    await screen.findByTestId("account-2fa-disable-password");
+
+    fireEvent.change(screen.getByTestId("account-2fa-disable-password"), {
+      target: { value: "my-password-123" },
+    });
+    fireEvent.click(screen.getByTestId("account-2fa-disable"));
+
+    await waitFor(() =>
+      expect(api.disableTwoFactor).toHaveBeenCalledWith("csrf-abc", "my-password-123"),
+    );
+    // Refetch flips the status to Off + brings back the enroll CTA.
+    await waitFor(() => expect(screen.getByTestId("account-2fa-status")).toHaveTextContent(/off/i));
+  });
+
+  it("requires a password before disabling (no POST when blank)", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(true));
+    renderRoute();
+    await screen.findByTestId("account-2fa-disable");
+
+    fireEvent.click(screen.getByTestId("account-2fa-disable"));
+    await waitFor(() =>
+      expect(screen.getByTestId("account-2fa-error")).toHaveTextContent(/current password/i),
+    );
+    expect(api.disableTwoFactor).not.toHaveBeenCalled();
+  });
+});

--- a/web/ui/src/routes/Account.tsx
+++ b/web/ui/src/routes/Account.tsx
@@ -1,0 +1,422 @@
+/**
+ * /admin/account — "My account": self-service password + 2FA for the
+ * signed-in user (hub#85). Aaron chose option B — native in the SPA rather
+ * than a link out to the server-rendered `/account/`.
+ *
+ * The owner is NOT special here: `two_factor_enabled` comes from `/api/me`
+ * (keyed off the session's own user), and every action POSTs to
+ * `/api/account/*`, which act on `session.userId`. Same path for the first
+ * admin and any friend user.
+ *
+ * Two sections:
+ *   - Password — current → new (+ confirm). 12-char floor mirrors the server
+ *     validator; the server is authoritative (its 400/401 message surfaces).
+ *   - Two-factor — status pill; when off, an enroll flow (QR + secret + verify
+ *     a code → backup codes shown ONCE); when on, a password-gated disable.
+ *
+ * The CSRF token + 2FA status are read from `/api/me` (the single who-am-I
+ * read App.tsx already does). We refetch it after a 2FA change so the status
+ * pill + section swap without a full reload.
+ */
+import { type FormEvent, useCallback, useEffect, useState } from "react";
+import {
+  type MeResponse,
+  type TwoFactorStart,
+  changeAccountPassword,
+  confirmTwoFactor,
+  disableTwoFactor,
+  getMe,
+  startTwoFactor,
+} from "../lib/api.ts";
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "signed-out" }
+  | { kind: "ok"; csrf: string; twoFactorEnabled: boolean };
+
+export function Account() {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  const refresh = useCallback(async () => {
+    try {
+      const me: MeResponse = await getMe();
+      if (!me.hasSession) {
+        setState({ kind: "signed-out" });
+        return;
+      }
+      setState({ kind: "ok", csrf: me.csrf, twoFactorEnabled: me.two_factor_enabled });
+    } catch {
+      setState({ kind: "signed-out" });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  if (state.kind === "loading") {
+    return <div className="empty">Loading account…</div>;
+  }
+  if (state.kind === "signed-out") {
+    return (
+      <div className="empty">
+        You're not signed in.{" "}
+        <a href={`/login?next=${encodeURIComponent(window.location.pathname)}`}>Sign in</a> to
+        manage your account.
+      </div>
+    );
+  }
+
+  return (
+    <section className="settings" data-testid="account-page">
+      <h1>My account</h1>
+      <p className="muted">
+        Manage your own sign-in credentials. Changes here apply to your account only.
+      </p>
+
+      <PasswordSection csrf={state.csrf} />
+      <TwoFactorSection
+        csrf={state.csrf}
+        enabled={state.twoFactorEnabled}
+        onChanged={() => void refresh()}
+      />
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Password change
+// ---------------------------------------------------------------------------
+
+function PasswordSection({ csrf }: { csrf: string }) {
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (busy) return;
+    setErr(null);
+    setNotice(null);
+    if (!current || !next || !confirm) {
+      setErr("All three fields are required.");
+      return;
+    }
+    if (next.length < 12) {
+      setErr("New password must be at least 12 characters (a passphrase is fine).");
+      return;
+    }
+    if (next !== confirm) {
+      setErr("New password and confirmation do not match.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await changeAccountPassword(csrf, current, next);
+      setCurrent("");
+      setNext("");
+      setConfirm("");
+      setNotice("Password changed. Tokens minted under your old password were revoked.");
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section
+      className="settings-block"
+      aria-labelledby="account-password-heading"
+      data-testid="account-password"
+    >
+      <h2 id="account-password-heading">Password</h2>
+      <p className="muted">Change the password you use to sign in to this hub.</p>
+
+      <form onSubmit={(e) => void onSubmit(e)} className="settings-form">
+        <label>
+          Current password
+          <input
+            type="password"
+            autoComplete="current-password"
+            value={current}
+            disabled={busy}
+            onChange={(e) => setCurrent(e.target.value)}
+            data-testid="account-current-password"
+          />
+        </label>
+        <label>
+          New password (12+ characters)
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={next}
+            disabled={busy}
+            onChange={(e) => setNext(e.target.value)}
+            data-testid="account-new-password"
+          />
+        </label>
+        <label>
+          Confirm new password
+          <input
+            type="password"
+            autoComplete="new-password"
+            value={confirm}
+            disabled={busy}
+            onChange={(e) => setConfirm(e.target.value)}
+            data-testid="account-confirm-password"
+          />
+        </label>
+        <div className="actions">
+          <button type="submit" disabled={busy} data-testid="account-change-password">
+            {busy ? "Saving…" : "Change password"}
+          </button>
+        </div>
+      </form>
+
+      {err && (
+        <div className="error" data-testid="account-password-error">
+          {err}
+        </div>
+      )}
+      {notice && (
+        <p className="muted" data-testid="account-password-notice">
+          {notice}
+        </p>
+      )}
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Two-factor (TOTP)
+// ---------------------------------------------------------------------------
+
+type TwoFactorView =
+  | { kind: "idle" }
+  | { kind: "enrolling"; start: TwoFactorStart }
+  | { kind: "backup-codes"; codes: string[] };
+
+function TwoFactorSection({
+  csrf,
+  enabled,
+  onChanged,
+}: {
+  csrf: string;
+  enabled: boolean;
+  onChanged: () => void;
+}) {
+  const [view, setView] = useState<TwoFactorView>({ kind: "idle" });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  // Enroll flow inputs.
+  const [code, setCode] = useState("");
+  // Disable flow input.
+  const [disablePassword, setDisablePassword] = useState("");
+
+  async function onStart() {
+    if (busy) return;
+    setErr(null);
+    setBusy(true);
+    try {
+      const start = await startTwoFactor(csrf);
+      setView({ kind: "enrolling", start });
+      setCode("");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onConfirm(e: FormEvent) {
+    e.preventDefault();
+    if (busy || view.kind !== "enrolling") return;
+    setErr(null);
+    if (!/^\d{6}$/.test(code.trim())) {
+      setErr("Enter the 6-digit code from your authenticator app.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const res = await confirmTwoFactor(csrf, view.start.secret, code.trim());
+      setView({ kind: "backup-codes", codes: res.backup_codes });
+      setCode("");
+      onChanged();
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function onCancelEnroll() {
+    setView({ kind: "idle" });
+    setCode("");
+    setErr(null);
+  }
+
+  async function onDisable(e: FormEvent) {
+    e.preventDefault();
+    if (busy) return;
+    setErr(null);
+    if (!disablePassword) {
+      setErr("Enter your current password to turn off two-factor.");
+      return;
+    }
+    setBusy(true);
+    try {
+      await disableTwoFactor(csrf, disablePassword);
+      setDisablePassword("");
+      setView({ kind: "idle" });
+      onChanged();
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <section
+      className="settings-block"
+      aria-labelledby="account-2fa-heading"
+      data-testid="account-2fa"
+    >
+      <h2 id="account-2fa-heading">Two-factor authentication</h2>
+      <p className="muted">
+        Add a time-based one-time code (TOTP) from an authenticator app as a second step at sign-in.
+      </p>
+
+      <p>
+        Status:{" "}
+        <span
+          className={`lock-status-pill ${enabled ? "lock-status-on" : "lock-status-off"}`}
+          data-testid="account-2fa-status"
+        >
+          {enabled ? "Enabled" : "Off"}
+        </span>
+      </p>
+
+      {/* Show the backup codes ONCE after a successful enrollment. */}
+      {view.kind === "backup-codes" ? (
+        <div data-testid="account-2fa-backup-codes">
+          <p>
+            <strong>Save these backup codes now.</strong> Each can be used once if you lose your
+            authenticator. They won't be shown again.
+          </p>
+          <ul className="backup-codes">
+            {view.codes.map((c) => (
+              <li key={c}>
+                <code>{c}</code>
+              </li>
+            ))}
+          </ul>
+          <div className="actions">
+            <button
+              type="button"
+              onClick={() => setView({ kind: "idle" })}
+              data-testid="account-2fa-codes-done"
+            >
+              I've saved my codes
+            </button>
+          </div>
+        </div>
+      ) : enabled ? (
+        // Enrolled → password-gated disable.
+        <form onSubmit={(e) => void onDisable(e)} className="settings-form">
+          <p className="muted">Turning off two-factor requires your current password.</p>
+          <label>
+            Current password
+            <input
+              type="password"
+              autoComplete="current-password"
+              value={disablePassword}
+              disabled={busy}
+              onChange={(e) => setDisablePassword(e.target.value)}
+              data-testid="account-2fa-disable-password"
+            />
+          </label>
+          <div className="actions">
+            <button
+              type="submit"
+              className="destructive"
+              disabled={busy}
+              data-testid="account-2fa-disable"
+            >
+              {busy ? "Turning off…" : "Turn off two-factor"}
+            </button>
+          </div>
+        </form>
+      ) : view.kind === "enrolling" ? (
+        // Mid-enroll → QR + secret + confirm a code.
+        <form onSubmit={(e) => void onConfirm(e)} className="settings-form">
+          <p>
+            Scan this QR code with your authenticator app, then enter the 6-digit code it shows to
+            confirm.
+          </p>
+          <img
+            src={view.start.qr_data_url}
+            alt="Two-factor QR code"
+            width={180}
+            height={180}
+            data-testid="account-2fa-qr"
+          />
+          <p className="muted">
+            Can't scan? Enter this key manually:{" "}
+            <code data-testid="account-2fa-secret">{view.start.secret}</code>
+          </p>
+          <label>
+            6-digit code
+            <input
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={6}
+              value={code}
+              disabled={busy}
+              onChange={(e) => setCode(e.target.value.replace(/[^0-9]/g, ""))}
+              data-testid="account-2fa-code"
+            />
+          </label>
+          <div className="actions">
+            <button type="submit" disabled={busy} data-testid="account-2fa-confirm">
+              {busy ? "Verifying…" : "Verify and enable"}
+            </button>
+            <button
+              type="button"
+              className="destructive"
+              disabled={busy}
+              onClick={onCancelEnroll}
+              data-testid="account-2fa-cancel"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        // Off, idle → start enrollment.
+        <div className="actions">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void onStart()}
+            data-testid="account-2fa-enroll"
+          >
+            {busy ? "Starting…" : "Set up two-factor"}
+          </button>
+        </div>
+      )}
+
+      {err && (
+        <div className="error" data-testid="account-2fa-error">
+          {err}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1542,3 +1542,18 @@ a.btn:hover {
   background: var(--bg-soft);
   color: var(--fg-muted);
 }
+
+/* One-time 2FA backup codes (My account page). Monospace grid for legibility. */
+.backup-codes {
+  list-style: none;
+  padding: 0;
+  margin: 0.5rem 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));
+  gap: 0.35rem;
+}
+
+.backup-codes li code {
+  font-size: 0.95rem;
+  letter-spacing: 0.02em;
+}


### PR DESCRIPTION
Closes #85.

## What

A native **"My account"** page in the hub admin SPA (option B — in `/admin`, not a link out to the server-rendered `/account/`) where the signed-in user — **including the owner / first-admin, on the same path, no special-casing** — manages their own **password** and **TOTP 2FA**. Previously 2FA fully worked at the server-rendered `/account/2fa`, but the SPA had no "My account" page and no link to it, so the owner (who lives in `/admin`) couldn't find it.

## Backend — new JSON self-service endpoints

Session-cookie + CSRF (`__csrf` double-submit) + same-origin belt, exactly mirroring `/api/admin-lock`. **Self-only**: every endpoint keys off `session.userId`, never a client-supplied id. NOT the host-admin Bearer posture — a user managing their own credentials needs no admin scope.

- `POST /api/account/2fa/start` → `{ secret, otpauth_url, qr_data_url }` (NOT persisted; the SPA holds the in-flight secret and round-trips it on confirm — same "abandoned setup leaves no state" model as the HTML flow)
- `POST /api/account/2fa/confirm {secret, code}` → verify a live code vs the in-flight secret, persist enrollment, return backup codes **once**
- `POST /api/account/2fa/disable {password}` → password-gated; clear 2FA
- `POST /api/account/password {current_password, new_password}` → verify current, set new, revoke the user's still-active tokens (atomic UPDATE + revoke in one tx; argon2id hash outside the tx)

All four **reuse `two-factor-store.ts` / `totp.ts` / `users.ts`** — no duplicated TOTP/secret/password logic. `/api/me` gains `two_factor_enabled` (additive) so the page renders status without an extra read.

**QR rendering judgment call:** `start` returns both the `otpauth://` URL (manual entry) and a **PNG data-URL** QR (`qrcode` is already a hub dependency), so the SPA renders a plain `<img>` with no new client dependency.

**Rate-limiting (reviewer fold):** `/password` and `/2fa/disable` share the `changePasswordRateLimiter` bucket (3/5min, keyed by `user.id`, before the argon2id verify) with the server-rendered change-password POST — uniform per-user argon2id budget across both surfaces.

## Frontend

`web/ui/src/routes/Account.tsx` + a **"My account"** nav entry/route in `App.tsx`; `lib/api.ts` client helpers; `.backup-codes` style. The server-rendered `/account/2fa` + `/account/change-password` pages stay (no-JS / friend path); **login-side 2FA enforcement is untouched** — this only adds a JSON surface.

## web/ui dist/build

`web/ui/dist` is gitignored; the root `package.json` `prepack` hook runs `build:spa` before publish and `files` ships `web/ui/dist`, so CI/publish always packs a fresh bundle (nothing to commit). The SPA build + `verify-base.mjs` pass locally.

## Auth model (self-only)

A user can manage only their **own** account. Disable + password-change require the current password. Backup codes shown once. No secrets logged (all responses `cache-control: no-store`). Owner = first-admin = same path; no privilege bypass.

## Gates

- hub `bun test ./src`: **3854 pass / 1 skip / 0 fail** (+21 new in `api-account-2fa.test.ts`)
- SPA `bun run test`: **322 pass** (+ `Account.test.tsx`; updated `App.test.tsx` nav order)
- hub `bun run typecheck` + SPA `bun run typecheck`: clean
- SPA `bun run build` + `verify-base`: pass
- `bunx biome check`: clean on the new files (one pre-existing `App.tsx:400` a11y error on the unrelated `InstalledServicesDropdown` span — present at baseline)

Version bumped `0.7.4-rc.9` → `0.7.4-rc.10`.

## Reviewer

Independent reviewer dispatched: **LGTM with nits, no blockers**. The one substantive nit (rate-limiting parity with the HTML twin) was folded inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)