### PR TITLE
feat(oauth): same-hub vs external trust marker on the consent screen (Closes #314)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.10",
+  "version": "0.7.4-rc.11",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -353,6 +353,88 @@ describe("handleAuthorizeGet", () => {
     }
   });
 
+  // hub#314 — same-hub vs external trust marker reaches the rendered consent
+  // screen via `client.sameHub`. An unnamed `vault:read` request from a
+  // same-hub client falls through to consent (the auto-approve gate requires
+  // `!hasUnnamedVault`), so we can assert the marker on the GET render.
+  test("renders the EXTERNAL trust marker for a third-party DCR client", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      // registerClient defaults sameHub:false → external (third-party DCR).
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "ThirdPartyApp",
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // Element form — the `.badge-trust-*` CSS class names are always in the
+      // inlined <style>; the rendered ELEMENT only appears when the marker fires.
+      expect(html).toContain('class="badge badge-trust-external"');
+      expect(html).toContain("third-party app that registered itself");
+      expect(html).not.toContain('class="badge badge-trust-same-hub"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("renders the FIRST-PARTY trust marker for a same-hub client", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "FirstPartyApp",
+        sameHub: true,
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          // Unnamed vault verb → bypasses the same-hub auto-approve gate
+          // (`!hasUnnamedVault`) and falls through to the consent render.
+          scope: "vault:read",
+        }),
+        {
+          headers: {
+            cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+          },
+        },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).toContain('class="badge badge-trust-same-hub"');
+      expect(html).toContain("Registered through this hub");
+      expect(html).not.toContain('class="badge badge-trust-external"');
+    } finally {
+      cleanup();
+    }
+  });
+
   test("rejects unknown client_id with 400", async () => {
     const { db, cleanup } = await makeDb();
     try {
@@ -10137,6 +10219,62 @@ describe("hub#689 — owner-on-own-vault verb selector + widening", () => {
       const html = await res.text();
       expect(html).not.toContain("Access level");
       expect(html).not.toContain('name="verb_select"');
+    } finally {
+      cleanup();
+    }
+  });
+
+  // GET render (hub#703, folded into hub#314): a user with MIXED authority —
+  // admin on vault A (role=write → holds admin) but only read on vault B
+  // (direct INSERT role=read) — does NOT see the selector. The user could pick
+  // either vault, but doesn't own (hold admin on) EVERY pickable vault, so the
+  // `userHoldsAdminOnPickable` predicate (`assignedVaults.every(v => verbs
+  // includes "admin")`) fails on vault B and the selector is suppressed. The
+  // suppression logic already ships + is correct (oauth-handlers.ts ~2963 +
+  // ~1226); this test closes the coverage gap with no code change.
+  test("selector NOT rendered for a mixed-authority user (admin on A, read-only on B)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const mixed = await createUser(db, "mixed", "pw", { allowMulti: true });
+      // Vault A ("work"): role=write → vaultVerbsForRole maps to [read,write,
+      // admin], so the user holds admin on A. (setUserVaults hardcodes write.)
+      setUserVaults(db, mixed.id, ["work"]);
+      // Vault B ("other"): direct INSERT role=read → holds read only, NOT admin.
+      // setUserVaults DELETEs first, so this INSERT must come after it to keep A.
+      db.prepare(
+        "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, 'read', ?)",
+      ).run(mixed.id, "other", new Date().toISOString());
+      const session = createSession(db, { userId: mixed.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        selDeps,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      // Suppressed: the `.every(v => verbs includes "admin")` check fails on B.
+      expect(html).not.toContain("Access level");
+      expect(html).not.toContain('name="verb_select"');
+      // Sanity: the multi-vault picker DID render (two assigned vaults), so the
+      // suppression is specifically the verb selector, not the whole flow.
+      expect(html).toContain('name="vault_pick" value="work"');
+      expect(html).toContain('name="vault_pick" value="other"');
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -306,6 +306,58 @@ describe("renderConsent", () => {
     expect(html).not.toContain("Access level");
     expect(html).not.toContain('name="verb_select"');
   });
+
+  // hub#314 — same-hub vs external trust marker. The `.badge-trust-*` class
+  // names are always present in the inlined <style> block, so assertions target
+  // the RENDERED ELEMENT form (`class="badge badge-trust-*"`) + the copy text,
+  // which only appear in the consent body when the marker actually renders.
+  test("renders the first-party trust marker for a same-hub client", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      sameHub: true,
+    });
+    expect(html).toContain('class="badge badge-trust-same-hub"');
+    expect(html).toContain(">First-party<");
+    expect(html).toContain("Registered through this hub");
+    // The external badge / copy must NOT appear for a same-hub client.
+    expect(html).not.toContain('class="badge badge-trust-external"');
+    expect(html).not.toContain("third-party app that registered itself");
+  });
+
+  test("renders the external trust marker for a third-party DCR client", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      sameHub: false,
+    });
+    expect(html).toContain('class="badge badge-trust-external"');
+    expect(html).toContain(">External<");
+    expect(html).toContain("third-party app that registered itself");
+    // The first-party badge / copy must NOT appear for an external client.
+    expect(html).not.toContain('class="badge badge-trust-same-hub"');
+    expect(html).not.toContain("Registered through this hub");
+  });
+
+  test("renders no trust marker when provenance is unknown (sameHub omitted)", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      // sameHub omitted → undefined → no badge
+    });
+    expect(html).not.toContain('class="trust-marker');
+    expect(html).not.toContain('class="badge badge-trust-same-hub"');
+    expect(html).not.toContain('class="badge badge-trust-external"');
+  });
 });
 
 describe("renderError", () => {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -2984,6 +2984,11 @@ function consentProps(
     blockApproveForStaleAssignment:
       staleAssignedVault !== undefined && (unnamedVerbs.length > 0 || hasNamedStaleVaultScope),
     userCanAuthorizeRequest,
+    // hub#314 — surface the client's provenance (same-hub first-party vs
+    // external third-party DCR) so the operator sees the trust level on the
+    // consent screen. Clean DB-backed signal: the `same_hub` column written
+    // at DCR time (bearer hub:admin / same-origin session → true).
+    sameHub: client.sameHub,
   };
 }
 

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -162,6 +162,21 @@ export interface ConsentViewProps {
    * the unnamed verb(s) on the picked vault; it never touches any other scope.
    */
   ownerVerbSelector?: OwnerVerbSelector;
+  /**
+   * hub#314 — same-hub vs external trust marker. True when the requesting
+   * client was registered through this hub's own flow / first-party install
+   * (`OAuthClient.sameHub` — bearer `hub:admin` OR session-cookie +
+   * same-origin DCR). False for a third-party Dynamic Client Registration
+   * (an external app, e.g. Claude.ai, that self-registered). Drives a small
+   * trust badge in the consent card header so the operator knows the trust
+   * level of the app they're approving before they click Approve.
+   *
+   * Omitted / undefined → no badge (provenance unknown; only the GET-handler
+   * call site, which always has the client row, populates it). Provenance is
+   * a clean DB-backed signal — see the `same_hub` column on `clients` and the
+   * `consentProps` call site in `oauth-handlers.ts`.
+   */
+  sameHub?: boolean;
 }
 
 export interface OwnerVerbSelector {
@@ -354,6 +369,7 @@ export function renderConsent(props: ConsentViewProps): string {
     blockApproveForStaleAssignment,
     userCanAuthorizeRequest,
     ownerVerbSelector,
+    sameHub,
   } = props;
   // Substitute unnamed `vault:<verb>` rows with the resolved named form so
   // the operator sees the scope shape that will appear in the token. Raw
@@ -418,6 +434,24 @@ export function renderConsent(props: ConsentViewProps): string {
             before authorizing vault access.
           </p>`
     : "";
+  // hub#314 — same-hub vs external trust marker. `sameHub === true` means the
+  // client was registered through this hub's own flow (first-party / operator-
+  // authenticated DCR); `false` means a third-party app self-registered via
+  // public Dynamic Client Registration. `undefined` → no badge (provenance
+  // unknown to the caller). The badge sits in the header so the operator sees
+  // the trust level before reading the scope list.
+  const trustMarker =
+    sameHub === undefined
+      ? ""
+      : sameHub
+        ? `<p class="trust-marker trust-marker-same-hub">
+            <span class="badge badge-trust-same-hub">First-party</span>
+            <span class="trust-marker-text">Registered through this hub.</span>
+          </p>`
+        : `<p class="trust-marker trust-marker-external">
+            <span class="badge badge-trust-external">External</span>
+            <span class="trust-marker-text">A third-party app that registered itself. Approve only if you recognise it.</span>
+          </p>`;
   const body = `
     <div class="card">
       <div class="card-header">
@@ -429,6 +463,7 @@ export function renderConsent(props: ConsentViewProps): string {
         <p class="subtitle">
           This app is requesting access to your Parachute account.
         </p>
+        ${trustMarker}
         <p class="client-meta">
           <span class="client-meta-label">client_id</span>
           <code>${escapeHtml(clientId)}</code>
@@ -1578,6 +1613,22 @@ const STYLES = `
   .badge-write { background: ${PALETTE.accentSoft}; color: ${PALETTE.accent}; }
   .badge-send { background: ${PALETTE.accentSoft}; color: ${PALETTE.accent}; }
   .badge-admin { background: ${PALETTE.danger}; color: ${PALETTE.cardBg}; }
+
+  /* hub#314 — same-hub vs external trust marker on the consent header. The
+     first-party badge uses the accent (calm/trusted); external uses the danger
+     tint so a third-party DCR client stands out without being alarmist. */
+  .trust-marker {
+    display: flex;
+    align-items: baseline;
+    gap: 0.45rem;
+    flex-wrap: wrap;
+    margin: 0.75rem 0 0;
+    font-size: 0.85rem;
+    color: ${PALETTE.fgMuted};
+  }
+  .trust-marker-text { flex: 1; min-width: 12rem; }
+  .badge-trust-same-hub { background: ${PALETTE.accentSoft}; color: ${PALETTE.accent}; }
+  .badge-trust-external { background: ${PALETTE.dangerSoft}; color: ${PALETTE.danger}; }
 
   @media (max-width: 480px) {
     main { padding: 0.75rem; }


### PR DESCRIPTION
Closes #314 — Consent & admin-SPA polish (consolidated quick-win bundle).

## What

### 1. Same-hub vs external trust marker on the consent screen
When the hub renders the OAuth consent / approve screen, surface whether the requesting client is **first-party (same-hub)** or **external (third-party DCR)** — a small header badge so the operator knows the trust level *before* clicking Approve.

- **First-party** (calm accent badge): client registered through this hub's own flow — bearer `hub:admin` OR same-origin session DCR.
- **External** (danger-tinted badge + "approve only if you recognise it" copy): a third-party app self-registered via public Dynamic Client Registration (e.g. Claude.ai).
- **Unknown** (`sameHub` omitted): no badge.

**Provenance signal.** Clean DB-backed flag — the `same_hub` column on the `clients` table, written at DCR time and already carried on `OAuthClient.sameHub` (set true when the registrant authenticated as the operator: bearer `hub:admin` OR session-cookie + same-origin POST; false for unauthenticated / external DCR). No new derivation needed — `consentProps` plumbs `client.sameHub` straight into the new `ConsentViewProps.sameHub`, and `renderConsent` renders the header badge. **No limitation** beyond what `same_hub` already encodes.

The marker uses only static literal copy (no client-derived strings); existing `escapeHtml` on `clientName` / `clientId` is untouched.

### 2. Owner-verb-selector mixed-authority suppression test (hub#703, folded in)
Pure test addition (no code change) closing a coverage gap: a user assigned to vault A (role=write → holds admin) AND vault B (direct INSERT role=read) has the consent owner-verb-selector **suppressed** — the `userHoldsAdminOnPickable` predicate (`assignedVaults.every(v => verbs includes "admin")`) fails on the read-only vault B. The suppression logic already ships and is correct (`oauth-handlers.ts:2963` + `~1226`).

## Tests
- **+6 new tests, all passing:** 3 unit (`renderConsent` first-party / external / unknown markers), 2 GET-handler integration (`handleAuthorizeGet` renders the right marker from `client.sameHub`), 1 mixed-authority suppression.
- `bun test ./src` → **3860 pass, 1 skip, 0 fail**
- `bun run typecheck` → clean
- `bunx biome check` → my files clean; 2 pre-existing `oauth-handlers.ts` errors (a `console.warn` useTemplate/noUnusedTemplateLiteral pair, unrelated to this diff) + the pre-existing `package.json` error left untouched per the bundle scope. No web/ui files touched.

## Version
`0.7.4-rc.10` → `0.7.4-rc.11`.

## Files changed
- `src/oauth-ui.ts` — `ConsentViewProps.sameHub`, trust-marker render + CSS
- `src/oauth-handlers.ts` — plumb `client.sameHub` through `consentProps`
- `src/__tests__/oauth-ui.test.ts` — 3 unit tests
- `src/__tests__/oauth-handlers.test.ts` — 2 integration tests + 1 mixed-authority suppression test
- `package.json` — rc bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)