### PR TITLE
fix(admin-vaults): last-vault delete runs the identity cascade — Closes #678 (core; optional active-vault guard deferred)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.12",
+  "version": "0.7.4-rc.13",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -940,27 +940,70 @@ describe("DELETE /vaults/<name> — gates", () => {
     }
   });
 
-  test("409 last_vault on the only remaining vault (CLI never runs)", async () => {
+  test("#678: deleting the LAST vault cascades + deletes (no 409), with a last_vault warning", async () => {
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
-        writeVaults(h.manifestPath, ["default"]);
+        // Only one vault on the hub — the previously-refused last-vault case.
+        writeVaults(h.manifestPath, ["solo"]);
+
+        // Seed identity artifacts naming the soon-to-be-deleted last vault.
+        registryRow(db, "jti-solo", ["vault:solo:write"]);
+        const carol = await createUser(db, "carol", "carol-passphrase-123");
+        const client = registerClient(db, { redirectUris: ["https://d.example/cb"] }).client
+          .clientId;
+        recordGrant(db, carol.id, client, ["vault:solo:admin"]);
+        setUserVaults(db, carol.id, ["solo"]);
+
         const runner = stubRun();
         const res = await callDelete({
-          name: "default",
+          name: "solo",
           db,
           manifestPath: h.manifestPath,
           connectionsStorePath: join(h.dir, "connections.json"),
           runCommand: runner.run,
         });
-        expect(res.status).toBe(409);
-        const out = (await res.json()) as { error: string; error_description: string };
-        expect(out.error).toBe("last_vault");
-        // Guidance names the CLI escape hatch + the resurrection reason.
-        expect(out.error_description).toContain("parachute-vault remove");
-        expect(runner.calls.length).toBe(0);
+
+        // No 409 — the delete completes.
+        expect(res.status).toBe(200);
+        const out = (await res.json()) as {
+          ok: boolean;
+          cascade: {
+            tokens_revoked: number;
+            grants_dropped: number;
+            user_vaults_removed: number;
+            vault_removed: boolean;
+          };
+          warnings?: { step: string; detail: string }[];
+        };
+        expect(out.ok).toBe(true);
+
+        // The cascade ran for the last vault: tokens/grants/assignments gone.
+        expect(out.cascade.tokens_revoked).toBe(1);
+        expect(findTokenRowByJti(db, "jti-solo")?.revokedAt).not.toBeNull();
+        expect(out.cascade.grants_dropped).toBe(1);
+        expect(findGrant(db, carol.id, client)).toBeNull();
+        expect(out.cascade.user_vaults_removed).toBe(1);
+        expect(
+          db
+            .query<{ vault_name: string }, [string]>(
+              "SELECT vault_name FROM user_vaults WHERE user_id = ?",
+            )
+            .all(carol.id),
+        ).toEqual([]);
+
+        // The underlying vault remove ran (the cascade no longer skips it).
+        expect(runner.calls).toContainEqual(["parachute-vault", "remove", "solo", "--yes"]);
+        expect(out.cascade.vault_removed).toBe(true);
+
+        // A last_vault heads-up warning is surfaced (name-agnostic — does not
+        // assume "default"); the auto_create:false marker prevents resurrection.
+        const lastVaultWarning = out.warnings?.find((w) => w.step === "last_vault");
+        expect(lastVaultWarning).toBeDefined();
+        expect(lastVaultWarning?.detail).toContain("auto_create: false");
+        expect(lastVaultWarning?.detail).not.toContain('"default"');
       } finally {
         db.close();
       }

--- a/src/__tests__/vault-remove.test.ts
+++ b/src/__tests__/vault-remove.test.ts
@@ -83,6 +83,7 @@ const SUCCESS_BODY = {
     grants_dropped: 2,
     user_vaults_removed: 4,
     invites_invalidated: 1,
+    vault_cap_removed: true,
     connections_torn_down: 1,
     orphaned_channels: [],
     vault_removed: true,
@@ -156,6 +157,7 @@ describe("vaultRemove — 200 success", () => {
     expect(text).toContain("3");
     expect(text).toContain("user_vaults removed:");
     expect(text).toContain("4");
+    expect(text).toContain("storage cap removed:");
     expect(text).toContain("vault removed:");
   });
 
@@ -194,19 +196,35 @@ describe("vaultRemove — 200 success", () => {
   });
 });
 
-describe("vaultRemove — 409 last_vault GUARDRAIL", () => {
-  test("returns NON-ZERO and NEVER spawns parachute-vault", async () => {
+describe("vaultRemove — last vault (#678: cascade-then-delete, no 409)", () => {
+  test("the last vault deletes via the cascade (200) and NEVER spawns parachute-vault directly", async () => {
     await withSpawnSpy(async (spawned) => {
-      const { fetch, calls } = fakeFetch([
-        {
-          status: 409,
-          body: {
-            error: "last_vault",
-            error_description:
-              '"scratch" is the last vault on this hub. Create another vault first, or use the CLI.',
-          },
+      // The endpoint no longer refuses the last vault — it returns 200 with the
+      // cascade summary, identical to any other delete. The CLI just renders it.
+      const lastVaultBody = {
+        ok: true,
+        name: "scratch",
+        cascade: {
+          tokens_revoked: 2,
+          grants_rewritten: 0,
+          grants_dropped: 1,
+          user_vaults_removed: 1,
+          invites_invalidated: 0,
+          vault_cap_removed: true,
+          connections_torn_down: 0,
+          orphaned_channels: [],
+          vault_removed: true,
+          module_restarted: true,
         },
-      ]);
+        warnings: [
+          {
+            step: "last_vault",
+            detail:
+              "the deleted vault was the last one on this hub — no vaults remain. The vault CLI wrote auto_create: false, so boot won't recreate a default vault. Create one with: parachute-vault create <name>",
+          },
+        ],
+      };
+      const { fetch, calls } = fakeFetch([{ status: 200, body: lastVaultBody }]);
       const sinks = makeSinks();
       const code = await vaultRemove(["scratch"], {
         resolveBearer: async () => BEARER,
@@ -214,17 +232,20 @@ describe("vaultRemove — 409 last_vault GUARDRAIL", () => {
         log: sinks.log,
         logError: sinks.logError,
       });
-      // Non-zero exit.
-      expect(code).not.toBe(0);
-      // Exactly ONE fetch (the DELETE) — no fall-through retry path.
+      // 200 → success exit; the cascade did its work.
+      expect(code).toBe(0);
+      // Exactly ONE fetch (the DELETE) — the cascade runs server-side over loopback.
       expect(calls).toHaveLength(1);
       expect(calls[0]?.method).toBe("DELETE");
-      // The load-bearing invariant: no `parachute-vault` spawn.
+      // The load-bearing invariant still holds: the CLI never spawns
+      // `parachute-vault` itself — destruction goes through the hub endpoint.
       expect(spawned.count).toBe(0);
-      // Surfaces the endpoint message + the cascade-skip warning on the escape hatch.
-      const errText = sinks.errText();
-      expect(errText).toContain("last vault");
-      expect(errText).toContain("SKIPS the identity cascade");
+      // The cascade summary renders, including the last_vault heads-up warning.
+      const text = sinks.text();
+      expect(text).toContain("tokens revoked:");
+      expect(text).toContain("vault removed:");
+      expect(text).toContain("last_vault");
+      expect(text).toContain("auto_create: false");
     });
   });
 });

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -630,14 +630,21 @@ export function listVaultInstanceNames(manifestPath: string): Set<string> {
  *
  * Refusals:
  *   - unknown vault → 404;
- *   - LAST remaining vault → 409. Vault's boot auto-creates `default` at
- *     zero vaults, so deleting the last one would silently resurrect a fresh
- *     `default` (with a fresh global API key) — refusing sidesteps the
- *     resurrection class entirely. The CLI (`parachute-vault remove`) is the
- *     escape hatch for an operator who really means it.
  *   - RESERVED names are deliberately ALLOWED (no reserved-name gate): a
  *     squatted `admin`/`new`/`assets` vault created before the B2h
  *     reservation must be removable through this endpoint.
+ *
+ * Last-vault handling (#678): deleting the LAST remaining vault runs the SAME
+ * cascade-then-delete as any other vault — it is NOT refused. The old 409 that
+ * steered the operator to the raw `parachute-vault remove` CLI was a
+ * correctness defect: that escape hatch SKIPS this cascade, orphaning tokens +
+ * grants that named the last vault. The resurrection risk the refusal once
+ * guarded (vault boot auto-creating a fresh-credentialed first vault at zero
+ * vaults) is handled downstream instead: the vault CLI writes an
+ * `auto_create: false` marker on last-vault removal and the vault boot gate
+ * honors it, so the server won't silently resurrect. Detection stays
+ * count-based + name-agnostic (no `name === "default"` special case); the last
+ * vault just adds a `last_vault` warning to the 200 response.
  *
  * Cascade, in order (identity first, mechanics last — revocation is the safe
  * direction if a later step fails):
@@ -661,6 +668,15 @@ export function listVaultInstanceNames(manifestPath: string): Set<string> {
  * Response: 200 with a structured per-step summary (counts +
  * `orphaned_channels` + warnings). A mechanics failure responds 500 with
  * the partial summary — the identity artifacts already revoked stay revoked.
+ *
+ * Bounded residual: the cascade revokes every *registered* token row naming
+ * the vault, but an UNREGISTERED interactive-mint (a host-admin browser
+ * session minting a short-lived vault token at ≤10-min TTL — see
+ * REGISTERED_MINT_TTL_THRESHOLD_SECONDS in admin-connections.ts) that was
+ * issued just before the delete leaves no registry row to sweep. Such a token
+ * stays valid for at most its remaining ≤10-min TTL, against a vault whose
+ * daemon is evicted in step 7 anyway. Same bound the auth-codes note below
+ * relies on; not eliminated, just bounded.
  */
 export async function handleDeleteVault(
   req: Request,
@@ -714,16 +730,20 @@ export async function handleDeleteVault(
     return jsonError(404, "not_found", `no vault named "${name}" on this hub`);
   }
 
-  // Last-vault refusal (resurrection guard).
+  // Last-vault detection (count-based, name-agnostic). Deleting the LAST
+  // vault used to refuse with 409 and steer the operator to the raw
+  // `parachute-vault remove` CLI — but that path SKIPS this whole identity
+  // cascade, orphaning tokens + grants that named the vault. The resurrection
+  // risk the refusal guarded against is already handled downstream: the vault
+  // CLI writes an `auto_create: false` marker when it removes the last vault
+  // (vault `cli.ts` cmdRemove) and the vault boot gate honors it
+  // (`bootAutoCreateAllowed` in vault `config.ts`), so the server won't
+  // silently resurrect a fresh-credentialed first vault. We therefore run the
+  // cascade-then-delete for the last vault exactly as for any other — the
+  // count is informational only (no refusal).
   const instanceNames = listVaultInstanceNames(manifestPath);
   instanceNames.delete(name);
-  if (instanceNames.size === 0) {
-    return jsonError(
-      409,
-      "last_vault",
-      `"${name}" is the last vault on this hub. Vault's boot auto-creates "default" at zero vaults, so deleting the last one would silently resurrect it with fresh credentials. Create another vault first, or use the CLI (parachute-vault remove ${name} --yes) if you really mean to empty the hub.`,
-    );
-  }
+  const isLastVault = instanceNames.size === 0;
 
   const summary = emptyCascadeSummary();
   const warnings: { step: string; detail: string }[] = [];
@@ -863,6 +883,18 @@ export async function handleDeleteVault(
       "server_error",
       `orchestration failed: ${msg} — identity artifacts already revoked (summary: ${JSON.stringify(summary)})`,
     );
+  }
+
+  // Last-vault heads-up. The vault CLI's remove wrote `auto_create: false`, so
+  // the next vault boot won't resurrect a fresh-credentialed first vault — the
+  // hub is now deliberately empty. Surface that so the operator knows to create
+  // one when they want the hub serving again.
+  if (isLastVault) {
+    warnings.push({
+      step: "last_vault",
+      detail:
+        "the deleted vault was the last one on this hub — no vaults remain. The vault CLI wrote auto_create: false, so boot won't recreate a default vault. Create one with: parachute-vault create <name>",
+    });
   }
 
   // --- 7. Daemon eviction: supervisor-restart the vault module. -------------

--- a/src/commands/vault-remove.ts
+++ b/src/commands/vault-remove.ts
@@ -31,14 +31,18 @@
  * `parachute:host:admin` — exactly the scope the endpoint gates on. This is the
  * same read-never-mint credential path `parachute start/stop/restart <svc>` use.
  *
- * ## The 409 guardrail (load-bearing)
+ * ## Last-vault handling (#678)
  *
- * On a `409 last_vault` the endpoint refuses (deleting the last vault would let
- * vault's boot silently resurrect a fresh `default`). We print the endpoint's
- * message + note the raw escape hatch (`parachute-vault remove <name> --yes`)
- * which SKIPS the cascade, then return NON-ZERO. We MUST NOT fall through to
- * spawning `parachute-vault` ourselves: a "helpful" fall-through would re-open
- * the exact orphaning bug B3 closes. The test locks this invariant.
+ * The last/only vault is deleted IDENTICALLY to any other vault: the endpoint
+ * runs the full cascade-then-delete and returns 200. There is no special-case
+ * here. (Older builds refused the last vault with a `409 last_vault` and steered
+ * the operator to the raw `parachute-vault remove --yes` — but that escape hatch
+ * SKIPS the cascade, orphaning the very identity artifacts B3 set out to clean
+ * up. hub#678 removed that refusal: vault's boot can no longer silently
+ * resurrect a fresh first vault because vault's CLI writes an
+ * `auto_create: false` marker on last-vault removal and the boot gate honors
+ * it.) This command therefore needs no 409 branch — the 200 path renders the
+ * cascade summary for the last vault just like every other delete.
  */
 
 import { CONFIG_DIR } from "../config.ts";
@@ -56,8 +60,9 @@ import {
 
 /**
  * Injectable seams. Production wires the real operator-token bearer resolver +
- * the global `fetch`; tests inject fakes to assert the request shape + lock the
- * 409 guardrail without a live hub or a real socket.
+ * the global `fetch`; tests inject fakes to assert the request shape + that
+ * destruction always goes through the hub endpoint (never a direct
+ * `parachute-vault` spawn) without a live hub or a real socket.
  */
 export interface VaultRemoveDeps {
   /**
@@ -84,6 +89,7 @@ interface CascadeSummaryWire {
   grants_dropped?: number;
   user_vaults_removed?: number;
   invites_invalidated?: number;
+  vault_cap_removed?: boolean;
   connections_torn_down?: number;
   orphaned_channels?: unknown;
   vault_removed?: boolean;
@@ -151,6 +157,7 @@ function renderCascadeSummary(
   log(`  grants dropped:        ${n(c.grants_dropped)}`);
   log(`  user_vaults removed:   ${n(c.user_vaults_removed)}`);
   log(`  invites invalidated:   ${n(c.invites_invalidated)}`);
+  log(`  storage cap removed:   ${c.vault_cap_removed === true ? "yes" : "no"}`);
   log(`  connections torn down: ${n(c.connections_torn_down)}`);
   log(`  vault removed:         ${c.vault_removed === true ? "yes" : "no"}`);
   log(`  vault module restarted:${c.module_restarted === true ? " yes" : " no"}`);
@@ -300,21 +307,6 @@ export async function vaultRemove(args: string[], deps: VaultRemoveDeps = {}): P
     // Idempotent: a re-run after a successful delete lands here. Not scary.
     log(`Vault "${name}" does not exist on this hub (already removed). Nothing to do.`);
     return 0;
-  }
-
-  if (res.status === 409 && error === "last_vault") {
-    // CRITICAL GUARDRAIL: print + exit non-zero. Do NOT fall through to spawning
-    // `parachute-vault` — that would re-open the orphaned-identity bug B3 closes.
-    logError(`parachute vault remove: ${error_description}`);
-    logError("");
-    logError(
-      `The raw mechanics-only path \`parachute-vault remove ${name} --yes\` can delete the last vault,`,
-    );
-    logError(
-      "but it SKIPS the identity cascade — live tokens, grants, and user_vaults rows for that",
-    );
-    logError("vault would be left orphaned. Create another vault first if you can.");
-    return 1;
   }
 
   if (res.status === 400 && error === "confirm_mismatch") {


### PR DESCRIPTION
## What

Closes #678 (core). Deleting the **last/only** vault on a hub used to hit a hard **409** at `src/admin-vaults.ts` that refused the delete and steered the operator to the raw `parachute-vault remove <name> --yes` CLI. But that escape hatch **skips the entire hub identity cascade** — so the last-vault case left **orphan tokens + stale grants + assignments** that named the vault. A real correctness defect.

## Fix

Replace the 409 refusal with **cascade-then-delete** for the last vault. It now runs the same standalone cascade fns that already live in this file's delete path, **before** shelling to the underlying `parachute-vault remove`:

| Step | Fn |
|---|---|
| tokens-registry sweep | `revokeTokensNamingVault` |
| grants rewrite/drop | `rewriteGrantsRemovingVault` |
| `user_vaults` rows | `removeVaultAssignments` |
| unredeemed invites | `revokeInvitesForVault` |
| per-vault storage cap (v15) | `removeVaultCap` |
| connections teardown | `teardownConnection` (+ report-only agent `/api/channels` scan) |

The resurrection risk the 409 once guarded is handled **downstream**: the vault CLI writes an `auto_create: false` marker on last-vault removal (`cli.ts` cmdRemove) and the vault boot gate honors it (`bootAutoCreateAllowed` in `config.ts`), so the server won't silently resurrect a fresh-credentialed first vault.

- Detection stays **count-based + name-agnostic** — no `name === "default"` special case added.
- The last vault now adds a `last_vault` **warning** to the 200 response (name-agnostic prose), so the operator knows the hub is now empty + how to re-create.
- Docstrings updated to describe cascade-then-delete + the **bounded residual**.

## Bounded residual (documented)

The cascade revokes every *registered* token row naming the vault, but an **unregistered interactive-mint** (host-admin browser session minting a short-lived vault token at ≤10-min TTL — `REGISTERED_MINT_TTL_THRESHOLD_SECONDS` in admin-connections.ts) issued just before the delete has no registry row to sweep. It stays valid for at most its remaining ≤10-min TTL, against a vault whose daemon is evicted in step 7 anyway. Same bound the existing auth-codes note relies on. Not eliminated — bounded.

## Deferred (sub-task 4)

The optional active-vault-by-identity guard stays **DEFERRED**: host-admin tokens carry no per-identity vault pin, so it's design-blocked and optional.

## Paired vault PR

Name-agnostic last-vault-removal prose: ParachuteComputer/parachute-vault#515

## Tests / gates

- Converted the old `409 last_vault` test into `#678: deleting the LAST vault cascades + deletes (no 409), with a last_vault warning` — asserts tokens revoked, grant dropped, assignment removed, the underlying remove ran, and the name-agnostic warning.
- Non-last-vault path unchanged (covered by the existing full-cascade suite).
- `bun test ./src`: **3876 pass / 1 skip / 0 fail**
- `tsc --noEmit`: clean
- biome: clean

Version: 0.7.4-rc.12 → **0.7.4-rc.13**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)