### PR TITLE
fix(admin-lock): heartbeat omitted idle_seconds → instant PIN re-lock loop

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.13",
+  "version": "0.7.4-rc.14",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-lock.test.ts
+++ b/src/__tests__/admin-lock.test.ts
@@ -527,7 +527,13 @@ describe("admin-lock management API", () => {
     const r2 = await handleAdminLock(lockReq("/heartbeat", cookie, {}), "/heartbeat", {
       db: harness.db,
     });
-    expect(((await r2.json()) as { locked: boolean }).locked).toBe(false);
+    const body2 = (await r2.json()) as { locked: boolean; idle_seconds?: number };
+    expect(body2.locked).toBe(false);
+    // The heartbeat MUST carry idle_seconds — the client re-anchors its local
+    // idle timer from it on every heartbeat. Omitting it poisoned the timer
+    // (undefined → NaN → instant re-lock). Regression guard for the PIN
+    // re-prompt loop.
+    expect(body2.idle_seconds).toBe(getIdleSeconds(harness.db));
   });
 
   test("unlock brute-force limiter: 6th attempt is 429", async () => {

--- a/src/api-admin-lock.ts
+++ b/src/api-admin-lock.ts
@@ -159,8 +159,15 @@ export async function handleAdminLock(
     case "/heartbeat":
       // Slide the idle window forward if (and only if) currently unlocked.
       refreshActivity(gate.sessionId, getIdleSeconds(db), now().getTime());
+      // `idle_seconds` is part of the response so the heartbeat fulfills the
+      // same `AdminLockStatus` shape as GET status — the client re-anchors its
+      // local idle timer from it on every heartbeat, so it MUST be present.
+      // Omitting it poisoned the client timer with `undefined` (→ NaN → instant
+      // re-lock), the bug this fixes. It also lets a live session pick up an
+      // idle-window change the operator made in Settings mid-session.
       return json(200, {
         locked: isLockConfigured(db) && !isSessionUnlocked(gate.sessionId, now().getTime()),
+        idle_seconds: getIdleSeconds(db),
         unlock_seconds_remaining: unlockSecondsRemaining(gate.sessionId, now().getTime()),
       });
     default:

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -43,6 +43,10 @@ vi.mock("./lib/api.ts", async (orig) => {
       idle_seconds: 900,
       unlock_seconds_remaining: 0,
     }),
+    // The real /heartbeat response carries idle_seconds (see api-admin-lock.ts);
+    // the client re-anchors its idle timer from it. (A prior mock that included
+    // idle_seconds masked the bug where the server omitted it — keep this
+    // matching the real wire shape.)
     adminLockHeartbeat: vi.fn().mockResolvedValue({
       configured: false,
       locked: false,

--- a/web/ui/src/lib/useAdminLock.test.ts
+++ b/web/ui/src/lib/useAdminLock.test.ts
@@ -1,0 +1,218 @@
+/**
+ * useAdminLock — the client timing logic behind the admin screen-lock.
+ *
+ * The regression these tests pin (the "PIN re-prompts every few seconds"
+ * loop, #678-adjacent): the hook re-anchors its LOCAL idle timer from the
+ * server's `idle_seconds` on every heartbeat. When the `/heartbeat` response
+ * OMITTED that field, `idleSeconds.current` was overwritten with `undefined`,
+ * `armIdleTimer` computed `Math.max(1, undefined) * 1000 = NaN`, and
+ * `setTimeout(fn, NaN)` coerced to `setTimeout(fn, 0)` — slamming the operator
+ * back to the lock screen almost instantly, over and over.
+ *
+ * Two halves of the fix are exercised here:
+ *   1. A heartbeat WITHOUT a usable `idle_seconds` must NOT poison the timer
+ *      (the client now guards with Number.isFinite + a 15-min fallback).
+ *   2. A heartbeat WITH `idle_seconds` re-anchors the window to that value.
+ */
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import * as api from "./api.ts";
+import { useAdminLock } from "./useAdminLock.ts";
+
+vi.mock("./api.ts", async (orig) => {
+  const actual = (await orig()) as typeof api;
+  return {
+    ...actual,
+    getAdminLockStatus: vi.fn(),
+    adminLockHeartbeat: vi.fn(),
+  };
+});
+
+const CSRF = "csrf-token";
+const FIFTEEN_MIN_MS = 15 * 60 * 1000;
+
+/** Flush microtasks (the awaited fetch promises inside the hook). */
+async function flush() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+/** Fire a single activity event the hook listens for. */
+function activity() {
+  act(() => {
+    window.dispatchEvent(new Event("pointerdown"));
+  });
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.runOnlyPendingTimers();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("useAdminLock — idle timer re-anchoring", () => {
+  it("a heartbeat WITHOUT idle_seconds does NOT instantly re-lock (the bug)", async () => {
+    // Configured + unlocked, idle window 900s.
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: true,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 900,
+    });
+    // The poisoned shape: the old server response omitted idle_seconds. We model
+    // it explicitly as a value the type claims is present but runtime lacks.
+    vi.mocked(api.adminLockHeartbeat).mockResolvedValue({
+      configured: true,
+      locked: false,
+      unlock_seconds_remaining: 900,
+    } as unknown as api.AdminLockStatus);
+
+    const { result } = renderHook(() => useAdminLock(CSRF, true));
+    await flush(); // initial getAdminLockStatus resolves
+
+    expect(result.current.configured).toBe(true);
+    expect(result.current.locked).toBe(false);
+
+    // First activity → fires the (poisoned) heartbeat AND arms the idle timer
+    // (with the load-time 900s). The heartbeat resolves and, in the BUGGY
+    // version, overwrote idleSeconds.current with undefined.
+    activity();
+    await flush();
+
+    // A SECOND activity re-arms the timer. In the buggy version this computed
+    // Math.max(1, undefined) * 1000 = NaN → setTimeout(fn, 0) → instant lock.
+    // (Advance past the heartbeat debounce so the 2nd activity is a clean
+    // re-arm, mirroring real continuous use.)
+    act(() => {
+      vi.advanceTimersByTime(31_000);
+    });
+    activity();
+    await flush();
+
+    // Advance well past the broken-instant window but short of the real one.
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+    // The bug locked here (NaN → 0ms). With the guard, still unlocked.
+    expect(result.current.locked).toBe(false);
+
+    // It DOES still lock at the legitimate fallback window (15 min) from the
+    // last re-arm.
+    act(() => {
+      vi.advanceTimersByTime(FIFTEEN_MIN_MS);
+    });
+    expect(result.current.locked).toBe(true);
+  });
+
+  it("a heartbeat WITH idle_seconds re-anchors the window to that value", async () => {
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: true,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 900,
+    });
+    // Heartbeat reports a SHORTER window (operator tightened it mid-session).
+    vi.mocked(api.adminLockHeartbeat).mockResolvedValue({
+      configured: true,
+      locked: false,
+      idle_seconds: 120,
+      unlock_seconds_remaining: 120,
+    });
+
+    const { result } = renderHook(() => useAdminLock(CSRF, true));
+    await flush();
+
+    // First activity: arms the timer with the load-time window (900s) AND sends
+    // a heartbeat. The heartbeat's idle_seconds (120) lands in the ref AFTER the
+    // timer was armed — armIdleTimer runs synchronously, the heartbeat resolves
+    // later — so it takes effect on the NEXT activity, not this timer.
+    activity();
+    await flush();
+
+    // A SUBSEQUENT activity (debounced past the heartbeat window via the clock)
+    // re-arms with the heartbeat-reported 120s.
+    act(() => {
+      vi.advanceTimersByTime(31_000); // past HEARTBEAT_DEBOUNCE_MS so a 2nd HB could fire
+    });
+    activity();
+    await flush();
+
+    // 119s after the re-arm: still unlocked (window is now 120s).
+    act(() => {
+      vi.advanceTimersByTime(119_000);
+    });
+    expect(result.current.locked).toBe(false);
+
+    // Cross 120s: re-lock fires at the heartbeat-reported window.
+    act(() => {
+      vi.advanceTimersByTime(2_000);
+    });
+    expect(result.current.locked).toBe(true);
+  });
+
+  it("a fresh load while a PIN is set + no unlock window starts locked", async () => {
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: true,
+      locked: true,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 0,
+    });
+
+    const { result } = renderHook(() => useAdminLock(CSRF, true));
+    await flush();
+
+    expect(result.current.configured).toBe(true);
+    expect(result.current.locked).toBe(true);
+  });
+
+  it("a heartbeat reporting locked (drift) flips to locked", async () => {
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: true,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 900,
+    });
+    vi.mocked(api.adminLockHeartbeat).mockResolvedValue({
+      configured: true,
+      locked: true,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 0,
+    });
+
+    const { result } = renderHook(() => useAdminLock(CSRF, true));
+    await flush();
+    expect(result.current.locked).toBe(false);
+
+    activity();
+    await flush();
+    expect(result.current.locked).toBe(true);
+  });
+
+  it("feature OFF (no PIN) never arms a timer or locks", async () => {
+    vi.mocked(api.getAdminLockStatus).mockResolvedValue({
+      configured: false,
+      locked: false,
+      idle_seconds: 900,
+      unlock_seconds_remaining: 0,
+    });
+
+    const { result } = renderHook(() => useAdminLock(CSRF, true));
+    await flush();
+
+    activity();
+    await flush();
+    act(() => {
+      vi.advanceTimersByTime(2 * FIFTEEN_MIN_MS);
+    });
+    expect(result.current.configured).toBe(false);
+    expect(result.current.locked).toBe(false);
+    // No heartbeat is sent while unconfigured.
+    expect(api.adminLockHeartbeat).not.toHaveBeenCalled();
+  });
+});

