### PR TITLE
harden(2fa): rate-limit /api/account/2fa/confirm — lenient enroll-seal bucket — Closes #712

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.15",
+  "version": "0.7.4-rc.16",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/api-account-2fa.test.ts
+++ b/src/__tests__/api-account-2fa.test.ts
@@ -312,6 +312,55 @@ describe("/api/account/2fa start + confirm", () => {
     const body = (await res.json()) as { error: string };
     expect(body.error).toBe("setup_expired");
   });
+
+  test("confirm is rate-limited after 10 attempts → 429 (lenient, #712)", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const startRes = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });
+    const { secret } = (await startRes.json()) as { secret: string };
+    // 10 honest mistypes are admitted (each 400 invalid_code) — the lenient
+    // bucket doesn't punish a fumbling enroller.
+    for (let i = 0; i < 10; i++) {
+      const r = await post("/2fa/confirm", cookie, {
+        __csrf: TEST_CSRF,
+        secret,
+        code: "000000",
+      });
+      expect(r.status).toBe(400);
+    }
+    // 11th is denied by the limiter BEFORE the code is checked.
+    const denied = await post("/2fa/confirm", cookie, {
+      __csrf: TEST_CSRF,
+      secret,
+      code: "000000",
+    });
+    expect(denied.status).toBe(429);
+    const body = (await denied.json()) as { error: string };
+    expect(body.error).toBe("too_many_attempts");
+    expect(denied.headers.get("retry-after")).toBeTruthy();
+    // The grind never touched enrollment.
+    expect(isTotpEnrolled(harness.db, userId)).toBe(false);
+  });
+
+  test("a few mistypes then the live code within budget still enrolls (lenient)", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const startRes = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });
+    const { secret } = (await startRes.json()) as { secret: string };
+    for (let i = 0; i < 3; i++) {
+      const r = await post("/2fa/confirm", cookie, {
+        __csrf: TEST_CSRF,
+        secret,
+        code: "000000",
+      });
+      expect(r.status).toBe(400);
+    }
+    const ok = await post("/2fa/confirm", cookie, {
+      __csrf: TEST_CSRF,
+      secret,
+      code: liveCode(secret),
+    });
+    expect(ok.status).toBe(200);
+    expect(isTotpEnrolled(harness.db, userId)).toBe(true);
+  });
 });
 
 describe("/api/account/2fa/disable", () => {

--- a/src/__tests__/api-account-2fa.test.ts
+++ b/src/__tests__/api-account-2fa.test.ts
@@ -341,6 +341,29 @@ describe("/api/account/2fa start + confirm", () => {
     expect(isTotpEnrolled(harness.db, userId)).toBe(false);
   });
 
+  test("malformed-secret POSTs don't burn the confirm budget (#712)", async () => {
+    const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
+    const startRes = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });
+    const { secret } = (await startRes.json()) as { secret: string };
+    // 10 junk POSTs are rejected by the format guard BEFORE the limiter runs.
+    for (let i = 0; i < 10; i++) {
+      const r = await post("/2fa/confirm", cookie, {
+        __csrf: TEST_CSRF,
+        secret: "not-base32!!",
+        code: "000000",
+      });
+      expect(r.status).toBe(400);
+    }
+    // Budget untouched — the legit live code still enrolls on the next attempt.
+    const ok = await post("/2fa/confirm", cookie, {
+      __csrf: TEST_CSRF,
+      secret,
+      code: liveCode(secret),
+    });
+    expect(ok.status).toBe(200);
+    expect(isTotpEnrolled(harness.db, userId)).toBe(true);
+  });
+
   test("a few mistypes then the live code within budget still enrolls (lenient)", async () => {
     const { userId, cookie } = await userWithSession(harness.db, "owner", "owner-password-123");
     const startRes = await post("/2fa/start", cookie, { __csrf: TEST_CSRF });

--- a/src/api-account-2fa.ts
+++ b/src/api-account-2fa.ts
@@ -40,7 +40,7 @@ import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import QRCode from "qrcode";
 import { verifyCsrfToken } from "./csrf.ts";
-import { changePasswordRateLimiter } from "./rate-limit.ts";
+import { changePasswordRateLimiter, totpEnrollConfirmRateLimiter } from "./rate-limit.ts";
 import { findActiveSession } from "./sessions.ts";
 import { generateTotpSecret, otpauthUrlFor, verifyTotpCode } from "./totp.ts";
 import {
@@ -219,6 +219,26 @@ async function handleConfirm(
   // Defensive — a confirm POST against an already-enrolled account.
   if (isTotpEnrolled(deps.db, user.id)) {
     return jsonError(409, "already_enrolled", "Two-factor is already enabled.");
+  }
+  // Bound a hijacked session grinding the in-flight (client-held) secret. Keyed
+  // by user.id, lenient (10/15min) so honest enroll mistypes aren't punished —
+  // defense-in-depth (#712). Fires AFTER the format + already-enrolled guards so
+  // junk/no-op POSTs don't burn the legit enroller's budget, and BEFORE the
+  // code verify so the grind window is actually bounded.
+  const confirmLimited = totpEnrollConfirmRateLimiter.checkAndRecord(
+    user.id,
+    deps.now ? deps.now() : new Date(),
+  );
+  if (!confirmLimited.allowed) {
+    const retryAfter = confirmLimited.retryAfterSeconds ?? 1;
+    return json(
+      429,
+      {
+        error: "too_many_attempts",
+        error_description: `Too many attempts. Try again in ${retryAfter} seconds.`,
+      },
+      { "retry-after": String(retryAfter) },
+    );
   }
   if (!verifyTotpCode(secret, code)) {
     return jsonError(

--- a/src/api-account-2fa.ts
+++ b/src/api-account-2fa.ts
@@ -224,7 +224,9 @@ async function handleConfirm(
   // by user.id, lenient (10/15min) so honest enroll mistypes aren't punished —
   // defense-in-depth (#712). Fires AFTER the format + already-enrolled guards so
   // junk/no-op POSTs don't burn the legit enroller's budget, and BEFORE the
-  // code verify so the grind window is actually bounded.
+  // code verify so the grind window is actually bounded. A SUCCESSFUL confirm
+  // also consumes one slot (checkAndRecord counts every attempt) — harmless,
+  // since an enrolled account 409s on any further confirm anyway.
   const confirmLimited = totpEnrollConfirmRateLimiter.checkAndRecord(
     user.id,
     deps.now ? deps.now() : new Date(),

--- a/src/rate-limit.ts
+++ b/src/rate-limit.ts
@@ -88,6 +88,21 @@ export const CHANGE_PASSWORD_WINDOW_MS = 5 * 60 * 1000;
  */
 export const CHANGE_PASSWORD_MAX_ATTEMPTS = 3;
 /**
+ * `/api/account/2fa/confirm` (TOTP enrollment seal) window: 15 minutes. This is
+ * the SELF-only, already-session-authenticated enrollment step — the operator is
+ * typing the first live code off their own authenticator while it drifts into
+ * sync, so legitimate mistypes are common and must not be punished. The threat
+ * is only a hijacked session grinding the (client-held, not-yet-persisted)
+ * in-flight secret, which the 10^6 code space + replay cache already make
+ * effectively non-exploitable — so this is defense-in-depth, deliberately MORE
+ * generous than the 3/5-min change-password bucket. NOT the `/login/2fa` bucket:
+ * that one is the strict, pre-auth brute-force door (5/15-min); enrollment is a
+ * different, lower-risk surface and gets its own lenient bucket.
+ */
+export const TOTP_ENROLL_CONFIRM_WINDOW_MS = 15 * 60 * 1000;
+/** `/api/account/2fa/confirm` attempts allowed per window. 11th is denied. */
+export const TOTP_ENROLL_CONFIRM_MAX_ATTEMPTS = 10;
+/**
  * `/login/2fa` window length: 15 minutes — same as `/login`. The second-
  * factor step (hub#473) sits behind a verified password + a short-lived
  * pending-login token, so the threat model is "attacker who already has the
@@ -290,6 +305,18 @@ export const changePasswordRateLimiter = new RateLimiter(
 export const totpRateLimiter = new RateLimiter(TOTP_MAX_ATTEMPTS, TOTP_WINDOW_MS);
 
 /**
+ * `/api/account/2fa/confirm` enrollment-seal bucket. Lenient (10 / 15 min),
+ * keyed by `user.id` (the session already establishes identity). Separate from
+ * `totpRateLimiter` so an enrollment mistype and a `/login/2fa` failure never
+ * share a window — different surfaces, different threat models (see the const
+ * docs above).
+ */
+export const totpEnrollConfirmRateLimiter = new RateLimiter(
+  TOTP_ENROLL_CONFIRM_MAX_ATTEMPTS,
+  TOTP_ENROLL_CONFIRM_WINDOW_MS,
+);
+
+/**
  * Coarse per-IP CEILING rate limiter — 60 attempts / 15 min, keyed by client
  * IP ONLY. Shared by all interactive auth doors (`/login`, the
  * `/oauth/authorize` password door, `/login/2fa`) as a backstop against
@@ -342,6 +369,7 @@ export function __resetForTests(): void {
   loginRateLimiter.reset();
   changePasswordRateLimiter.reset();
   totpRateLimiter.reset();
+  totpEnrollConfirmRateLimiter.reset();
   vaultTokenMintRateLimiter.reset();
   signupRateLimiter.reset();
   authIpCeilingRateLimiter.reset();


### PR DESCRIPTION
## What

`/api/account/2fa/confirm` (the TOTP enrollment seal) verified the live code against the client-held, not-yet-persisted secret with **no rate limit** (caught in the #711 review). Effectively non-exploitable today (10^6 code space + replay cache), so this is defense-in-depth — but a hijacked session could otherwise grind the in-flight secret unbounded.

## Fix

A dedicated **lenient** limiter `totpEnrollConfirmRateLimiter` (**10 / 15 min**, keyed by `user.id`):
- **More generous** than the 3/5-min change-password bucket — honest enroll mistypes (typing the first live code while the authenticator drifts into sync) must not be punished.
- **Separate** from the strict pre-auth `/login/2fa` bucket (5/15-min) — different surface, different threat model; an enroll fumble and a login-2FA failure shouldn't share a window.
- Gate fires **after** the secret-format + already-enrolled guards (junk/no-op POSTs don't burn the legit enroller's budget) and **before** `verifyTotpCode` (so the grind window is actually bounded).
- Returns the same `429 too_many_attempts` + `retry-after` shape as the password endpoints. Added to `__resetForTests`.

## Tests
- 11th attempt → `429 too_many_attempts`, enrollment untouched.
- 3 mistypes then the live code within budget still enrolls (leniency proven).

## Gates
`bun test ./src` → **3896 pass / 1 skip / 0 fail**; `tsc --noEmit` clean; biome clean.

Files: `src/rate-limit.ts`, `src/api-account-2fa.ts`, `src/__tests__/api-account-2fa.test.ts`, `package.json` (rc.15 → rc.16).