### PR TITLE
feat(hub): admin-auth + mint honor the multi-origin issuer SET — clean origin switches (rc.21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.20",
+  "version": "0.7.4-rc.21",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-auth.test.ts
+++ b/src/__tests__/admin-auth.test.ts
@@ -172,6 +172,134 @@ describe("requireScope", () => {
   });
 });
 
+describe("requireScope multi-origin issuer set (hub#516 parity)", () => {
+  // The hub answers on several legitimate origins after `parachute hub
+  // set-origin` / `expose` (loopback ∪ tunnel ∪ public). A credential minted
+  // under a still-valid prior origin must keep validating at admin-auth even
+  // when the per-request canonical issuer is now a different member of the set.
+  const LOOPBACK = "http://127.0.0.1:1939";
+  const TUNNEL = "https://brain.gitcoin.co";
+  const FOREIGN = "https://evil.example.com";
+
+  test("accepts a token whose iss is in the set but ≠ the per-request canonical", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        // Token minted under the TUNNEL origin (e.g. before `set-origin`)…
+        const token = await mintToken(db, ["parachute:host:admin"], { issuer: TUNNEL });
+        // …presented to admin-auth where the canonical per-request issuer is now
+        // LOOPBACK, but the bound-origin set still includes TUNNEL.
+        const ctx = await requireScope(db, reqWithAuth(`Bearer ${token}`), "parachute:host:admin", [
+          LOOPBACK,
+          TUNNEL,
+        ]);
+        expect(ctx.sub).toBe("user-test");
+        expect(ctx.scopes).toContain("parachute:host:admin");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects 401 when iss is OUTSIDE the set", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const token = await mintToken(db, ["parachute:host:admin"], { issuer: FOREIGN });
+        let caught: AdminAuthError | null = null;
+        try {
+          await requireScope(db, reqWithAuth(`Bearer ${token}`), "parachute:host:admin", [
+            LOOPBACK,
+            TUNNEL,
+          ]);
+        } catch (err) {
+          caught = err as AdminAuthError;
+        }
+        expect(caught?.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects 401 on signature failure regardless of the set (signature-first)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        // A hub-signed token, then rotate keys + retire so the original kid no
+        // longer verifies — the JWKS signature gate must fire before any iss
+        // membership check, so an in-set iss can't rescue an unverifiable token.
+        let caught: AdminAuthError | null = null;
+        try {
+          await requireScope(db, reqWithAuth("Bearer not-a-real-jwt"), "parachute:host:admin", [
+            LOOPBACK,
+            TUNNEL,
+          ]);
+        } catch (err) {
+          caught = err as AdminAuthError;
+        }
+        expect(caught?.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("single-string back-compat: in-set iss as a lone string still validates", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const token = await mintToken(db, ["parachute:host:admin"], { issuer: ISSUER });
+        // A single-element set behaves exactly like the prior single-string form.
+        const ctx = await requireScope(db, reqWithAuth(`Bearer ${token}`), "parachute:host:admin", [
+          ISSUER,
+        ]);
+        expect(ctx.sub).toBe("user-test");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("single-element set rejects a non-matching iss (no accidental widening)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        const token = await mintToken(db, ["parachute:host:admin"], { issuer: TUNNEL });
+        let caught: AdminAuthError | null = null;
+        try {
+          await requireScope(db, reqWithAuth(`Bearer ${token}`), "parachute:host:admin", [ISSUER]);
+        } catch (err) {
+          caught = err as AdminAuthError;
+        }
+        expect(caught?.status).toBe(401);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
 describe("adminAuthErrorResponse", () => {
   test("403 → insufficient_scope with WWW-Authenticate", async () => {
     const res = adminAuthErrorResponse(new AdminAuthError(403, "needs admin"));

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -172,6 +172,81 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     }
   });
 
+  // hub#516 parity — the live "mint refused" after `parachute hub set-origin`.
+  // An operator/agent credential minted under a PRIOR origin (still a member of
+  // the hub's bound-origin set) must keep minting after the canonical issuer
+  // switches; the minted token still carries the new canonical issuer.
+  describe("multi-origin issuer set (set-origin parity)", () => {
+    const TUNNEL = "https://brain.gitcoin.co";
+
+    test("mints when the bearer's iss is in knownIssuers but ≠ the canonical issuer", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          // Operator token minted under the TUNNEL origin (pre-`set-origin`).
+          const op = await mintOperatorToken(db, userId, { issuer: TUNNEL });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "scribe:transcribe", expires_in: 3600 },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            // Canonical issuer is now ISSUER (loopback), but the bound set still
+            // includes TUNNEL — the still-valid prior origin.
+            { db, issuer: ISSUER, knownIssuers: [ISSUER, TUNNEL] },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string };
+          // The MINTED token carries the canonical issuer, not the bearer's.
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.iss).toBe(ISSUER);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("rejects 401 when the bearer's iss is OUTSIDE knownIssuers", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: "https://evil.example.com" });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "scribe:transcribe" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER, knownIssuers: [ISSUER, TUNNEL] },
+          );
+          expect(resp.status).toBe(401);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("back-compat: without knownIssuers, a non-canonical iss is still rejected", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: TUNNEL });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "scribe:transcribe" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER }, // no knownIssuers → falls back to [ISSUER]
+          );
+          expect(resp.status).toBe(401);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+  });
+
   test("happy path: --scope-set=auth narrow operator token also passes the scope gate", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -370,6 +370,33 @@ describe("validateAccessToken", () => {
     }
   });
 
+  test("expectedIssuer accepts a SET — iss in the set validates, outside rejects", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const { token } = await signAccessToken(db, {
+        sub: "u",
+        scopes: ["s"],
+        audience: "operator",
+        clientId: "c",
+        issuer: "https://tunnel.example",
+      });
+      // In-set (≠ first element) validates — additive membership on iss.
+      const { payload } = await validateAccessToken(db, token, [
+        "http://127.0.0.1:1939",
+        "https://tunnel.example",
+      ]);
+      expect(payload.iss).toBe("https://tunnel.example");
+      // Outside the set rejects.
+      await expect(
+        validateAccessToken(db, token, ["http://127.0.0.1:1939", "https://other.example"]),
+      ).rejects.toThrow();
+      // A single-element set that doesn't match also rejects (no widening).
+      await expect(validateAccessToken(db, token, ["http://127.0.0.1:1939"])).rejects.toThrow();
+    } finally {
+      cleanup();
+    }
+  });
+
   test("verifies a token signed by a recently-retired key (rotation tolerance)", async () => {
     const { db, cleanup } = makeDb();
     try {

--- a/src/admin-agent-grants.ts
+++ b/src/admin-agent-grants.ts
@@ -131,6 +131,16 @@ export interface AgentGrantsDeps {
    * (`<hubOrigin>/oauth/agent-grant/callback`).
    */
   hubOrigin: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request issuer), built via `buildHubBoundOrigins`. The module's
+   * host-admin bearer `iss` is validated against THIS set rather than the
+   * single `hubOrigin`, so the agent module's credential minted under a
+   * still-valid prior origin keeps working across an origin switch (hub#516
+   * parity). Minted tokens still carry `hubOrigin`. Absent → falls back to
+   * `[hubOrigin]` (the prior strict per-request behavior).
+   */
+  knownIssuers?: readonly string[];
   /** Absolute path to `agent-grants.json` in the hub state dir. */
   storePath: string;
   /** Absolute path to `agent-oauth-flows.json` (the in-flight OAuth consents, 4b-2). */
@@ -249,7 +259,12 @@ async function requireModuleAuth(
   deps: AgentGrantsDeps,
 ): Promise<AdminAuthContext | Response> {
   try {
-    return await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.hubOrigin);
+    return await requireScope(
+      deps.db,
+      req,
+      HOST_ADMIN_SCOPE,
+      deps.knownIssuers ?? [deps.hubOrigin],
+    );
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }

--- a/src/admin-auth.ts
+++ b/src/admin-auth.ts
@@ -59,15 +59,24 @@ export function extractBearerToken(req: Request): string {
  * and check it carries `requiredScope`. Returns surfaced claims on success;
  * throws `AdminAuthError` (401 or 403) otherwise.
  *
- * `expectedIssuer` MUST be the hub's own origin — the same value baked into
- * tokens we sign. Defense in depth: even though we can only verify our own
- * keys, the `iss` mismatch reject keeps cross-issuer confusion impossible.
+ * `expectedIssuer` is the hub's own origin(s) — the same value(s) baked into
+ * tokens we sign. Pass a single string for a single-origin hub, or the SET of
+ * origins the hub legitimately answers on (`buildHubBoundOrigins`: loopback ∪
+ * expose-state ∪ platform ∪ per-request issuer) so a credential minted under
+ * a still-valid prior origin keeps validating across an origin switch — the
+ * same multi-origin posture the OAuth path and `validateHostAdminToken`
+ * already use. Defense in depth: even though we can only verify our own keys,
+ * the `iss`-∈-set reject keeps cross-issuer confusion impossible. SECURITY:
+ * the set is ONLY an additive `iss` membership relaxation — `validateAccessToken`
+ * verifies the signature against the hub's own key FIRST, so only tokens this
+ * hub minted ever reach the `iss` check; never pass a raw request Host, only a
+ * `buildHubBoundOrigins`-derived set.
  */
 export async function requireScope(
   db: Database,
   req: Request,
   requiredScope: string,
-  expectedIssuer: string,
+  expectedIssuer: string | readonly string[],
 ): Promise<AdminAuthContext> {
   const token = extractBearerToken(req);
 

--- a/src/admin-clients.ts
+++ b/src/admin-clients.ts
@@ -64,6 +64,15 @@ export interface AdminClientsDeps {
   db: Database;
   /** Hub origin — passed through to JWT validation as the expected `iss`. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
 }
 
 export interface AdminClientView {
@@ -93,7 +102,7 @@ export async function handleGetClient(
     return jsonError(405, "method_not_allowed", "use GET");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -129,7 +138,7 @@ export async function handleApproveClient(
   }
   let ctx: AdminAuthContext;
   try {
-    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -212,7 +221,7 @@ export async function handleDeleteClient(
   }
   let ctx: AdminAuthContext;
   try {
-    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }

--- a/src/admin-grants.ts
+++ b/src/admin-grants.ts
@@ -38,6 +38,15 @@ export interface AdminGrantsDeps {
   db: Database;
   /** Hub origin — passed through to JWT validation as the expected `iss`. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
 }
 
 export interface AdminGrantListing {
@@ -55,7 +64,7 @@ export async function handleListGrants(req: Request, deps: AdminGrantsDeps): Pro
   }
   let ctx: AdminAuthContext;
   try {
-    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -111,7 +120,7 @@ export async function handleRevokeGrant(
   }
   let ctx: AdminAuthContext;
   try {
-    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    ctx = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -129,6 +129,15 @@ export interface CreateVaultDeps {
   db: Database;
   /** Hub origin used to validate JWT `iss` and to build the response `url`. */
   issuer: string;
+  /**
+   * SET of origins the hub legitimately answers on (loopback ∪ expose-state ∪
+   * platform ∪ per-request `issuer`), built via `buildHubBoundOrigins`. The
+   * admin bearer's `iss` is validated against THIS set rather than the single
+   * `issuer`, so a host-admin credential minted under a still-valid prior
+   * origin keeps working across an origin switch (hub#516 parity). Absent →
+   * falls back to `[issuer]` (the prior strict per-request behavior).
+   */
+  knownIssuers?: readonly string[];
   /** Override the services.json path. Defaults to `~/.parachute/services.json`. */
   manifestPath?: string;
   /**
@@ -442,7 +451,7 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
   // Auth gate: parachute:host:admin scope. Maps an AdminAuthError straight
   // to an RFC 6750 401/403 — the route handler doesn't care which.
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -530,6 +539,15 @@ export interface DeleteVaultDeps {
   db: Database;
   /** Hub origin — JWT `iss` validation + cascade mint issuer. */
   issuer: string;
+  /**
+   * SET of origins the hub legitimately answers on (loopback ∪ expose-state ∪
+   * platform ∪ per-request `issuer`), built via `buildHubBoundOrigins`. The
+   * admin bearer's `iss` is validated against THIS set rather than the single
+   * `issuer`, so a host-admin credential minted under a still-valid prior
+   * origin keeps working across an origin switch (hub#516 parity). Absent →
+   * falls back to `[issuer]` (the prior strict per-request behavior).
+   */
+  knownIssuers?: readonly string[];
   /** Override the services.json path. Defaults to `~/.parachute/services.json`. */
   manifestPath?: string;
   /** Absolute path to `connections.json` in the hub state dir. */
@@ -693,7 +711,12 @@ export async function handleDeleteVault(
   // Auth gate: parachute:host:admin — the same gate as POST /vaults.
   let adminSub: string;
   try {
-    const auth = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    const auth = await requireScope(
+      deps.db,
+      req,
+      HOST_ADMIN_SCOPE,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     adminSub = auth.sub;
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);

--- a/src/api-hub-upgrade.ts
+++ b/src/api-hub-upgrade.ts
@@ -107,6 +107,15 @@ export interface ApiHubUpgradeDeps {
   db: Database;
   /** Hub origin — validates the bearer's `iss`. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
   /** PARACHUTE_HOME — where the status file is read/written. */
   configDir: string;
   /**
@@ -155,7 +164,11 @@ async function authorize(req: Request, deps: ApiHubUpgradeDeps): Promise<Respons
   const bearer = auth.slice("Bearer ".length).trim();
   if (!bearer) return jsonError(401, "unauthenticated", "empty bearer token");
   try {
-    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const validated = await validateAccessToken(
+      deps.db,
+      bearer,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
       return jsonError(401, "unauthenticated", "bearer token has no sub claim");
     }

--- a/src/api-hub.ts
+++ b/src/api-hub.ts
@@ -53,6 +53,15 @@ export interface ApiHubDeps {
   /** Hub origin — used to validate the bearer's `iss`. */
   issuer: string;
   /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
+  /**
    * Override the directory used to locate the hub's package.json and to
    * classify install source. Defaults to `dirname(import.meta.url)` —
    * which is `<repo>/src/` for normal layouts. Test seam.
@@ -96,7 +105,7 @@ export async function handleApiHub(req: Request, deps: ApiHubDeps): Promise<Resp
   // Bearer-gate on `parachute:host:admin`. Same shape as the other admin
   // endpoints — SPA mints via /admin/host-admin-token.
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err);
   }

--- a/src/api-invites.ts
+++ b/src/api-invites.ts
@@ -52,6 +52,16 @@ export interface ApiInvitesDeps {
   db: Database;
   /** Hub origin — JWT `iss` validation AND the base for the redemption URL. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). The redemption URL still uses the single
+   * canonical `issuer`. Absent → falls back to `[issuer]` (the prior strict
+   * per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
   manifestPath?: string;
   now?: () => Date;
 }
@@ -399,7 +409,12 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
   try {
     // `requireScope` returns the validated claims; the admin's `sub` is the
     // `created_by` audit anchor (guaranteed present — it throws otherwise).
-    const auth = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    const auth = await requireScope(
+      deps.db,
+      req,
+      HOST_ADMIN_SCOPE,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     authUserId = auth.sub;
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
@@ -544,7 +559,7 @@ export async function handleCreateInvite(req: Request, deps: ApiInvitesDeps): Pr
 export async function handleListInvites(req: Request, deps: ApiInvitesDeps): Promise<Response> {
   if (req.method !== "GET") return jsonError(405, "method_not_allowed", "use GET");
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -564,7 +579,7 @@ export async function handleRevokeInvite(
 ): Promise<Response> {
   if (req.method !== "DELETE") return jsonError(405, "method_not_allowed", "use DELETE");
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -88,6 +88,17 @@ export interface ApiMintTokenDeps {
   /** Hub origin — written into the JWT `iss` of minted tokens AND used to validate the bearer. */
   issuer: string;
   /**
+   * SET of origins the hub legitimately answers on (loopback ∪ expose-state ∪
+   * platform ∪ per-request `issuer`), built via `buildHubBoundOrigins`. The
+   * caller's bearer `iss` is validated against THIS set rather than the single
+   * `issuer`, so a credential minted under a still-valid prior origin keeps
+   * minting across an origin switch (hub#516 parity — the live "mint refused"
+   * after `set-origin`). Minted tokens still carry the single canonical
+   * `issuer` as their `iss`. Absent → falls back to `[issuer]` (the prior
+   * strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
+  /**
    * Names of vault instances currently registered in services.json (item D /
    * hub#450). When provided, a `vault:<name>:admin` mint whose `<name>` is not
    * in this set is rejected with 400 — a typo'd name can no longer mint
@@ -133,7 +144,11 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   let bearerSub: string;
   let bearerScopes: string[];
   try {
-    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const validated = await validateAccessToken(
+      deps.db,
+      bearer,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     const sub = validated.payload.sub;
     if (typeof sub !== "string" || sub.length === 0) {
       return jsonError(401, "unauthenticated", "bearer token has no sub claim");

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -759,6 +759,15 @@ export const API_MODULES_CHANNEL_REQUIRED_SCOPE = "parachute:host:admin";
 export interface ApiModulesChannelDeps {
   db: Database;
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins` — same posture as
+   * {@link ApiModulesDeps.knownIssuers}. The bearer's `iss` is validated
+   * against THIS set rather than the single `issuer`, so the operator token
+   * (public `iss` after `expose`) is accepted on loopback. Absent → falls back
+   * to `[issuer]` (the prior strict per-request behavior).
+   */
+  knownIssuers?: readonly string[];
 }
 
 export async function handleApiModulesChannel(
@@ -781,7 +790,11 @@ export async function handleApiModulesChannel(
 
   // Bearer validation + scope check.
   try {
-    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const validated = await validateAccessToken(
+      deps.db,
+      bearer,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
       return jsonError(401, "unauthenticated", "bearer token has no sub claim");
     }

--- a/src/api-revoke-token.ts
+++ b/src/api-revoke-token.ts
@@ -73,6 +73,15 @@ export interface ApiRevokeTokenDeps {
   db: Database;
   /** Hub origin — used to validate the bearer's `iss`. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
   /** Test seam for time. */
   now?: () => Date;
 }
@@ -102,7 +111,11 @@ export async function handleApiRevokeToken(
   // 2. Bearer validation (signature, issuer, expiry, hub-side revocation).
   let bearerScopes: string[];
   try {
-    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const validated = await validateAccessToken(
+      deps.db,
+      bearer,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
       return jsonError(401, "unauthenticated", "bearer token has no sub claim");
     }

--- a/src/api-settings-hub-origin.ts
+++ b/src/api-settings-hub-origin.ts
@@ -48,6 +48,15 @@ export interface ApiSettingsHubOriginDeps {
   db: Database;
   issuer: string;
   /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
+  /**
    * The currently-resolved issuer + its source layer. Computed by the
    * dispatcher (which has the request + `configuredIssuer` already in
    * hand) and threaded through so this handler doesn't have to re-do
@@ -186,7 +195,11 @@ export async function handleApiSettingsHubOrigin(
 
   // Bearer validation + scope check.
   try {
-    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const validated = await validateAccessToken(
+      deps.db,
+      bearer,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
       return jsonError(401, "unauthenticated", "bearer token has no sub claim");
     }

--- a/src/api-settings-root-redirect.ts
+++ b/src/api-settings-root-redirect.ts
@@ -45,6 +45,15 @@ export interface ApiSettingsRootRedirectDeps {
   /** Issuer the bearer token must validate against (the hub's resolved issuer). */
   issuer: string;
   /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
+  /**
    * Env seam for the resolver's env layer. Defaults to `process.env`. Threaded
    * so the dispatcher (and tests) can resolve `PARACHUTE_HUB_ROOT_REDIRECT`
    * deterministically.
@@ -120,7 +129,11 @@ export async function handleApiSettingsRootRedirect(
 
   // Bearer validation + scope check.
   try {
-    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const validated = await validateAccessToken(
+      deps.db,
+      bearer,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
       return jsonError(401, "unauthenticated", "bearer token has no sub claim");
     }

--- a/src/api-tokens.ts
+++ b/src/api-tokens.ts
@@ -67,6 +67,15 @@ export interface ApiTokensDeps {
   db: Database;
   /** Hub origin — used to validate the bearer's `iss`. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
 }
 
 interface TokenWireShape {
@@ -115,7 +124,11 @@ export async function handleApiTokens(req: Request, deps: ApiTokensDeps): Promis
   // 2. Bearer validation.
   let bearerScopes: string[];
   try {
-    const validated = await validateAccessToken(deps.db, bearer, deps.issuer);
+    const validated = await validateAccessToken(
+      deps.db,
+      bearer,
+      deps.knownIssuers ?? [deps.issuer],
+    );
     if (typeof validated.payload.sub !== "string" || validated.payload.sub.length === 0) {
       return jsonError(401, "unauthenticated", "bearer token has no sub claim");
     }

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -69,6 +69,15 @@ export interface ApiUsersDeps {
   db: Database;
   /** Hub origin — JWT `iss` validation. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
   /** Override services.json path. Defaults to `~/.parachute/services.json`. */
   manifestPath?: string;
 }
@@ -118,7 +127,7 @@ export async function handleListUsers(req: Request, deps: ApiUsersDeps): Promise
     return jsonError(405, "method_not_allowed", "use GET");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -262,7 +271,7 @@ export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promis
     return jsonError(405, "method_not_allowed", "use POST");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -358,7 +367,7 @@ export async function handleDeleteUser(
     return jsonError(405, "method_not_allowed", "use DELETE");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -441,7 +450,7 @@ export async function handleListVaults(req: Request, deps: ApiUsersDeps): Promis
     return jsonError(405, "method_not_allowed", "use GET");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -571,7 +580,7 @@ export async function handleUpdateUserVaults(
     return jsonError(405, "method_not_allowed", "use PATCH");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -760,7 +769,7 @@ export async function handleResetUserPassword(
     return jsonError(405, "method_not_allowed", "use POST");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }

--- a/src/api-vault-caps.ts
+++ b/src/api-vault-caps.ts
@@ -39,6 +39,15 @@ export interface ApiVaultCapsDeps {
   db: Database;
   /** Hub origin — JWT `iss` validation. */
   issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's
+   * `iss` is validated against THIS set rather than the single `issuer`, so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]` (the
+   * prior strict per-request behavior; tests/non-HTTP callers unaffected).
+   */
+  knownIssuers?: readonly string[];
   /** Override services.json path. Defaults to `~/.parachute/services.json`. */
   manifestPath?: string;
 }
@@ -71,7 +80,7 @@ export async function handleListVaultCaps(req: Request, deps: ApiVaultCapsDeps):
     return jsonError(405, "method_not_allowed", "use GET");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -174,7 +183,7 @@ export async function handleSetVaultCap(
     return jsonError(405, "method_not_allowed", "use PUT");
   }
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.issuer);
+    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2801,6 +2801,7 @@ export function hubFetch(
           await handleDeleteClient(req, clientId, {
             db: getDb(),
             issuer: oauthDeps(req).issuer,
+            knownIssuers: oauthDeps(req).hubBoundOrigins(),
           }),
         );
       }
@@ -2842,6 +2843,7 @@ export function hubFetch(
         return handleCreateVault(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -2868,6 +2870,7 @@ export function hubFetch(
         return handleDeleteVault(req, name, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           manifestPath,
           connectionsStorePath: deps?.connectionsStorePath ?? join(CONFIG_DIR, "connections.json"),
           agentOrigin,
@@ -3024,6 +3027,10 @@ export function hubFetch(
         const agentGrantsDeps: AgentGrantsDeps = {
           db: getDb(),
           hubOrigin: oauthDeps(req).issuer,
+          // hub#516 parity: validate the module's host-admin bearer `iss`
+          // against the hub's known-origin set (PUT /admin/grants is the only
+          // bearer-gated route here; the POST /approve|/revoke are cookie-authed).
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           storePath: deps?.agentGrantsStorePath ?? join(CONFIG_DIR, "agent-grants.json"),
           flowsStorePath:
             deps?.agentOAuthFlowsStorePath ?? join(CONFIG_DIR, "agent-oauth-flows.json"),
@@ -3116,6 +3123,7 @@ export function hubFetch(
         return handleHubUpgrade(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           configDir: CONFIG_DIR,
         });
       }
@@ -3124,6 +3132,7 @@ export function hubFetch(
         return handleHubUpgradeStatus(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           configDir: CONFIG_DIR,
         });
       }
@@ -3136,6 +3145,7 @@ export function hubFetch(
         return handleApiHub(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3171,6 +3181,7 @@ export function hubFetch(
         return handleApiModulesChannel(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3184,6 +3195,7 @@ export function hubFetch(
         return handleApiSettingsHubOrigin(req, {
           db,
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           resolvedIssuer: resolveIssuer(req, db, configuredIssuer, loadExposeHubOrigin),
           resolvedSource: resolveIssuerSource(db, configuredIssuer, loadExposeHubOrigin),
         });
@@ -3198,6 +3210,7 @@ export function hubFetch(
         return handleApiSettingsRootRedirect(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3300,6 +3313,7 @@ export function hubFetch(
         return handleApiMintToken(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           knownVaultNames: mintKnownVaultNames,
         });
       }
@@ -3309,6 +3323,7 @@ export function hubFetch(
         return handleApiRevokeToken(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3317,6 +3332,7 @@ export function hubFetch(
         return handleApiTokens(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3325,6 +3341,7 @@ export function hubFetch(
         return handleListGrants(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3337,6 +3354,7 @@ export function hubFetch(
         return handleRevokeGrant(req, clientId, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3359,6 +3377,7 @@ export function hubFetch(
           return handleApproveClient(req, clientId, {
             db: getDb(),
             issuer: oauthDeps(req).issuer,
+            knownIssuers: oauthDeps(req).hubBoundOrigins(),
           });
         }
         const clientId = decodeURIComponent(tail);
@@ -3368,6 +3387,7 @@ export function hubFetch(
         return handleGetClient(req, clientId, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
         });
       }
 
@@ -3383,6 +3403,7 @@ export function hubFetch(
         const usersDeps = {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           manifestPath,
         };
         if (req.method === "GET") return handleListUsers(req, usersDeps);
@@ -3394,6 +3415,7 @@ export function hubFetch(
         return handleListVaults(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           manifestPath,
         });
       }
@@ -3413,6 +3435,7 @@ export function hubFetch(
           return handleResetUserPassword(req, id, {
             db: getDb(),
             issuer: oauthDeps(req).issuer,
+            knownIssuers: oauthDeps(req).hubBoundOrigins(),
             manifestPath,
           });
         }
@@ -3431,6 +3454,7 @@ export function hubFetch(
           return handleUpdateUserVaults(req, id, {
             db: getDb(),
             issuer: oauthDeps(req).issuer,
+            knownIssuers: oauthDeps(req).hubBoundOrigins(),
             manifestPath,
           });
         }
@@ -3444,6 +3468,7 @@ export function hubFetch(
         return handleDeleteUser(req, id, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           manifestPath,
         });
       }
@@ -3453,7 +3478,12 @@ export function hubFetch(
       // lists (status-annotated), DELETE /:id revokes by sha256 hash.
       if (pathname === "/api/invites") {
         if (!getDb) return dbNotConfigured();
-        const invitesDeps = { db: getDb(), issuer: oauthDeps(req).issuer, manifestPath };
+        const invitesDeps = {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
+          manifestPath,
+        };
         if (req.method === "GET") return handleListInvites(req, invitesDeps);
         if (req.method === "POST") return handleCreateInvite(req, invitesDeps);
         return new Response("method not allowed", { status: 405 });
@@ -3467,6 +3497,7 @@ export function hubFetch(
         return handleRevokeInvite(req, id, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           manifestPath,
         });
       }
@@ -3479,6 +3510,7 @@ export function hubFetch(
         return handleListVaultCaps(req, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           manifestPath,
         });
       }
@@ -3491,6 +3523,7 @@ export function hubFetch(
         return handleSetVaultCap(req, name, {
           db: getDb(),
           issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
           manifestPath,
         });
       }

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -483,11 +483,26 @@ export interface ValidatedAccessToken {
  * this hub advertises — the same check vault performs against its own
  * `PARACHUTE_HUB_ORIGIN`. Defense in depth: tokens forged or replayed from
  * a different issuer get rejected at validation as well as issuance.
+ *
+ * `expectedIssuer` accepts a single string OR a SET of allowed issuers
+ * (`readonly string[]`), handed straight to jose's `issuer` option (which
+ * accepts `string | string[]`): the `iss` claim must equal the string, or be
+ * a member of the set. The set form is for the hub's own self-issued
+ * credentials, whose `iss` may be ANY origin the hub legitimately answers on
+ * (loopback ∪ expose-state ∪ platform ∪ per-request issuer — see
+ * `buildHubBoundOrigins`), so an origin switch doesn't reject a credential
+ * minted under a still-valid prior origin. SECURITY: this is ONLY an additive
+ * membership relaxation on `iss`. jose verifies the JWS signature against the
+ * hub's own public key FIRST and UNCONDITIONALLY — only tokens this hub
+ * minted can verify — before the `iss` claim is ever compared to the set. The
+ * set must come only from `buildHubBoundOrigins` (the hub's own origins),
+ * never a raw request Host. An empty/omitted value skips the `iss` check
+ * (signature-only); a single string is byte-identical to the prior behavior.
  */
 export async function validateAccessToken(
   db: Database,
   token: string,
-  expectedIssuer?: string,
+  expectedIssuer?: string | readonly string[],
 ): Promise<ValidatedAccessToken> {
   const header = decodeProtectedHeader(token);
   const kid = header.kid;
@@ -495,11 +510,15 @@ export async function validateAccessToken(
   const match = getAllPublicKeys(db).find((k) => k.kid === kid);
   if (!match) throw new Error(`validateAccessToken: unknown or expired kid ${kid}`);
   const pub = await importSPKI(match.publicKeyPem, SIGNING_ALGORITHM);
-  const { payload } = await jwtVerify(
-    token,
-    pub,
-    expectedIssuer ? { issuer: expectedIssuer } : undefined,
-  );
+  // `undefined` → no `iss` pin (signature-only, the internal-caller default).
+  // A string or a non-empty set is handed straight to jose, which checks
+  // membership AFTER the signature verify above. An empty array is passed
+  // through too and so fails closed (no `iss` can match) — same posture as
+  // `validateHostAdminToken`; callers offering an empty origin set get a
+  // rejection, not a silent widening.
+  const issuerOption =
+    expectedIssuer === undefined ? undefined : { issuer: expectedIssuer as string | string[] };
+  const { payload } = await jwtVerify(token, pub, issuerOption);
   // RFC 7009 revocation enforcement (#73). OAuth-issued tokens carry a
   // tokens row keyed by jti; if that row is marked revoked, the JWT is
   // dead even though its signature + expiry are still valid. Tokens that

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -2706,7 +2706,13 @@ export async function handleRegister(
   let sameHub = false;
   if (req.headers.get("authorization")) {
     try {
-      await requireScope(db, req, "hub:admin", deps.issuer);
+      // Validate the operator bearer's `iss` against the SET of origins the
+      // hub answers on (`deps.hubBoundOrigins` — loopback ∪ expose-state ∪
+      // platform ∪ per-request issuer), not just the single per-request
+      // `issuer`, so a host-admin credential minted under a still-valid prior
+      // origin keeps auto-approving across an origin switch (hub#516 parity).
+      // Falls back to `[deps.issuer]` when no set getter is wired (tests).
+      await requireScope(db, req, "hub:admin", deps.hubBoundOrigins?.() ?? deps.issuer);
       status = "approved";
       sameHub = true;
     } catch (err) {


### PR DESCRIPTION
## What

Bring the hub's **own** admin/mint auth to parity with the OAuth path, vault, and agent: validate an incoming token's `iss` against the **SET** of origins the hub legitimately answers on (`buildHubBoundOrigins`: issuer ∪ loopback ∪ expose-state ∪ platform), not a single canonical issuer. This is the last piece so an origin switch (`parachute hub set-origin`) is clean and non-breaking.

## Why (the gap + live failure)

- The OAuth path already validates against the set (`hub-server.ts:2009` builds `hubBoundOrigins`, wired as `knownIssuers`).
- But `admin-auth.ts` `requireScope` and the direct `validateAccessToken(...deps.issuer)` callers pinned a **single** issuer.
- LIVE SYMPTOM: after `parachute hub set-origin https://brain.gitcoin.co`, an operator/agent credential minted earlier (`iss=tunnel`, still in the set) hit the **mint endpoint** → `unexpected "iss" claim value` → "mint refused" → the agent's turn failed. (Resource servers accepted it; only the hub's admin-auth didn't.)

## Changes

- `validateAccessToken(db, token, expectedIssuer?)` accepts `string | readonly string[]`, handed straight to jose's `issuer` option (`string | string[]`). `undefined` → signature-only (unchanged); a single string is byte-identical to before; an array is jose membership (empty fails closed, matching `validateHostAdminToken`).
- `requireScope(...)` accepts `string | readonly string[]` and forwards it.
- Every hub admin/mint call site validating a **requestor** token now passes `knownIssuers: buildHubBoundOrigins(...)` (built exactly as the OAuth path), falling back to `[issuer]` when absent — the established `api-modules.ts` idiom — so single-origin deploys + tests are byte-identical. Sites: **mint**, hub-upgrade (+status), api-hub, api-tokens, api-revoke-token, settings-hub-origin, settings-root-redirect, modules-channel, vaults (create/delete), users (×6), grants, agent-grants (module PUT), clients (get/approve/delete), invites, vault-caps, and the oauth-handlers same-hub auto-approve (reuses its existing `hubBoundOrigins`).

## Security invariant held

- JWKS **signature verify runs FIRST + unconditionally** (jose verifies signature before the `iss` check) — only tokens this hub minted ever reach the membership check.
- The set is **only additive** `iss` membership; it comes **solely** from `buildHubBoundOrigins` (never a raw request Host).
- Collapsing to a single origin (no expose-state / single-origin deploy, or absent `knownIssuers`) is **byte-identical** to today.

## Audited & left as-is (with reason)

- `host-admin-token-validation` / module-ops (`api-modules`, `api-modules-ops`) / `audience-gate` / `operator-token` — already honor the set.
- `admin-connections` renew/claim — validate **signature-only** (no `iss` pin) by design (more permissive than the set; an origin switch can't break them).
- Cookie/session-gated mint endpoints (`host-admin-token`, `agent-token`, `module-token`, `vault-admin-token`, `account-vault-token`) — sign with the canonical issuer and never validate a requestor token's `iss`, so out of scope.

## Tests / gates

- New tests: multi-origin set accept/reject + signature-first + single-origin back-compat at the `admin-auth`, `api-mint-token`, and `jwt-sign` layers.
- `bun test ./src`: **3988 pass, 1 skip, 0 fail**. `bun run typecheck` clean. `bun install --frozen-lockfile` clean.
- rc bump `0.7.4-rc.20` → `rc.21`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S