### PR TITLE
release: hub 0.7.4 (@latest promotion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.4-rc.22",
+  "version": "0.7.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Graduates the **0.7.4-rc.22** chain to a stable **@latest** release: drops the `-rc` suffix, keeps the same patch number.

## What ships
The rc chain's headline work was the release-hardening of #725 — **sliding sessions**, **login-unlock**, and making **service-admin scopes non-requestable**. This PR promotes that validated rc chain to stable.

## Diff
- `package.json`: `0.7.4-rc.22` → `0.7.4` (version line only)
- `bun.lock`: unchanged — the root workspace version isn't tracked in the lockfile, so a version-only bump produces no lock change.

## Gates (all green)
- `bun run typecheck` — clean (tsc --noEmit, exit 0)
- `bun test ./src` — **4000 pass, 1 skip, 0 fail** (4001 tests, 149 files)
- `bun install --frozen-lockfile` — passes, no changes

No stray changes; the only file touched is `package.json`.

Per governance: do not merge until Aaron clicks merge; the `v0.7.4` tag is pushed after merge (CI publishes `@latest` on tag).