--- a/web/ui/src/lib/useAdminLock.ts
+++ b/web/ui/src/lib/useAdminLock.ts
@@ -58,14 +58,18 @@ export function useAdminLock(csrf: string | null, enabled: boolean): UseAdminLoc
     clearIdleTimer();
     // Local idle expiry → show the lock screen. The server window is the same
     // length, so by the time this fires the next mint would 423 anyway.
-    idleTimer.current = setTimeout(() => setLocked(true), Math.max(1, idleSeconds.current) * 1000);
+    // Guard against a non-finite ref value: a bad/absent server `idle_seconds`
+    // (NaN/undefined) must NOT collapse to setTimeout(fn, 0) and slam the
+    // operator to the lock screen instantly — fall back to the 15-min default.
+    const seconds = Number.isFinite(idleSeconds.current) ? idleSeconds.current : 15 * 60;
+    idleTimer.current = setTimeout(() => setLocked(true), Math.max(1, seconds) * 1000);
   }, [clearIdleTimer]);
 
   const applyStatus = useCallback(
     (s: AdminLockStatus) => {
       setConfigured(s.configured);
       setLocked(s.locked);
-      idleSeconds.current = s.idle_seconds;
+      if (Number.isFinite(s.idle_seconds)) idleSeconds.current = s.idle_seconds;
       if (s.configured && !s.locked) {
         armIdleTimer();
       } else {
@@ -111,7 +115,10 @@ export function useAdminLock(csrf: string | null, enabled: boolean): UseAdminLoc
         .then((s) => {
           // The server may report a lock that drifted (e.g. another tab locked).
           if (s.locked) setLocked(true);
-          else idleSeconds.current = s.idle_seconds;
+          // Re-anchor the local idle window from the heartbeat — but ONLY when
+          // the server actually sent a usable number. Assigning an absent field
+          // here is what poisoned the timer (→ NaN → instant re-lock).
+          else if (Number.isFinite(s.idle_seconds)) idleSeconds.current = s.idle_seconds;
         })
         .catch(() => {
           // Ignore — the idle timer + next mint failure are the backstop.


### PR DESCRIPTION
## Root cause (one-liner)

The `/api/admin-lock/heartbeat` response **omits `idle_seconds`** → the client (`useAdminLock`) overwrites its good `900` with `undefined` → `armIdleTimer` computes `setTimeout(fn, Math.max(1, undefined) * 1000)` = `setTimeout(fn, NaN)` → coerced to `setTimeout(fn, 0)` → **instant re-lock**. Re-entering the PIN works, then the next heartbeat (~every 30s) re-poisons the ref and it re-locks again — the "PIN re-prompts every few seconds instead of every 15 minutes" loop.

The api client **typed** `adminLockHeartbeat` as `Promise<AdminLockStatus>` (which declares `idle_seconds: number`) via a `as` cast, so TypeScript never saw the gap; the server's heartbeat test only asserted `locked`, so it didn't catch the missing field either.

## Fix (both sides of the contract)

1. **Server** — `src/api-admin-lock.ts`: the `/heartbeat` 200 now includes `idle_seconds: getIdleSeconds(db)`, fulfilling the same `AdminLockStatus` shape as `GET /api/admin-lock`. Bonus: a live session now picks up an idle-window change the operator makes in Settings mid-session.
2. **Client** — `web/ui/src/lib/useAdminLock.ts` (defense-in-depth): only re-anchor `idleSeconds.current` from a `Number.isFinite` value (heartbeat read, `applyStatus`), and `armIdleTimer` falls back to the 15-min default for any non-finite ref. A future contract drift can never collapse the timer to `0` again.

## Files touched

- `src/api-admin-lock.ts` — heartbeat response includes `idle_seconds`.
- `web/ui/src/lib/useAdminLock.ts` — finite-guard the timer re-anchor (3 spots) + 15-min fallback in `armIdleTimer`.
- `web/ui/src/lib/useAdminLock.test.ts` — **NEW** regression suite (see below).
- `src/__tests__/admin-lock.test.ts` — heartbeat test now asserts `idle_seconds` is present.
- `web/ui/src/App.test.tsx` — heartbeat mock annotated to mirror the now-consistent wire shape.
- `package.json` — `0.7.4-rc.13` → **`0.7.4-rc.14`** (rc.13 is taken by #715/#678 per coordinator sequencing).

## Regression test

Added `web/ui/src/lib/useAdminLock.test.ts` (renderHook + vitest fake timers). The headline case drives the **REAL heartbeat wire shape** — `adminLockHeartbeat` resolves an object **without `idle_seconds`** — and asserts that after activity the idle timer does **NOT** instantly re-lock (stays unlocked past the broken-instant window, then legitimately re-locks at the ~15-min fallback). **Verified this test FAILS against the pre-fix code** (reverted both guards → the regression case errored exactly at the "still unlocked" assertion). Plus: re-anchor-to-heartbeat-window, lock-on-fresh-load, drift-to-locked, and feature-off (no heartbeat sent). Also fixed/annotated the App.test heartbeat mock to match the real server.

## Gates

- `bun test ./src` (server): **3876 pass / 1 skip / 0 fail**
- `bun run test` (web/ui vitest): **327 pass** (22 files, +1 new)
- `tsc --noEmit`: clean (server + web/ui)
- biome: clean

## Notes

- No git tag pushed — coordinator pushes the rc.14 tag after merge.
- Branch is isolated off `origin/main` (not stacked on the #678 `ag-unforced-dev` work). A trivial version-line conflict may appear after #715 lands; coordinator will handle the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)