### PR TITLE
feat(hub): surface deploy tokens — git-native PAT for remote clients (Surface Git Transport Phase 3a)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.5-rc.4",
+  "version": "0.7.5-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -17,6 +17,7 @@
   "files": [
     "src",
     "web/ui/dist",
+    "scripts/git-credential-parachute",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/git-credential-parachute
+++ b/scripts/git-credential-parachute
@@ -1,0 +1,50 @@
+#!/bin/sh
+# git-credential-parachute — static git credential helper for Parachute surface
+# deploy tokens (Surface Git Transport Phase 3a).
+#
+# Lets a remote/external git client (a `claude -p` agent, or any machine) push
+# and pull a Parachute surface's hub-hosted repo (https://<hub>/git/<name>) with
+# nothing but a static secret — the "add a secret, git just works" path. Same
+# credential shape the internal-agent GIT_ASKPASS uses (Phase 2), generalized to
+# a static token. NO parachute install required — only POSIX sh + git.
+#
+# It reads the deploy token from $PARACHUTE_SURFACE_TOKEN and hands git a Basic
+# credential of `x-access-token:<token>`, which the hub git endpoint accepts
+# (git-transport.ts extractToken). Works on any git version.
+#
+# Setup on the remote machine:
+#
+#   1. Put this file on PATH (any of these works):
+#        - copy it to a dir on PATH as `git-credential-parachute`, chmod +x, then
+#            git config --global credential.helper parachute
+#        - or point git at its absolute path:
+#            git config --global credential.helper /abs/path/to/git-credential-parachute
+#
+#   2. Export the token the operator gave you:
+#        export PARACHUTE_SURFACE_TOKEN=<the-token>
+#
+#   3. Clone / push:
+#        git clone https://<hub-origin>/git/<name>
+#        git push
+#
+# Security: the token stays in the environment, never in .git/config or the URL.
+# Scope it to one surface + verb, and revoke a leaked one with
+# `parachute surface token revoke <jti>` on the hub.
+#
+# This is the STATIC-token helper only. A later phase adds an interactive
+# loopback-PKCE / device-flow mode for humans (git-credential-oauth style).
+
+# git calls the helper with the operation as the first arg: get | store | erase.
+# We only answer `get`; store/erase are no-ops (nothing is cached to disk).
+[ "$1" = "get" ] || exit 0
+
+if [ -z "$PARACHUTE_SURFACE_TOKEN" ]; then
+  echo "git-credential-parachute: PARACHUTE_SURFACE_TOKEN is not set" >&2
+  # Emit nothing — git falls through to its next helper / prompts.
+  exit 0
+fi
+
+# The password carries the token; the username is the GitHub-compat sentinel the
+# hub endpoint recognizes for Basic auth.
+printf 'username=x-access-token\n'
+printf 'password=%s\n' "$PARACHUTE_SURFACE_TOKEN"

--- a/src/__tests__/surface-command.test.ts
+++ b/src/__tests__/surface-command.test.ts
@@ -1,0 +1,492 @@
+import { describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { surface } from "../commands/surface.ts";
+import { ensureSurfaceRepo, isSurfaceRegistered, registerSurface } from "../git-registry.ts";
+import { handleGitTransport } from "../git-transport.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { issueOperatorToken } from "../operator-token.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+const HELPER = join(import.meta.dir, "..", "..", "scripts", "git-credential-parachute");
+
+interface Tmp {
+  dir: string;
+  dbPath: string;
+  userId: string;
+  cleanup: () => void;
+}
+
+/** Seed a hub with a signing key, an owner user, and an admin operator token. */
+async function makeTmp(): Promise<Tmp> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-surfcmd-"));
+  const dbPath = hubDbPath(dir);
+  const db = openHubDb(dbPath);
+  let userId: string;
+  try {
+    rotateSigningKey(db);
+    const u = await createUser(db, "owner", "pw");
+    userId = u.id;
+    await issueOperatorToken(db, userId, { dir, issuer: ISSUER });
+  } finally {
+    db.close();
+  }
+  return {
+    dir,
+    dbPath,
+    userId,
+    cleanup: () => rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+async function capture(fn: () => Promise<number> | number): Promise<{
+  code: number;
+  stdout: string;
+  stderr: string;
+}> {
+  const origLog = console.log;
+  const origErr = console.error;
+  let stdout = "";
+  let stderr = "";
+  console.log = (...a: unknown[]) => {
+    stdout += `${a.map(String).join(" ")}\n`;
+  };
+  console.error = (...a: unknown[]) => {
+    stderr += `${a.map(String).join(" ")}\n`;
+  };
+  try {
+    const code = await fn();
+    return { code, stdout, stderr };
+  } finally {
+    console.log = origLog;
+    console.error = origErr;
+  }
+}
+
+/** Synchronous git — for setup ops that never touch the in-process server. */
+function git(
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): { code: number; err: string } {
+  const r = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0", ...env },
+  });
+  return { code: r.status ?? -1, err: r.stderr ?? "" };
+}
+
+/** Async git — for ops that talk to the in-process Bun.serve (avoids event-loop deadlock). */
+async function gitAsync(
+  args: string[],
+  cwd: string,
+  env?: Record<string, string>,
+): Promise<{ code: number; err: string }> {
+  const proc = Bun.spawn(["git", ...args], {
+    cwd,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: "0", ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [code, err] = await Promise.all([
+    proc.exited,
+    new Response(proc.stderr as ReadableStream<Uint8Array>).text(),
+  ]);
+  return { code, err };
+}
+
+// ---------------------------------------------------------------------------
+// help / dispatch
+// ---------------------------------------------------------------------------
+
+describe("parachute surface dispatch", () => {
+  test("--help exits 0", async () => {
+    const { code, stdout } = await capture(() => surface(["--help"]));
+    expect(code).toBe(0);
+    expect(stdout).toContain("Deploy tokens");
+  });
+
+  test("no args prints help + exits 1", async () => {
+    const { code } = await capture(() => surface([]));
+    expect(code).toBe(1);
+  });
+
+  test("unknown subcommand exits 1", async () => {
+    const { code, stderr } = await capture(() => surface(["frobnicate"]));
+    expect(code).toBe(1);
+    expect(stderr).toContain("unknown subcommand");
+  });
+
+  test("token with no action prints help + exits 1", async () => {
+    const { code } = await capture(() => surface(["token"]));
+    expect(code).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mint
+// ---------------------------------------------------------------------------
+
+describe("parachute surface token mint", () => {
+  test("no operator.token is an actionable error", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-surfcmd-"));
+    try {
+      const { code, stderr } = await capture(() =>
+        surface(["token", "mint", "foo"], { dbPath: hubDbPath(dir), configDir: dir }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("operator.token");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("missing name is a usage error", async () => {
+    const t = await makeTmp();
+    try {
+      const { code, stderr } = await capture(() =>
+        surface(["token", "mint"], { dbPath: t.dbPath, configDir: t.dir }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("missing surface name");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("--read and --write are mutually exclusive", async () => {
+    const t = await makeTmp();
+    try {
+      const { code, stderr } = await capture(() =>
+        surface(["token", "mint", "foo", "--read", "--write"], {
+          dbPath: t.dbPath,
+          configDir: t.dir,
+        }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("mutually exclusive");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("mints a write token: stdout is JUST the token, guidance on stderr", async () => {
+    const t = await makeTmp();
+    try {
+      const { code, stdout, stderr } = await capture(() =>
+        surface(["token", "mint", "gitcoin-brain", "--write"], {
+          dbPath: t.dbPath,
+          configDir: t.dir,
+        }),
+      );
+      expect(code).toBe(0);
+      const token = stdout.trim();
+      expect(stdout).toBe(`${token}\n`); // pipe purity: token + newline only
+      expect(token.split(".").length).toBe(3);
+      // Guidance names the surface, the remote, and how to revoke.
+      expect(stderr).toContain("surface:gitcoin-brain:write");
+      expect(stderr).toContain("/git/gitcoin-brain");
+      expect(stderr).toContain("PARACHUTE_SURFACE_TOKEN");
+      expect(stderr).toContain("parachute surface token revoke");
+
+      const db = openHubDb(t.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token, [ISSUER]);
+        expect(validated.payload.scope).toBe("surface:gitcoin-brain:write");
+      } finally {
+        db.close();
+      }
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("--json emits token + jti + scope + remoteUrl + helper", async () => {
+    const t = await makeTmp();
+    try {
+      const { code, stdout } = await capture(() =>
+        surface(["token", "mint", "docs", "--read", "--json"], {
+          dbPath: t.dbPath,
+          configDir: t.dir,
+        }),
+      );
+      expect(code).toBe(0);
+      const blob = JSON.parse(stdout) as Record<string, unknown>;
+      expect(blob.scope).toBe("surface:docs:read");
+      expect(blob.access).toBe("read");
+      expect(blob.surface).toBe("docs");
+      expect(String(blob.remoteUrl)).toContain("/git/docs");
+      expect(typeof blob.jti).toBe("string");
+      expect(String(blob.credentialHelper)).toContain("x-access-token");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("--ttl parses a duration; a bad one errors", async () => {
+    const t = await makeTmp();
+    try {
+      const ok = await capture(() =>
+        surface(["token", "mint", "foo", "--ttl", "30d"], { dbPath: t.dbPath, configDir: t.dir }),
+      );
+      expect(ok.code).toBe(0);
+      const bad = await capture(() =>
+        surface(["token", "mint", "foo", "--ttl", "banana"], {
+          dbPath: t.dbPath,
+          configDir: t.dir,
+        }),
+      );
+      expect(bad.code).toBe(1);
+      expect(bad.stderr).toContain("invalid --ttl");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("rejects a TTL over the 365d cap (--ttl and --expires-in)", async () => {
+    const t = await makeTmp();
+    try {
+      const overTtl = await capture(() =>
+        surface(["token", "mint", "foo", "--ttl", "400d"], { dbPath: t.dbPath, configDir: t.dir }),
+      );
+      expect(overTtl.code).toBe(1);
+      expect(overTtl.stderr).toContain("365d cap");
+
+      const overSecs = await capture(() =>
+        surface(["token", "mint", "foo", "--expires-in", String(366 * 86400)], {
+          dbPath: t.dbPath,
+          configDir: t.dir,
+        }),
+      );
+      expect(overSecs.code).toBe(1);
+      expect(overSecs.stderr).toContain("365d cap");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("rejects an invalid surface name", async () => {
+    const t = await makeTmp();
+    try {
+      const { code, stderr } = await capture(() =>
+        surface(["token", "mint", "../evil"], { dbPath: t.dbPath, configDir: t.dir }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("invalid surface name");
+    } finally {
+      t.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+describe("parachute surface token list", () => {
+  test("lists minted tokens; --json is structured; narrows by name", async () => {
+    const t = await makeTmp();
+    try {
+      const deps = { dbPath: t.dbPath, configDir: t.dir };
+      await capture(() => surface(["token", "mint", "alpha", "--write"], deps));
+      await capture(() => surface(["token", "mint", "beta", "--read"], deps));
+
+      const human = await capture(() => surface(["token", "list"], deps));
+      expect(human.code).toBe(0);
+      expect(human.stdout).toContain("alpha");
+      expect(human.stdout).toContain("beta");
+      expect(human.stdout).toContain("active");
+
+      const json = await capture(() => surface(["token", "list", "alpha", "--json"], deps));
+      const rows = JSON.parse(json.stdout) as Array<Record<string, unknown>>;
+      expect(rows.length).toBe(1);
+      expect(rows[0]?.name).toBe("alpha");
+      expect(rows[0]?.status).toBe("active");
+      // never leaks the token bytes
+      expect(json.stdout).not.toContain("eyJ");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("empty list is a friendly message", async () => {
+    const t = await makeTmp();
+    try {
+      const { code, stdout } = await capture(() =>
+        surface(["token", "list"], { dbPath: t.dbPath, configDir: t.dir }),
+      );
+      expect(code).toBe(0);
+      expect(stdout).toContain("No surface deploy tokens");
+    } finally {
+      t.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revoke
+// ---------------------------------------------------------------------------
+
+describe("parachute surface token revoke", () => {
+  test("revokes a minted token; re-revoke is idempotent; unknown jti errors", async () => {
+    const t = await makeTmp();
+    try {
+      const deps = { dbPath: t.dbPath, configDir: t.dir };
+      const mint = await capture(() =>
+        surface(["token", "mint", "foo", "--write", "--json"], deps),
+      );
+      const jti = String((JSON.parse(mint.stdout) as Record<string, unknown>).jti);
+
+      const r1 = await capture(() => surface(["token", "revoke", jti], deps));
+      expect(r1.code).toBe(0);
+      expect(r1.stdout).toContain("Revoked");
+
+      const r2 = await capture(() => surface(["token", "revoke", jti], deps));
+      expect(r2.code).toBe(0);
+      expect(r2.stdout).toContain("already revoked");
+
+      const r3 = await capture(() => surface(["token", "revoke", "nope"], deps));
+      expect(r3.code).toBe(1);
+      expect(r3.stderr).toContain("no surface deploy token");
+    } finally {
+      t.cleanup();
+    }
+  });
+
+  test("missing jti is a usage error", async () => {
+    const t = await makeTmp();
+    try {
+      const { code, stderr } = await capture(() =>
+        surface(["token", "revoke"], { dbPath: t.dbPath, configDir: t.dir }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("missing jti");
+    } finally {
+      t.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// scope enforcement (handler-level, deterministic)
+// ---------------------------------------------------------------------------
+
+describe("deploy-token scope enforcement", () => {
+  test("a --read token cannot push (git-receive-pack → 403)", async () => {
+    const t = await makeTmp();
+    try {
+      const mint = await capture(() =>
+        surface(["token", "mint", "foo", "--read", "--json"], {
+          dbPath: t.dbPath,
+          configDir: t.dir,
+        }),
+      );
+      const token = String((JSON.parse(mint.stdout) as Record<string, unknown>).token);
+      const gitRoot = join(t.dir, "git");
+      const db = openHubDb(t.dbPath);
+      try {
+        const res = await handleGitTransport(
+          new Request("http://127.0.0.1/git/foo/info/refs?service=git-receive-pack", {
+            headers: { authorization: `Bearer ${token}` },
+          }),
+          {
+            db,
+            gitRoot,
+            knownIssuers: () => [ISSUER],
+            isDeclared: () => true,
+            ensureRepo: (name) => ensureSurfaceRepo(gitRoot, name),
+          },
+        );
+        expect(res.status).toBe(403);
+      } finally {
+        db.close();
+      }
+    } finally {
+      t.cleanup();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// real git push round-trip via the shipped credential helper
+// ---------------------------------------------------------------------------
+
+describe("deploy token → real git push via git-credential-parachute", () => {
+  test("a command-minted write token pushes; revoke then blocks the next push", async () => {
+    const t = await makeTmp();
+    const gitRoot = join(t.dir, "git");
+    const work = mkdtempSync(join(tmpdir(), "phub-surfcmd-work-"));
+    // Mint via the COMMAND (own handle, closes before the server opens).
+    const mint = await capture(() =>
+      surface(["token", "mint", "foo", "--write", "--json"], {
+        dbPath: t.dbPath,
+        configDir: t.dir,
+      }),
+    );
+    const parsed = JSON.parse(mint.stdout) as { token: string; jti: string };
+
+    // Declare the surface → provisions the bare repo (Phase-1 lifecycle).
+    await registerSurface(gitRoot, "foo");
+
+    const db = openHubDb(t.dbPath);
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (req) =>
+        handleGitTransport(req, {
+          db,
+          gitRoot,
+          knownIssuers: () => [ISSUER],
+          isDeclared: (name) => isSurfaceRegistered(gitRoot, name),
+          ensureRepo: (name) => ensureSurfaceRepo(gitRoot, name),
+        }),
+    });
+    const base = `http://127.0.0.1:${server.port}`;
+    // The static-token mechanism: the SHIPPED helper reads $PARACHUTE_SURFACE_TOKEN.
+    const helperEnv = { PARACHUTE_SURFACE_TOKEN: parsed.token };
+    const helperCfg = `credential.helper=${HELPER}`;
+    try {
+      // Author a commit.
+      expect(git(["init", "-q", "-b", "main", work], tmpdir()).code).toBe(0);
+      git(["config", "user.email", "t@parachute.computer"], work);
+      git(["config", "user.name", "T"], work);
+      await Bun.write(join(work, "index.html"), "<h1>surface</h1>\n");
+      expect(git(["add", "-A"], work).code).toBe(0);
+      expect(git(["commit", "-q", "-m", "first"], work).code).toBe(0);
+
+      // Push using ONLY the static deploy token, supplied by the helper script.
+      const push = await gitAsync(
+        ["-c", helperCfg, "push", `${base}/git/foo`, "main"],
+        work,
+        helperEnv,
+      );
+      expect(push.code).toBe(0);
+      expect(existsSync(join(gitRoot, "foo.git", "post-receive.log"))).toBe(true);
+
+      // Revoke the token (through the same DB handle the server validates on).
+      const { revokeSurfaceToken } = await import("../surface-token.ts");
+      expect(revokeSurfaceToken(db, parsed.jti, new Date()).status).toBe("revoked");
+
+      // A follow-up push with the now-revoked token is rejected (git exits non-zero).
+      await Bun.write(join(work, "index.html"), "<h1>v2</h1>\n");
+      git(["commit", "-qam", "second"], work);
+      const push2 = await gitAsync(
+        ["-c", helperCfg, "push", `${base}/git/foo`, "main"],
+        work,
+        helperEnv,
+      );
+      expect(push2.code).not.toBe(0);
+    } finally {
+      server.stop(true);
+      db.close();
+      rmSync(work, { recursive: true, force: true });
+      t.cleanup();
+    }
+  });
+});

--- a/src/__tests__/surface-token.test.ts
+++ b/src/__tests__/surface-token.test.ts
@@ -1,0 +1,276 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { recordTokenMint, signAccessToken, validateAccessToken } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import {
+  SURFACE_TOKEN_CREATED_VIA,
+  SURFACE_TOKEN_TTL_DEFAULT_SECONDS,
+  listSurfaceTokens,
+  mintSurfaceToken,
+  revokeSurfaceToken,
+  surfaceScope,
+} from "../surface-token.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+
+interface Harness {
+  db: ReturnType<typeof openHubDb>;
+  userId: string;
+  cleanup: () => void;
+}
+
+async function makeHarness(): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-surftok-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const u = await createUser(db, "owner", "pw");
+  return {
+    db,
+    userId: u.id,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+describe("surfaceScope", () => {
+  test("builds the canonical scope", () => {
+    expect(surfaceScope("gitcoin-brain", "write")).toBe("surface:gitcoin-brain:write");
+    expect(surfaceScope("gitcoin-brain", "read")).toBe("surface:gitcoin-brain:read");
+  });
+});
+
+describe("mintSurfaceToken", () => {
+  test("mints a validatable, registered surface:<name>:write token", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await mintSurfaceToken(h.db, {
+        name: "gitcoin-brain",
+        access: "write",
+        issuer: ISSUER,
+        userId: h.userId,
+      });
+      expect(minted.scope).toBe("surface:gitcoin-brain:write");
+      expect(minted.token.split(".").length).toBe(3);
+
+      // It validates through the SAME path the git endpoint uses.
+      const validated = await validateAccessToken(h.db, minted.token, [ISSUER]);
+      expect(validated.payload.scope).toBe("surface:gitcoin-brain:write");
+      expect(validated.payload.aud).toBe("surface.gitcoin-brain");
+      expect(validated.payload.jti).toBe(minted.jti);
+
+      // A registry row exists, tagged as a deploy token (so list/revoke find it).
+      const listed = listSurfaceTokens(h.db);
+      expect(listed.map((r) => r.jti)).toContain(minted.jti);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("read access mints surface:<name>:read", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await mintSurfaceToken(h.db, {
+        name: "docs",
+        access: "read",
+        issuer: ISSUER,
+      });
+      expect(minted.scope).toBe("surface:docs:read");
+      const validated = await validateAccessToken(h.db, minted.token, [ISSUER]);
+      expect(validated.payload.scope).toBe("surface:docs:read");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("defaults to a 90-day TTL; honors an explicit ttlSeconds", async () => {
+    const h = await makeHarness();
+    try {
+      const now = () => new Date("2026-06-30T00:00:00Z");
+      const dflt = await mintSurfaceToken(h.db, {
+        name: "foo",
+        access: "write",
+        issuer: ISSUER,
+        now,
+      });
+      const expectedDefault = new Date(
+        Date.parse("2026-06-30T00:00:00Z") + SURFACE_TOKEN_TTL_DEFAULT_SECONDS * 1000,
+      ).toISOString();
+      expect(dflt.expiresAt).toBe(expectedDefault);
+
+      const custom = await mintSurfaceToken(h.db, {
+        name: "bar",
+        access: "write",
+        issuer: ISSUER,
+        ttlSeconds: 3600,
+        now,
+      });
+      expect(custom.expiresAt).toBe(
+        new Date(Date.parse("2026-06-30T00:00:00Z") + 3600 * 1000).toISOString(),
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("rejects an invalid surface name (path-traversal safety)", async () => {
+    const h = await makeHarness();
+    try {
+      await expect(
+        mintSurfaceToken(h.db, { name: "../evil", access: "write", issuer: ISSUER }),
+      ).rejects.toThrow(/invalid surface name/);
+      await expect(
+        mintSurfaceToken(h.db, { name: "a/b", access: "write", issuer: ISSUER }),
+      ).rejects.toThrow(/invalid surface name/);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("listSurfaceTokens", () => {
+  test("lists only deploy tokens, narrows by surface, ignores other mints", async () => {
+    const h = await makeHarness();
+    try {
+      const a = await mintSurfaceToken(h.db, { name: "alpha", access: "write", issuer: ISSUER });
+      const b = await mintSurfaceToken(h.db, { name: "beta", access: "read", issuer: ISSUER });
+
+      // A generic cli_mint token that ALSO names a surface scope must NOT appear
+      // (deploy tokens are a distinct class, keyed by created_via).
+      const other = await signAccessToken(h.db, {
+        sub: h.userId,
+        scopes: ["surface:alpha:write"],
+        audience: "surface",
+        clientId: "test",
+        issuer: ISSUER,
+      });
+      recordTokenMint(h.db, {
+        jti: other.jti,
+        createdVia: "cli_mint",
+        subject: "someone",
+        clientId: "test",
+        scopes: ["surface:alpha:write"],
+        expiresAt: other.expiresAt,
+      });
+
+      const all = listSurfaceTokens(h.db);
+      const jtis = all.map((r) => r.jti);
+      expect(jtis).toContain(a.jti);
+      expect(jtis).toContain(b.jti);
+      expect(jtis).not.toContain(other.jti);
+
+      const alphaOnly = listSurfaceTokens(h.db, "alpha");
+      expect(alphaOnly.map((r) => r.jti)).toEqual([a.jti]);
+      expect(alphaOnly[0]?.access).toBe("write");
+      expect(alphaOnly[0]?.name).toBe("alpha");
+      expect(alphaOnly[0]?.revokedAt).toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("empty when none minted", async () => {
+    const h = await makeHarness();
+    try {
+      expect(listSurfaceTokens(h.db)).toEqual([]);
+      expect(listSurfaceTokens(h.db, "nope")).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("revokeSurfaceToken", () => {
+  test("revokes a deploy token; the endpoint path then rejects it", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await mintSurfaceToken(h.db, {
+        name: "foo",
+        access: "write",
+        issuer: ISSUER,
+      });
+      // Valid before revoke.
+      await validateAccessToken(h.db, minted.token, [ISSUER]);
+
+      const res = revokeSurfaceToken(h.db, minted.jti, new Date());
+      expect(res.status).toBe("revoked");
+
+      // Revocation is enforced at validation (the git endpoint's path).
+      await expect(validateAccessToken(h.db, minted.token, [ISSUER])).rejects.toThrow(/revoked/);
+
+      // list reflects the revoked state.
+      const row = listSurfaceTokens(h.db, "foo")[0];
+      expect(row?.revokedAt).not.toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("re-revoke is idempotent (already-revoked)", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await mintSurfaceToken(h.db, {
+        name: "foo",
+        access: "write",
+        issuer: ISSUER,
+      });
+      const first = revokeSurfaceToken(h.db, minted.jti, new Date());
+      expect(first.status).toBe("revoked");
+      const second = revokeSurfaceToken(h.db, minted.jti, new Date());
+      expect(second.status).toBe("already-revoked");
+      if (second.status === "already-revoked") {
+        expect(second.revokedAt).toBeTruthy();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unknown jti → not-found", async () => {
+    const h = await makeHarness();
+    try {
+      expect(revokeSurfaceToken(h.db, "no-such-jti", new Date()).status).toBe("not-found");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("refuses to revoke a non-deploy-token jti (fails closed)", async () => {
+    const h = await makeHarness();
+    try {
+      const other = await signAccessToken(h.db, {
+        sub: h.userId,
+        scopes: ["vault:default:read"],
+        audience: "vault.default",
+        clientId: "test",
+        issuer: ISSUER,
+      });
+      recordTokenMint(h.db, {
+        jti: other.jti,
+        createdVia: "cli_mint",
+        subject: "someone",
+        clientId: "test",
+        scopes: ["vault:default:read"],
+        expiresAt: other.expiresAt,
+      });
+      const res = revokeSurfaceToken(h.db, other.jti, new Date());
+      expect(res.status).toBe("not-surface-token");
+      if (res.status === "not-surface-token") {
+        expect(res.createdVia).toBe("cli_mint");
+      }
+      // Confirm it was NOT revoked.
+      await validateAccessToken(h.db, other.token, [ISSUER]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("SURFACE_TOKEN_CREATED_VIA is the stable tag", () => {
+    expect(SURFACE_TOKEN_CREATED_VIA).toBe("surface_token");
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1038,6 +1038,12 @@ async function main(argv: string[]): Promise<number> {
       return await mod.hub(rest);
     }
 
+    case "surface": {
+      const mod = await loadCommand("surface", () => import("./commands/surface.ts"));
+      if (!mod) return 1;
+      return await mod.surface(rest);
+    }
+
     case "vault": {
       const mod = await loadCommand("vault", () => import("./commands/vault.ts"));
       if (!mod) return 1;

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -23,7 +23,6 @@
  *     `<hub-origin>/account/2fa` (QR + backup codes).
  */
 
-import { join } from "node:path";
 import { createInterface } from "node:readline/promises";
 import {
   DEFAULT_REAP_AGE_MS,
@@ -36,11 +35,9 @@ import {
   reapClient,
 } from "../clients.ts";
 import { CONFIG_DIR } from "../config.ts";
-import { readExposeState } from "../expose-state.ts";
 import { listGrantsForUser, revokeGrant } from "../grants.ts";
-import { HUB_DEFAULT_PORT, readHubPort } from "../hub-control.ts";
 import { openHubDb } from "../hub-db.ts";
-import { deriveHubOrigin } from "../hub-origin.ts";
+import { resolveHubIssuer } from "../hub-issuer.ts";
 import { inferAudience } from "../jwt-audience.ts";
 import {
   findTokenRowByJti,
@@ -304,27 +301,6 @@ export interface AuthDeps {
    * for `PARACHUTE_HUB_ORIGIN` so the token's iss matches what services see.
    */
   hubOrigin?: string;
-}
-
-/**
- * Resolve the hub origin used as `iss` for operator tokens. Mirrors
- * lifecycle.resolveHubOrigin's order, but falls back to the canonical
- * loopback (`http://127.0.0.1:1939`) instead of `undefined` — operator
- * tokens MUST carry an issuer, and on first-run before any expose has
- * happened the canonical loopback is what services will validate against.
- */
-function resolveHubIssuer(override: string | undefined, configDir: string): string {
-  if (override) {
-    const fromOverride = deriveHubOrigin({ override });
-    if (fromOverride) return fromOverride;
-  }
-  const state = readExposeState(join(configDir, "expose-state.json"));
-  if (state?.hubOrigin) return state.hubOrigin;
-  const exposeFqdn = state?.canonicalFqdn;
-  return (
-    deriveHubOrigin({ exposeFqdn, hubPort: readHubPort(configDir) }) ??
-    `http://127.0.0.1:${HUB_DEFAULT_PORT}`
-  );
 }
 
 function defaultRotateKey(): { kid: string; createdAt: string } {

--- a/src/commands/surface.ts
+++ b/src/commands/surface.ts
@@ -1,0 +1,493 @@
+/**
+ * `parachute surface` — operator management for the Surface Git Transport.
+ *
+ * Phase 3a ships the DEPLOY TOKEN sub-surface: `parachute surface token
+ * mint|list|revoke`. A deploy token is the PAT-equivalent — a scoped, revocable,
+ * long-lived `surface:<name>:<read|write>` credential the operator mints on the
+ * box and hands to an EXTERNAL/remote git client (a `claude -p` agent, or any
+ * machine) so it can `git push`/`git clone` a surface's hub-hosted repo with
+ * nothing but a static secret. No browser, no device flow (those are the human
+ * paths, later phases) — "a GitHub PAT, but for a parachute surface, git-native."
+ *
+ * The token mechanics live in the pure `surface-token.ts` library (mint / list /
+ * revoke against an open hub DB, reusing the same `signAccessToken` +
+ * registered-mint discipline as agent grants). This command layer owns:
+ *   - operator-auth (the on-disk `operator.token` must carry `parachute:host:auth`,
+ *     mirroring `auth mint-token` / `auth revoke-token` — minting/revoking a
+ *     credential is privileged); and
+ *   - argument parsing + the "just works" copy-paste git config guidance.
+ *
+ * Operator-managed governance: the operator minting on their own box IS the
+ * authority (the same way `auth mint-token` mints a scope directly). List + revoke
+ * give GitHub-PAT-style management — kill a leaked token.
+ */
+import { CONFIG_DIR } from "../config.ts";
+import { surfaceGitRemoteUrl } from "../git-registry.ts";
+import { surfaceHelp } from "../help.ts";
+import { openHubDb } from "../hub-db.ts";
+import { resolveHubIssuer } from "../hub-issuer.ts";
+import { OperatorTokenExpiredError, useOperatorTokenWithAutoRotate } from "../operator-token.ts";
+import {
+  SURFACE_TOKEN_TTL_DEFAULT_SECONDS,
+  SURFACE_TOKEN_TTL_MAX_SECONDS,
+  type SurfaceAccess,
+  listSurfaceTokens,
+  mintSurfaceToken,
+  revokeSurfaceToken,
+} from "../surface-token.ts";
+
+/** Injectable deps for tests — otherwise defaults to the real hub DB + config dir. */
+export interface SurfaceDeps {
+  /** Override the hub-db path. Tests point at a tmp dir. */
+  dbPath?: string;
+  /** Override the config dir where `operator.token` / `expose-state.json` live. */
+  configDir?: string;
+  /** Override the hub origin used as the minted token's `iss`. */
+  hubOrigin?: string;
+  /** Test seam for the clock. */
+  now?: () => Date;
+}
+
+/**
+ * Entry point for `parachute surface …`. Only the `token` sub-surface exists in
+ * Phase 3a; unknown subcommands fall through to help with exit 1.
+ */
+export async function surface(args: readonly string[], deps: SurfaceDeps = {}): Promise<number> {
+  const sub = args[0];
+  if (sub === undefined || sub === "--help" || sub === "-h" || sub === "help") {
+    console.log(surfaceHelp());
+    return sub === undefined ? 1 : 0;
+  }
+  if (sub === "token") {
+    return await runToken(args.slice(1), deps);
+  }
+  console.error(`parachute surface: unknown subcommand "${sub}"`);
+  console.error("run `parachute surface --help` for usage");
+  return 1;
+}
+
+async function runToken(args: readonly string[], deps: SurfaceDeps): Promise<number> {
+  const verb = args[0];
+  if (verb === undefined || verb === "--help" || verb === "-h" || verb === "help") {
+    console.log(surfaceHelp());
+    return verb === undefined ? 1 : 0;
+  }
+  switch (verb) {
+    case "mint":
+      return await runTokenMint(args.slice(1), deps);
+    case "list":
+      return await runTokenList(args.slice(1), deps);
+    case "revoke":
+      return await runTokenRevoke(args.slice(1), deps);
+    default:
+      console.error(`parachute surface token: unknown action "${verb}"`);
+      console.error("usage: parachute surface token <mint|list|revoke> …");
+      return 1;
+  }
+}
+
+// ===========================================================================
+// Operator-auth gate — the on-disk operator.token must carry parachute:host:auth
+// ===========================================================================
+
+/**
+ * Load + validate the on-disk operator token and require `parachute:host:auth`
+ * (the `auth` or `admin` scope-set). Mirrors the gate in `auth mint-token` /
+ * `auth revoke-token` — minting / revoking a credential is privileged, and a
+ * narrowly-scoped JWT stashed at operator.token must not be able to do it. On
+ * success returns the operator's `userId` (registry attribution) + the resolved
+ * issuer; on any failure prints an actionable error and returns the exit code.
+ */
+async function requireOperatorHostAuth(
+  db: ReturnType<typeof openHubDb>,
+  deps: SurfaceDeps,
+  label: string,
+): Promise<{ userId: string; issuer: string } | number> {
+  const configDir = deps.configDir ?? CONFIG_DIR;
+  const issuer = resolveHubIssuer(deps.hubOrigin, configDir);
+
+  let used: Awaited<ReturnType<typeof useOperatorTokenWithAutoRotate>>;
+  try {
+    used = await useOperatorTokenWithAutoRotate(db, { configDir, issuer });
+  } catch (err) {
+    if (err instanceof OperatorTokenExpiredError) {
+      console.error(`${label}: ${err.message}`);
+      return 1;
+    }
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`${label}: operator token invalid — ${msg}`);
+    console.error(
+      "run `parachute auth rotate-operator` to mint a fresh one, or check that the hub origin matches",
+    );
+    return 1;
+  }
+  if (!used) {
+    console.error(`${label}: no operator token found at ~/.parachute/operator.token`);
+    console.error(
+      "run `parachute auth set-password` (first run) or `parachute auth rotate-operator` to mint one",
+    );
+    return 1;
+  }
+  if (used.rotated) {
+    console.error(
+      `${label}: operator token within 7d of expiry — auto-rotated to ${used.rotated.expiresAt} (scope_set=${used.rotated.scopeSet})`,
+    );
+  }
+  const operatorSub = used.payload.sub;
+  if (typeof operatorSub !== "string" || operatorSub.length === 0) {
+    console.error(`${label}: operator token has no sub claim`);
+    return 1;
+  }
+  const tokenScope =
+    typeof used.payload.scope === "string"
+      ? used.payload.scope.split(/\s+/).filter((s) => s.length > 0)
+      : [];
+  if (!tokenScope.includes("parachute:host:auth")) {
+    console.error(`${label}: operator token lacks parachute:host:auth scope`);
+    console.error(
+      "narrowed scope-sets without `auth` (install/start/expose/vault) can't manage deploy tokens — run `parachute auth rotate-operator --scope-set auth` (or `admin`)",
+    );
+    return 1;
+  }
+  return { userId: operatorSub, issuer };
+}
+
+// ===========================================================================
+// mint
+// ===========================================================================
+
+interface MintFlags {
+  name?: string;
+  access: SurfaceAccess;
+  ttlSeconds: number;
+  json: boolean;
+  error?: string;
+}
+
+/**
+ * Parse the mint args: a single surface-name positional + `--read|--write`
+ * (default write — a deploy token's job is to push) + `--ttl <dur>` /
+ * `--expires-in <s>` (default 90d, cap 365d) + `--json`.
+ */
+function parseMintFlags(args: readonly string[]): MintFlags {
+  let name: string | undefined;
+  let access: SurfaceAccess | undefined;
+  let ttlSeconds = SURFACE_TOKEN_TTL_DEFAULT_SECONDS;
+  let json = false;
+
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i]!;
+    if (a === "--read") {
+      if (access === "write")
+        return {
+          access: "write",
+          ttlSeconds,
+          json,
+          error: "--read and --write are mutually exclusive",
+        };
+      access = "read";
+    } else if (a === "--write") {
+      if (access === "read")
+        return {
+          access: "read",
+          ttlSeconds,
+          json,
+          error: "--read and --write are mutually exclusive",
+        };
+      access = "write";
+    } else if (a === "--json") {
+      json = true;
+    } else if (a === "--ttl" || a === "--expires-in") {
+      const val = args[++i];
+      if (val === undefined)
+        return { access: access ?? "write", ttlSeconds, json, error: `${a} requires a value` };
+      const parsed = a === "--ttl" ? parseDuration(val) : parseSeconds(val);
+      if ("error" in parsed)
+        return { access: access ?? "write", ttlSeconds, json, error: parsed.error };
+      ttlSeconds = parsed.seconds;
+    } else if (a.startsWith("--")) {
+      return { access: access ?? "write", ttlSeconds, json, error: `unknown flag "${a}"` };
+    } else if (name === undefined) {
+      name = a;
+    } else {
+      return {
+        access: access ?? "write",
+        ttlSeconds,
+        json,
+        error: `unexpected argument "${a}" (only one surface name)`,
+      };
+    }
+  }
+  return { name, access: access ?? "write", ttlSeconds, json };
+}
+
+async function runTokenMint(args: readonly string[], deps: SurfaceDeps): Promise<number> {
+  const label = "parachute surface token mint";
+  const flags = parseMintFlags(args);
+  if (flags.error) {
+    console.error(`${label}: ${flags.error}`);
+    return 1;
+  }
+  if (!flags.name) {
+    console.error(`${label}: missing surface name`);
+    console.error(
+      "usage: parachute surface token mint <name> [--read|--write] [--ttl <dur>] [--json]",
+    );
+    return 1;
+  }
+
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const auth = await requireOperatorHostAuth(db, deps, label);
+    if (typeof auth === "number") return auth;
+
+    let minted: Awaited<ReturnType<typeof mintSurfaceToken>>;
+    try {
+      minted = await mintSurfaceToken(db, {
+        name: flags.name,
+        access: flags.access,
+        issuer: auth.issuer,
+        ttlSeconds: flags.ttlSeconds,
+        userId: auth.userId,
+        ...(deps.now !== undefined ? { now: deps.now } : {}),
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`${label}: ${msg}`);
+      return 1;
+    }
+
+    const remoteUrl = surfaceGitRemoteUrl(auth.issuer, flags.name);
+    const loopback = /^https?:\/\/(127\.0\.0\.1|\[::1\]|localhost)(:|\/|$)/.test(auth.issuer);
+
+    if (flags.json) {
+      // Machine-consumable: everything a remote client needs to configure git,
+      // in one blob (easy to hand a `claude -p` agent as config).
+      console.log(
+        JSON.stringify(
+          {
+            token: minted.token,
+            jti: minted.jti,
+            scope: minted.scope,
+            surface: flags.name,
+            access: flags.access,
+            expiresAt: minted.expiresAt,
+            remoteUrl,
+            credentialHelper: CREDENTIAL_HELPER_INLINE,
+          },
+          null,
+          2,
+        ),
+      );
+      return 0;
+    }
+
+    // Human path: the token is the ONLY thing on stdout (pipe purity — e.g.
+    // `parachute surface token mint x --write | pbcopy`); everything else is
+    // guidance on stderr.
+    console.log(minted.token);
+    console.error("");
+    console.error(`Surface deploy token minted for "${flags.name}" (${flags.access}).`);
+    console.error(`  jti:      ${minted.jti}`);
+    console.error(`  scope:    ${minted.scope}`);
+    console.error(`  expires:  ${minted.expiresAt}`);
+    console.error(`  remote:   ${remoteUrl}`);
+    console.error(`  revoke:   parachute surface token revoke ${minted.jti}`);
+    console.error("");
+    console.error("The token was printed to stdout. Hand it to the remote client as a secret,");
+    console.error("then, on that machine (any box with git — NO parachute install needed):");
+    console.error("");
+    console.error("  export PARACHUTE_SURFACE_TOKEN=<paste-the-token>");
+    console.error(`  git config --global credential.helper '${CREDENTIAL_HELPER_INLINE}'`);
+    console.error(`  git clone ${remoteUrl} my-surface   # then edit + git push`);
+    console.error("");
+    console.error("Keep the token in an env var / credential helper — never commit it or put it");
+    console.error("in a remote URL (it would leak into .git/config).");
+    if (loopback) {
+      console.error("");
+      console.error(
+        `NOTE: the hub origin is loopback (${auth.issuer}) — a remote client can only reach`,
+      );
+      console.error(
+        "this surface once the box is exposed (`parachute expose …`). Re-mint after exposing so",
+      );
+      console.error("the remote URL points at the public origin.");
+    }
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+// ===========================================================================
+// list
+// ===========================================================================
+
+async function runTokenList(args: readonly string[], deps: SurfaceDeps): Promise<number> {
+  const label = "parachute surface token list";
+  let name: string | undefined;
+  let json = false;
+  for (const a of args) {
+    if (a === "--json") json = true;
+    else if (a.startsWith("--")) {
+      console.error(`${label}: unknown flag "${a}"`);
+      return 1;
+    } else if (name === undefined) name = a;
+    else {
+      console.error(`${label}: unexpected argument "${a}" (only one surface name)`);
+      return 1;
+    }
+  }
+
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const auth = await requireOperatorHostAuth(db, deps, label);
+    if (typeof auth === "number") return auth;
+
+    const now = deps.now?.() ?? new Date();
+    const rows = listSurfaceTokens(db, name).map((r) => ({
+      ...r,
+      status: statusOf(r.revokedAt, r.expiresAt, now),
+    }));
+
+    if (json) {
+      console.log(JSON.stringify(rows, null, 2));
+      return 0;
+    }
+    if (rows.length === 0) {
+      console.log(
+        name
+          ? `No surface deploy tokens for "${name}".`
+          : "No surface deploy tokens. Mint one with `parachute surface token mint <name>`.",
+      );
+      return 0;
+    }
+    // Fixed-ish columns; jti + surface names are bounded, so a simple pad reads
+    // cleanly without a table lib.
+    console.log(
+      `${pad("JTI", 24)}  ${pad("SURFACE", 20)}  ${pad("ACCESS", 6)}  ${pad("STATUS", 8)}  EXPIRES`,
+    );
+    for (const r of rows) {
+      console.log(
+        `${pad(r.jti, 24)}  ${pad(r.name, 20)}  ${pad(r.access, 6)}  ${pad(r.status, 8)}  ${r.expiresAt}`,
+      );
+    }
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
+// ===========================================================================
+// revoke
+// ===========================================================================
+
+async function runTokenRevoke(args: readonly string[], deps: SurfaceDeps): Promise<number> {
+  const label = "parachute surface token revoke";
+  const positionals = args.filter((a) => !a.startsWith("--"));
+  const flags = args.filter((a) => a.startsWith("--"));
+  if (flags.length > 0) {
+    console.error(
+      `${label}: unexpected flag "${flags[0]}" (this command takes a jti positional only)`,
+    );
+    return 1;
+  }
+  if (positionals.length === 0) {
+    console.error(`${label}: missing jti argument`);
+    console.error(
+      "usage: parachute surface token revoke <jti>  (find it with `parachute surface token list`)",
+    );
+    return 1;
+  }
+  if (positionals.length > 1) {
+    console.error(`${label}: unexpected argument "${positionals[1]}" (only one jti at a time)`);
+    return 1;
+  }
+  const jti = positionals[0]!;
+
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const auth = await requireOperatorHostAuth(db, deps, label);
+    if (typeof auth === "number") return auth;
+
+    const result = revokeSurfaceToken(db, jti, deps.now?.() ?? new Date());
+    switch (result.status) {
+      case "revoked":
+        console.log(
+          `Revoked surface deploy token ${jti}. The git endpoint rejects it within ~60s (revocation list poll).`,
+        );
+        return 0;
+      case "already-revoked":
+        console.log(`already revoked at ${result.revokedAt}: jti=${jti}`);
+        return 0;
+      case "not-found":
+        console.error(`${label}: no surface deploy token with jti ${jti} in the registry`);
+        return 1;
+      case "not-surface-token":
+        console.error(
+          `${label}: jti ${jti} is not a surface deploy token (it is a ${result.createdVia} token)`,
+        );
+        console.error("use `parachute auth revoke-token` to revoke non-surface tokens");
+        return 1;
+    }
+  } finally {
+    db.close();
+  }
+}
+
+// ===========================================================================
+// Shared helpers
+// ===========================================================================
+
+/**
+ * The zero-file git credential helper (inline `!`-command form) — the "just
+ * works" mechanism. On `get`, emits `x-access-token:<token>` from
+ * `$PARACHUTE_SURFACE_TOKEN`, which the hub git endpoint accepts as Basic
+ * (`extractToken` in git-transport.ts). Works on ANY git version + any box with
+ * `sh` — no parachute install, no extra file. The named `git-credential-parachute`
+ * script (scripts/) is the equivalent for repeated use.
+ */
+const CREDENTIAL_HELPER_INLINE =
+  '!f() { test "$1" = get && printf "username=x-access-token\\npassword=%s\\n" "$PARACHUTE_SURFACE_TOKEN"; }; f';
+
+function statusOf(revokedAt: string | null, expiresAt: string, now: Date): string {
+  if (revokedAt) return "revoked";
+  if (Date.parse(expiresAt) <= now.getTime()) return "expired";
+  return "active";
+}
+
+function pad(s: string, width: number): string {
+  return s.length >= width ? s : s + " ".repeat(width - s.length);
+}
+
+function parseSeconds(input: string): { seconds: number } | { error: string } {
+  const seconds = Number.parseInt(input, 10);
+  if (!Number.isFinite(seconds) || String(seconds) !== input.trim() || seconds <= 0) {
+    return {
+      error: `invalid --expires-in "${input}" — must be a positive integer number of seconds`,
+    };
+  }
+  if (seconds > SURFACE_TOKEN_TTL_MAX_SECONDS) {
+    return {
+      error: `--expires-in "${input}" exceeds the 365d cap (${SURFACE_TOKEN_TTL_MAX_SECONDS} seconds)`,
+    };
+  }
+  return { seconds };
+}
+
+/** Parse a duration with a d/h/m/s suffix (e.g. `90d`, `24h`, `30m`, `60s`). */
+function parseDuration(input: string): { seconds: number } | { error: string } {
+  const m = /^(\d+)([dhms])$/.exec(input.trim());
+  if (!m) {
+    return { error: `invalid --ttl "${input}" — use a duration like 90d, 24h, 30m, or 60s` };
+  }
+  const n = Number.parseInt(m[1]!, 10);
+  const unit = m[2]!;
+  const mult = unit === "d" ? 86400 : unit === "h" ? 3600 : unit === "m" ? 60 : 1;
+  const seconds = n * mult;
+  if (seconds <= 0) return { error: `invalid --ttl "${input}" — must be > 0` };
+  if (seconds > SURFACE_TOKEN_TTL_MAX_SECONDS) {
+    return { error: `--ttl "${input}" exceeds the 365d cap` };
+  }
+  return { seconds };
+}

--- a/src/commands/surface.ts
+++ b/src/commands/surface.ts
@@ -414,7 +414,7 @@ async function runTokenRevoke(args: readonly string[], deps: SurfaceDeps): Promi
     switch (result.status) {
       case "revoked":
         console.log(
-          `Revoked surface deploy token ${jti}. The git endpoint rejects it within ~60s (revocation list poll).`,
+          `Revoked surface deploy token ${jti}. Effective immediately — the git endpoint rejects it on the next push.`,
         );
         return 0;
       case "already-revoked":

--- a/src/help.ts
+++ b/src/help.ts
@@ -29,6 +29,8 @@ Usage:
   parachute migrate --to-supervised move a legacy detached install to the managed hub
   parachute migrate [--dry-run]     archive legacy files at ecosystem root
   parachute auth <cmd>              identity (set password, manage 2FA)
+  parachute surface token <cmd>     mint/list/revoke surface deploy tokens
+                                    (a git-native PAT for pushing to a surface)
   parachute hub set-origin <url>    set the canonical public hub origin (OAuth issuer)
                                     — for reverse-proxy / Caddy-direct boxes
   parachute vault <args...>         vault-specific ops (tokens, 2fa, config, init,
@@ -799,5 +801,66 @@ Examples:
   parachute migrate --yes             sweep without prompting
   parachute migrate --to-supervised   move to the supervised (serve-under-manager) model
   parachute migrate --teardown        remove the hub unit (roll back the cutover)
+`;
+}
+
+export function surfaceHelp(): string {
+  return `parachute surface — manage Parachute surfaces (Surface Git Transport)
+
+Usage:
+  parachute surface token mint <name> [--read|--write] [--ttl <dur> | --expires-in <s>] [--json]
+  parachute surface token list [<name>] [--json]
+  parachute surface token revoke <jti>
+
+Deploy tokens — a GitHub-PAT-equivalent, git-native:
+  A surface lives as a git repo the hub authenticates (\`/git/<name>\`). A deploy
+  token lets an EXTERNAL/remote git client — a \`claude -p\` agent, or any machine
+  — push/pull that repo with nothing but a static secret. No browser, no device
+  flow. Mint one, hand it over, and \`git push\` just works.
+
+  The token is scoped to ONE surface + one verb (read xor write), registered, and
+  revocable — so you can list your deploy tokens and kill a leaked one, exactly
+  like managing GitHub PATs. Default lifetime is 90 days (re-mint to renew).
+
+token mint <name>          mint a deploy token for surface <name>.
+  --write                  push access — \`surface:<name>:write\` (DEFAULT; a
+                           deploy token's job is to push). write also allows fetch.
+  --read                   clone/fetch only — \`surface:<name>:read\`.
+  --ttl <dur>              lifetime as a duration (90d / 24h / 30m / 60s).
+                           Default 90d; capped at 365d.
+  --expires-in <seconds>   lifetime in integer seconds (alternative to --ttl).
+  --json                   emit a JSON blob (token + jti + scope + remoteUrl +
+                           the git credential-helper one-liner) for scripted /
+                           agent config. Otherwise the token is printed to stdout
+                           (pipe-safe) and setup guidance to stderr.
+
+token list [<name>]        list deploy tokens (newest first), optionally narrowed
+                           to one surface. Shows jti, surface, access, status
+                           (active / revoked / expired), and expiry. --json for
+                           machine output. Never prints the token bytes.
+
+token revoke <jti>         revoke a deploy token by jti (find it via \`token list\`).
+                           The git endpoint rejects it within ~60s (revocation
+                           list poll). Idempotent. Refuses non-deploy-token jtis —
+                           use \`parachute auth revoke-token\` for those.
+
+The remote-client setup (git-native, no \`gh\`, no parachute install needed):
+
+  # on the remote machine:
+  export PARACHUTE_SURFACE_TOKEN=<the-token>
+  git config --global credential.helper \\
+    '!f() { test "$1" = get && printf "username=x-access-token\\npassword=%s\\n" "$PARACHUTE_SURFACE_TOKEN"; }; f'
+  git clone https://<hub-origin>/git/<name> && cd <name>   # edit, then:
+  git push
+
+  \`parachute surface token mint\` prints this with your hub origin filled in.
+  A reusable \`git-credential-parachute\` helper script ships in the hub repo's
+  scripts/ for boxes that prefer a named helper on PATH.
+
+Auth:
+  mint / list / revoke require the on-disk operator token to carry
+  \`parachute:host:auth\` (the \`auth\` or \`admin\` scope-set) — the same gate as
+  \`parachute auth mint-token\`. Run \`parachute auth set-password\` (first run) or
+  \`parachute auth rotate-operator\` if you don't have one.
 `;
 }

--- a/src/help.ts
+++ b/src/help.ts
@@ -840,9 +840,10 @@ token list [<name>]        list deploy tokens (newest first), optionally narrowe
                            machine output. Never prints the token bytes.
 
 token revoke <jti>         revoke a deploy token by jti (find it via \`token list\`).
-                           The git endpoint rejects it within ~60s (revocation
-                           list poll). Idempotent. Refuses non-deploy-token jtis —
-                           use \`parachute auth revoke-token\` for those.
+                           Effective immediately — the git endpoint rejects it on
+                           the next push (per-request revocation check). Idempotent.
+                           Refuses non-deploy-token jtis — use
+                           \`parachute auth revoke-token\` for those.
 
 The remote-client setup (git-native, no \`gh\`, no parachute install needed):
 

--- a/src/hub-issuer.ts
+++ b/src/hub-issuer.ts
@@ -1,0 +1,30 @@
+import { join } from "node:path";
+import { readExposeState } from "./expose-state.ts";
+import { HUB_DEFAULT_PORT, readHubPort } from "./hub-control.ts";
+import { deriveHubOrigin } from "./hub-origin.ts";
+
+/**
+ * Resolve the hub origin used as `iss` for operator-minted tokens (the CLI mint
+ * paths: `auth mint-token`, `auth revoke-token`, `surface token …`). Mirrors
+ * `lifecycle.resolveHubOrigin`'s order, but falls back to the canonical loopback
+ * (`http://127.0.0.1:1939`) instead of `undefined` — operator-minted tokens MUST
+ * carry an issuer, and on first-run before any expose has happened the canonical
+ * loopback is what services will validate against.
+ *
+ * Hoisted out of `commands/auth.ts` so every operator-mint surface resolves the
+ * issuer identically — a divergence here would mint tokens whose `iss` fails the
+ * resource server's strict check even when scopes match.
+ */
+export function resolveHubIssuer(override: string | undefined, configDir: string): string {
+  if (override) {
+    const fromOverride = deriveHubOrigin({ override });
+    if (fromOverride) return fromOverride;
+  }
+  const state = readExposeState(join(configDir, "expose-state.json"));
+  if (state?.hubOrigin) return state.hubOrigin;
+  const exposeFqdn = state?.canonicalFqdn;
+  return (
+    deriveHubOrigin({ exposeFqdn, hubPort: readHubPort(configDir) }) ??
+    `http://127.0.0.1:${HUB_DEFAULT_PORT}`
+  );
+}

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -179,7 +179,15 @@ export type TokenCreatedVia =
   // Agent-connector grants (Phase 4b-1) — a vault token the hub mints when the
   // operator approves an agent's `vault:<name>:<verb>` connection grant. Stored
   // in the agent-grants store; registered here so revoke can drop it.
-  | "agent_grant";
+  | "agent_grant"
+  // Surface DEPLOY tokens (Surface Git Transport Phase 3a) — a long-lived,
+  // scoped, revocable `surface:<name>:<read|write>` token an operator mints for
+  // an EXTERNAL/remote git client (a `claude -p` agent or any box) to push/pull
+  // a surface's hub-hosted repo. The PAT-equivalent: distinct from `agent_grant`
+  // (in-framework, approval-gated, per-turn-injected) and `cli_mint` (generic),
+  // so `parachute surface token list` can show exactly these. Registered here so
+  // `surface token revoke` (and the revocation list) can drop it.
+  | "surface_token";
 
 export interface SignedRefreshToken {
   /** Opaque token to return to the client. NOT recoverable from the DB. */

--- a/src/surface-token.ts
+++ b/src/surface-token.ts
@@ -1,0 +1,244 @@
+/**
+ * Surface DEPLOY tokens — the PAT-equivalent for the Surface Git Transport
+ * (Phase 3a, design doc 2026-06-30-surface-git-transport.md §6b).
+ *
+ * Phases 0a–2 gave the hub an authenticated `git http-backend` endpoint
+ * (`/git/<name>`) that validates `surface:<name>:read|write`, plus an in-framework
+ * grant flow that injects a per-turn token into an internal agent's `GIT_ASKPASS`.
+ * This module serves the OTHER actor: an EXTERNAL/remote git client — a
+ * `claude -p` agent (or any box) on a different machine — that just needs to hold
+ * a static secret and `git push`.
+ *
+ * The answer is a scoped, REGISTERED, REVOCABLE, LISTABLE token the operator
+ * mints and hands over: "a GitHub PAT, but for a parachute surface, git-native."
+ * It reuses the exact same mint (`signAccessToken`) + registered-mint discipline
+ * (`recordTokenMint` → the git endpoint's `validateAccessToken` accepts it, the
+ * revocation list kills it) as the agent-grant path ({@link mintSurfaceGrant} in
+ * admin-agent-grants.ts) — minus the approval flow, because the operator minting
+ * it on their own box IS the governance.
+ *
+ * Security posture (design §7): the token is scoped to ONE surface + one verb
+ * (read xor write), registered so the operator can list + revoke it (kill a
+ * leaked one, like GitHub PAT management), and fixed-TTL (default 90d — re-mint
+ * to renew). Blast radius is a deploy-key, not a master key: even a push builds
+ * in surface-host's sandbox (Phase 0c). The secret lives in the token the
+ * operator hands over — never persisted here beyond the registry row (which holds
+ * the jti + scope + expiry for revocation, NOT the token bytes).
+ *
+ * This is a pure library — no CLI I/O, no operator-token loading. The command
+ * (`commands/surface.ts`) does the operator-auth gate + argument parsing +
+ * output; these functions do the token mechanics against an open hub DB.
+ */
+import type { Database } from "bun:sqlite";
+import { SURFACE_NAME_RE } from "./git-registry.ts";
+import {
+  findTokenRowByJti,
+  listTokens,
+  recordTokenMint,
+  revokeTokenByJti,
+  signAccessToken,
+} from "./jwt-sign.ts";
+
+/** A deploy token's authority — read (clone/fetch) xor write (push). Write ⊇ read
+ *  at the git endpoint (a writer can always fetch), matching GitHub's model. */
+export type SurfaceAccess = "read" | "write";
+
+/**
+ * `created_via` tag stamped on deploy-token registry rows. The narrowing key for
+ * `listSurfaceTokens` / `revokeSurfaceToken` — so deploy tokens are managed as a
+ * distinct class from agent grants (`agent_grant`) and generic CLI mints
+ * (`cli_mint`), even though all three can carry a `surface:<name>:<verb>` scope.
+ */
+export const SURFACE_TOKEN_CREATED_VIA = "surface_token" as const;
+
+/** `sub` + registry `subject` for a deploy token — no hub user is tied to it (it's
+ *  handed to an external client). Surfaces as `REMOTE_USER` in the git endpoint. */
+export const SURFACE_TOKEN_SUBJECT = "surface-deploy";
+
+/** `client_id` on a deploy token — distinguishes it in the registry / admin UI. */
+export const SURFACE_TOKEN_CLIENT_ID = "parachute-surface-token";
+
+/**
+ * Default deploy-token lifetime — 90 days, matching the surface/vault GRANT
+ * posture (long-lived-but-revocable; a headless client holds it, re-mint to
+ * renew). Long-lived is a convenience/exposure tradeoff — kept bounded + easily
+ * revocable rather than never-expiring (design §7 "consider a sane default TTL").
+ */
+export const SURFACE_TOKEN_TTL_DEFAULT_SECONDS = 90 * 24 * 60 * 60;
+
+/** Hard cap on `--ttl`/`--expires-in` — 365 days, matching `auth mint-token`. */
+export const SURFACE_TOKEN_TTL_MAX_SECONDS = 365 * 24 * 60 * 60;
+
+/**
+ * A `surface:<name>:<verb>` scope, verb ∈ {read, write}. The name group MUST
+ * stay in sync with `SURFACE_NAME_RE` (git-registry.ts) — it is the same
+ * kebab/alnum charset, inlined here (rather than composed from `.source`) to
+ * keep this a plain anchored literal. If `SURFACE_NAME_RE`'s charset ever
+ * widens (e.g. dots), widen this too or `listSurfaceTokens` will silently drop
+ * tokens whose name uses the new character.
+ */
+const SURFACE_SCOPE_RE = /^surface:([a-zA-Z0-9][a-zA-Z0-9_-]{0,63}):(read|write)$/;
+
+/** Build the canonical deploy-token scope string. */
+export function surfaceScope(name: string, access: SurfaceAccess): string {
+  return `surface:${name}:${access}`;
+}
+
+export interface MintSurfaceTokenOpts {
+  /** Surface name — a `SURFACE_NAME_RE` slug (validated here; throws otherwise). */
+  name: string;
+  /** read (clone/fetch) or write (push). */
+  access: SurfaceAccess;
+  /** Hub origin → the token's `iss` (resolved by the caller via `resolveHubIssuer`). */
+  issuer: string;
+  /** Lifetime; defaults to {@link SURFACE_TOKEN_TTL_DEFAULT_SECONDS}. */
+  ttlSeconds?: number;
+  /**
+   * Optional hub user_id to tie the registry row to (the minting operator's
+   * user). The `sub`/`subject` stay {@link SURFACE_TOKEN_SUBJECT} regardless —
+   * the token is for an external client, not a hub user session.
+   */
+  userId?: string;
+  /** Test seam — defaults to the real `signAccessToken`. */
+  signToken?: typeof signAccessToken;
+  now?: () => Date;
+}
+
+export interface MintedSurfaceToken {
+  /** The JWT to hand the external client. NOT recoverable from the DB afterward. */
+  token: string;
+  jti: string;
+  expiresAt: string;
+  scope: string;
+}
+
+/**
+ * Mint a surface deploy token: a REGISTERED (`created_via: "surface_token"`)
+ * `surface:<name>:<verb>` JWT the git-transport endpoint validates (signature →
+ * hub keys, `iss` ∈ the multi-origin hub-bound set, revocation, then
+ * `scopes.includes("surface:<name>:<verb>")`). Mirrors {@link mintSurfaceGrant}
+ * — same registered-mint discipline so `revokeSurfaceToken` (and the revocation
+ * list) can kill it — minus the vault-only bits (no `vaultScope`, no
+ * `scoped_tags`). Audience is `surface.<name>` for symmetry with `vault.<name>`;
+ * the git endpoint doesn't check `aud` (it keys purely off the URL path + the
+ * scope), so it's cosmetic but honest.
+ *
+ * The scope is signed VERBATIM — the operator minting on their own box (holding
+ * `parachute:host:auth`, gated upstream in the command) IS the authority, the
+ * same way `auth mint-token` mints a scope directly.
+ */
+export async function mintSurfaceToken(
+  db: Database,
+  opts: MintSurfaceTokenOpts,
+): Promise<MintedSurfaceToken> {
+  if (!SURFACE_NAME_RE.test(opts.name)) {
+    throw new Error(
+      `invalid surface name "${opts.name}" — must match ${SURFACE_NAME_RE} (kebab/alnum, no slashes or dots)`,
+    );
+  }
+  const scope = surfaceScope(opts.name, opts.access);
+  const ttlSeconds = opts.ttlSeconds ?? SURFACE_TOKEN_TTL_DEFAULT_SECONDS;
+  const sign = opts.signToken ?? signAccessToken;
+  const signed = await sign(db, {
+    sub: SURFACE_TOKEN_SUBJECT,
+    scopes: [scope],
+    audience: `surface.${opts.name}`,
+    clientId: SURFACE_TOKEN_CLIENT_ID,
+    issuer: opts.issuer,
+    ttlSeconds,
+    vaultScope: [], // not a per-user vault credential
+    ...(opts.now !== undefined ? { now: opts.now } : {}),
+  });
+  // Register the long-lived mint so revoke can drop it (registered-mint rule —
+  // an unregistered long-lived token is unrevocable).
+  recordTokenMint(db, {
+    jti: signed.jti,
+    createdVia: SURFACE_TOKEN_CREATED_VIA,
+    subject: SURFACE_TOKEN_SUBJECT,
+    ...(opts.userId ? { userId: opts.userId } : {}),
+    clientId: SURFACE_TOKEN_CLIENT_ID,
+    scopes: [scope],
+    expiresAt: signed.expiresAt,
+    ...(opts.now !== undefined ? { now: opts.now } : {}),
+  });
+  return { token: signed.token, jti: signed.jti, expiresAt: signed.expiresAt, scope };
+}
+
+/** A deploy token's listing row (metadata only — never the token bytes). */
+export interface SurfaceTokenListing {
+  jti: string;
+  /** Surface name parsed from the scope. */
+  name: string;
+  access: SurfaceAccess;
+  scope: string;
+  createdAt: string;
+  expiresAt: string;
+  /** ISO timestamp when revoked, or null if live. */
+  revokedAt: string | null;
+}
+
+/**
+ * List surface deploy tokens, newest-first, optionally narrowed to one surface.
+ * Pages through the whole `surface_token` class (the registry filter) and keeps
+ * only rows whose scope is a well-formed `surface:<name>:<verb>` — a deploy token
+ * always carries exactly that one scope. Metadata only; the token bytes are never
+ * stored, so they never appear here.
+ */
+export function listSurfaceTokens(db: Database, name?: string): SurfaceTokenListing[] {
+  const out: SurfaceTokenListing[] = [];
+  let cursor: string | null = null;
+  do {
+    const page = listTokens(db, {
+      filter: { createdVia: SURFACE_TOKEN_CREATED_VIA },
+      cursor,
+    });
+    for (const row of page.rows) {
+      const scope = row.scopes.find((s) => SURFACE_SCOPE_RE.test(s));
+      if (!scope) continue;
+      const m = SURFACE_SCOPE_RE.exec(scope);
+      if (!m) continue;
+      const parsedName = m[1] ?? "";
+      const access = (m[2] ?? "read") as SurfaceAccess;
+      if (name !== undefined && parsedName !== name) continue;
+      out.push({
+        jti: row.jti,
+        name: parsedName,
+        access,
+        scope,
+        createdAt: row.createdAt,
+        expiresAt: row.expiresAt,
+        revokedAt: row.revokedAt,
+      });
+    }
+    cursor = page.nextCursor;
+  } while (cursor);
+  return out;
+}
+
+/** Outcome of a revoke attempt. */
+export type RevokeSurfaceTokenResult =
+  | { status: "revoked"; jti: string }
+  | { status: "already-revoked"; jti: string; revokedAt: string }
+  | { status: "not-found"; jti: string }
+  | { status: "not-surface-token"; jti: string; createdVia: string };
+
+/**
+ * Revoke a surface deploy token by jti. Fails closed on a jti that is NOT a
+ * deploy token (`not-surface-token`) so this command can't be turned into a
+ * general token-revoker — the operator uses `auth revoke-token` for other kinds.
+ * Idempotent: re-revoking an already-revoked deploy token reports its existing
+ * `revokedAt` (the caller exits 0).
+ */
+export function revokeSurfaceToken(db: Database, jti: string, now: Date): RevokeSurfaceTokenResult {
+  const row = findTokenRowByJti(db, jti);
+  if (!row) return { status: "not-found", jti };
+  if (row.createdVia !== SURFACE_TOKEN_CREATED_VIA) {
+    return { status: "not-surface-token", jti, createdVia: row.createdVia };
+  }
+  if (row.revokedAt) return { status: "already-revoked", jti, revokedAt: row.revokedAt };
+  const ok = revokeTokenByJti(db, jti, now);
+  // Race: the row existed then vanished/was-revoked between our lookups. Report
+  // not-found rather than silently succeeding (mirrors `auth revoke-token`).
+  if (!ok) return { status: "not-found", jti };
+  return { status: "revoked", jti };
+}


### PR DESCRIPTION
## What & why

Aaron's framing: *"add a GitHub PAT and git just works — what's the simplest way, given we don't have `gh`?"* Answer: a scoped, revocable **surface deploy token**.

The Surface Git Transport (design §6b) lets a client `git push`/`clone` a surface's hub-hosted repo (`/git/<name>`) with a hub-issued `surface:<name>:read|write` token. Phases 0a–2 (merged #727–#730) shipped the authenticated endpoint + the in-framework grant flow that injects a per-turn token into an **internal** agent's `GIT_ASKPASS`. **Phase 3a serves the OTHER actor:** an EXTERNAL/remote git client — a `claude -p` agent, or any machine — that just holds a static secret. No browser, no device-flow (those are the human paths, 3b/3c).

## Deliverables

**1. Deploy token (hub) — the PAT-equivalent.**
- `parachute surface token mint <name> [--read|--write] [--ttl <dur> | --expires-in <s>] [--json]` — mints a **registered, revocable** `surface:<name>:<verb>` JWT. Default `--write` (a deploy token's job is to push), 90d TTL (cap 365d). Token → stdout (pipe-safe); copy-paste git-config guidance → stderr; `--json` for scripted/agent config.
- `parachute surface token list [<name>] [--json]` — jti · surface · access · status (active/revoked/expired). Never the token bytes.
- `parachute surface token revoke <jti>` — kill a leaked one (endpoint rejects within ~60s). Idempotent; fails closed on a non-deploy-token jti.
- Reuses the Phase-0a/2 mint (`signAccessToken`) + registered-mint discipline (`recordTokenMint` → `validateAccessToken` accepts it, revocation list kills it) verbatim — same machinery as `mintSurfaceGrant`, minus the approval flow (the operator minting on their own box IS the governance). A new `created_via: "surface_token"` tags deploy tokens as a distinct class. `mint`/`list`/`revoke` require the operator token to carry `parachute:host:auth` (same gate as `auth mint-token`).

**2. The remote-client git-config mechanism (git-native, no `gh`).**
- `scripts/git-credential-parachute` — static helper: reads `$PARACHUTE_SURFACE_TOKEN`, emits `x-access-token:<token>` (Basic, accepted by the endpoint's `extractToken`). Any git, any box, no parachute install. Same credential shape as Phase 2's askpass, generalized to a static secret.
- The mint output prints the zero-file inline `credential.helper '!f(){…}'` form (the "just works" one-liner) + the token-in-URL leak is flagged, never recommended.

**3. Docs** — the remote-agent flow lands in the design doc (separate PR in `parachute.computer`, `ag-surface-deploy-token-docs`).

## The one-liner an operator gives a remote agent

```bash
export PARACHUTE_SURFACE_TOKEN=<the-token>
git config --global credential.helper \
  '!f() { test "$1" = get && printf "username=x-access-token\npassword=%s\n" "$PARACHUTE_SURFACE_TOKEN"; }; f'
git clone https://<hub-origin>/git/<name> && cd <name> && git push
```

## Security posture

Scoped to ONE surface + one verb, registered + revocable (list/kill like GitHub PAT management), fixed-TTL (default 90d, re-mint to renew) — a deploy-key, not a master key (even a push builds in surface-host's sandbox, Phase 0c). Token lives in env/helper, never `.git/config`. No existing auth weakened; `resolveHubIssuer` was hoisted to `src/hub-issuer.ts` with **no behavior change** to `auth.ts`.

## Tests & gates

- Real `git push` via the shipped credential helper: mint (via the command) → push succeeds → revoke → next push rejected; a `:read` token can't push (403).
- Lib unit tests (mint/list/revoke, fail-closed on non-deploy-token jti) + command tests (UX, errors, pipe purity, `--json`).
- **hub gate: 4110 pass / 1 skip / 0 fail**; `bun run typecheck` + `biome check` clean. Sandboxed CLI smoke (fresh `PARACHUTE_HOME`) verified mint/list/revoke/idempotency.
- Version: `0.7.5-rc.4 → rc.5`.

Design: `parachute.computer/design/2026-06-30-surface-git-transport.md` §6b Phase-3a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01T6HAzWsgiJy4ndsWSCWY5S