### PR TITLE
feat(doctor): parachute doctor health/diagnostics command — Closes #717

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.14",
+  "version": "0.7.4-rc.15",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -333,6 +333,11 @@ describe("doctor — failure modes (each detected in isolation; others stay gree
       const { code, checks } = await runDoctor(h, healthyDeps());
       expect(byName(checks, "migration-detached")?.status).toBe("warn");
       expect(byName(checks, "migration-detached")?.fix).toContain("--to-supervised");
+      // Title must describe the DETECTED condition, not its absence — a warn
+      // titled "No legacy detached install" is the title-vs-status bug.
+      const detachedTitle = byName(checks, "migration-detached")?.title ?? "";
+      expect(detachedTitle.toLowerCase()).toContain("detached");
+      expect(detachedTitle).not.toMatch(/^no /i);
       // A WARN is advisory — exit code stays 0.
       expect(code).toBe(0);
       expectNoUnexpectedNonPass(checks, ["migration-detached"]);
@@ -351,6 +356,10 @@ describe("doctor — failure modes (each detected in isolation; others stay gree
       const { code, checks } = await runDoctor(h, healthyDeps());
       expect(byName(checks, "migration-cruft")?.status).toBe("warn");
       expect(byName(checks, "migration-cruft")?.fix).toBe("parachute migrate");
+      // Title must describe the DETECTED condition, not its absence.
+      const cruftTitle = byName(checks, "migration-cruft")?.title ?? "";
+      expect(cruftTitle.toLowerCase()).toContain("cruft");
+      expect(cruftTitle).not.toMatch(/^no /i);
       expect(code).toBe(0);
       expectNoUnexpectedNonPass(checks, ["migration-cruft"]);
     } finally {

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { type CheckResult, type DoctorDeps, doctor } from "../commands/doctor.ts";
+import { writePid } from "../process-state.ts";
+
+/**
+ * Doctor tests. The headline is the fresh-install-green guard (#717): a
+ * sandboxed PARACHUTE_HOME with a minimal-but-current services.json + a valid
+ * operator.token → ALL GREEN, zero WARN/FAIL. Every other test drives ONE
+ * failure mode and asserts that check fails while the others stay green.
+ *
+ * Every external side effect is stubbed through the `deps` seam — no real
+ * network probe, no real launchd/systemd query, no touching `~/.parachute`. The
+ * only real fs is the sandboxed PARACHUTE_HOME (services.json / operator.token /
+ * pidfiles) so the on-disk readers exercise genuine state.
+ */
+
+interface Harness {
+  configDir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "parachute-doctor-test-"));
+  return {
+    configDir: dir,
+    manifestPath: join(dir, "services.json"),
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+/** A minimal-but-current services.json with the canonical vault row. */
+function seedCurrentManifest(manifestPath: string): void {
+  const services = [
+    {
+      name: "parachute-vault",
+      port: 1940,
+      paths: ["/vault/default"],
+      health: "/health",
+      version: "0.7.4",
+    },
+  ];
+  writeFileSync(manifestPath, JSON.stringify({ services }, null, 2));
+}
+
+/** A hand-rolled (unsigned) JWT — doctor DECODES `iss`, never verifies it. */
+function fakeOperatorToken(iss: string): string {
+  const b64 = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+  return [
+    b64({ alg: "none", typ: "JWT" }),
+    b64({ iss, aud: "operator", sub: "u1", pa_scope_set: "admin" }),
+    "sig",
+  ].join(".");
+}
+
+function seedOperatorToken(configDir: string, iss = "http://127.0.0.1:1939"): void {
+  writeFileSync(join(configDir, "operator.token"), `${fakeOperatorToken(iss)}\n`, { mode: 0o600 });
+}
+
+/**
+ * Deps for a HEALTHY box: hub answers /health, the vault module answers /health,
+ * the manager reports active, every bin resolves on PATH, nothing exposed.
+ * Individual tests override one field to drive a specific failure.
+ */
+function healthyDeps(over: Partial<DoctorDeps> = {}): DoctorDeps {
+  return {
+    probeHubHealth: async () => true,
+    probeModuleHealth: async () => true,
+    probePublicHealth: async () => true,
+    queryHubUnitState: () => ({ state: "active" }),
+    // A `which` that resolves everything — so the bin exec-bit check passes
+    // without the real module binaries being on the test host's PATH.
+    which: (binary) => `/usr/local/bin/${binary}`,
+    now: () => new Date("2026-06-27T00:00:00Z"),
+    ...over,
+  };
+}
+
+async function runDoctor(
+  h: Harness,
+  deps: DoctorDeps,
+): Promise<{ code: number; checks: CheckResult[] }> {
+  const lines: string[] = [];
+  const code = await doctor({
+    configDir: h.configDir,
+    manifestPath: h.manifestPath,
+    print: (l) => lines.push(l),
+    json: true,
+    deps,
+  });
+  const payload = JSON.parse(lines.join("\n")) as { checks: CheckResult[] };
+  return { code, checks: payload.checks };
+}
+
+function byName(checks: CheckResult[], name: string): CheckResult | undefined {
+  return checks.find((c) => c.name === name);
+}
+
+function expectNoUnexpectedNonPass(checks: CheckResult[], allowedFailing: string[]): void {
+  const offenders = checks.filter((c) => c.status !== "pass" && !allowedFailing.includes(c.name));
+  if (offenders.length > 0) {
+    throw new Error(
+      `unexpected non-pass checks: ${offenders.map((c) => `${c.name}=${c.status}`).join(", ")}`,
+    );
+  }
+}
+
+describe("doctor — the fresh-install-green headline guard (#717)", () => {
+  test("a minimal-but-current install with a valid operator.token → ALL GREEN, exit 0", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(h, healthyDeps());
+
+      // The load-bearing assertion: not a single WARN or FAIL anywhere.
+      const nonPass = checks.filter((c) => c.status !== "pass");
+      expect(nonPass.map((c) => `${c.name}=${c.status}`)).toEqual([]);
+      expect(checks.every((c) => c.status === "pass")).toBe(true);
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a brand-new box (no services.json, no operator.token) → ALL GREEN, exit 0", async () => {
+    const h = makeHarness();
+    try {
+      // Nothing seeded at all — the truly-fresh case before `parachute init`.
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      const nonPass = checks.filter((c) => c.status !== "pass");
+      expect(nonPass.map((c) => `${c.name}=${c.status}`)).toEqual([]);
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("an EXPOSED + reachable box stays GREEN", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir, "https://vault.example.com");
+      writeFileSync(
+        join(h.configDir, "expose-state.json"),
+        JSON.stringify({
+          version: 1,
+          layer: "public",
+          mode: "path",
+          canonicalFqdn: "vault.example.com",
+          port: 1939,
+          funnel: true,
+          entries: [],
+          hubOrigin: "https://vault.example.com",
+        }),
+      );
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({ probePublicHealth: async () => true }),
+      );
+      const nonPass = checks.filter((c) => c.status !== "pass");
+      expect(nonPass.map((c) => `${c.name}=${c.status}`)).toEqual([]);
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("doctor — failure modes (each detected in isolation; others stay green)", () => {
+  test("hub down → hub-reachable FAILs, exit 1, modules check WARNs (not N fails)", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({
+          probeHubHealth: async () => false,
+          queryHubUnitState: () => ({ state: "inactive" }),
+        }),
+      );
+      expect(byName(checks, "hub-reachable")?.status).toBe("fail");
+      // A down hub → don't pile N module FAILs; surface one WARN pointing at the hub.
+      expect(byName(checks, "modules-alive")?.status).toBe("warn");
+      expect(code).toBe(1);
+      // Everything else stays green.
+      expectNoUnexpectedNonPass(checks, ["hub-reachable", "modules-alive"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a configured module that doesn't answer /health on a healthy hub → that module FAILs", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({ probeModuleHealth: async () => false }),
+      );
+      const mod = byName(checks, "module-alive:vault");
+      expect(mod?.status).toBe("fail");
+      expect(mod?.fix).toContain("parachute restart vault");
+      expect(code).toBe(1);
+      expectNoUnexpectedNonPass(checks, ["module-alive:vault"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing operator token → operator-token PASSES (feature-not-configured, NOT a failure)", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      // No operator.token seeded.
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      expect(byName(checks, "operator-token")?.status).toBe("pass");
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("corrupt operator token (not a JWT) → operator-token FAILs, exit 1", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      writeFileSync(join(h.configDir, "operator.token"), "not-a-jwt\n", { mode: 0o600 });
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      expect(byName(checks, "operator-token")?.status).toBe("fail");
+      expect(byName(checks, "operator-token")?.detail).toContain("decodable");
+      expect(code).toBe(1);
+      expectNoUnexpectedNonPass(checks, ["operator-token"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("issuer mismatch (foreign iss) → operator-token FAILs with the 'not signed in' detail", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      // An `iss` that is neither loopback nor any exposed/env origin.
+      seedOperatorToken(h.configDir, "https://stale.example.com");
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      const op = byName(checks, "operator-token");
+      expect(op?.status).toBe("fail");
+      expect(op?.detail).toContain("not signed in");
+      expect(op?.fix).toContain("start hub");
+      expect(code).toBe(1);
+      expectNoUnexpectedNonPass(checks, ["operator-token"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module bin missing the exec bit (100644) → module-bin FAILs with a chmod +x fix", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      // `which` returns null (Bun.which requires X_OK → null on a 100644 bin),
+      // and the secondary probe finds the present-but-non-executable file.
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({
+          which: () => null,
+          findNonExecutable: (binary) => `/usr/local/bin/${binary}`,
+        }),
+      );
+      const bin = byName(checks, "module-bin:vault");
+      expect(bin?.status).toBe("fail");
+      expect(bin?.detail).toContain("NOT executable");
+      expect(bin?.fix).toContain("chmod +x");
+      expect(code).toBe(1);
+      expectNoUnexpectedNonPass(checks, ["module-bin:vault"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("module bin genuinely not on PATH → module-bin FAILs with a reinstall fix", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({ which: () => null, findNonExecutable: () => null }),
+      );
+      const bin = byName(checks, "module-bin:vault");
+      expect(bin?.status).toBe("fail");
+      expect(bin?.fix).toContain("parachute install vault");
+      expect(code).toBe(1);
+      expectNoUnexpectedNonPass(checks, ["module-bin:vault"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("malformed services.json → services-manifest FAILs, exit 1", async () => {
+    const h = makeHarness();
+    try {
+      // A row missing the required `port` field → strict readManifest throws.
+      writeFileSync(
+        h.manifestPath,
+        JSON.stringify({
+          services: [{ name: "parachute-vault", paths: ["/v"], health: "/health", version: "1" }],
+        }),
+      );
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      expect(byName(checks, "services-manifest")?.status).toBe("fail");
+      expect(code).toBe(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("legacy detached install (hub pidfile present) → migration WARNs, exit STAYS 0", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      // The detached-era fingerprint: a hub pidfile.
+      mkdirSync(join(h.configDir, "hub", "run"), { recursive: true });
+      writePid("hub", 12345, h.configDir);
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      expect(byName(checks, "migration-detached")?.status).toBe("warn");
+      expect(byName(checks, "migration-detached")?.fix).toContain("--to-supervised");
+      // A WARN is advisory — exit code stays 0.
+      expect(code).toBe(0);
+      expectNoUnexpectedNonPass(checks, ["migration-detached"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("known cruft at the ecosystem root → migration WARNs, exit STAYS 0", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      // `server.yaml` is an explicit KNOWN_CRUFT rule (legacy server config).
+      writeFileSync(join(h.configDir, "server.yaml"), "legacy: true\n");
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      expect(byName(checks, "migration-cruft")?.status).toBe("warn");
+      expect(byName(checks, "migration-cruft")?.fix).toBe("parachute migrate");
+      expect(code).toBe(0);
+      expectNoUnexpectedNonPass(checks, ["migration-cruft"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("an UNKNOWN file at the root does NOT trip migration (allowlist, not blocklist)", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      // A file doctor has never heard of — the exact thing #717 forbids flagging.
+      writeFileSync(join(h.configDir, "my-own-thing.json"), "{}\n");
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      // Migration stays a single PASS — no false WARN on the unfamiliar file.
+      expect(byName(checks, "migration")?.status).toBe("pass");
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("doctor — Tier 2 exposure (guarded hard)", () => {
+  test("not exposed → 'loopback only' is benign info (PASS), not a warning", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      // No expose-state.json — the loopback-only box.
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      const ex = byName(checks, "exposure");
+      expect(ex?.status).toBe("pass");
+      expect(ex?.detail).toContain("loopback only");
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("exposed but the public origin doesn't answer → WARN (never FAIL), exit STAYS 0", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir, "https://vault.example.com");
+      writeFileSync(
+        join(h.configDir, "expose-state.json"),
+        JSON.stringify({
+          version: 1,
+          layer: "public",
+          mode: "path",
+          canonicalFqdn: "vault.example.com",
+          port: 1939,
+          funnel: true,
+          entries: [],
+          hubOrigin: "https://vault.example.com",
+        }),
+      );
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({ probePublicHealth: async () => false }),
+      );
+      expect(byName(checks, "exposure")?.status).toBe("warn");
+      expect(code).toBe(0);
+      expectNoUnexpectedNonPass(checks, ["exposure"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("doctor — version drift (cosmetic; never FAIL)", () => {
+  test("a 0.0.0-linked stopgap version → WARN labeled cosmetic, exit STAYS 0", async () => {
+    const h = makeHarness();
+    try {
+      writeFileSync(
+        h.manifestPath,
+        JSON.stringify({
+          services: [
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/health",
+              version: "0.0.0-linked",
+            },
+          ],
+        }),
+      );
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      const vd = byName(checks, "version-drift");
+      expect(vd?.status).toBe("warn");
+      expect(vd?.detail).toContain("cosmetic");
+      expect(code).toBe(0);
+      expectNoUnexpectedNonPass(checks, ["version-drift"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -22,6 +22,7 @@ import type { setup } from "./commands/setup.ts";
 import type { upgrade } from "./commands/upgrade.ts";
 import { ExposeStateError } from "./expose-state.ts";
 import {
+  doctorHelp,
   exposeHelp,
   initHelp,
   installHelp,
@@ -573,6 +574,23 @@ async function main(argv: string[]): Promise<number> {
         if (!mod) return 1;
         return await mod.status({ supervisor: {} });
       }
+
+    case "doctor": {
+      if (isHelpFlag(rest[0])) {
+        console.log(doctorHelp());
+        return 0;
+      }
+      const json = rest.includes("--json");
+      const unknown = rest.find((a) => a !== "--json");
+      if (unknown !== undefined) {
+        console.error(`parachute doctor: unknown argument "${unknown}"`);
+        console.error("usage: parachute doctor [--json]");
+        return 1;
+      }
+      const mod = await loadCommand("doctor", () => import("./commands/doctor.ts"));
+      if (!mod) return 1;
+      return await mod.doctor({ json });
+    }
 
     case "expose": {
       const hubExtract = extractHubOrigin(rest);

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -1,0 +1,892 @@
+/**
+ * `parachute doctor` — health / diagnostics for a Parachute install.
+ *
+ * The one command that answers "is my Parachute healthy, and if not, what's
+ * the one thing to fix?" Today operators piece that together from `parachute
+ * status`, log tailing, and tribal knowledge; `doctor` is the single readout.
+ *
+ * ## The load-bearing constraint (#717)
+ *
+ * Doctor MUST NOT false-positive on a fresh or fully-current install. In the
+ * past the migration checker suggested "things need migrating" on a clean box
+ * purely because it hadn't been taught about newer features — an "anything I
+ * don't recognize = broken" design. That class of bug is unacceptable here.
+ *
+ * Design rule, enforced check-by-check below: **positively detect a known-bad
+ * condition; never treat "unfamiliar" or "not configured" as a failure.**
+ *   - Distinguish *feature-not-configured* (→ PASS / benign info) from
+ *     *configured-but-broken* (→ FAIL).
+ *   - Migration checks reuse the existing ALLOWLIST detectors (`migrateNotice`
+ *     / `hasPriorDetachedInstall`) which only flag explicitly-known cruft — a
+ *     fresh root flags nothing.
+ *   - Version drift (services.json cached vs live package.json, hub#243) is
+ *     WARN at most, never FAIL, and labeled cosmetic.
+ *   - Exposure checks only run when expose-state says the box is exposed;
+ *     a loopback-only box reads "loopback only" as benign info (PASS), never
+ *     a warning.
+ *
+ * The headline guarantee is the fresh-install fixture test: a sandboxed
+ * PARACHUTE_HOME with a minimal-but-current services.json + a valid
+ * operator.token → ALL GREEN, zero WARN/FAIL.
+ *
+ * ## Reuse, not reinvention
+ *
+ * Doctor stitches together primitives the rest of the hub already owns rather
+ * than re-deriving them: `status.ts`'s liveness-probe shape (2xx OR 401 = live,
+ * #700), `migrate.ts`'s allowlist detectors, `operator-token.ts`'s known-issuer
+ * set, `services-manifest.ts`'s strict parse, `service-spec.ts`'s startCmd
+ * resolution, and depcheck's `ensureExecutable` for the +x check (channel#41).
+ *
+ * Every external read (network probe, manager query, fs) is bounded + degrades
+ * gracefully and is behind an injectable seam so tests drive it without a real
+ * network/manager/db call — same discipline as `status.ts`.
+ */
+
+import { readFileSync } from "node:fs";
+import {
+  type MissingDependencyError,
+  NonExecutableError,
+  ensureExecutable,
+} from "@openparachute/depcheck";
+import { decodeJwt } from "jose";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
+import { type ExposeState, readExposeState } from "../expose-state.ts";
+import { HUB_SVC, readHubPort } from "../hub-control.ts";
+import {
+  HUB_UNIT_DEFAULT_PORT,
+  type HubUnitDeps,
+  type HubUnitStateResult,
+  defaultHubUnitDeps,
+  queryHubUnitState as queryHubUnitStateImpl,
+} from "../hub-unit.ts";
+import { hasPriorDetachedInstall } from "../migrate-offer.ts";
+import { buildKnownIssuersForOperatorToken, operatorTokenPath } from "../operator-token.ts";
+import { getSpec, getSpecFromInstallDir, shortNameForManifest } from "../service-spec.ts";
+import {
+  type ServiceEntry,
+  ServicesManifestError,
+  readManifest,
+  readManifestLenient,
+} from "../services-manifest.ts";
+import { migrateNotice } from "./migrate.ts";
+
+// ---------------------------------------------------------------------------
+// Check model
+// ---------------------------------------------------------------------------
+
+export type CheckStatus = "pass" | "warn" | "fail";
+
+export interface CheckResult {
+  /** Stable identifier (e.g. "hub-reachable") — what `--json` consumers key on. */
+  name: string;
+  /** Human-readable check title for the grouped report. */
+  title: string;
+  status: CheckStatus;
+  /** One-line detail explaining the verdict. */
+  detail: string;
+  /** A copy-pasteable fix-it command, when there is one. */
+  fix?: string;
+}
+
+/** A logical group of checks in the human report. */
+const GROUP_ORDER = ["Hub", "Modules", "Configuration", "Migration", "Exposure"] as const;
+type Group = (typeof GROUP_ORDER)[number];
+
+interface GroupedCheck extends CheckResult {
+  group: Group;
+}
+
+// ---------------------------------------------------------------------------
+// Injectable deps (test seam) — mirrors status.ts's `supervisor` block. Every
+// real-world side effect (network probe, manager query, fs read of the token,
+// PATH resolution) is injectable so the whole command runs deterministically
+// in tests with no network / launchd / systemd / real ~/.parachute touched.
+// ---------------------------------------------------------------------------
+
+export interface DoctorDeps {
+  /**
+   * Probe the loopback hub `/health`. True on any answer that proves the hub is
+   * serving. Production reuses the bounded 1.5s fetch shape from status.ts.
+   */
+  probeHubHealth?: (port: number) => Promise<boolean>;
+  /**
+   * Unauthenticated module-liveness probe (#700): `http://127.0.0.1:<port><health>`.
+   * Treats 2xx AND 401 as live (auth-gated health = healthy, #423). Bounded;
+   * never throws.
+   */
+  probeModuleHealth?: (port: number, health: string) => Promise<boolean>;
+  /**
+   * Probe a public origin's `/health` (Tier-2 exposure reachability). Bounded;
+   * follows redirects off-box is NOT chased — we only care that the hub answers.
+   * Returns false on any network error / non-live status.
+   */
+  probePublicHealth?: (origin: string) => Promise<boolean>;
+  /** Query the platform manager for the hub unit's run-state. */
+  queryHubUnitState?: (deps: HubUnitDeps) => HubUnitStateResult;
+  /** Deps passed to `queryHubUnitState`. Default production. */
+  hubUnitDeps?: HubUnitDeps;
+  /**
+   * PATH resolver for the module-bin exec-bit check (`ensureExecutable`).
+   * Production is `Bun.which`; tests inject a stub so the check runs without
+   * the real module binaries on the test host's PATH.
+   */
+  which?: (binary: string) => string | null;
+  /**
+   * #634 secondary probe for the exec-bit check: when `which` returns null,
+   * find a present-but-non-executable file on PATH. Production lets depcheck's
+   * real PATH walk run; tests inject to drive the non-executable branch.
+   */
+  findNonExecutable?: (binary: string) => string | null;
+  /** Clock seam for date-stamped detectors (migrate). */
+  now?: () => Date;
+}
+
+export interface DoctorOpts {
+  configDir?: string;
+  manifestPath?: string;
+  print?: (line: string) => void;
+  /** Emit a single JSON object instead of the human report. */
+  json?: boolean;
+  deps?: DoctorDeps;
+}
+
+// ---------------------------------------------------------------------------
+// Default real-world deps
+// ---------------------------------------------------------------------------
+
+/** Bounded loopback `/health` probe — 2xx is live. Mirrors hub-unit's default. */
+async function defaultProbeHubHealth(port: number): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(1500),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+/** Bounded module `/health` probe — 2xx OR 401 is live (#700 / #423). */
+async function defaultProbeModuleHealth(port: number, health: string): Promise<boolean> {
+  try {
+    const res = await fetch(`http://127.0.0.1:${port}${health}`, {
+      signal: AbortSignal.timeout(1500),
+      redirect: "manual",
+    });
+    return res.ok || res.status === 401;
+  } catch {
+    return false;
+  }
+}
+
+/** Bounded public-origin `/health` probe — 2xx OR 401 is live (auth-gated hub). */
+async function defaultProbePublicHealth(origin: string): Promise<boolean> {
+  try {
+    const res = await fetch(`${origin.replace(/\/+$/, "")}/health`, {
+      signal: AbortSignal.timeout(4000),
+    });
+    return res.ok || res.status === 401;
+  } catch {
+    return false;
+  }
+}
+
+interface ResolvedDeps {
+  probeHubHealth: (port: number) => Promise<boolean>;
+  probeModuleHealth: (port: number, health: string) => Promise<boolean>;
+  probePublicHealth: (origin: string) => Promise<boolean>;
+  queryHubUnitState: (deps: HubUnitDeps) => HubUnitStateResult;
+  hubUnitDeps: HubUnitDeps;
+  which: (binary: string) => string | null;
+  findNonExecutable: ((binary: string) => string | null) | undefined;
+  now: () => Date;
+}
+
+function resolveDeps(d: DoctorDeps | undefined): ResolvedDeps {
+  return {
+    probeHubHealth: d?.probeHubHealth ?? defaultProbeHubHealth,
+    probeModuleHealth: d?.probeModuleHealth ?? defaultProbeModuleHealth,
+    probePublicHealth: d?.probePublicHealth ?? defaultProbePublicHealth,
+    queryHubUnitState: d?.queryHubUnitState ?? queryHubUnitStateImpl,
+    hubUnitDeps: d?.hubUnitDeps ?? defaultHubUnitDeps,
+    which: d?.which ?? Bun.which,
+    findNonExecutable: d?.findNonExecutable,
+    now: d?.now ?? (() => new Date()),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tier 1 checks
+// ---------------------------------------------------------------------------
+
+/**
+ * Hub supervisor reachable on :1939. The hub is the substrate every module
+ * runs under, so a down hub is the single most actionable failure. We compose
+ * the platform-manager view (`queryHubUnitState`) with the `/health` probe the
+ * same way `status.ts` does, but render a doctor verdict:
+ *   - `/health` answers → PASS (it's serving; manager nuance is informational).
+ *   - manager says `failed` → FAIL (surface the exit code).
+ *   - manager says `active`/`activating` but no `/health` → FAIL (wedged/starting).
+ *   - no manager (container) + no `/health` → FAIL.
+ *   - manager `inactive`/`no-unit` + no `/health` → FAIL ("hub is not running").
+ * Never throws — a manager-query failure degrades to the `/health` verdict.
+ */
+async function checkHubReachable(configDir: string, deps: ResolvedDeps): Promise<CheckResult> {
+  const port = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  let healthy = false;
+  try {
+    healthy = await deps.probeHubHealth(port);
+  } catch {
+    healthy = false;
+  }
+
+  if (healthy) {
+    return {
+      name: "hub-reachable",
+      title: `Hub supervisor reachable on :${port}`,
+      status: "pass",
+      detail: `hub answered /health on http://127.0.0.1:${port}`,
+    };
+  }
+
+  // Not answering /health — consult the manager for a more specific verdict.
+  let managerState: HubUnitStateResult["state"] = "unknown";
+  let lastExitCode: number | undefined;
+  try {
+    const q = deps.queryHubUnitState(deps.hubUnitDeps);
+    managerState = q.state;
+    lastExitCode = q.lastExitCode;
+  } catch {
+    managerState = "unknown";
+  }
+
+  const fix = "parachute start hub";
+  if (managerState === "failed") {
+    return {
+      name: "hub-reachable",
+      title: `Hub supervisor reachable on :${port}`,
+      status: "fail",
+      detail:
+        lastExitCode !== undefined
+          ? `service manager reports the hub unit failed (last exit code ${lastExitCode})`
+          : "service manager reports the hub unit failed",
+      fix,
+    };
+  }
+  if (managerState === "active" || managerState === "activating") {
+    return {
+      name: "hub-reachable",
+      title: `Hub supervisor reachable on :${port}`,
+      status: "fail",
+      detail:
+        "service manager reports the hub unit up, but /health isn't answering (starting or wedged)",
+      fix: "parachute restart hub",
+    };
+  }
+  return {
+    name: "hub-reachable",
+    title: `Hub supervisor reachable on :${port}`,
+    status: "fail",
+    detail: `hub is not running — nothing answered /health on http://127.0.0.1:${port}`,
+    fix,
+  };
+}
+
+/**
+ * Each CONFIGURED module alive via its own loopback `/health` (2xx OR 401).
+ * Only modules present in services.json are checked — an absent module is
+ * "feature-not-configured," never a failure. When the hub itself is down every
+ * child is down with it, so we surface a single WARN pointing at the hub fix
+ * rather than N module FAILs that are all really the one hub problem.
+ *
+ * A configured-but-not-answering module on a healthy hub is a real FAIL.
+ */
+async function checkModulesAlive(
+  manifest: { services: ServiceEntry[] },
+  hubHealthy: boolean,
+  deps: ResolvedDeps,
+): Promise<CheckResult[]> {
+  const modules = manifest.services;
+  if (modules.length === 0) {
+    return [
+      {
+        name: "modules-alive",
+        title: "Configured modules alive",
+        status: "pass",
+        detail: "no modules installed yet — nothing to check",
+      },
+    ];
+  }
+
+  if (!hubHealthy) {
+    // The hub is down → every supervised child is down WITH it. Don't pile N
+    // module FAILs on top of the one real problem (the hub check already FAILed).
+    return [
+      {
+        name: "modules-alive",
+        title: "Configured modules alive",
+        status: "warn",
+        detail: "skipped — the hub is down, so its modules are stopped too (fix the hub first)",
+        fix: "parachute start hub",
+      },
+    ];
+  }
+
+  const results = await Promise.all(
+    modules.map(async (entry): Promise<CheckResult> => {
+      let alive = false;
+      try {
+        alive = await deps.probeModuleHealth(entry.port, entry.health);
+      } catch {
+        alive = false;
+      }
+      const short = shortNameForManifest(entry.name) ?? entry.name;
+      if (alive) {
+        return {
+          name: `module-alive:${short}`,
+          title: `Module ${short} alive`,
+          status: "pass",
+          detail: `answered ${entry.health} on http://127.0.0.1:${entry.port}`,
+        };
+      }
+      return {
+        name: `module-alive:${short}`,
+        title: `Module ${short} alive`,
+        status: "fail",
+        detail: `${short} is configured (services.json) but didn't answer ${entry.health} on :${entry.port}`,
+        fix: `parachute restart ${short}`,
+      };
+    }),
+  );
+  return results;
+}
+
+/**
+ * services.json parses + required fields valid. A MISSING manifest is the fresh
+ * pre-install state, not a failure → PASS with benign info. A PRESENT but
+ * malformed manifest is configured-but-broken → FAIL with the parser's own
+ * diagnostic (we read strictly here precisely to surface the error; the rest of
+ * doctor reads leniently so one bad row doesn't sink every other check).
+ */
+function checkServicesManifest(manifestPath: string): CheckResult {
+  let raw: string | undefined;
+  try {
+    raw = readFileSync(manifestPath, "utf8");
+  } catch {
+    // ENOENT (or unreadable) — treat absence as the fresh, pre-install state.
+    return {
+      name: "services-manifest",
+      title: "services.json parses + valid",
+      status: "pass",
+      detail: "no services.json yet — fresh install (nothing configured)",
+    };
+  }
+  void raw;
+  try {
+    const manifest = readManifest(manifestPath);
+    return {
+      name: "services-manifest",
+      title: "services.json parses + valid",
+      status: "pass",
+      detail: `parsed ${manifest.services.length} service${manifest.services.length === 1 ? "" : "s"}, all required fields valid`,
+    };
+  } catch (err) {
+    const message =
+      err instanceof ServicesManifestError
+        ? err.message
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return {
+      name: "services-manifest",
+      title: "services.json parses + valid",
+      status: "fail",
+      detail: `services.json is malformed: ${message}`,
+      fix: `edit ${manifestPath} to fix the offending entry`,
+    };
+  }
+}
+
+/**
+ * operator.token exists, parses, and its `iss` matches a hub-legitimate issuer.
+ *
+ * Absent token → PASS/info (a box that hasn't created its first admin yet, or
+ * one that never minted an operator token — feature-not-configured, NOT broken;
+ * `parachute status` / `auth set-password` is the path, doctor doesn't force it).
+ *
+ * Present token:
+ *   - undecodable / no `iss` claim → FAIL (corrupt credential).
+ *   - `iss` matches the hub's known-issuer SET (loopback aliases ∪ expose-state
+ *     public origin ∪ platform origin — the SAME set the live auth path uses,
+ *     `buildKnownIssuersForOperatorToken`) → PASS.
+ *   - `iss` is foreign to that set → FAIL: the recurring "not signed in to the
+ *     hub" / issuer-mismatch class (hub#481). Fix is `start hub` (self-heals)
+ *     or `auth rotate-operator`.
+ *
+ * Deliberately a DECODE-only `iss` check, not a full signature/JWKS validation:
+ * doctor must run without a live hub or DB, and an unsigned-but-decodable token
+ * still tells us the issuer-mismatch story. The known-issuer set is the same
+ * one the real validation layers `iss` against on top of the signature check.
+ */
+function checkOperatorToken(configDir: string): CheckResult {
+  const path = operatorTokenPath(configDir);
+  let token: string;
+  try {
+    token = readFileSync(path, "utf8").trim();
+  } catch {
+    return {
+      name: "operator-token",
+      title: "operator.token valid + issuer matches",
+      status: "pass",
+      detail:
+        "no operator.token yet — fine for a box that hasn't created its first admin (run `parachute auth set-password` when ready)",
+    };
+  }
+  if (token.length === 0) {
+    return {
+      name: "operator-token",
+      title: "operator.token valid + issuer matches",
+      status: "pass",
+      detail: "operator.token is empty — treated as not configured",
+    };
+  }
+
+  let iss: string | undefined;
+  try {
+    const payload = decodeJwt(token);
+    iss = typeof payload.iss === "string" ? payload.iss : undefined;
+  } catch {
+    return {
+      name: "operator-token",
+      title: "operator.token valid + issuer matches",
+      status: "fail",
+      detail: `operator.token at ${path} is not a decodable JWT`,
+      fix: "parachute auth rotate-operator",
+    };
+  }
+  if (!iss) {
+    return {
+      name: "operator-token",
+      title: "operator.token valid + issuer matches",
+      status: "fail",
+      detail: "operator.token has no `iss` claim",
+      fix: "parachute auth rotate-operator",
+    };
+  }
+
+  // Build the issuer set the live auth path validates against (loopback aliases
+  // ∪ expose-state public origin ∪ platform origin). Seed with the resolved
+  // loopback issuer so a never-exposed box still has its own loopback in the set.
+  const seedIssuer = `http://127.0.0.1:${readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT}`;
+  let knownIssuers: readonly string[] = [];
+  try {
+    knownIssuers = buildKnownIssuersForOperatorToken(configDir, seedIssuer);
+  } catch {
+    knownIssuers = [seedIssuer];
+  }
+  if (knownIssuers.includes(iss)) {
+    return {
+      name: "operator-token",
+      title: "operator.token valid + issuer matches",
+      status: "pass",
+      detail: `operator.token issuer (${iss}) matches the hub`,
+    };
+  }
+  return {
+    name: "operator-token",
+    title: "operator.token valid + issuer matches",
+    status: "fail",
+    detail: `operator.token issuer (${iss}) doesn't match any origin this hub answers on — the "not signed in to the hub" class. Expected one of: ${knownIssuers.join(", ")}`,
+    fix: "parachute start hub  # self-heals the issuer; or `parachute auth rotate-operator`",
+  };
+}
+
+/**
+ * Module bin resolvable via `Bun.which` (exec bit present) — the 100644
+ * start-failure class (channel#41): a module whose `bin` lost its +x bit
+ * resolves to null under `Bun.which` (which requires X_OK), so the supervisor
+ * reports "<binary> not installed" despite an intact symlink + services.json.
+ *
+ * For each configured module we resolve its startCmd binary the SAME way the
+ * supervisor does (spec.startCmd over the entry; module.json wins when
+ * installDir is stamped) and run depcheck's `ensureExecutable`:
+ *   - resolves cleanly → PASS.
+ *   - `NonExecutableError` (present but no +x) → FAIL with the `chmod +x` fix —
+ *     the exact bug this check exists for.
+ *   - `MissingDependencyError` (genuinely not on PATH) → FAIL (reinstall).
+ *
+ * A module whose spec has no resolvable startCmd (CLI-only module, unreadable
+ * module.json) is SKIPPED — there's no bin to check, and "no startCmd" is not a
+ * broken-bin condition. Modules with no spec at all (third-party, no fallback)
+ * are likewise skipped — we can't know their bin name, and absence of knowledge
+ * is never a failure (the #717 rule).
+ */
+async function checkModuleBins(
+  manifest: { services: ServiceEntry[] },
+  deps: ResolvedDeps,
+): Promise<CheckResult[]> {
+  const checks = await Promise.all(
+    manifest.services.map(async (entry): Promise<CheckResult | undefined> => {
+      const short = shortNameForManifest(entry.name);
+      if (!short) return undefined; // third-party / unknown — no bin to reason about.
+      const binary = await resolveStartBinary(short, entry);
+      if (!binary) return undefined; // CLI-only module / unreadable module.json — nothing to check.
+
+      try {
+        const ensureOpts: Parameters<typeof ensureExecutable>[1] = { which: deps.which };
+        if (deps.findNonExecutable) ensureOpts.findNonExecutable = deps.findNonExecutable;
+        ensureExecutable(binary, ensureOpts);
+        return {
+          name: `module-bin:${short}`,
+          title: `Module ${short} bin executable`,
+          status: "pass",
+          detail: `${binary} resolves on PATH with the exec bit set`,
+        };
+      } catch (err) {
+        if (err instanceof NonExecutableError) {
+          return {
+            name: `module-bin:${short}`,
+            title: `Module ${short} bin executable`,
+            status: "fail",
+            detail: `${binary} is present at ${err.path} but is NOT executable (lost its +x bit) — the supervisor will report it "not installed"`,
+            fix: `chmod +x ${err.path}`,
+          };
+        }
+        // MissingDependencyError (or anything else) → the bin isn't resolvable.
+        const missing = err as MissingDependencyError;
+        const why =
+          typeof missing?.message === "string"
+            ? missing.message.split("\n")[0]
+            : `${binary} not found on PATH`;
+        return {
+          name: `module-bin:${short}`,
+          title: `Module ${short} bin executable`,
+          status: "fail",
+          detail: `${binary} for module ${short} isn't resolvable on PATH: ${why}`,
+          fix: `parachute install ${short}  # reinstall the module`,
+        };
+      }
+    }),
+  );
+  const present = checks.filter((c): c is CheckResult => c !== undefined);
+  if (present.length === 0) {
+    return [
+      {
+        name: "module-bins",
+        title: "Module bins executable",
+        status: "pass",
+        detail: "no first-party module bins to check",
+      },
+    ];
+  }
+  return present;
+}
+
+/**
+ * Resolve the startCmd binary (`cmd[0]`) for a configured module, mirroring the
+ * supervisor's resolution: module.json wins when installDir is stamped, else the
+ * imperative spec startCmd. Returns undefined when there's no spec or no
+ * resolvable startCmd (CLI-only / unreadable manifest). Never throws.
+ */
+async function resolveStartBinary(short: string, entry: ServiceEntry): Promise<string | undefined> {
+  let spec = getSpec(short);
+  if (entry.installDir) {
+    try {
+      const resolved = await getSpecFromInstallDir(entry.installDir, entry.name);
+      if (resolved) spec = resolved;
+    } catch {
+      // Unreadable / malformed module.json — fall back to the imperative spec.
+    }
+  }
+  if (!spec?.startCmd) return undefined;
+  let cmd: readonly string[] | undefined;
+  try {
+    cmd = spec.startCmd(entry);
+  } catch {
+    return undefined;
+  }
+  return cmd && cmd.length > 0 ? cmd[0] : undefined;
+}
+
+/**
+ * Migration via the SAFE detectors only (never a "scan for unfamiliar files"
+ * approach — that's the exact false-positive class #717 forbids):
+ *   - `hasPriorDetachedInstall` — a pidfile (the detached-era fingerprint).
+ *     A supervised/fresh box writes none → no warning. WARN (not FAIL): the
+ *     box still works; doctor nudges toward the supervised cutover.
+ *   - `migrateNotice` — the allowlist archive detector. Only flags entries
+ *     matching an explicit KNOWN_CRUFT rule; a fresh root flags nothing. WARN.
+ *
+ * Both clean → a single PASS.
+ */
+function checkMigration(
+  configDir: string,
+  manifestPath: string,
+  deps: ResolvedDeps,
+): CheckResult[] {
+  const out: CheckResult[] = [];
+
+  let priorDetached = false;
+  try {
+    priorDetached = hasPriorDetachedInstall(configDir, manifestPath);
+  } catch {
+    priorDetached = false;
+  }
+  if (priorDetached) {
+    out.push({
+      name: "migration-detached",
+      title: "No legacy detached install",
+      status: "warn",
+      detail:
+        "this box has a prior detached-model install (pidfiles present) — the current hub runs supervised under a process manager",
+      fix: "parachute migrate --to-supervised",
+    });
+  }
+
+  let notice: string | undefined;
+  try {
+    notice = migrateNotice(configDir, deps.now());
+  } catch {
+    notice = undefined;
+  }
+  if (notice) {
+    out.push({
+      name: "migration-cruft",
+      title: "No archivable cruft at ecosystem root",
+      status: "warn",
+      detail: notice.replace(/^parachute migrate: /, "").replace(/ — run.*$/, ""),
+      fix: "parachute migrate",
+    });
+  }
+
+  if (out.length === 0) {
+    out.push({
+      name: "migration",
+      title: "Migration",
+      status: "pass",
+      detail: "no legacy detached install, no archivable cruft at the ecosystem root",
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Tier 2 checks (guarded hard — never FAIL on not-configured)
+// ---------------------------------------------------------------------------
+
+/**
+ * Exposure reachability + issuer consistency — ONLY when expose-state says the
+ * box is exposed. If NOT exposed → benign "loopback only" info (PASS, never
+ * WARN): a box reachable only on loopback is a legitimate, common configuration.
+ *
+ * When exposed:
+ *   - missing `hubOrigin` in expose-state → WARN (cosmetic — we can't verify
+ *     reachability without it, but the box may well be fine).
+ *   - public origin answers `/health` → PASS.
+ *   - public origin doesn't answer → WARN (not FAIL): the tunnel may be mid-
+ *     bring-up, or an upstream CDN/bot-protection may shape server-to-server
+ *     probes (the known Cloudflare-bot-protection class) — doctor flags it for
+ *     attention without declaring the install broken.
+ */
+async function checkExposure(configDir: string, deps: ResolvedDeps): Promise<CheckResult> {
+  let state: ExposeState | undefined;
+  try {
+    state = readExposeState(`${configDir}/expose-state.json`);
+  } catch {
+    // A malformed expose-state.json must not crash doctor; treat as not-exposed
+    // info (the malformed-file case is the operator's to clear, and the CLI's
+    // own ExposeStateError surfaces it elsewhere).
+    return {
+      name: "exposure",
+      title: "Exposure",
+      status: "pass",
+      detail: "expose-state.json is unreadable — treating as loopback only",
+    };
+  }
+
+  if (!state) {
+    return {
+      name: "exposure",
+      title: "Exposure",
+      status: "pass",
+      detail: "loopback only — not exposed to a tailnet or the public internet (this is fine)",
+    };
+  }
+
+  const origin = state.hubOrigin;
+  if (!origin) {
+    return {
+      name: "exposure",
+      title: "Exposure reachable",
+      status: "warn",
+      detail: `exposed (${state.layer}) but expose-state has no hubOrigin to verify reachability`,
+    };
+  }
+
+  let reachable = false;
+  try {
+    reachable = await deps.probePublicHealth(origin);
+  } catch {
+    reachable = false;
+  }
+  if (reachable) {
+    return {
+      name: "exposure",
+      title: "Exposure reachable",
+      status: "pass",
+      detail: `public origin ${origin} answers /health`,
+    };
+  }
+  return {
+    name: "exposure",
+    title: "Exposure reachable",
+    status: "warn",
+    detail: `exposed at ${origin} but it didn't answer /health — the tunnel may be starting, or upstream bot-protection may be shaping the probe`,
+    fix: "parachute expose <layer>  # re-bring-up the exposure if it's down",
+  };
+}
+
+/**
+ * Version drift (hub#243) — WARN at most, never FAIL, and labeled cosmetic.
+ * services.json caches each module's version string; on a bun-linked checkout
+ * that can lag the live package.json after a rebuild. Purely cosmetic — the
+ * running code is whatever the bundle is, not the cached string. We only flag
+ * the obvious shape (cached `0.0.0-linked` stopgap) so the check stays
+ * positive-detection: a cached real version we have no live value to compare
+ * against is NOT flagged (we don't have status.ts's install-source machinery
+ * wired here, and guessing would risk a false WARN — #717).
+ */
+function checkVersionDrift(manifest: { services: ServiceEntry[] }): CheckResult {
+  const stopgaps = manifest.services.filter((s) => s.version === "0.0.0-linked");
+  if (stopgaps.length === 0) {
+    return {
+      name: "version-drift",
+      title: "Version freshness (cosmetic)",
+      status: "pass",
+      detail: "no obvious version-drift markers in services.json",
+    };
+  }
+  const names = stopgaps.map((s) => shortNameForManifest(s.name) ?? s.name).join(", ");
+  return {
+    name: "version-drift",
+    title: "Version freshness (cosmetic)",
+    status: "warn",
+    detail: `services.json still has the install-time stopgap version "0.0.0-linked" for: ${names} (cosmetic — the running code is the live bundle)`,
+    fix: "parachute restart <module>  # lets the module re-stamp its real version",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration + rendering
+// ---------------------------------------------------------------------------
+
+/**
+ * Run every check and return them grouped, in report order. Pure-ish: reads fs
+ * + (stubbable) network, never mutates. The hub-reachability probe runs once
+ * and gates the module-liveness check (a down hub means every child is down).
+ */
+async function runChecks(
+  configDir: string,
+  manifestPath: string,
+  deps: ResolvedDeps,
+): Promise<GroupedCheck[]> {
+  // Lenient manifest read for the checks that iterate modules — a single bad
+  // row must not sink hub/operator/migration checks. The STRICT parse is the
+  // services-manifest check's own job (it WANTS to surface the parse error).
+  const manifest = readManifestLenient(manifestPath);
+
+  const hub = await checkHubReachable(configDir, deps);
+  const hubHealthy = hub.status === "pass";
+
+  const [modules, bins, exposure] = await Promise.all([
+    checkModulesAlive(manifest, hubHealthy, deps),
+    checkModuleBins(manifest, deps),
+    checkExposure(configDir, deps),
+  ]);
+  const manifestCheck = checkServicesManifest(manifestPath);
+  const operator = checkOperatorToken(configDir);
+  const migration = checkMigration(configDir, manifestPath, deps);
+  const versionDrift = checkVersionDrift(manifest);
+
+  const grouped: GroupedCheck[] = [];
+  const add = (group: Group, checks: CheckResult[]) => {
+    for (const c of checks) grouped.push({ ...c, group });
+  };
+  add("Hub", [hub]);
+  add("Modules", [...modules, ...bins]);
+  add("Configuration", [manifestCheck, operator]);
+  add("Migration", migration);
+  add("Exposure", [exposure, versionDrift]);
+  return grouped;
+}
+
+const MARK: Record<CheckStatus, string> = { pass: "✓", warn: "⚠", fail: "✗" };
+
+function renderHuman(checks: GroupedCheck[], print: (line: string) => void): void {
+  print("parachute doctor — health check");
+  print("");
+  for (const group of GROUP_ORDER) {
+    const inGroup = checks.filter((c) => c.group === group);
+    if (inGroup.length === 0) continue;
+    print(`${group}:`);
+    for (const c of inGroup) {
+      print(`  ${MARK[c.status]} ${c.title}`);
+      print(`      ${c.detail}`);
+      if (c.fix) print(`      fix: ${c.fix}`);
+    }
+    print("");
+  }
+  const fails = checks.filter((c) => c.status === "fail").length;
+  const warns = checks.filter((c) => c.status === "warn").length;
+  const passes = checks.filter((c) => c.status === "pass").length;
+  if (fails === 0 && warns === 0) {
+    print(`All clear — ${passes} check${passes === 1 ? "" : "s"} passed.`);
+  } else {
+    const parts: string[] = [`${passes} ok`];
+    if (warns > 0) parts.push(`${warns} warning${warns === 1 ? "" : "s"}`);
+    if (fails > 0) parts.push(`${fails} failure${fails === 1 ? "" : "s"}`);
+    print(`Summary: ${parts.join(", ")}.`);
+    if (fails === 0) print("No failures — warnings are advisory.");
+  }
+}
+
+function renderJson(checks: GroupedCheck[], print: (line: string) => void): void {
+  const fails = checks.filter((c) => c.status === "fail").length;
+  const warns = checks.filter((c) => c.status === "warn").length;
+  const passes = checks.filter((c) => c.status === "pass").length;
+  const payload = {
+    ok: fails === 0,
+    summary: { pass: passes, warn: warns, fail: fails },
+    checks: checks.map((c) => ({
+      name: c.name,
+      group: c.group,
+      title: c.title,
+      status: c.status,
+      detail: c.detail,
+      ...(c.fix ? { fix: c.fix } : {}),
+    })),
+  };
+  print(JSON.stringify(payload, null, 2));
+}
+
+/**
+ * `parachute doctor`. Returns the process exit code: 0 when no check FAILs
+ * (WARN is allowed), non-zero on any FAIL. Never throws — every check is
+ * individually wrapped + degrades gracefully, so doctor is itself a reliable
+ * diagnostic regardless of the box's state.
+ */
+export async function doctor(opts: DoctorOpts = {}): Promise<number> {
+  const configDir = opts.configDir ?? CONFIG_DIR;
+  const manifestPath = opts.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const print = opts.print ?? ((line) => console.log(line));
+  const deps = resolveDeps(opts.deps);
+
+  const checks = await runChecks(configDir, manifestPath, deps);
+  if (opts.json) {
+    renderJson(checks, print);
+  } else {
+    renderHuman(checks, print);
+  }
+  const anyFail = checks.some((c) => c.status === "fail");
+  return anyFail ? 1 : 0;
+}

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -369,9 +369,12 @@ async function checkModulesAlive(
  * doctor reads leniently so one bad row doesn't sink every other check).
  */
 function checkServicesManifest(manifestPath: string): CheckResult {
-  let raw: string | undefined;
+  // Probe presence FIRST so we can tell apart absent (→ fresh-install PASS)
+  // from present-but-malformed (→ FAIL below). Without this split a missing
+  // services.json would reach readManifest's throw and be reported as
+  // "malformed" — a false positive on the fresh install we must never flag.
   try {
-    raw = readFileSync(manifestPath, "utf8");
+    readFileSync(manifestPath, "utf8");
   } catch {
     // ENOENT (or unreadable) — treat absence as the fresh, pre-install state.
     return {
@@ -381,7 +384,6 @@ function checkServicesManifest(manifestPath: string): CheckResult {
       detail: "no services.json yet — fresh install (nothing configured)",
     };
   }
-  void raw;
   try {
     const manifest = readManifest(manifestPath);
     return {
@@ -635,7 +637,7 @@ function checkMigration(
   if (priorDetached) {
     out.push({
       name: "migration-detached",
-      title: "No legacy detached install",
+      title: "Legacy detached install detected",
       status: "warn",
       detail:
         "this box has a prior detached-model install (pidfiles present) — the current hub runs supervised under a process manager",
@@ -652,7 +654,7 @@ function checkMigration(
   if (notice) {
     out.push({
       name: "migration-cruft",
-      title: "No archivable cruft at ecosystem root",
+      title: "Archivable cruft at ecosystem root",
       status: "warn",
       detail: notice.replace(/^parachute migrate: /, "").replace(/ — run.*$/, ""),
       fix: "parachute migrate",

--- a/src/help.ts
+++ b/src/help.ts
@@ -17,6 +17,7 @@ Usage:
   parachute install <service>       install and register a service
                                     services: ${services}
   parachute status                  show installed services, run state, health
+  parachute doctor                  run health checks + tell you the one thing to fix
   parachute start   [service]       start a module via the supervisor (or ensure the hub is up)
   parachute stop    [service]       stop a module via the supervisor (or stop the hub unit)
   parachute restart [service]       restart a module via the supervisor (or restart the hub unit)
@@ -364,6 +365,43 @@ Example:
     → http://127.0.0.1:1940/vault/default/mcp
   parachute-app    1946  0.2.0    active  12346  2h 12m  3ms      npm (0.2.0-rc.4)
     → http://127.0.0.1:1946/surface/notes
+`;
+}
+
+export function doctorHelp(): string {
+  return `parachute doctor — health / diagnostics for your Parachute install
+
+Usage:
+  parachute doctor [--json]
+
+What it does:
+  Runs a set of independent health checks and prints a grouped report
+  (✓ pass / ⚠ warn / ✗ fail), each with a one-line detail and — where there
+  is one — a copy-pasteable fix-it command. The single command that answers
+  "is my Parachute healthy, and if not, what's the one thing to fix?"
+
+  Checks (each PASSES on a fresh / fully-current install — doctor positively
+  detects a known-bad condition and never treats "not configured" as broken):
+    - Hub supervisor reachable on :1939 (/health).
+    - Each CONFIGURED module alive via its loopback /health (2xx or 401 = live).
+    - services.json parses + required fields valid (a missing file is the
+      fresh pre-install state, not a failure).
+    - operator.token exists, parses, and its issuer matches the hub (the
+      recurring "not signed in to the hub" / issuer-mismatch class).
+    - Each first-party module bin is executable (catches the lost-+x-bit
+      start-failure class).
+    - Migration: legacy detached install? known cruft at the ecosystem root?
+      (allowlist detectors only — a fresh root flags nothing).
+    - Exposure: if exposed, is the public origin reachable? If not exposed,
+      "loopback only" is reported as benign info, never a warning.
+    - Version freshness (cosmetic) — drift is WARN at most, never a failure.
+
+Flags:
+  --json     emit a single JSON object instead of the human report
+
+Exit codes:
+  0   no failures (warnings are advisory and still exit 0)
+  1   one or more checks failed
 `;
 }
 


### PR DESCRIPTION
## What

Adds `parachute doctor` — the single command that answers *"is my Parachute healthy, and if not, what's the one thing to fix?"* Today operators piece that together from `parachute status`, log tailing, and tribal knowledge.

Closes #717. Version bumped 0.7.4-rc.14 → **0.7.4-rc.15** (no tag pushed — coordinator tags after merge).

## The #1 constraint (#717): no false positives on a fresh/current install

Design rule enforced **check-by-check**: *positively detect a known-bad condition; never treat "unfamiliar" or "not configured" as a failure.* Every check distinguishes **feature-not-configured** (→ PASS / benign info) from **configured-but-broken** (→ FAIL).

How the fresh-install-green guarantee is made concrete: the headline test seeds a sandboxed `PARACHUTE_HOME` with a minimal-but-current `services.json` + a valid `operator.token`, stubs the probes "healthy", and asserts **zero WARN/FAIL across every check** (`expect(nonPass).toEqual([])`) + exit 0. A second variant asserts the same on a *brand-new* box with nothing seeded at all. Because each check is positive-detection, neither a missing file nor an unfamiliar one can ever flip it red — there's an explicit test that an UNKNOWN root file does **not** trip migration.

## Checks

**Tier 1 (all implemented):**
- **Hub supervisor reachable on :1939** — composes the `/health` probe with the platform-manager view (`queryHubUnitState`), reusing `status.ts`'s probe shape.
- **Each *configured* module alive** via its loopback `/health` (2xx OR 401 = live, #700). An absent module is not-configured (PASS). When the hub is down, one WARN points at the hub fix instead of N module FAILs that are all the one problem.
- **services.json parses + valid** — strict read for this check (it *wants* to surface the parse error); a MISSING file is the fresh pre-install state → PASS.
- **operator.token exists + decodes + `iss` matches the hub** — validated against the hub's known-issuer SET (`buildKnownIssuersForOperatorToken` — the same set the live auth path layers on the signature check: loopback aliases ∪ expose-state public origin ∪ platform origin). Absent token → PASS (a box that hasn't created its first admin); foreign `iss` → FAIL (the recurring *"not signed in to the hub"* / issuer-mismatch class, hub#481). Deliberately a **decode-only** `iss` check so doctor runs with no live hub or DB.
- **Module bin resolvable via `Bun.which`** — depcheck's `ensureExecutable`; `NonExecutableError` → FAIL with a `chmod +x` fix (the 100644 lost-exec-bit start-failure class, channel#41); not-on-PATH → FAIL with a reinstall fix.
- **Migration** — the **SAFE allowlist detectors only** (`hasPriorDetachedInstall` + `migrateNotice`). A fresh root flags nothing; both are WARN, never FAIL.

**Tier 2 (guarded hard):**
- **Exposure** — only probed when expose-state says exposed; a loopback-only box reads "loopback only" as benign info (PASS, never WARN). An unreachable public origin → WARN (the tunnel may be starting / upstream bot-protection may shape the probe), never FAIL.
- **Version drift** → WARN, cosmetic, never FAIL.

## Output / contract

Grouped human report (✓ pass / ⚠ warn / ✗ fail, each with a one-line detail + a fix-it command where there is one) and `--json`. **Exit 0 when no FAIL** (WARN allowed); non-zero on any FAIL. Every external read is bounded + behind an injectable `deps` seam, so doctor never hangs/crashes regardless of box state and tests drive it with no real network/manager/db.

## Reuse (no reinvention)

`status.ts` liveness-probe shape (2xx/401), `migrate.ts`/`migrate-offer.ts` allowlist detectors, `operator-token.ts` known-issuer set + `operatorTokenPath`, `services-manifest.ts` strict + lenient reads, `service-spec.ts` startCmd resolution (module.json wins when installDir stamped — mirrors the supervisor), `@openparachute/depcheck` `ensureExecutable`.

## Files

- `src/commands/doctor.ts` (new) — the command + checks, flat module + injectable deps seam.
- `src/__tests__/doctor.test.ts` (new) — sandboxed-`PARACHUTE_HOME` tests.
- `src/cli.ts` — `case "doctor"` + help import.
- `src/help.ts` — `doctorHelp()` + top-level help line.
- `package.json` — rc.14 → rc.15.

## Gates

- `bun test ./src` → **3893 pass / 1 skip / 0 fail** (doctor suite: **17/17**).
- `bun run typecheck` → clean.
- `bunx biome check` on changed files → clean.
- Real local install (read-only): `parachute doctor` exits **0**, all critical checks ✓. The lone ⚠ ("1 archivable entry at ecosystem root") is a *genuine* benign finding from the allowlist detector — correctly advisory (exit 0), not a false positive.

## Judgment calls

- **Decode-only issuer check** (not full JWKS/signature validation): doctor must run without a live hub/DB. An unsigned-but-decodable token still tells the issuer-mismatch story; the known-issuer set is the same one the real validation layers `iss` against on top of the signature gate.
- **Branch:** pushed on a one-off `ag-doctor-717` branch (not the shared `ag-unforced-dev`, whose remote carried stale pre-merge #678 commits) to avoid any clobber risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)