### PR TITLE
release: hub 0.7.5 (@latest promotion)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.5-rc.5",
+  "version": "0.7.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Graduates the **0.7.5-rc.5** chain to a stable **@latest** release: drops the `-rc` suffix, keeps the same patch number.

## What ships
The rc chain's headline is the **Surface Git Transport hub substrate** (Phases 0a–3a): authenticated git smart-HTTP endpoint (#727), push→notify hand-off to surface-host (#728), surface→repo registry + declared-surface gate (#729), the `surface` grant kind (#730), and surface deploy tokens (#731).

## Why now
Aaron's call (2026-07-01): promote all libraries to @latest to **mark the baseline** before the upcoming coherence-cleanup batch (from the 2026-07-01 ecosystem review) lands as one clean upgrade.

## Diff
- `package.json`: `0.7.5-rc.5` → `0.7.5` (version line only)
- `bun.lock`: unchanged — root workspace version isn't tracked in the lockfile.

## Gates
- `bun install --frozen-lockfile` — no changes
- `bun run typecheck` — clean (tsc --noEmit, exit 0)
- Full test suite: PR CI (not run locally — the hub suite can boot out the live daemon on this box)

After merge: push `v0.7.5` → CI publishes `@latest` with provenance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB