### PR TITLE
fix(hub): sliding session renewal + unlock-at-login (frequent re-login & PIN-after-login)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.21",
+  "version": "0.7.4-rc.22",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -8,6 +8,7 @@ import {
   handleAdminLoginPost,
   handleAdminLogoutPost,
 } from "../admin-handlers.ts";
+import { _resetUnlockStateForTest, requireUnlocked, setPin } from "../admin-lock.ts";
 import { CSRF_COOKIE_NAME, CSRF_FIELD_NAME } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
@@ -167,6 +168,33 @@ describe("handleAdminLoginPost", () => {
     expect(res.status).toBe(302);
     expect(res.headers.get("location")).toBe("/admin/permissions");
     expect(res.headers.get("set-cookie") ?? "").toContain("parachute_hub_session=");
+  });
+
+  test("Fix B: a fresh login with a PIN configured records an unlock (no immediate lock)", async () => {
+    // The admin-lock PIN guards the idle/grabbed tab — NOT the instant after a
+    // full login. The operator just proved their password; re-gating on the PIN
+    // the moment after is pure friction. A freshly-minted session must land
+    // within an unlock window so the SPA doesn't show the lock screen.
+    _resetUnlockStateForTest();
+    await createUser(harness.db, "admin", "pw", { passwordChanged: true });
+    await setPin(harness.db, "4827"); // lock feature ON
+    const { body, headers } = formBody({
+      [CSRF_FIELD_NAME]: TEST_CSRF,
+      username: "admin",
+      password: "pw",
+      next: "/admin/permissions",
+    });
+    const req = new Request("http://hub.test/admin/login", {
+      method: "POST",
+      headers: { ...headers, cookie: CSRF_COOKIE },
+      body,
+    });
+    const res = await handleAdminLoginPost(harness.db, req);
+    expect(res.status).toBe(302);
+    const sid = (res.headers.get("set-cookie") ?? "").match(/parachute_hub_session=([^;]+)/)?.[1];
+    expect(sid?.length).toBeTruthy();
+    // The just-minted session is unlocked — recordLoginUnlock ran during login.
+    expect(requireUnlocked(harness.db, sid ?? "").ok).toBe(true);
   });
 
   test("ignores an absolute-URL next= from the form", async () => {

--- a/src/__tests__/admin-host-admin-token.test.ts
+++ b/src/__tests__/admin-host-admin-token.test.ts
@@ -18,7 +18,13 @@ import { HOST_ADMIN_TOKEN_TTL_SECONDS, handleHostAdminToken } from "../admin-hos
 import { handleApiTokens } from "../api-tokens.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
-import { SESSION_TTL_MS, buildSessionCookie, createSession, deleteSession } from "../sessions.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  createSession,
+  deleteSession,
+  findSession,
+} from "../sessions.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import { createUser } from "../users.ts";
 
@@ -184,6 +190,57 @@ describe("handleHostAdminToken", () => {
     const body = (await res.json()) as { token: string };
     const validated = await validateAccessToken(harness.db, body.token, ISSUER);
     expect(validated.payload.sub).toBe(adminId);
+  });
+
+  // Sliding session renewal (Fix A) — a successful mint pushes the session's
+  // expiry forward and re-issues the cookie, so an active operator (the SPA
+  // re-mints ~every 10 min) isn't hard-logged-out at the 24h mark. The cookie
+  // must keep the EXACT attributes creation uses — not broadened.
+  test("200 renews the session cookie (HttpOnly/Secure/SameSite/host-only) and slides expiry", async () => {
+    const user = await createUser(harness.db, "operator", "hunter2");
+    // Create the session 12h in the past so the forward slide is observable.
+    const twelveHoursAgo = new Date(Date.now() - 12 * 60 * 60 * 1000);
+    const session = createSession(harness.db, { userId: user.id, now: () => twelveHoursAgo });
+    const originalExpiry = new Date(session.expiresAt).getTime();
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    rotateSigningKey(harness.db);
+
+    const res = await handleHostAdminToken(
+      new Request(`${ISSUER}/admin/host-admin-token`, { headers: { cookie } }),
+      { db: harness.db, issuer: ISSUER },
+    );
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("parachute_hub_session=");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure"); // ISSUER is https → Secure kept
+    expect(setCookie).toContain("SameSite=Lax");
+    expect(setCookie).toContain("Path=/");
+    expect(setCookie).not.toContain("Path=/oauth");
+    // Host-only: the renewed cookie must NOT add a Domain (no broadening).
+    expect(setCookie.toLowerCase()).not.toContain("domain=");
+
+    // The session's expiry slid forward (touchSession ran on the success path).
+    const found = findSession(harness.db, session.id);
+    expect(new Date(found?.expiresAt ?? 0).getTime()).toBeGreaterThan(originalExpiry);
+  });
+
+  test("renewed cookie omits Secure over plain HTTP (protocol-correct, not broadened)", async () => {
+    const { cookie } = await withSession();
+    rotateSigningKey(harness.db);
+    // HTTP origin → isHttpsRequest false → no Secure, so the browser keeps the
+    // cookie on http://localhost:1939 — mirrors how the session cookie is minted.
+    const res = await handleHostAdminToken(
+      new Request("http://hub.test/admin/host-admin-token", { headers: { cookie } }),
+      { db: harness.db, issuer: ISSUER },
+    );
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("parachute_hub_session=");
+    expect(setCookie).not.toContain("Secure");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("SameSite=Lax");
   });
 
   // Regression for the end-to-end bug that motivated adding `:host:auth`

--- a/src/__tests__/admin-lock.test.ts
+++ b/src/__tests__/admin-lock.test.ts
@@ -30,6 +30,7 @@ import {
   getIdleSeconds,
   isLockConfigured,
   isSessionUnlocked,
+  recordLoginUnlock,
   recordUnlock,
   refreshActivity,
   requireUnlocked,
@@ -209,6 +210,31 @@ describe("requireUnlocked gate", () => {
     recordUnlock("sid-1", 60, t0);
     // 61s later, with no intervening activity → expired → locked.
     expect(requireUnlocked(harness.db, "sid-1", t0 + 61_000).ok).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recordLoginUnlock (Fix B) — unlock at the auth boundary so a fresh login
+// doesn't immediately hit the PIN lock screen.
+// ---------------------------------------------------------------------------
+
+describe("recordLoginUnlock", () => {
+  test("opens an unlock window when a PIN is configured", async () => {
+    await setPin(harness.db, "4827");
+    // A fresh session with a PIN set but no unlock is locked.
+    expect(requireUnlocked(harness.db, "sid-login").ok).toBe(false);
+    recordLoginUnlock(harness.db, "sid-login");
+    // After login → the freshly-authenticated session is unlocked.
+    expect(requireUnlocked(harness.db, "sid-login").ok).toBe(true);
+    expect(isSessionUnlocked("sid-login")).toBe(true);
+  });
+
+  test("no-op when the lock feature is OFF (no PIN) — records nothing", () => {
+    // Feature off → requireUnlocked is always ok anyway; the helper must not
+    // record a spurious window (meaningless, and would grow the map).
+    recordLoginUnlock(harness.db, "sid-no-pin");
+    expect(isSessionUnlocked("sid-no-pin")).toBe(false);
+    expect(requireUnlocked(harness.db, "sid-no-pin").ok).toBe(true);
   });
 });
 

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -7448,6 +7448,43 @@ describe("DCR same-hub auto-trust (hub#312)", () => {
     }
   });
 
+  test("authorize: explicit scribe:admin → invalid_scope (service-admin, operator-only) (2026-06-30)", async () => {
+    // Symmetry with hub:admin: the other service-admin scope is non-requestable
+    // too. Scribe's admin UI gets scribe:admin via the cookie-gated
+    // /admin/module-token/scribe path, never /oauth/authorize — so rejecting it
+    // here breaks no first-party path.
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+        sameHub: true,
+      });
+      const { challenge } = makePkce();
+      const req = new Request(
+        authorizeUrl({
+          client_id: reg.client.clientId,
+          redirect_uri: "https://app.example/cb",
+          response_type: "code",
+          scope: "scribe:admin",
+          code_challenge: challenge,
+          code_challenge_method: "S256",
+          state: "abc",
+        }),
+        { headers: { cookie: buildSessionCookie(session.id, SESSION_COOKIE_TTL_S) } },
+      );
+      const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.searchParams.get("error")).toBe("invalid_scope");
+      expect(loc.searchParams.get("error_description")).toContain("scribe:admin");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("authorize: same_hub=true + unnamed vault verb → consent screen (picker needed)", async () => {
     // Unnamed `vault:read` needs the picker to narrow to
     // `vault:<name>:read` before mint. The same-hub gate must not

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -119,7 +119,9 @@ describe("authorizationServerMetadata", () => {
     expect(scopesSupported).toContain("vault:read");
     expect(scopesSupported).toContain("vault:admin");
     expect(scopesSupported).toContain("scribe:transcribe"); // scribe is in the fixture manifest
-    expect(scopesSupported).toContain("hub:admin");
+    // hub:admin + scribe:admin are operator-only (non-requestable) — never advertised (2026-06-30)
+    expect(scopesSupported).not.toContain("hub:admin");
+    expect(scopesSupported).not.toContain("scribe:admin");
     // agent isn't in the fixture manifest → its scopes aren't advertised
     // (hub#…: optional-module scopes only surface when the module is installed).
     expect(scopesSupported).not.toContain("agent:send");
@@ -169,9 +171,10 @@ describe("authorizationServerMetadata", () => {
     // First-party still advertised — no regression
     expect(scopesSupported).toContain("vault:read");
     expect(scopesSupported).toContain("vault:admin");
-    expect(scopesSupported).toContain("hub:admin");
-    // NON_REQUESTABLE filter still applies even when the scope is declared
+    // NON_REQUESTABLE filter applies even when the scope is declared:
+    // host-* AND the service-admin scopes (hub:admin/scribe:admin) are filtered.
     expect(scopesSupported).not.toContain("parachute:host:admin");
+    expect(scopesSupported).not.toContain("hub:admin");
   });
 
   test("advertises an optional module's scopes only when it's installed", async () => {
@@ -209,7 +212,8 @@ describe("authorizationServerMetadata", () => {
     // core scopes survive
     expect(scopes).toContain("vault:read");
     expect(scopes).toContain("vault:admin");
-    expect(scopes).toContain("hub:admin");
+    // hub:admin is operator-only (non-requestable) — never advertised
+    expect(scopes).not.toContain("hub:admin");
     // uninstalled optional-module scopes are dropped
     expect(scopes).not.toContain("scribe:transcribe");
     expect(scopes).not.toContain("scribe:admin");
@@ -241,6 +245,10 @@ describe("authorizationServerMetadata", () => {
     });
     const scopes2 = ((await res2.json()) as Record<string, unknown>).scopes_supported as string[];
     expect(scopes2).toContain("scribe:transcribe");
+    // scribe:admin stays dropped EVEN WITH scribe installed — proving it's the
+    // requestability gate (non-requestable, 2026-06-30) doing the work here, not
+    // the optional-module-not-installed gate that drops scribe:transcribe above.
+    expect(scopes2).not.toContain("scribe:admin");
     expect(scopes2).not.toContain("agent:send"); // agent still not installed
   });
 });
@@ -7366,12 +7374,12 @@ describe("DCR same-hub auto-trust (hub#312)", () => {
     }
   });
 
-  test("authorize: same_hub=true + admin scope → consent screen (high-power sanity gate)", async () => {
-    // hub:admin is requestable via DCR (only `parachute:host:admin` and
-    // per-vault `vault:*:admin` are non-requestable). For same-hub
-    // clients we DO still show consent on admin scopes — the operator
-    // who registered the client may not want to grant their own session
-    // hub-wide admin access without an explicit click.
+  test("authorize: same_hub=true + hub:admin → invalid_scope (operator-only, even for same-hub) (2026-06-30)", async () => {
+    // hub:admin is now non-requestable via /oauth/authorize (a vault MCP
+    // connector pointed at the hub-level AS would otherwise be offered
+    // hub-wide admin). Even a trusted same-hub client with an owner session
+    // is rejected with invalid_scope — fails closed before consent. The
+    // legit hub-admin paths are operator-bearer/session, not authorize-flow.
     const { db, cleanup } = await makeDb();
     try {
       const user = await createUser(db, "owner", "pw");
@@ -7390,24 +7398,24 @@ describe("DCR same-hub auto-trust (hub#312)", () => {
           scope: "hub:admin",
           code_challenge: challenge,
           code_challenge_method: "S256",
+          state: "abc",
         }),
         { headers: { cookie: buildSessionCookie(session.id, SESSION_COOKIE_TTL_S) } },
       );
       const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
-      // Consent rendered, not silent-approve.
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toContain("text/html");
-      const html = await res.text();
-      expect(html).toContain("hub:admin");
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.searchParams.get("error")).toBe("invalid_scope");
+      expect(loc.searchParams.get("error_description")).toContain("hub:admin");
     } finally {
       cleanup();
     }
   });
 
-  test("authorize: same_hub=true + mixed admin+non-admin → consent screen (any admin scope shows consent)", async () => {
-    // Defensive: a request asking for `vault:default:read hub:admin` must
-    // NOT silent-approve on the strength of the non-admin scope. Any
-    // admin scope present forces consent.
+  test("authorize: same_hub=true + mixed vault + hub:admin → invalid_scope (a non-requestable scope rejects the whole request) (2026-06-30)", async () => {
+    // A request mixing a requestable scope with hub:admin must NOT slip the
+    // non-requestable scope through on the strength of the others — the whole
+    // request is rejected with invalid_scope (same as parachute:host:admin).
     const { db, cleanup } = await makeDb();
     try {
       const user = await createUser(db, "owner", "pw");
@@ -7426,12 +7434,15 @@ describe("DCR same-hub auto-trust (hub#312)", () => {
           scope: "vault:default:read hub:admin",
           code_challenge: challenge,
           code_challenge_method: "S256",
+          state: "abc",
         }),
         { headers: { cookie: buildSessionCookie(session.id, SESSION_COOKIE_TTL_S) } },
       );
       const res = handleAuthorizeGet(db, req, { issuer: ISSUER });
-      expect(res.status).toBe(200);
-      expect(res.headers.get("content-type")).toContain("text/html");
+      expect(res.status).toBe(302);
+      const loc = new URL(res.headers.get("location") ?? "");
+      expect(loc.searchParams.get("error")).toBe("invalid_scope");
+      expect(loc.searchParams.get("error_description")).toContain("hub:admin");
     } finally {
       cleanup();
     }

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -129,11 +129,15 @@ describe("NON_REQUESTABLE_SCOPES (#96)", () => {
     expect(NON_REQUESTABLE_SCOPES.has("parachute:host:admin")).toBe(true);
   });
 
-  test("does NOT contain hub:admin (intentional asymmetry)", () => {
-    // hub:admin is service management an operator may legitimately delegate
-    // to a tooling app. parachute:host:admin is cross-vault data sovereignty
-    // and stays operator-only-mintable.
-    expect(NON_REQUESTABLE_SCOPES.has("hub:admin")).toBe(false);
+  test("contains the service-admin scopes hub:admin and scribe:admin (2026-06-30 over-permissioning fix)", () => {
+    // A vault MCP connector (e.g. Claude) is pointed at the hub-level AS by the
+    // vault's protected-resource metadata, so hub:admin/scribe:admin would be
+    // advertised on its consent screen + minted if approved — wildly
+    // over-privileged for a vault reader. Every legit use is operator-bearer /
+    // session (operator token, DCR self-registration, admin SPA), never
+    // /oauth/authorize — so these fail closed without breaking operator paths.
+    expect(NON_REQUESTABLE_SCOPES.has("hub:admin")).toBe(true);
+    expect(NON_REQUESTABLE_SCOPES.has("scribe:admin")).toBe(true);
   });
 
   test("every non-requestable scope is a known first-party scope", () => {
@@ -148,11 +152,16 @@ describe("isRequestableScope", () => {
     expect(isRequestableScope("parachute:host:admin")).toBe(false);
   });
 
-  test("true for hub:admin and other first-party scopes", () => {
-    expect(isRequestableScope("hub:admin")).toBe(true);
+  test("false for service-admin scopes hub:admin and scribe:admin (operator-only, 2026-06-30)", () => {
+    expect(isRequestableScope("hub:admin")).toBe(false);
+    expect(isRequestableScope("scribe:admin")).toBe(false);
+  });
+
+  test("true for non-admin first-party scopes", () => {
     expect(isRequestableScope("vault:read")).toBe(true);
     expect(isRequestableScope("vault:admin")).toBe(true);
     expect(isRequestableScope("agent:send")).toBe(true);
+    expect(isRequestableScope("scribe:transcribe")).toBe(true);
   });
 
   test("true for unknown scopes (third-party module scopes pass through)", () => {
@@ -194,8 +203,10 @@ describe("isRequestableScope", () => {
     expect(isNonRequestableScope("parachute:Host:Install")).toBe(true);
     // Canonical lowercase still works unchanged.
     expect(isNonRequestableScope("parachute:host:auth")).toBe(true);
-    // A non-host scope (even uppercased) stays requestable.
-    expect(isNonRequestableScope("HUB:ADMIN")).toBe(false);
+    // Service-admin scopes are non-requestable too, case-insensitively (2026-06-30).
+    expect(isNonRequestableScope("HUB:ADMIN")).toBe(true);
+    // A genuinely requestable scope (even uppercased) stays requestable.
+    expect(isNonRequestableScope("VAULT:READ")).toBe(false);
   });
 });
 

--- a/src/__tests__/sessions.test.ts
+++ b/src/__tests__/sessions.test.ts
@@ -5,12 +5,14 @@ import { join } from "node:path";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
   SESSION_COOKIE_NAME,
+  SESSION_MAX_LIFETIME_MS,
   buildSessionClearCookie,
   buildSessionCookie,
   createSession,
   deleteSession,
   findSession,
   parseSessionCookie,
+  touchSession,
 } from "../sessions.ts";
 import { createUser } from "../users.ts";
 
@@ -61,6 +63,84 @@ describe("createSession + findSession", () => {
       // Still valid one second before expiry.
       const justBefore = new Date(epoch.getTime() + 24 * 3600 * 1000 - 1000);
       expect(findSession(db, s.id, () => justBefore)?.id).toBe(s.id);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("touchSession (sliding renewal)", () => {
+  const HOUR = 3600 * 1000;
+  const DAY = 24 * HOUR;
+
+  test("slides expires_at forward to now + TTL", async () => {
+    const { db, userId, cleanup } = await makeDb();
+    try {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      const s = createSession(db, { userId, now: () => t0 });
+      // Original expiry: t0 + 24h.
+      expect(new Date(s.expiresAt).getTime()).toBe(t0.getTime() + DAY);
+      // Touch 1h later → expiry becomes (t0 + 1h) + 24h.
+      const t1 = new Date(t0.getTime() + HOUR);
+      touchSession(db, s.id, () => t1);
+      const found = findSession(db, s.id, () => t1);
+      expect(new Date(found?.expiresAt ?? 0).getTime()).toBe(t1.getTime() + DAY);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a touched session outlives the ORIGINAL 24h expiry", async () => {
+    const { db, userId, cleanup } = await makeDb();
+    try {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      const s = createSession(db, { userId, now: () => t0 });
+      // Activity at +12h slides expiry to +36h.
+      touchSession(db, s.id, () => new Date(t0.getTime() + 12 * HOUR));
+      // At +30h — PAST the original +24h — the session is still alive.
+      const at30h = new Date(t0.getTime() + 30 * HOUR);
+      expect(findSession(db, s.id, () => at30h)?.id).toBe(s.id);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("an UNtouched session still expires at the original 24h", async () => {
+    const { db, userId, cleanup } = await makeDb();
+    try {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      const s = createSession(db, { userId, now: () => t0 });
+      // No touch — at +25h it's gone (today's absolute-TTL behavior preserved
+      // for idle / closed tabs that stop re-minting).
+      const at25h = new Date(t0.getTime() + 25 * HOUR);
+      expect(findSession(db, s.id, () => at25h)).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("caps at created_at + SESSION_MAX_LIFETIME_MS (sliding can't run forever)", async () => {
+    const { db, userId, cleanup } = await makeDb();
+    try {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      const s = createSession(db, { userId, now: () => t0 });
+      const ceiling = t0.getTime() + SESSION_MAX_LIFETIME_MS;
+      // A touch near the ceiling would slide to now + 24h, but the cap pins it.
+      const nearCeiling = new Date(ceiling - HOUR); // raw slide would be ceiling + 23h
+      touchSession(db, s.id, () => nearCeiling);
+      const found = findSession(db, s.id, () => nearCeiling);
+      expect(new Date(found?.expiresAt ?? 0).getTime()).toBe(ceiling);
+      // Past the ceiling the session is dead even though it was just "active".
+      expect(findSession(db, s.id, () => new Date(ceiling + 1000))).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no-op on an unknown session id (does not throw)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      expect(() => touchSession(db, "no-such-session")).not.toThrow();
     } finally {
       cleanup();
     }

--- a/src/account-setup.ts
+++ b/src/account-setup.ts
@@ -62,6 +62,7 @@
  * scope-guard.
  */
 import type { Database } from "bun:sqlite";
+import { recordLoginUnlock } from "./admin-lock.ts";
 import { renderAdminError, renderInviteSetup } from "./admin-login-ui.ts";
 import { type RunResult, provisionVault } from "./admin-vaults.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
@@ -528,6 +529,7 @@ export async function handleAccountSetupPost(
 
   // (6) Sign the invitee in + land them on /account/.
   const session = createSession(deps.db, { userId });
+  recordLoginUnlock(deps.db, session.id);
   const sessionCookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
     secure: isHttpsRequest(req),
   });

--- a/src/admin-handlers.ts
+++ b/src/admin-handlers.ts
@@ -11,6 +11,7 @@
  * (`parachute_hub_csrf` cookie + `__csrf` form field, constant-time compare).
  */
 import type { Database } from "bun:sqlite";
+import { recordLoginUnlock } from "./admin-lock.ts";
 import { renderAdminError, renderAdminLogin, renderTotpChallenge } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import {
@@ -283,6 +284,7 @@ function mintSessionAndRedirect(
   extraCookies: string[] = [],
 ): Response {
   const session = createSession(db, { userId: user.id });
+  recordLoginUnlock(db, session.id);
   const sessionCookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
     secure: isHttpsRequest(req),
   });

--- a/src/admin-host-admin-token.ts
+++ b/src/admin-host-admin-token.ts
@@ -49,7 +49,14 @@
 import type { Database } from "bun:sqlite";
 import { lockedResponse, requireUnlocked } from "./admin-lock.ts";
 import { signAccessToken } from "./jwt-sign.ts";
-import { findSession, parseSessionCookie } from "./sessions.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  findSession,
+  parseSessionCookie,
+  touchSession,
+} from "./sessions.ts";
 import { isFirstAdmin } from "./users.ts";
 
 /** Short TTL — page-snapshot threats can't carry the token forever. */
@@ -115,6 +122,21 @@ export async function handleHostAdminToken(
     // sentinel matching admin OAuth tokens.
     vaultScope: [],
   });
+  // Sliding session renewal (THE frequent-re-login fix). The SPA re-mints here
+  // roughly every ~10 min while a tab is open; each successful mint pushes the
+  // session's `expires_at` forward, so an active operator isn't hard-logged-out
+  // at the 24h mark. A closed tab stops minting and still expires; the absolute
+  // ceiling in `touchSession` bounds a left-open-but-idle tab. The renewed
+  // Set-Cookie keeps the EXACT attributes session creation uses — HttpOnly,
+  // Secure-when-https, SameSite=Lax, Path=/, host-only (no Domain) — so the
+  // cookie's Max-Age tracks the extended expiry without broadening the cookie.
+  // This does NOT touch the admin-lock idle window (sliding there is
+  // heartbeat-only, by design — see admin-lock.ts); the two windows are
+  // independent.
+  touchSession(deps.db, sid);
+  const sessionCookie = buildSessionCookie(sid, Math.floor(SESSION_TTL_MS / 1000), {
+    secure: isHttpsRequest(req),
+  });
   return new Response(
     JSON.stringify({
       token: minted.token,
@@ -128,6 +150,7 @@ export async function handleHostAdminToken(
         // No browser cache — token rotates per-fetch, and a stale 200 from a
         // back/forward navigation could hand the SPA a long-expired JWT.
         "cache-control": "no-store",
+        "set-cookie": sessionCookie,
       },
     },
   );

--- a/src/admin-lock.ts
+++ b/src/admin-lock.ts
@@ -175,6 +175,22 @@ export function recordUnlock(
 }
 
 /**
+ * Open an unlock window for a session that JUST completed a full auth
+ * (password + any 2FA). The PIN's threat model is the idle/grabbed tab, NOT a
+ * third gate the instant after the auth boundary — re-prompting for the PIN
+ * the moment after a successful login is pure friction with no security gain
+ * (the user just proved a stronger factor). No-op when the lock feature is off.
+ *
+ * Called from every session-mint point (password login, OAuth login,
+ * account-setup, setup-wizard) so a freshly-authenticated session always lands
+ * working, never on the lock screen. Idle re-entry still re-locks as before.
+ */
+export function recordLoginUnlock(db: Database, sessionId: string, now: number = Date.now()): void {
+  if (!isLockConfigured(db)) return;
+  recordUnlock(sessionId, getIdleSeconds(db), now);
+}
+
+/**
  * Slide the unlock window forward by `idleSeconds` IF the session is currently
  * unlocked. Called on admin activity (heartbeat + every successful mint) so an
  * actively-used console doesn't lock mid-work. Does NOT create an unlock for a

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -23,6 +23,7 @@
  */
 import type { Database } from "bun:sqlite";
 import { AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import { recordLoginUnlock } from "./admin-lock.ts";
 import { renderTotpChallenge } from "./admin-login-ui.ts";
 import {
   AuthCodeExpiredError,
@@ -1501,6 +1502,7 @@ async function handleLoginSubmit(
   }
 
   const session = createSession(db, { userId: user.id });
+  recordLoginUnlock(db, session.id);
   const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
     secure: isHttpsRequest(req),
   });

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -282,8 +282,9 @@ export function isNonRequestableScope(scope: string): boolean {
   // Per-vault `vault:<name>:admin` is NO LONGER globally non-requestable
   // (single-consent change, 2026-05-29). It flows through the public OAuth
   // consent path and through `canGrant` rule 1, capped to the consenting
-  // user's held authority at the `issueAuthCodeRedirect` choke-point. Only
-  // the host-level operator scopes stay non-requestable here.
+  // user's held authority at the `issueAuthCodeRedirect` choke-point. The
+  // host-level operator scopes AND the service-admin scopes (hub:admin,
+  // scribe:admin) stay non-requestable here (see NON_REQUESTABLE_SCOPES).
   //
   // Item C — case-insensitive guard. The membership check is exact-string,
   // but Parachute scope tokens are canonically lowercase. A casing variant

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -127,13 +127,23 @@ export const FIRST_PARTY_SCOPES = Object.keys(SCOPE_EXPLANATIONS).sort();
  *      RFC 8414 §2 says `scopes_supported` is the list a client *can*
  *      request, so omitting these is the spec-compliant call.
  *
- * Why `parachute:host:admin` is on this list and `hub:admin` is not:
- * `parachute:host:admin` provisions and destroys vaults — cross-vault
- * data sovereignty that the operator alone owns. `hub:admin` is service
- * management (signing keys, registered clients, user accounts) which an
- * operator may legitimately delegate to a tooling app. The asymmetry is
- * intentional: the blast radius of compromised cross-vault admin doesn't
- * justify third-party requestability.
+ * Service-admin scopes (`hub:admin`, `scribe:admin`) are on this list as of
+ * 2026-06-30. They read as "delegable to a tooling app," but in practice a
+ * vault MCP connector (e.g. Claude) is pointed at the hub-level authorization
+ * server by the vault's protected-resource metadata, so the full hub catalog —
+ * including `hub:admin` (manage signing keys, registered clients, user
+ * accounts) — gets advertised on its consent screen and, if approved, minted
+ * into its token. That's wildly over-privileged for a vault reader (cf.
+ * hub#671, where the agent-grants client had to hardcode least-privilege to
+ * dodge exactly this). The scope-narrowing that should strip it only fires
+ * when the client echoes a resolvable RFC 8707 vault `resource`, which MCP
+ * clients often don't. Every legitimate hub-admin / scribe-admin use is
+ * operator-bearer or session based (operator token, DCR self-registration via
+ * `requireScope`, the admin SPA host-admin token) — none route through
+ * `/oauth/authorize` — so making these non-requestable fails closed against
+ * third-party requests without breaking any first-party operator path.
+ * `parachute:host:*` remains for the original reason: it provisions/destroys
+ * vaults (cross-vault sovereignty the operator alone owns).
  */
 export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
   "parachute:host:admin",
@@ -142,6 +152,9 @@ export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
   "parachute:host:expose",
   "parachute:host:auth",
   "parachute:host:vault",
+  // Service-admin scopes: operator-only, never requestable via /oauth/authorize.
+  "hub:admin",
+  "scribe:admin",
 ]);
 
 /**

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -101,9 +101,12 @@ export function findSession(
  * expires 24h after its last activity. The ceiling bounds a left-open-but-idle
  * tab (background polls keep re-minting) so sliding can't run forever.
  *
- * Monotonic by construction: `now` only moves forward, so the slid value never
- * undershoots a previously-written expiry; once it reaches the ceiling it stays
- * pinned there. `now` is injectable for tests, matching {@link findSession}.
+ * Monotonic in practice: the production wall clock only moves forward, so the
+ * slid value never undershoots a previously-written expiry; once it reaches the
+ * ceiling it stays pinned there. (The write is unconditional — it does not read
+ * the current expiry — so an injected backward `now` in tests would shorten the
+ * session: a conservative failure mode, not a security issue.) `now` is
+ * injectable for tests, matching {@link findSession}.
  */
 export function touchSession(db: Database, id: string, now: () => Date = () => new Date()): void {
   const row = db.query<Row, [string]>("SELECT * FROM sessions WHERE id = ?").get(id);

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -4,8 +4,12 @@
  * with that cookie skip the login form and go straight to consent.
  *
  * Stored in `sessions` (one row per active session), so logout / forced
- * revocation is just a delete. Cookies are 24h; sliding extension is a
- * follow-up — for now, a session expires absolutely at `expires_at`.
+ * revocation is just a delete. Sessions are SLIDING: `expires_at` starts at
+ * `created_at + SESSION_TTL_MS`, and {@link touchSession} pushes it forward on
+ * genuine activity (the admin SPA re-mints `/admin/host-admin-token` every
+ * ~10 min while a tab is open). An idle session — no more mints — still
+ * expires at the original 24h mark, and {@link SESSION_MAX_LIFETIME_MS} caps
+ * total life so sliding can't keep a left-open tab alive forever.
  *
  * The cookie value is the session id directly. It's a 32-byte base64url
  * random; collision is statistically impossible. No HMAC needed because the
@@ -17,6 +21,15 @@ import { randomBytes } from "node:crypto";
 
 export const SESSION_COOKIE_NAME = "parachute_hub_session";
 export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Absolute ceiling on a session's total lifetime, independent of sliding
+ * renewal. Sliding ({@link touchSession}) keeps an active console signed in,
+ * but a left-open-but-idle tab whose background polls keep re-minting must
+ * still be force-logged-out eventually — this caps life at
+ * `created_at + SESSION_MAX_LIFETIME_MS` so renewal can't extend forever.
+ */
+export const SESSION_MAX_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;
 
 export interface Session {
   id: string;
@@ -75,6 +88,31 @@ export function findSession(
   const session = rowToSession(row);
   if (now().getTime() > new Date(session.expiresAt).getTime()) return null;
   return session;
+}
+
+/**
+ * Slide a session's expiry forward to `now + SESSION_TTL_MS`, capped at
+ * `created_at + SESSION_MAX_LIFETIME_MS`. No-op when the session doesn't exist.
+ *
+ * This is what makes sessions sliding rather than fixed-24h: the admin SPA
+ * re-mints `/admin/host-admin-token` roughly every ~10 min while a tab is open,
+ * and each successful mint calls this — so an actively-used console isn't
+ * hard-logged-out at the 24h mark, while a closed tab (no more mints) still
+ * expires 24h after its last activity. The ceiling bounds a left-open-but-idle
+ * tab (background polls keep re-minting) so sliding can't run forever.
+ *
+ * Monotonic by construction: `now` only moves forward, so the slid value never
+ * undershoots a previously-written expiry; once it reaches the ceiling it stays
+ * pinned there. `now` is injectable for tests, matching {@link findSession}.
+ */
+export function touchSession(db: Database, id: string, now: () => Date = () => new Date()): void {
+  const row = db.query<Row, [string]>("SELECT * FROM sessions WHERE id = ?").get(id);
+  if (!row) return;
+  const nowMs = now().getTime();
+  const slidMs = nowMs + SESSION_TTL_MS;
+  const ceilingMs = new Date(row.created_at).getTime() + SESSION_MAX_LIFETIME_MS;
+  const newExpiresAt = new Date(Math.min(slidMs, ceilingMs)).toISOString();
+  db.prepare("UPDATE sessions SET expires_at = ? WHERE id = ?").run(newExpiresAt, id);
 }
 
 export function deleteSession(db: Database, id: string): void {

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -40,6 +40,7 @@
 import type { Database } from "bun:sqlite";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
+import { recordLoginUnlock } from "./admin-lock.ts";
 import { type OperationsRegistry, runInstall, specFor } from "./api-modules-ops.ts";
 import { CURATED_MODULES, type CuratedModuleShort } from "./api-modules.ts";
 import {
@@ -1978,6 +1979,7 @@ export async function handleSetupAccountPost(
     // account creation the operator just completed.
     await ensureOperatorTokenForFirstAdmin(deps, user.id);
     const session = createSession(deps.db, { userId: user.id });
+    recordLoginUnlock(deps.db, session.id);
     const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
       secure: isHttpsRequest(req),
     });


### PR DESCRIPTION
## What & why

Two confirmed, diagnosed auth-session bugs (the `@latest` blocker), fixed in one cohesive change. Both are minimal and do **not** weaken auth.

### Fix A — sliding session renewal (THE frequent-re-login fix)

**Bug:** sessions had a 24h **absolute** TTL with no renewal — `createSession` set `expires_at = createdAt + 24h` once, `findSession` rejected past it, and nothing ever updated it. So the operator was hard-logged-out exactly 24h after login regardless of activity (the SPA hard-redirects to `/login` whenever `GET /admin/host-admin-token` 401s).

**Fix:**
- `sessions.ts`: new `touchSession(db, id, now?)` → `UPDATE sessions SET expires_at = ?` to `now + SESSION_TTL_MS`, **capped at `created_at + SESSION_MAX_LIFETIME_MS`** (new 30-day ceiling). Monotonic by construction.
- `admin-host-admin-token.ts`: on a successful mint (the SPA re-mints `/admin/host-admin-token` ~every 10 min while a tab is open) call `touchSession` and append a fresh `Set-Cookie` via `buildSessionCookie(sid, 86400, { secure: isHttpsRequest(req) })`. Active operators get effectively-sliding sessions; idle/closed tabs (no more mints) still expire at 24h.

**Max-lifetime ceiling — added (cleanly).** Because a left-open-but-idle tab's background polls (e.g. the 30s version badge) keep calling `getHostAdminToken`, which re-mints every ~10 min, sliding *without* a ceiling would keep an open idle tab alive forever — a regression from today's hard 24h. The `created_at + 30d` cap closes that: an open idle tab is force-logged-out at 30 days. Clean (one constant + a `Math.min`), so it's in rather than deferred.

### Fix B — record an unlock at full login (the PIN-right-after-login UX bug)

**Bug:** no login path recorded an admin-lock unlock, so a freshly authenticated session (password + 2FA) immediately showed the PIN lock screen. The PIN's threat model is the idle/grabbed tab, **not** a third gate the instant after the auth boundary.

**Fix:**
- `admin-lock.ts`: new `recordLoginUnlock(db, sid)` — opens an unlock window when `isLockConfigured(db)`, no-op otherwise (one shared helper, rationale documented once).
- Called after `createSession` at **all four** session-mint points: password+2FA login (`admin-handlers.mintSessionAndRedirect`), OAuth login (`oauth-handlers`), `account-setup`, `setup-wizard`. The PIN then gates idle re-entry only.

**Known amplifier (out of scope, noted):** the in-memory unlock map is wiped on hub restart (`admin-lock.ts`), so a restart re-locks open tabs until the next heartbeat/unlock. Not a release blocker; left as a follow-up.

## Security (held — not weakened)
- Sliding renewal keeps the renewed cookie **host-only** (no `Domain`) + `HttpOnly` + `Secure`-when-https + `SameSite=Lax`, exactly matching creation. Idle/closed tabs still die at 24h; the 30d ceiling bounds idle-but-open tabs.
- The renewal does **not** slide the admin-lock idle window (that stays heartbeat-only by design) — the two windows are independent.
- Recording an unlock at login is correct: the user just proved password + 2FA, so the idle-tab PIN shouldn't re-gate the same instant. The PIN is not removed and its idle behavior is unchanged.
- `iss` / multi-origin paths (#724) untouched.

## Tests
- `sessions.test.ts`: `touchSession` slides expiry; a touched session outlives the original 24h; an untouched session still expires at 24h; the ceiling caps total lifetime; no-op on unknown id.
- `admin-host-admin-token.test.ts`: the 200 renews the cookie with `HttpOnly`/`Secure`(https)/`SameSite=Lax`/`Path=/`/no-`Domain` **and** slides expiry; over plain HTTP the renewed cookie omits `Secure`.
- `admin-lock.test.ts`: `recordLoginUnlock` opens a window when a PIN is set, no-op when off.
- `admin-handlers.test.ts`: a real password login with a PIN configured records an unlock (no immediate lock).

**Gates:** `bun test ./src` → **3998 pass, 1 skip, 0 fail**. `bun run typecheck` clean. `bun install --frozen-lockfile` ok. Version `0.7.4-rc.21` → `rc.22`.

## Patterns
Touches the session / admin-lock auth surfaces; conforms to existing cookie + clock-injection conventions (no new pattern established). Governance: rc bump per rule 2; reviewer-gated, no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S
