### PR TITLE
chore(hub): Fable-cleanup slice — retire runner from offer surfaces, TTL assert, versioned state files (0.7.6-rc.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.5",
+  "version": "0.7.6-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/admin-module-token.test.ts
+++ b/src/__tests__/admin-module-token.test.ts
@@ -7,7 +7,7 @@
  *   - 401 when the cookie names a deleted session.
  *   - 405 on POST.
  *   - 200 + JWT carrying `aud: "<short>"` and `<short>:admin` for known modules
- *     (scribe / runner / surface).
+ *     (scribe / surface / agent).
  *   - 400 for `vault` (per-instance — points at /admin/vault-admin-token/<name>).
  *   - 404 for an unknown short.
  *   - First-admin gate: 403 for a signed-in non-first-admin (friend).
@@ -111,8 +111,10 @@ describe("handleModuleToken", () => {
   });
 
   // The known single-audience modules the generic mint serves. Each gets
-  // `<short>:admin` with `aud: <short>`.
-  for (const short of ["scribe", "runner", "surface", "agent"]) {
+  // `<short>:admin` with `aud: <short>`. (runner left this set with its
+  // 2026-07-01 registry removal — a LEGACY install still mints via the
+  // self-registration gate, pinned below.)
+  for (const short of ["scribe", "surface", "agent"]) {
     test(`200 mints a JWT carrying aud:${short} + ${short}:admin`, async () => {
       const { cookie, userId } = await withSession();
       rotateSigningKey(harness.db);
@@ -200,6 +202,41 @@ describe("handleModuleToken", () => {
     );
     return dir;
   }
+
+  test("200 mints for a LEGACY runner install via the self-registration gate (registry removal 2026-07-01)", async () => {
+    // runner is no longer a known short, so path 2 (bootstrap registry) is
+    // gone — but an existing install that self-registered (row + module.json)
+    // keeps minting `runner:admin` through path 1, exactly like a third-party
+    // module. Its config UI keeps working post-removal.
+    const { cookie } = await withSession();
+    rotateSigningKey(harness.db);
+    const installDir = writeManifestDir("parachute-runner");
+    try {
+      const services: ServiceEntry[] = [
+        {
+          name: "parachute-runner",
+          port: 1945,
+          paths: ["/runner"],
+          health: "/runner/healthz",
+          version: "0.2.0",
+          installDir,
+        },
+      ];
+      // The row matches by its literal services.json name (the third-party
+      // convention) — `runner` the bare short no longer resolves anywhere.
+      const req = new Request(urlFor("parachute-runner"), { headers: { cookie } });
+      const res = await handleModuleToken(req, "parachute-runner", depsWith(services));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { scopes: string[] };
+      expect(body.scopes).toEqual(["parachute-runner:admin"]);
+      // The bare `runner` short 404s — nothing known + no row named "runner".
+      const bareReq = new Request(urlFor("runner"), { headers: { cookie } });
+      const bareRes = await handleModuleToken(bareReq, "runner", depsWith(services));
+      expect(bareRes.status).toBe(404);
+    } finally {
+      rmSync(installDir, { recursive: true, force: true });
+    }
+  });
 
   test("200 mints for a self-registered third-party module (row + readable module.json)", async () => {
     const { cookie, userId } = await withSession();

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -218,9 +218,9 @@ describe("parseModulesPath", () => {
       short: "agent",
       rest: "install",
     });
-    // Other known modules (runner / surface) resolve too.
-    expect(parseModulesPath("/api/modules/runner/install")).toEqual({
-      short: "runner",
+    // Other known modules (surface) resolve too.
+    expect(parseModulesPath("/api/modules/surface/install")).toEqual({
+      short: "surface",
       rest: "install",
     });
   });
@@ -231,6 +231,11 @@ describe("parseModulesPath", () => {
     // module-ops switch never acts on them.
     expect(parseModulesPath("/api/modules/hub/install")).toBeUndefined();
     expect(parseModulesPath("/api/modules/random/install")).toBeUndefined();
+    // runner left the registries on 2026-07-01 — module-ops no longer
+    // addresses it by short, same as any third-party module. (A legacy
+    // install still boots under `parachute serve` via its installDir; see
+    // serve-boot tests.)
+    expect(parseModulesPath("/api/modules/runner/install")).toBeUndefined();
   });
 
   test("rejects malformed paths", () => {

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -222,10 +222,11 @@ describe("GET /api/modules", () => {
     // by the UNION of the bootstrap registries (KNOWN_MODULES ∪
     // FIRST_PARTY_FALLBACKS), NOT a curated whitelist. Every known module
     // surfaces — core (vault/scribe/surface) in the headline tier, agent as
-    // `experimental`, and notes/runner as `deprecated` (2026-06-25, still
+    // `experimental`, and notes as `deprecated` (2026-06-25, still
     // resolvable but not offered for fresh installs) — so the agent-not-installed
     // class (running but invisible) can't recur while deprecated modules stop
-    // being pushed on a fresh box.
+    // being pushed on a fresh box. runner left the registries entirely on
+    // 2026-07-01 and must NOT surface on a fresh catalog.
     const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
     const res = await handleApiModules(getReq({ authorization: `Bearer ${bearer}` }), {
       db: h.db,
@@ -250,31 +251,31 @@ describe("GET /api/modules", () => {
     // ahead of every experimental module, which lead the deprecated ones.
     expect(shorts.indexOf("vault")).toBeLessThan(shorts.indexOf("scribe"));
     expect(shorts.indexOf("scribe")).toBeLessThan(shorts.indexOf("agent"));
-    // agent (experimental) sorts ahead of notes/runner (deprecated).
-    expect(shorts.indexOf("agent")).toBeLessThan(shorts.indexOf("runner"));
+    // agent (experimental) sorts ahead of notes (deprecated).
     expect(shorts.indexOf("agent")).toBeLessThan(shorts.indexOf("notes"));
     // Every known module is discoverable — vault/scribe/surface (core),
-    // agent (experimental), notes/runner (deprecated).
-    for (const s of ["vault", "scribe", "surface", "agent", "runner", "notes"]) {
+    // agent (experimental), notes (deprecated). runner is gone (2026-07-01
+    // registry removal) — a fresh box never sees it.
+    for (const s of ["vault", "scribe", "surface", "agent", "notes"]) {
       expect(shorts).toContain(s);
     }
+    expect(shorts).not.toContain("runner");
+    expect(shorts).not.toContain("parachute-runner");
     // Focus tier resolves from the default map.
     const byShort = new Map(body.modules.map((m) => [m.short, m]));
     expect(byShort.get("vault")?.focus).toBe("core");
     expect(byShort.get("scribe")?.focus).toBe("core");
     expect(byShort.get("surface")?.focus).toBe("core");
     expect(byShort.get("agent")?.focus).toBe("experimental");
-    expect(byShort.get("runner")?.focus).toBe("deprecated");
     expect(byShort.get("notes")?.focus).toBe("deprecated");
     // `available` stays true for every known module (re-installable), but the
     // fresh-install OFFER (`available_to_install`) drops the deprecated tier —
-    // notes/runner aren't pushed on a fresh box; agent (experimental) still is.
+    // notes isn't pushed on a fresh box; agent (experimental) still is.
     expect(body.modules.every((m) => m.available)).toBe(true);
     expect(byShort.get("vault")?.available_to_install).toBe(true);
     expect(byShort.get("scribe")?.available_to_install).toBe(true);
     expect(byShort.get("surface")?.available_to_install).toBe(true);
     expect(byShort.get("agent")?.available_to_install).toBe(true);
-    expect(byShort.get("runner")?.available_to_install).toBe(false);
     expect(byShort.get("notes")?.available_to_install).toBe(false);
     expect(body.modules.every((m) => !m.installed)).toBe(true);
     expect(body.modules.every((m) => m.latest_version === "0.9.9")).toBe(true);
@@ -282,11 +283,13 @@ describe("GET /api/modules", () => {
     expect(body.supervisor_available).toBe(false);
   });
 
-  test("an installed deprecated module (runner) still surfaces for management but is not offered for fresh install (2026-06-25)", async () => {
-    // A legacy operator with runner on disk: the row must remain visible
-    // (installed: true) + manageable, in the `deprecated` tier — but
-    // `available_to_install` is false so the SPA's install catalog won't push
-    // it. Mirrors the notes-daemon back-compat posture.
+  test("an installed LEGACY runner row still surfaces as a third-party row post-registry-removal (2026-07-01)", async () => {
+    // A legacy operator with runner on disk: post-removal the row no longer
+    // resolves to a known short, so it surfaces under its own manifest name
+    // (`parachute-runner`) exactly like a third-party module — visible
+    // (installed: true), never offered (`available` false: no install package
+    // known to the hub), and NEVER crashes the catalog. This is the graceful
+    // existing-install posture the removal preserves.
     writeManifest(h.manifestPath, [
       {
         name: "parachute-runner",
@@ -313,13 +316,18 @@ describe("GET /api/modules", () => {
         available_to_install: boolean;
       }>;
     };
-    const runner = body.modules.find((m) => m.short === "runner");
+    // No known short resolves anymore — the row surfaces under its own
+    // manifest name, the third-party fallback convention.
+    expect(body.modules.find((m) => m.short === "runner")).toBeUndefined();
+    const runner = body.modules.find((m) => m.short === "parachute-runner");
     expect(runner).toBeDefined();
     expect(runner?.installed).toBe(true);
     expect(runner?.installed_version).toBe("0.2.0");
-    expect(runner?.focus).toBe("deprecated");
-    // Still hub-installable (re-install path) but NOT offered fresh.
-    expect(runner?.available).toBe(true);
+    // Unlisted shorts default to the experimental tier (no special-casing
+    // survives the removal).
+    expect(runner?.focus).toBe("experimental");
+    // No install package known to the hub → not installable, never offered.
+    expect(runner?.available).toBe(false);
     expect(runner?.available_to_install).toBe(false);
   });
 

--- a/src/__tests__/connections-store.test.ts
+++ b/src/__tests__/connections-store.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tests for the connections registry store (`connections.json`,
+ * `connections-store.ts`). The store's behavior is otherwise exercised
+ * indirectly through `admin-connections.test.ts`; this file pins the on-disk
+ * shape directly — specifically the `version` field added 2026-07-01 (the
+ * future-migration seam) and the legacy-file tolerance that makes it safe.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  CONNECTIONS_FILE_VERSION,
+  type ConnectionRecord,
+  getConnection,
+  putConnection,
+  readConnections,
+  removeConnection,
+} from "../connections-store.ts";
+
+let dir: string;
+let storePath: string;
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "phub-connections-store-"));
+  storePath = join(dir, "connections.json");
+});
+afterEach(() => {
+  rmSync(dir, { recursive: true, force: true });
+});
+
+function rec(over: Partial<ConnectionRecord> = {}): ConnectionRecord {
+  return {
+    id: over.id ?? "conn-1",
+    source: over.source ?? { module: "vault", vault: "default", event: "note.created" },
+    sink: over.sink ?? { module: "agent", action: "message.deliver" },
+    provisioned: over.provisioned ?? { type: "vault-trigger", triggerName: "t1", vault: "default" },
+    createdAt: over.createdAt ?? "2026-07-01T00:00:00.000Z",
+  };
+}
+
+describe("file versioning (2026-07-01 — future-migration seam)", () => {
+  test("every write stamps version: 1 and put → read round-trips", () => {
+    putConnection(storePath, rec());
+    const onDisk = JSON.parse(readFileSync(storePath, "utf8")) as { version?: unknown };
+    expect(onDisk.version).toBe(CONNECTIONS_FILE_VERSION);
+    expect(onDisk.version).toBe(1);
+    const back = readConnections(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]).toEqual(rec());
+    // Rewrites (upsert + remove) keep stamping it.
+    putConnection(storePath, rec({ id: "conn-2" }));
+    removeConnection(storePath, "conn-1");
+    const after = JSON.parse(readFileSync(storePath, "utf8")) as {
+      version?: unknown;
+      connections: unknown[];
+    };
+    expect(after.version).toBe(1);
+    expect(after.connections).toHaveLength(1);
+  });
+
+  test("a LEGACY file without version loads fine (treated as v1)", () => {
+    const legacy = rec();
+    writeFileSync(storePath, JSON.stringify({ connections: [legacy] }));
+    const back = readConnections(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]).toEqual(legacy);
+    expect(getConnection(storePath, legacy.id)?.id).toBe(legacy.id);
+    // First write-through upgrades the file to the versioned shape without
+    // losing the legacy record.
+    putConnection(storePath, rec({ id: "conn-2" }));
+    const upgraded = JSON.parse(readFileSync(storePath, "utf8")) as {
+      version?: unknown;
+      connections: unknown[];
+    };
+    expect(upgraded.version).toBe(1);
+    expect(upgraded.connections).toHaveLength(2);
+  });
+
+  test("a missing or garbage file still reads as empty (fresh hub)", () => {
+    expect(readConnections(storePath)).toEqual([]);
+    writeFileSync(storePath, "not-json{");
+    expect(readConnections(storePath)).toEqual([]);
+  });
+});

--- a/src/__tests__/git-notify.test.ts
+++ b/src/__tests__/git-notify.test.ts
@@ -2,7 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { notifySurfacePushed } from "../git-notify.ts";
+import { REGISTERED_MINT_TTL_THRESHOLD_SECONDS } from "../admin-connections.ts";
+import {
+  NOTIFY_TTL_SECONDS,
+  PULL_TTL_SECONDS,
+  assertUnregisteredMintTtl,
+  notifySurfacePushed,
+} from "../git-notify.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { validateAccessToken } from "../jwt-sign.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
@@ -36,6 +42,28 @@ function fetchSpy(status = 200, body = '{"ok":true}') {
   }) as unknown as typeof fetch;
   return { impl, calls };
 }
+
+describe("unregistered-mint TTL policy guard", () => {
+  test("the shipped TTLs sit strictly under the registered-mint threshold", () => {
+    // The import of git-notify.ts at the top of this file already ran the
+    // module-load asserts — reaching here means they passed. Pin the values
+    // explicitly too, so a bumped TTL fails with a readable diff.
+    expect(NOTIFY_TTL_SECONDS).toBeLessThan(REGISTERED_MINT_TTL_THRESHOLD_SECONDS);
+    expect(PULL_TTL_SECONDS).toBeLessThan(REGISTERED_MINT_TTL_THRESHOLD_SECONDS);
+  });
+
+  test("the guard throws at/above the threshold and passes just under it", () => {
+    expect(() =>
+      assertUnregisteredMintTtl("PULL_TTL_SECONDS", REGISTERED_MINT_TTL_THRESHOLD_SECONDS),
+    ).toThrow(/registered-mint/);
+    expect(() =>
+      assertUnregisteredMintTtl("PULL_TTL_SECONDS", REGISTERED_MINT_TTL_THRESHOLD_SECONDS + 1),
+    ).toThrow(/PULL_TTL_SECONDS/);
+    expect(() =>
+      assertUnregisteredMintTtl("NOTIFY_TTL_SECONDS", REGISTERED_MINT_TTL_THRESHOLD_SECONDS - 1),
+    ).not.toThrow();
+  });
+});
 
 describe("notifySurfacePushed", () => {
   test("no surface module installed → no-op, no fetch", async () => {

--- a/src/__tests__/grants-store.test.ts
+++ b/src/__tests__/grants-store.test.ts
@@ -7,11 +7,12 @@
  * the lenient-read posture.
  */
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { mkdtempSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type ConnectionSpec,
+  GRANTS_FILE_VERSION,
   type GrantRecord,
   connectionKey,
   getGrant,
@@ -90,6 +91,37 @@ describe("round-trip", () => {
     expect(listGrantsForAgent(storePath, "agentone")).toHaveLength(1);
     expect(listGrantsForAgent(storePath, "AGENTTWO")).toHaveLength(1);
     expect(listGrantsForAgent(storePath, "nope")).toHaveLength(0);
+  });
+});
+
+describe("file versioning (2026-07-01 — future-migration seam)", () => {
+  test("every write stamps version: 1 and a rewrite preserves it", () => {
+    putGrant(storePath, rec());
+    const first = JSON.parse(readFileSync(storePath, "utf8")) as { version?: unknown };
+    expect(first.version).toBe(GRANTS_FILE_VERSION);
+    expect(first.version).toBe(1);
+    // Round-trip through the store API keeps stamping it.
+    putGrant(storePath, rec({ id: "second", agent: "agent2" }));
+    const second = JSON.parse(readFileSync(storePath, "utf8")) as { version?: unknown };
+    expect(second.version).toBe(1);
+    expect(readGrants(storePath)).toHaveLength(2);
+  });
+
+  test("a LEGACY file without version loads fine (treated as v1)", () => {
+    const legacy = rec();
+    writeFileSync(storePath, JSON.stringify({ grants: [legacy] }));
+    const back = readGrants(storePath);
+    expect(back).toHaveLength(1);
+    expect(back[0]).toEqual(legacy);
+    // First write-through upgrades the file to the versioned shape without
+    // losing the legacy record.
+    putGrant(storePath, rec({ id: "new-row", agent: "agent2" }));
+    const upgraded = JSON.parse(readFileSync(storePath, "utf8")) as {
+      version?: unknown;
+      grants: unknown[];
+    };
+    expect(upgraded.version).toBe(1);
+    expect(upgraded.grants).toHaveLength(2);
   });
 });
 

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -34,6 +34,34 @@ describe("install", () => {
     }
   });
 
+  test("refuses `install runner` with a retirement message — never bun-adds npm's unrelated `runner` package (2026-07-01)", async () => {
+    const { path, cleanup } = makeTempPath();
+    try {
+      const calls: string[][] = [];
+      const logs: string[] = [];
+      const code = await install("runner", {
+        runner: async (cmd) => {
+          calls.push([...cmd]);
+          return 0;
+        },
+        manifestPath: path,
+        startService: async () => 0,
+        isLinked: () => false,
+        portProbe: async () => false,
+        log: (l) => logs.push(l),
+      });
+      expect(code).toBe(1);
+      // The load-bearing bit: no `bun add -g runner` ever fires. Without the
+      // retired-short guard the bare short falls through the npm arm and
+      // installs an unrelated package that happens to be named `runner`.
+      expect(calls).toEqual([]);
+      expect(logs.join("\n")).toMatch(/retired from the hub's module registry/);
+      expect(logs.join("\n")).toMatch(/@openparachute\/runner/);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("runs bun add -g then init; seeds manifest when service didn't write one", async () => {
     const { path, cleanup } = makeTempPath();
     try {

--- a/src/__tests__/serve-boot.test.ts
+++ b/src/__tests__/serve-boot.test.ts
@@ -333,6 +333,66 @@ describe("bootSupervisedModules", () => {
     expect(recorder.calls).toEqual([]);
     expect(logs.some((l) => l.includes("no startCmd resolvable"))).toBe(true);
   });
+
+  test("a LEGACY parachute-runner row boots gracefully post-registry-removal (2026-07-01)", async () => {
+    // runner left the bootstrap registries (decision: Aaron 2026-07-01 — the
+    // module set of record is vault / hub / agent / scribe / surface). An
+    // existing operator's services.json still carries the row, and it must
+    // take the unknown/third-party path, never crash the boot sweep:
+    //   - with installDir + module.json → spawned via the module's own
+    //     declared startCmd (third-party convention);
+    //   - without installDir → logged + skipped (`no-spec`).
+    const installDir = join(h.dir, "runner-install");
+    mkdirSync(join(installDir, ".parachute"), { recursive: true });
+    writeFileSync(
+      join(installDir, ".parachute", "module.json"),
+      JSON.stringify({
+        name: "runner",
+        manifestName: "parachute-runner",
+        port: 1945,
+        paths: ["/runner", "/.parachute"],
+        health: "/runner/healthz",
+        startCmd: ["parachute-runner", "serve"],
+      }),
+    );
+    const withInstallDir: ServiceEntry = {
+      name: "parachute-runner",
+      port: 1945,
+      paths: ["/runner", "/.parachute"],
+      health: "/runner/healthz",
+      version: "0.2.0",
+      installDir,
+    };
+    writeManifest({ services: [withInstallDir] }, h.manifestPath);
+    const recorder = makeRecorder();
+    const sup = new Supervisor({ spawnFn: recorder.spawn });
+    const results = await bootSupervisedModules(sup, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0]?.status).toBe("started");
+    // The short is the row name now (no registry mapping survives), and the
+    // spawn cmd comes from the module's OWN module.json.
+    expect(results[0]?.short).toBe("parachute-runner");
+    expect(recorder.calls[0]?.cmd).toEqual(["parachute-runner", "serve"]);
+
+    // Same row WITHOUT installDir: skipped with reason, no crash.
+    const { installDir: _drop, ...bare } = withInstallDir;
+    writeManifest({ services: [bare] }, h.manifestPath);
+    const recorder2 = makeRecorder();
+    const sup2 = new Supervisor({ spawnFn: recorder2.spawn });
+    const logs: string[] = [];
+    const results2 = await bootSupervisedModules(sup2, {
+      manifestPath: h.manifestPath,
+      configDir: h.dir,
+      log: (l) => logs.push(l),
+    });
+    expect(results2).toHaveLength(1);
+    expect(results2[0]?.status).toBe("skipped");
+    expect(results2[0]?.reason).toBe("no-spec");
+    expect(recorder2.calls).toEqual([]);
+  });
 });
 
 // agent (then channel)#41 — a transiently-wrong (drifted) services.json port for a

--- a/src/__tests__/service-spec-discovery.test.ts
+++ b/src/__tests__/service-spec-discovery.test.ts
@@ -6,6 +6,7 @@ import {
   findServiceByShort,
   focusForShort,
   isKnownModuleShort,
+  shortNameForManifest,
 } from "../service-spec.ts";
 
 // 2026-06-09 modular-UI architecture (P2): discovery is driven by the union of
@@ -26,7 +27,7 @@ describe("discoverableShorts", () => {
 
   test("includes agent (the module the whitelist used to hide) + the core set", () => {
     const shorts = discoverableShorts();
-    for (const s of ["vault", "scribe", "surface", "runner", "agent", "notes"]) {
+    for (const s of ["vault", "scribe", "surface", "agent", "notes"]) {
       expect(shorts).toContain(s);
     }
   });
@@ -55,10 +56,8 @@ describe("focusForShort", () => {
     expect(focusForShort("surface")).toBe("core");
     // agent stays a legit experimental preview — still offered on a fresh install.
     expect(focusForShort("agent")).toBe("experimental");
-    // notes (notes-daemon, deprecated 2026-05-22) + runner (per Aaron
-    // 2026-06-25, not for new installs) are `deprecated`: still resolvable +
-    // shown-if-installed, but NOT offered on a fresh setup.
-    expect(focusForShort("runner")).toBe("deprecated");
+    // notes (notes-daemon, deprecated 2026-05-22) is `deprecated`: still
+    // resolvable + shown-if-installed, but NOT offered on a fresh setup.
     expect(focusForShort("notes")).toBe("deprecated");
   });
 
@@ -74,18 +73,42 @@ describe("focusForShort", () => {
   test("deprecated shorts stay resolvable (discoverable) — back-compat for existing installs", () => {
     // The deprecated tier de-emphasizes + drops the fresh-install OFFER; it does
     // NOT remove the short from the resolution surface, so an existing
-    // notes/runner install keeps routing + lifecycle.
+    // notes install keeps routing + lifecycle.
     const shorts = discoverableShorts();
     expect(shorts).toContain("notes");
-    expect(shorts).toContain("runner");
     expect(isKnownModuleShort("notes")).toBe(true);
-    expect(isKnownModuleShort("runner")).toBe(true);
+  });
+});
+
+// Runner registry removal (decision: Aaron 2026-07-01 — the module set of
+// record is vault / hub / agent / scribe / surface). Runner is fully out of
+// the bootstrap registries: not discoverable, not a known short, and its
+// manifest name no longer resolves. It is NOT in RETIRED_MODULES (that would
+// GC a legacy operator's services.json row on load) — an existing install is
+// handled as an unknown/third-party row instead (see serve-boot tests).
+describe("runner registry removal (2026-07-01)", () => {
+  test("runner is no longer a known/discoverable short", () => {
+    expect(isKnownModuleShort("runner")).toBe(false);
+    expect(discoverableShorts()).not.toContain("runner");
+    expect("runner" in KNOWN_MODULES).toBe(false);
+    expect("runner" in FIRST_PARTY_FALLBACKS).toBe(false);
+  });
+
+  test("parachute-runner no longer resolves to a short — legacy rows are third-party-shaped", () => {
+    // Consumers (status / serve-boot / api-modules) fall back to the row's
+    // own name when this returns undefined, which is what keeps an existing
+    // runner install rendering + booting instead of crashing.
+    expect(shortNameForManifest("parachute-runner")).toBeUndefined();
+  });
+
+  test("an unlisted runner short defaults to the experimental tier, like any third-party", () => {
+    expect(focusForShort("runner")).toBe("experimental");
   });
 });
 
 describe("isKnownModuleShort", () => {
   test("true for every known module (the install/config gate)", () => {
-    for (const s of ["vault", "scribe", "surface", "runner", "agent", "notes"]) {
+    for (const s of ["vault", "scribe", "surface", "agent", "notes"]) {
       expect(isKnownModuleShort(s)).toBe(true);
     }
   });

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -119,9 +119,12 @@ describe("isOfferable (fresh-install OFFER, 2026-06-25)", () => {
     expect(isOfferable({ short: "agent", installed: false })).toBe(true);
   });
 
-  test("does NOT offer a deprecated module (notes / runner) on a fresh install", () => {
+  test("does NOT offer a deprecated module (notes) on a fresh install", () => {
     expect(isOfferable({ short: "notes", installed: false })).toBe(false);
-    expect(isOfferable({ short: "runner", installed: false })).toBe(false);
+    // runner is stronger than deprecated now: it left the registries entirely
+    // (2026-07-01), so it never reaches the survey → isOfferable never sees
+    // it. (The bare predicate would say true for an unknown short — the OFFER
+    // gate for runner is `knownServices()` no longer containing it.)
   });
 
   test("never offers an already-installed module regardless of tier", () => {
@@ -137,6 +140,9 @@ describe("setup", () => {
       // Pre-seed every first-party shortname so survey returns all-installed.
       // Distinct canonical ports per service — services-manifest.ts now
       // rejects duplicate ports between distinct services (hub#195).
+      // parachute-runner rides along as a LEGACY row (runner left the
+      // registries 2026-07-01): it must neither block the all-installed exit
+      // nor crash the survey.
       const seeds: Array<{ name: string; port: number }> = [
         { name: "parachute-vault", port: 1940 },
         { name: "parachute-notes", port: 1942 },
@@ -175,12 +181,13 @@ describe("setup", () => {
     }
   });
 
-  test("fresh box: the offered 'Available to install' list excludes deprecated notes/runner (2026-06-25)", async () => {
+  test("fresh box: the offered 'Available to install' list excludes deprecated notes + removed runner", async () => {
     const h = makeHarness();
     try {
       // 'all' picks every OFFERED service. With a clean services.json the survey
-      // sees every known short; the offered filter must drop notes + runner
-      // (deprecated) while keeping vault/scribe/surface/agent. Only vault +
+      // sees every known short; the offered filter must drop notes (deprecated,
+      // 2026-06-25) while runner never even reaches the survey (registry
+      // removal, 2026-07-01) — keeping vault/scribe/surface/agent. Only vault +
       // scribe have pre-install follow-up prompts (vault name, scribe provider);
       // surface + agent have none — so the scripted answers below are complete.
       const availability = scriptedAvailability([
@@ -221,10 +228,57 @@ describe("setup", () => {
   test("an already-installed deprecated module still shows in 'Already installed' + isn't re-offered (back-compat)", async () => {
     const h = makeHarness();
     try {
-      // Legacy operator with runner (deprecated) on disk. It must surface in the
-      // "Already installed" banner (so they know it's there + can manage it via
-      // `parachute <verb> runner`), and must NOT reappear in the fresh-install
-      // OFFER list.
+      // Legacy operator with notes-daemon (deprecated) on disk. It must surface
+      // in the "Already installed" banner (so they know it's there + can manage
+      // it via `parachute <verb> notes`), and must NOT reappear in the
+      // fresh-install OFFER list.
+      upsertService(
+        {
+          name: "parachute-notes",
+          version: "0.3.15",
+          port: 1942,
+          paths: ["/notes"],
+          health: "/notes/health",
+        },
+        h.manifestPath,
+      );
+      const availability = scriptedAvailability([
+        "surface", // pick a still-offered module
+      ]);
+      const code = await setup({
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        log: (l) => h.logs.push(l),
+        availability,
+        installFn: async (short, opts) => {
+          h.calls.push({ short, opts });
+          return 0;
+        },
+      });
+      expect(code).toBe(0);
+      const joined = h.logs.join("\n");
+      // Banner lists notes as already installed…
+      const installedBlock = joined.slice(
+        joined.indexOf("Already installed:"),
+        joined.indexOf("Available to install:"),
+      );
+      expect(installedBlock).toMatch(/\bnotes\b/);
+      // …but notes is NOT in the fresh-install offer.
+      const availableBlock = joined.slice(joined.indexOf("Available to install:"));
+      expect(availableBlock).not.toMatch(/\bnotes\b/);
+      expect(h.calls.map((c) => c.short)).not.toContain("notes");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a LEGACY parachute-runner row doesn't break setup and is never offered (registry removal 2026-07-01)", async () => {
+    const h = makeHarness();
+    try {
+      // runner left the registries entirely — the survey no longer knows the
+      // short, so the row is simply invisible to setup (not in "Already
+      // installed", not in the offer). The load-bearing assertions: setup
+      // still runs to completion and never tries to install runner.
       upsertService(
         {
           name: "parachute-runner",
@@ -250,16 +304,10 @@ describe("setup", () => {
       });
       expect(code).toBe(0);
       const joined = h.logs.join("\n");
-      // Banner lists runner as already installed…
-      const installedBlock = joined.slice(
-        joined.indexOf("Already installed:"),
-        joined.indexOf("Available to install:"),
-      );
-      expect(installedBlock).toMatch(/\brunner\b/);
-      // …but runner is NOT in the fresh-install offer.
       const availableBlock = joined.slice(joined.indexOf("Available to install:"));
       expect(availableBlock).not.toMatch(/\brunner\b/);
       expect(h.calls.map((c) => c.short)).not.toContain("runner");
+      expect(h.calls.map((c) => c.short)).toContain("surface");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/stale-module-units.test.ts
+++ b/src/__tests__/stale-module-units.test.ts
@@ -55,7 +55,7 @@ function joined(calls: string[][]): string[] {
 describe("targetModuleShorts() — known module shorts, never hub/cloudflared", () => {
   test("includes the canonical module shorts and excludes hub", () => {
     const shorts = targetModuleShorts();
-    // The canonical knownServices() set: vault / scribe / runner / surface / notes / channel.
+    // The canonical knownServices() set: vault / scribe / surface / notes / agent.
     expect(shorts).toContain("vault");
     expect(shorts).toContain("scribe");
     expect(shorts).toContain("surface");

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -1797,8 +1797,12 @@ function sessionUser(req: Request, deps: ConnectionsDeps): { userId: string } {
  * the rule found this engine minting ~90-day tokens with no registry row — an
  * unrevocable-by-construction credential (`api-revoke-token` 404s unknown
  * jtis; the revocation list only carries registered jtis).
+ *
+ * Exported so other unregistered-by-policy mint sites (git-notify.ts's
+ * fire-and-forget notify/pull tokens) can statically assert their TTLs stay
+ * under this policy line instead of restating `600` in a comment.
  */
-const REGISTERED_MINT_TTL_THRESHOLD_SECONDS = 10 * 60;
+export const REGISTERED_MINT_TTL_THRESHOLD_SECONDS = 10 * 60;
 
 interface MintSpec {
   scopes: string[];

--- a/src/admin-module-token.ts
+++ b/src/admin-module-token.ts
@@ -4,7 +4,7 @@
  *
  * Why this exists (2026-06-09 modular-UI architecture, P3): modules now own
  * their config/admin UIs and declare `configUiUrl` in `module.json` (scribe
- * `/scribe/admin`, runner `/runner/admin`, surface `/surface/admin/`, …). The
+ * `/scribe/admin`, surface `/surface/admin/`, …). The
  * hub frames/links those surfaces consistently (the Modules page "Configure"
  * action). Each module-owned config UI, served behind the hub proxy to a
  * logged-in portal operator, needs an admin-scoped hub Bearer to call its own
@@ -16,7 +16,7 @@
  *
  * Scope + audience: `<short>:admin`, audience = `<short>` (the bare service
  * prefix). Modules validate the JWT's `aud` against their literal short name
- * (`scribe`, `runner`, `surface`, `agent`) — the same shape `inferAudience`
+ * (`scribe`, `surface`, `agent`) — the same shape `inferAudience`
  * stamps for the public OAuth flow, so a hub-minted and an OAuth-minted admin
  * token are indistinguishable to the module. This mirrors the per-request
  * `<short>:admin` proxy token `api-modules-config.ts` used to mint; the

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -354,13 +354,13 @@ async function authorize(req: Request, deps: ApiModulesOpsDeps): Promise<Respons
  * reach the same spec the API handlers use without duplicating the
  * curated-table lookup.
  *
- * Two source paths (post-FALLBACK-retirement: vault/scribe/runner in
+ * Two source paths (post-FALLBACK-retirement: vault/scribe in
  * hub#310, channel in boundary D3):
  *
  *   - **FIRST_PARTY_FALLBACKS** (notes): vendored manifest is
  *     authoritative pre-install — the embedded `manifest.startCmd` /
  *     `manifest.paths` / etc. drive the install + spawn flow.
- *   - **KNOWN_MODULES** (vault / scribe / runner / channel / surface): no
+ *   - **KNOWN_MODULES** (vault / scribe / agent / surface): no
  *     vendored manifest.
  *     Pre-install we know only the npm package + manifestName + canonical
  *     port + imperative `extras` (init, postInstallFooter, urlForEntry,
@@ -831,7 +831,7 @@ export async function runInstall(
     });
   }
 
-  // KNOWN_MODULES shorts (vault / scribe / runner / channel / surface):
+  // KNOWN_MODULES shorts (vault / scribe / agent / surface):
   // module.json is the canonical source for startCmd. Re-resolve the spec
   // from `<installDir>/.parachute/module.json` when installDir is stamped so
   // the module is authoritative for its own spawn cmd. Falls back to the

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -18,7 +18,7 @@
  * `focus` ("core" | "experimental" | "deprecated") comes from each module's
  * `module.json` when declared, else `focusForShort`'s default map. The SPA
  * groups core first, de-emphasizes experimental, and de-emphasizes
- * `deprecated` (notes-daemon / runner) further — it NEVER hides an installed
+ * `deprecated` (notes-daemon) further — it NEVER hides an installed
  * module (so an existing operator can still manage / uninstall a deprecated
  * one). This is what makes a running, self-registered module (channel) visible
  * + installable; the old `CURATED_MODULES = ["vault","scribe"]` whitelist made
@@ -67,7 +67,7 @@ import {
 } from "./service-spec.ts";
 // `FIRST_PARTY_FALLBACKS` and `KNOWN_MODULES` are both consulted by
 // `lookupModule` below — the former for notes (vendored manifest still
-// required) and the latter for vault/scribe/runner/agent (post-FALLBACK
+// required) and the latter for vault/scribe/agent/surface (post-FALLBACK
 // retirement, hub#310). The local helper hides the split from the rest of
 // this file. `discoverableShorts` enumerates their UNION — the
 // self-registration-driven discovery surface that replaced the old
@@ -83,7 +83,7 @@ import type { ModuleStartError, ModuleState, Supervisor } from "./supervisor.ts"
 /**
  * Resolve a known module to the display + install bootstrap data the admin SPA
  * renders. Reads from FIRST_PARTY_FALLBACKS (notes) first,
- * KNOWN_MODULES (vault / scribe / runner / channel / surface) second.
+ * KNOWN_MODULES (vault / scribe / agent / surface) second.
  *
  * Returns `undefined` if the short is in neither table — a genuinely
  * third-party module discovered only via services.json / the supervisor. The
@@ -249,10 +249,10 @@ interface ModuleWireShape {
    * Discovery tier (2026-06-09 modular-UI architecture; `deprecated` added
    * 2026-06-25). `core` modules render in the headline group; `experimental`
    * modules render in a de-emphasized "Experimental" group; `deprecated`
-   * modules (notes-daemon / runner) render in a further-de-emphasized
+   * modules (notes-daemon) render in a further-de-emphasized
    * "Deprecated" group — never hidden when installed. Resolved from the
    * module's `module.json` `focus` when declared, else `focusForShort`'s
-   * default map (vault/scribe/hub/surface → core, notes/runner → deprecated,
+   * default map (vault/scribe/hub/surface → core, notes → deprecated,
    * others → experimental).
    */
   focus: ModuleFocus;
@@ -269,7 +269,7 @@ interface ModuleWireShape {
    * The fresh-install OFFER (2026-06-25): whether the hub presents this module
    * in the "available to install fresh" set. `available && focus !==
    * "deprecated"`. The SPA's "Install a module" catalog filters on this so
-   * notes-daemon / runner aren't pushed on a fresh box; an already-installed
+   * notes-daemon isn't pushed on a fresh box; an already-installed
    * deprecated module still surfaces (in the Installed section) for management.
    */
   available_to_install: boolean;
@@ -315,8 +315,8 @@ interface ModuleWireShape {
   install_dir: string | null;
   /**
    * Hierarchical sub-units beneath this module (hub#313). Empty when the
-   * module's services.json row doesn't declare `uis` (vault, scribe, notes,
-   * runner today). Used by parachute-app to surface each hosted UI as its
+   * module's services.json row doesn't declare `uis` (vault, scribe, notes
+   * today). Used by parachute-app to surface each hosted UI as its
    * own discoverable sub-row under the App module. Per parachute-app
    * design doc §12.
    */
@@ -336,8 +336,8 @@ interface ModuleWireShape {
    *      the operator UI (App today).
    *   3. Null when the module hasn't declared either field — the SPA
    *      renders a disabled "Open" tooltip (pointing at Configure when
-   *      `config_ui_url` is set — runner's shape today — or "module
-   *      hasn't shipped an admin UI yet" otherwise).
+   *      `config_ui_url` is set — or "module hasn't shipped an admin UI
+   *      yet" otherwise).
    *
    * Always an absolute path on the hub origin (leading `/`) — the SPA
    * navigates same-origin, no need to worry about cross-origin
@@ -660,7 +660,7 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
   // module's manifest-declared `focus` (when installed + declared) wins; else
   // the `focusForShort` default map. Sort: `core` group first (with the
   // CURATED_MODULES recommended-install order floated to the top of that
-  // group), then `experimental`, then `deprecated` (notes / runner) last — the
+  // group), then `experimental`, then `deprecated` (notes) last — the
   // SPA renders the groups; `focus` never hides an installed module.
   const recommendedOrder = new Map<string, number>(
     (CURATED_MODULES as readonly string[]).map((s, i) => [s, i]),
@@ -684,7 +684,7 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
       // package) is not hub-installable → false.
       available: m !== undefined,
       // Fresh-install OFFER (2026-06-25): installable AND not deprecated. A
-      // deprecated short (notes / runner) stays `available` (re-installable
+      // deprecated short (notes) stays `available` (re-installable
       // for back-compat) but is dropped from the offer set so the SPA's
       // "Install a module" catalog doesn't push it on a fresh box.
       available_to_install: m !== undefined && focus !== "deprecated",
@@ -867,7 +867,7 @@ let warnedLegacyVaultAdminCandidate = false;
  *   - `undefined` candidate → `undefined` (the module didn't declare it).
  *   - Absolute http(s) URL → returned verbatim (off-origin escape hatch).
  *   - Leading-`/` path → ORIGIN-ABSOLUTE, returned verbatim. Single-instance
- *     modules (surface, scribe, runner, agent) declare their full hub-origin
+ *     modules (surface, scribe, agent) declare their full hub-origin
  *     path this way (`/surface/admin/`, `/scribe/admin`, `/agent/admin`);
  *     vault's daemon-level surface is `/vault/admin/`.
  *   - Relative path (no leading slash) → MOUNT-JOINED: the per-instance form

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -65,7 +65,7 @@ export type Runner = (cmd: readonly string[]) => Promise<number>;
  * Rationale: the canonical Render deploy ships the hub container from
  * `main` (which tracks the rc chain per governance rule 2). Without this
  * env var the supervisor's `/admin/modules` install API would still
- * resolve `@latest` for vault / app / scribe / runner — leaving a hub-on-rc
+ * resolve `@latest` for vault / surface / scribe — leaving a hub-on-rc
  * cluster bootstrapping its other modules on stable, which silently
  * fragments the cluster's version axis. Setting `PARACHUTE_INSTALL_CHANNEL=rc`
  * at the platform level cascades the rc-ness across every module install,
@@ -135,6 +135,22 @@ export function resolveInstallChannel(opts: {
 const SERVICE_ALIASES: Record<string, string> = {
   lens: "notes",
   channel: "agent",
+};
+
+/**
+ * Former first-party shorts that were RETIRED from the registries (not
+ * renamed — no alias target). Without this guard the bare short would fall
+ * through resolveInstallTarget's "anything else is npm" arm and `bun add -g`
+ * an UNRELATED npm package that happens to share the name (`runner` is a
+ * real, non-Parachute package on npm). Install refuses with the message
+ * instead.
+ */
+const RETIRED_INSTALL_SHORTS: Record<string, string> = {
+  runner:
+    "parachute-runner was retired from the hub's module registry on 2026-07-01 " +
+    "(the module set of record is vault, hub, agent, scribe, surface). " +
+    "An existing install keeps running under `parachute serve`; to install it anyway, " +
+    "pass the explicit npm package name (@openparachute/runner) or a local checkout path.",
 };
 
 export interface InstallOpts {
@@ -625,7 +641,8 @@ async function readInstalledManifest(
  *   - **fallback**: notes / channel still ship a vendored manifest + extras
  *     in FIRST_PARTY_FALLBACKS. Missing `module.json` is non-fatal — the
  *     embedded manifest carries the install through.
- *   - **known**: vault / scribe / runner have retired their FALLBACK entries.
+ *   - **known**: vault / scribe / agent / surface have retired their FALLBACK
+ *     entries (runner had too, before its 2026-07-01 registry removal).
  *     We know the package + manifestName + imperative extras (init,
  *     postInstallFooter, urlForEntry, hasAuth) but NOT the static manifest;
  *     `module.json` is the contract and a missing one is a hard error,
@@ -671,6 +688,15 @@ function resolveInstallTarget(
   // absolute paths pass through unaltered.
   const aliased = SERVICE_ALIASES[input];
   const candidate = aliased ?? input;
+
+  // Retired shorts refuse BEFORE the npm fallback: `install runner` must not
+  // `bun add -g` npm's unrelated `runner` package. Explicit package names /
+  // paths still pass through the arms below.
+  const retiredMessage = RETIRED_INSTALL_SHORTS[candidate];
+  if (retiredMessage !== undefined) {
+    log(`✗ ${retiredMessage}`);
+    return null;
+  }
 
   const fb = FIRST_PARTY_FALLBACKS[candidate];
   if (fb) {
@@ -943,7 +969,7 @@ export async function install(input: string, opts: InstallOpts = {}): Promise<nu
     manifest = installedManifest ?? target.fallback.manifest;
     extras = target.fallback.extras;
   } else if (target.kind === "known-module") {
-    // KNOWN_MODULES shorts (vault / scribe / runner) carry no vendored
+    // KNOWN_MODULES shorts (vault / scribe / agent / surface) carry no vendored
     // manifest (hub#310). The module's own `.parachute/module.json` is the
     // canonical source. When it's unreadable (legacy installs from before
     // module.json shipped, or test fixtures that mock the disk path without

--- a/src/commands/migrate.ts
+++ b/src/commands/migrate.ts
@@ -77,6 +77,11 @@ export const ARCHIVE_PREFIX = ".archive-";
 export function safelistEntries(): Set<string> {
   return new Set<string>([
     ...knownServices(),
+    // `runner` left the registries on 2026-07-01 (module set of record:
+    // vault / hub / agent / scribe / surface) but legacy installs still have
+    // a `~/.parachute/runner/` dir — keep it safelisted so it doesn't count
+    // as unrecognized-root noise in `migrateNotice`.
+    "runner",
     "hub",
     "services.json",
     "expose-state.json",

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -66,7 +66,7 @@ export interface SetupOpts {
  * Survey row. Pre-install we know manifestName + the optional
  * `urlForEntry` quirk (vault wants `/mcp`, scribe wants the bare port); the
  * full ServiceSpec only exists post-install for KNOWN_MODULES shorts
- * (vault / scribe / runner — hub#310). The survey uses just these two
+ * (vault / scribe / … — hub#310). The survey uses just these two
  * fields, so a minimal shape avoids the spec round-trip pre-install.
  */
 interface ServiceChoice {
@@ -110,17 +110,19 @@ function defaultAvailability(): InteractiveAvailability {
 
 /**
  * Survey ALL known first-party shortnames (vault / notes / scribe / agent /
- * runner / surface) regardless of tier — `installed` is true when the service
+ * surface) regardless of tier — `installed` is true when the service
  * has a row in services.json. The fresh-install OFFER is narrowed downstream
  * by `isOfferable` (drops already-installed + `deprecated`-tier shorts —
- * notes / runner); agent (`experimental`) is flagged exploratory in its blurb
+ * notes); agent (`experimental`) is flagged exploratory in its blurb
  * but stays offered. Surveying everything keeps `installed` detection complete
  * (the "already installed" banner still lists a deprecated module an operator
- * has on disk).
+ * has on disk). A legacy `parachute-runner` row is NOT surveyed (runner left
+ * the registries 2026-07-01 — see the KNOWN_MODULES note in service-spec.ts);
+ * like any unknown row it neither blocks setup nor appears in the offer.
  *
  * The full ServiceSpec is only available pre-install for FIRST_PARTY_FALLBACKS
  * shorts (notes — it carries a vendored manifest). KNOWN_MODULES shorts
- * (vault / scribe / runner / agent / surface) ship `.parachute/module.json`
+ * (vault / scribe / agent / surface) ship `.parachute/module.json`
  * and self-register; pre-install we know manifestName + the urlForEntry quirk
  * from `KNOWN_MODULES[short].extras`, which is all the survey/summary needs.
  */
@@ -157,7 +159,7 @@ function surveyServices(manifestPath: string): ServiceChoice[] {
 /**
  * A surveyed service is OFFERED on a fresh setup iff it is not already
  * installed AND its discovery tier is not `deprecated` (2026-06-25). The
- * deprecated tier (notes-daemon, runner) stays resolvable + manageable for an
+ * deprecated tier (notes-daemon) stays resolvable + manageable for an
  * existing install — it just isn't pushed on a fresh box. `agent`
  * (`experimental`) is still offered. Exported so the setup tests can pin the
  * exclusion directly.
@@ -175,11 +177,10 @@ const BLURBS: Record<string, string> = {
   surface: "Parachute UI host — auto-installs Notes on first boot (the recommended UI path)",
   // `app` is the pre-2026-05-27 name for `surface`; kept for any legacy survey row.
   app: "Parachute UI host — auto-installs Notes on first boot (recommended over notes-daemon)",
-  // notes / runner are `deprecated` (not offered on a fresh setup) — these
-  // blurbs only render if a legacy install surfaces them in the survey.
+  // notes is `deprecated` (not offered on a fresh setup) — this blurb only
+  // renders if a legacy install surfaces it in the survey.
   notes: "Notes PWA — web/mobile UI on top of vault (notes-daemon; superseded by `surface`)",
   scribe: "audio transcription for dictation + recordings",
-  runner: "vault-as-job-substrate — scheduled claude -p against vault job notes",
   agent:
     "(exploratory) chat with your Claude Code sessions — a channel per session (renamed from channel)",
 };

--- a/src/connections-store.ts
+++ b/src/connections-store.ts
@@ -113,12 +113,22 @@ export interface ConnectionRecord {
   readonly requestedBy?: string;
 }
 
+/**
+ * On-disk schema version stamped on every write (2026-07-01). Readers treat a
+ * file WITHOUT a `version` field as v1 — every connections.json written before
+ * this field existed is a v1 file, so absence tolerance is the whole
+ * back-compat story. No migration logic exists today; the field is here so a
+ * FUTURE shape change can branch on it instead of sniffing record shapes.
+ */
+export const CONNECTIONS_FILE_VERSION = 1;
+
 interface ConnectionsFile {
+  version: number;
   connections: ConnectionRecord[];
 }
 
 function emptyFile(): ConnectionsFile {
-  return { connections: [] };
+  return { version: CONNECTIONS_FILE_VERSION, connections: [] };
 }
 
 /** Read the store. A missing/garbage file reads as empty (fresh hub). */
@@ -136,6 +146,9 @@ export function readConnections(storePath: string): ConnectionRecord[] {
     return [];
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  // `version` is deliberately NOT validated here: an absent field is a legacy
+  // v1 file (see CONNECTIONS_FILE_VERSION) and there is only one version
+  // today. When v2 lands, this is where the migration branches.
   const arr = (parsed as { connections?: unknown }).connections;
   if (!Array.isArray(arr)) return [];
   // Lenient: drop any malformed row rather than failing the whole read, so one
@@ -156,7 +169,7 @@ export function readConnections(storePath: string): ConnectionRecord[] {
 
 function writeAll(storePath: string, records: ConnectionRecord[]): void {
   mkdirSync(dirname(storePath), { recursive: true });
-  const file: ConnectionsFile = { connections: records };
+  const file: ConnectionsFile = { version: CONNECTIONS_FILE_VERSION, connections: records };
   // Written WITHOUT 0o600 because this file holds NO secrets — the provisioned
   // webhook bearer lives only in the vault trigger's row, never here; records
   // carry source/sink/trigger-name metadata only. Consistent with the default

--- a/src/git-notify.ts
+++ b/src/git-notify.ts
@@ -31,6 +31,7 @@
  * validates when it comes back in over loopback.
  */
 import type { Database } from "bun:sqlite";
+import { REGISTERED_MINT_TTL_THRESHOLD_SECONDS } from "./admin-connections.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 
 /** Provenance identity stamped on the hub-internal notify + pull tokens. */
@@ -43,18 +44,46 @@ const SURFACE_AUDIENCE = "surface";
 /**
  * notify-auth TTL. The POST is fired immediately; a small window covers a
  * momentarily-busy loopback without leaving a usable credential lying around.
+ *
+ * Exported for the TTL-policy guard test only.
  */
-const NOTIFY_TTL_SECONDS = 120;
+export const NOTIFY_TTL_SECONDS = 120;
 
 /**
  * pull-token TTL. Long enough for surface-host to `git clone --depth 1` a
  * source surface right after the notify lands, short enough that a leaked
  * token is near-useless. Both TTLs here MUST stay well under the hub's
- * registered-mint threshold (admin-connections REGISTERED_MINT_TTL_THRESHOLD,
- * 600s) so these fire-and-forget tokens remain unregistered-by-policy — bumping
- * either past it without registering them would leak unrevocable tokens.
+ * registered-mint threshold (`REGISTERED_MINT_TTL_THRESHOLD_SECONDS`, 600s —
+ * imported from admin-connections.ts, where the policy lives) so these
+ * fire-and-forget tokens remain unregistered-by-policy — bumping either past
+ * it without registering them would leak unrevocable tokens. Enforced by
+ * {@link assertUnregisteredMintTtl} at module load, not just this comment.
+ *
+ * Exported for the TTL-policy guard test only.
  */
-const PULL_TTL_SECONDS = 300;
+export const PULL_TTL_SECONDS = 300;
+
+/**
+ * Registered-mint policy guard (hub-module-boundary charter): a TTL minted
+ * WITHOUT a tokens-table registration must stay strictly under the
+ * registered-mint threshold. Throws at module load when a future edit bumps
+ * one of this file's fire-and-forget TTLs to/past the line — turning a silent
+ * "unrevocable token" policy leak into an immediate boot failure.
+ *
+ * Exported for tests; not for reuse as a general validator (registered mint
+ * sites legitimately exceed the threshold — they register the jti instead).
+ */
+export function assertUnregisteredMintTtl(name: string, ttlSeconds: number): void {
+  if (ttlSeconds >= REGISTERED_MINT_TTL_THRESHOLD_SECONDS) {
+    throw new Error(
+      `git-notify: ${name} (${ttlSeconds}s) must stay under the registered-mint threshold (${REGISTERED_MINT_TTL_THRESHOLD_SECONDS}s). Tokens minted here are fire-and-forget and never registered in the tokens table — at/above the threshold they'd be long-lived AND unrevocable. Either shorten the TTL or register the mint (see admin-connections.ts registered-mint rule).`,
+    );
+  }
+}
+
+// Module-load enforcement of the policy the comments above describe.
+assertUnregisteredMintTtl("NOTIFY_TTL_SECONDS", NOTIFY_TTL_SECONDS);
+assertUnregisteredMintTtl("PULL_TTL_SECONDS", PULL_TTL_SECONDS);
 
 /** Bound the notify HTTP call so a wedged surface-host can't hang the caller. */
 const NOTIFY_FETCH_TIMEOUT_MS = 10_000;

--- a/src/grants-store.ts
+++ b/src/grants-store.ts
@@ -143,7 +143,17 @@ export interface GrantRecord {
   readonly approvedAt?: string;
 }
 
+/**
+ * On-disk schema version stamped on every write (2026-07-01). Readers treat a
+ * file WITHOUT a `version` field as v1 — every agent-grants.json written
+ * before this field existed is a v1 file, so absence tolerance is the whole
+ * back-compat story. No migration logic exists today; the field is here so a
+ * FUTURE shape change can branch on it instead of sniffing record shapes.
+ */
+export const GRANTS_FILE_VERSION = 1;
+
 interface GrantsFile {
+  version: number;
   grants: GrantRecord[];
 }
 
@@ -194,7 +204,7 @@ export function grantId(agent: string, spec: ConnectionSpec): string {
 }
 
 function emptyFile(): GrantsFile {
-  return { grants: [] };
+  return { version: GRANTS_FILE_VERSION, grants: [] };
 }
 
 function isConnectionSpec(v: unknown): v is ConnectionSpec {
@@ -221,6 +231,9 @@ export function readGrants(storePath: string): GrantRecord[] {
     return [];
   }
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return [];
+  // `version` is deliberately NOT validated here: an absent field is a legacy
+  // v1 file (see GRANTS_FILE_VERSION) and there is only one version today.
+  // When v2 lands, this is where the migration branches.
   const arr = (parsed as { grants?: unknown }).grants;
   if (!Array.isArray(arr)) return [];
   // Lenient: drop a malformed row rather than failing the whole read (mirrors
@@ -245,7 +258,7 @@ export function readGrants(storePath: string): GrantRecord[] {
 
 function writeAll(storePath: string, records: GrantRecord[]): void {
   mkdirSync(dirname(storePath), { recursive: true });
-  const file: GrantsFile = { grants: records };
+  const file: GrantsFile = { version: GRANTS_FILE_VERSION, grants: records };
   // 0600 — UNLIKE connections.json, this file holds the granted secrets
   // (minted vault tokens + pasted service creds in `material`). `writeFileSync`'s
   // `mode` applies at CREATE time (passed to open(O_CREAT)), so a fresh file is

--- a/src/help.ts
+++ b/src/help.ts
@@ -103,8 +103,8 @@ Flags:
 Environment:
   PARACHUTE_INSTALL_CHANNEL=rc|latest
                             cluster-wide default channel. Lets a Render deploy
-                            running the hub at \`@rc\` cascade rc to vault / app /
-                            scribe / runner installed via the admin SPA — without
+                            running the hub at \`@rc\` cascade rc to vault / surface /
+                            scribe installed via the admin SPA — without
                             an explicit \`--channel\` per call. Loses to \`--channel\`
                             and \`--tag\`. Defaults to \`latest\` when unset.
 
@@ -144,7 +144,7 @@ What it does:
   Fresh-install front door, one command for both laptops AND remote
   servers (EC2, DigitalOcean, Hetzner, any VPS). The admin SPA already
   walks operators through the rest (install vault, set up the admin
-  user, install scribe / runner / app); this command's only job is to
+  user, install scribe / surface); this command's only job is to
   get you to that wizard.
 
   Idempotent — every re-run is safe:

--- a/src/install-source.ts
+++ b/src/install-source.ts
@@ -123,7 +123,7 @@ function packageNameFor(entryName: string): string | undefined {
   if (short === undefined) return undefined;
   const fb = FIRST_PARTY_FALLBACKS[short];
   if (fb) return fb.package;
-  // KNOWN_MODULES (vault / scribe / runner — post hub#310 FALLBACK
+  // KNOWN_MODULES (vault / scribe / agent / surface — post hub#310 FALLBACK
   // retirement) carries the package name without an embedded manifest.
   return KNOWN_MODULES[short]?.package;
 }

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -322,7 +322,7 @@ const NOTES_FALLBACK: FirstPartyFallback = {
  * Indexed by short name (the `parachute install <X>` token).
  *
  * Only notes remains — see the block comment above for the rationale
- * (vault/scribe/runner/agent now self-register and ship their own
+ * (vault/scribe/agent now self-register and ship their own
  * module.json). Other code paths consult both this table AND `KNOWN_MODULES`
  * (which carries the post-self-register-retirement entries) via the helpers
  * in this file (`shortNameForManifest`, `knownServices`, …).
@@ -437,27 +437,17 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
       ],
     },
   },
-  runner: {
-    short: "runner",
-    package: "@openparachute/runner",
-    manifestName: "parachute-runner",
-    canonicalPort: 1945,
-    displayName: "Runner",
-    tagline:
-      "Vault-as-job-substrate engine — spawns claude -p against vault job notes on schedule.",
-    canonicalPaths: ["/runner", "/.parachute"],
-    canonicalHealth: "/runner/healthz",
-    canonicalStripPrefix: false,
-    extras: {
-      // Backward-compat startCmd — same rationale as scribe / vault above.
-      startCmd: () => ["parachute-runner", "serve"],
-      // Runner's HTTP routes (everything past `/healthz`) gate on a
-      // hub-issued JWT carrying `runner:admin` scope (see runner's
-      // `src/auth.ts`). Surfaces in `parachute status` as auth-required by
-      // default, same posture as vault.
-      hasAuth: true,
-    },
-  },
+  // NOTE (2026-07-01): `runner` was REMOVED from this registry (decision:
+  // Aaron 2026-07-01 — the module set of record is vault / hub / agent /
+  // scribe / surface). Runner is no longer offered, installable, or
+  // lifecycle-addressable by short name from the hub's bootstrap registries.
+  // Existing installs stay GRACEFUL: a legacy `parachute-runner` services.json
+  // row is handled exactly like any unknown/third-party row — `parachute
+  // status` renders it (short falls back to the row name), `parachute serve`
+  // boots it via `<installDir>/.parachute/module.json` when installDir is
+  // stamped and logs-and-skips otherwise. Deliberately NOT added to
+  // RETIRED_MODULES: that registry GC-drops rows on load, which would break
+  // routing for operators still running the runner daemon.
   agent: {
     short: "agent",
     package: "@openparachute/agent",
@@ -474,7 +464,7 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
     canonicalStripPrefix: true,
     extras: {
       // Backward-compat startCmd for rows without installDir — same rationale
-      // as scribe / vault / runner. The bare binary IS the daemon (agent's
+      // as scribe / vault. The bare binary IS the daemon (agent's
       // package.json bin maps `parachute-agent` → src/daemon.ts).
       startCmd: () => ["parachute-agent"],
       // Agent gates its endpoints behind hub-issued JWTs (agent:* scopes).
@@ -498,14 +488,14 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
     canonicalHealth: "/surface/healthz",
     canonicalStripPrefix: false,
     extras: {
-      // Backward-compat startCmd — same rationale as scribe / vault / runner
+      // Backward-compat startCmd — same rationale as scribe / vault
       // above. Post-self-register, lifecycle reads module.json's startCmd via
       // `composeKnownModuleSpec` and that path wins.
       startCmd: () => ["parachute-surface", "serve"],
       // Surface's admin + per-UI surfaces gate behind hub-issued JWTs (design
       // doc §6 same-hub auto-trust + scope `surface:admin`). Surfaces in
-      // `parachute status` as auth-required by default, same posture as vault
-      // + runner.
+      // `parachute status` as auth-required by default, same posture as
+      // vault.
       hasAuth: true,
     },
   },
@@ -646,10 +636,11 @@ export function knownServices(): string[] {
  *   - `experimental` — agent (legit preview; still OFFERED on a fresh install)
  *     + any unlisted third-party short.
  *   - `deprecated` — notes (notes-daemon deprecated 2026-05-22; notes-ui moved
- *     into parachute-surface) + runner (per Aaron 2026-06-25: not for new
- *     installs). Still RESOLVABLE (discoverableShorts unchanged) and
- *     SHOWN-IF-INSTALLED so an existing operator can manage/uninstall, but NOT
- *     OFFERED on a fresh setup.
+ *     into parachute-surface). Still RESOLVABLE (discoverableShorts unchanged)
+ *     and SHOWN-IF-INSTALLED so an existing operator can manage/uninstall, but
+ *     NOT OFFERED on a fresh setup. `runner` used to sit here too (deprecated
+ *     2026-06-25) until its full registry removal on 2026-07-01 — see the note
+ *     in KNOWN_MODULES.
  *
  * **Show all installed; never hide** — `focus` groups + labels; the one
  * behavioral lever is the fresh-install OFFER, which drops `deprecated` shorts.
@@ -660,7 +651,6 @@ const FOCUS_DEFAULTS: Record<string, ModuleFocus> = {
   hub: "core",
   surface: "core",
   agent: "experimental",
-  runner: "deprecated",
   notes: "deprecated",
 };
 
@@ -671,7 +661,7 @@ const FOCUS_DEFAULTS: Record<string, ModuleFocus> = {
  * returns undefined — the Modules screen always has a tier to group by.
  *
  * Tier semantics: `core`/`experimental` are both OFFERED on a fresh install;
- * `deprecated` (notes / runner) is NOT offered on a fresh setup but stays
+ * `deprecated` (notes) is NOT offered on a fresh setup but stays
  * resolvable + shown-if-installed (the `isKnownModuleShort` /
  * `discoverableShorts` resolution surface is unchanged). The fresh-install
  * filters in `setup.ts` + `api-modules.ts` consult this tier to drop
@@ -689,14 +679,16 @@ export function focusForShort(short: string, declared?: ModuleFocus): ModuleFocu
  * `CURATED_MODULES` whitelist (2026-06-09 modular-UI architecture, P2): every
  * module the hub can resolve a package/manifest for is discoverable + installable,
  * regardless of `focus` tier. Deduped, with FIRST_PARTY_FALLBACKS shorts first
- * (notes) then KNOWN_MODULES (vault / scribe / runner / agent / surface).
+ * (notes) then KNOWN_MODULES (vault / scribe / agent / surface).
  *
- * `notes` (and `runner`) are intentionally included — still resolvable
- * (vendored fallback / KNOWN_MODULES) for legacy installs; they surface as
- * `deprecated` (2026-06-25) and aren't OFFERED on a fresh install. The
- * fresh-install OFFER (setup wizard + admin SPA) filters by tier
- * (`focus !== "deprecated"`); `discoverableShorts` itself stays the full
- * resolution surface so existing installs keep working.
+ * `notes` is intentionally included — still resolvable (vendored fallback)
+ * for legacy installs; it surfaces as `deprecated` (2026-06-25) and isn't
+ * OFFERED on a fresh install. The fresh-install OFFER (setup wizard + admin
+ * SPA) filters by tier (`focus !== "deprecated"`); `discoverableShorts`
+ * itself stays the full resolution surface so existing installs keep working.
+ * `runner` is NOT here anymore (registry removal 2026-07-01 — see the
+ * KNOWN_MODULES note); a legacy runner install is handled as an
+ * unknown/third-party row.
  */
 export function discoverableShorts(): string[] {
   const seen = new Set<string>();
@@ -750,7 +742,7 @@ export function canonicalPortForManifest(manifestName: string): number | undefin
  * spec with embedded manifest + extras — the vendored manifest is the
  * source of truth pre-install and the install path preserves it through.
  *
- * KNOWN_MODULES shorts (vault / scribe / runner / agent / surface — post
+ * KNOWN_MODULES shorts (vault / scribe / agent / surface — post
  * FALLBACK retirement) return a **minimal** spec carrying `package`, `manifestName`,
  * and the imperative `extras` fields
  * (`init`, `hasAuth`, `urlForEntry`, `postInstallFooter`). They do NOT carry
@@ -860,7 +852,7 @@ const LEGACY_MANIFEST_ALIASES: Record<string, string> = {
 
 /** Short name for a given manifest name, e.g. `parachute-vault` → `vault`.
  *  Consults both FIRST_PARTY_FALLBACKS (notes) and KNOWN_MODULES
- *  (vault / scribe / runner / agent / surface — post-FALLBACK-retirement).
+ *  (vault / scribe / agent / surface — post-FALLBACK-retirement).
  *  Returns undefined for unknown manifests. */
 export function shortNameForManifest(manifestName: string): string | undefined {
   for (const [short, fb] of Object.entries(FIRST_PARTY_FALLBACKS)) {
@@ -887,7 +879,7 @@ export function shortNameForManifest(manifestName: string): string | undefined {
  * here — `shortNameForManifest` only knows the canonical `parachute-vault`, so
  * `findServiceByShort(services, "vault")` returns undefined even when a vault is
  * installed. Vault rows are resolved by mount path via `findVaultUpstream`; this
- * helper is for single-instance modules (agent / scribe / runner / surface).
+ * helper is for single-instance modules (agent / scribe / surface).
  */
 export function findServiceByShort<T extends { name: string }>(
   services: readonly T[],
@@ -901,7 +893,7 @@ export function findServiceByShort<T extends { name: string }>(
  * manifest data the caller has on hand (typically read from
  * `<installDir>/.parachute/module.json`).
  *
- * Used at install-time and lifecycle-time for vault / scribe / runner —
+ * Used at install-time and lifecycle-time for vault / scribe / surface —
  * where hub no longer vendors the manifest (services.json + module.json
  * are authoritative) but still needs the imperative `extras` bits
  * (`init`, `postInstallFooter`, `urlForEntry`, `hasAuth`) the CLI install

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -124,7 +124,7 @@ const UI_AUDIENCE_VALUES: readonly UiAudience[] = ["public", "hub-users", "opera
  * one shot without touching its siblings.
  *
  * Backwards-compat: this is purely additive. Modules that don't use `uis`
- * (vault, scribe, notes, runner today) continue to render as flat rows;
+ * (vault, scribe, notes today) continue to render as flat rows;
  * the field is optional throughout the read + write paths.
  */
 export interface UiSubUnit {

--- a/src/stale-module-units.ts
+++ b/src/stale-module-units.ts
@@ -22,7 +22,7 @@
  * SCOPE + OWNERSHIP SAFETY (the hard constraint): we ONLY ever disable a unit
  * whose name EXACTLY matches `parachute-<short>.service` (systemd) or
  * `computer.parachute.<short>` (launchd) for a KNOWN module short
- * (`knownServices()` — vault / scribe / runner / surface / notes / channel). We
+ * (`knownServices()` — vault / scribe / surface / notes / agent). We
  * NEVER disable an arbitrary or unrecognized unit — an unknown unit is invisible
  * to this sweep by construction (we look up exact names, never enumerate-and-
  * match-loosely). On top of that we EXPLICITLY exclude the units the supervised
@@ -98,7 +98,7 @@ function isProtectedLaunchdLabel(label: string): boolean {
 /**
  * The module shorts whose stale standalone autostart units the sweep targets.
  * Derived from `knownServices()` (the canonical FIRST_PARTY_FALLBACKS +
- * KNOWN_MODULES list — vault / scribe / runner / surface / notes / channel), so
+ * KNOWN_MODULES list — vault / scribe / surface / notes / agent), so
  * a future module is covered automatically. `hub` is deliberately NOT in that
  * list — the hub unit is the supervised model itself; we never disable it. As a
  * defensive double-check we also drop any short whose derived unit name lands in

--- a/src/well-known.ts
+++ b/src/well-known.ts
@@ -88,7 +88,7 @@ export interface WellKnownServicesEntry {
    * Sub-units hosted under this module, surfaced as an array (the on-disk
    * shape is a map; the well-known shape is an array so consumers iterate
    * cleanly). Each entry promotes the map key into `name`. Absent on
-   * modules that don't declare `uis` (vault, scribe, notes, runner today).
+   * modules that don't declare `uis` (vault, scribe, notes today).
    * See `UiSubUnit` in services-manifest.ts + parachute-app design doc §12.
    */
   uis?: WellKnownUiSubUnit[];
@@ -318,8 +318,8 @@ export function buildWellKnown(opts: BuildWellKnownOpts): WellKnownDocument {
       // an array of records so JS consumers iterate cleanly without a second
       // Object.entries round-trip. `name` promotes the map key into a field
       // — same convention as `WellKnownVaultEntry`. Absent on the parent
-      // when the entry doesn't declare `uis`, so vault / notes / scribe /
-      // runner rows stay byte-identical to their pre-#313 shape.
+      // when the entry doesn't declare `uis`, so vault / notes / scribe
+      // rows stay byte-identical to their pre-#313 shape.
       //
       // Emitted on every path of a multi-path entry — today only vault has
       // multi-path entries, and vault doesn't declare `uis` yet, so the


### PR DESCRIPTION
"Fable cleanup" batch on the just-shipped 0.7.5 @latest baseline. Three scoped cleanups + the rc bump.

## 1. Runner retirement from the offer surfaces

Decision (Aaron, 2026-07-01): the module set of record is **vault, hub, agent, scribe, surface**. hub#690's `deprecated` tier had already stopped offering runner on fresh installs; this goes the rest of the way and removes runner from the registries entirely.

**Removed:**
- `KNOWN_MODULES.runner` (`src/service-spec.ts`) — runner is no longer discoverable (`discoverableShorts`), a known short (`isKnownModuleShort`), installable by short, or addressable via module-ops (`/api/modules/runner/<verb>` now falls through like any third-party short).
- `FOCUS_DEFAULTS.runner` — an unlisted short defaults to `experimental`, the standard third-party tier.
- Runner blurb/copy in `setup.ts` + `help.ts`; docstring sweeps across the registry consumers (api-modules, api-modules-ops, install, install-source, stale-module-units, well-known, services-manifest, admin-module-token). Historical references (hub#310 FALLBACK retirement, the parachute-runner#4 self-register fixup, `runner:admin` as a hypothetical-scope example) intentionally left.

**Why not `RETIRED_MODULES`** (the terminal state `app`/`parachute-app` got): that registry GC-drops services.json rows on load — correct for uninstallable modules, wrong here. Operators still running the runner daemon would lose routing until re-register. `notes`' pattern (deprecated-but-registered) is also not the mirror: notes stays registered because the hub itself serves its static shim; runner has no hub-side machinery, so full removal to third-party-shaped handling is the right terminal state.

**How existing installs behave (tested):**
- `parachute serve` — a legacy `parachute-runner` row boots via its own `installDir/.parachute/module.json` (third-party path); without installDir it's logged + skipped (`no-spec`), never fatal. New regression test in `serve-boot.test.ts`.
- `parachute status` — the row renders under its own manifest name (third-party fallback convention); no crash.
- `/api/modules` — the row surfaces `installed: true` under short `parachute-runner`, `available: false`, `available_to_install: false` (test updated to pin the new shape).
- Config UI — the C5 self-registration gate still mints `parachute-runner:admin` for a self-registered install (new test); the bare `runner` short 404s.
- `parachute install runner` — **new `RETIRED_INSTALL_SHORTS` guard** refuses with a retirement message. Without it the bare short fell through resolveInstallTarget's npm arm and would `bun add -g` npm's unrelated `runner` package. Explicit `@openparachute/runner` / local-path installs still pass through.
- `parachute migrate` — `runner` kept in the root safelist explicitly so a legacy `~/.parachute/runner/` dir doesn't become unrecognized-root noise.

## 2. TTL static assert (`src/git-notify.ts`)

`NOTIFY_TTL_SECONDS` (120) / `PULL_TTL_SECONDS` (300) must stay under the 600s registered-mint threshold — previously enforced by comment only. `REGISTERED_MINT_TTL_THRESHOLD_SECONDS` is now **exported** from `admin-connections.ts` (where the policy lives; no import cycle — admin-connections doesn't import git-notify) and `assertUnregisteredMintTtl()` throws **at module load** if either TTL reaches it. Tests pin the guard's throw/pass boundary and the shipped values.

## 3. Versioned state files

`agent-grants.json` (`grants-store.ts`) + `connections.json` (`connections-store.ts`) now stamp `"version": 1` on every write; reads tolerate an absent field (a legacy file is v1 by definition — that tolerance is the whole point). No migration logic; the field exists so a FUTURE shape change can branch on it. Tests: write stamps + round-trips preserve `version: 1`; legacy files without it load fine and upgrade on first write-through (new `connections-store.test.ts`, extended `grants-store.test.ts`).

## 4. Version

`0.7.5` → `0.7.6-rc.1` per governance rule 2 (new rc chain at next-patch).

## Gates

- `bun run typecheck` — clean
- `bun test ./src` (canonical form) — **4124 pass / 1 skip / 0 fail** (4125 tests, 156 files, 39049 expect() calls). No launchctl interaction observed in the run; live hub daemon verified healthy before/after (not restarted).
- `bunx biome check` — 19 errors / 6 warnings, **byte-identical to the origin/main baseline** (all pre-existing in untouched files; the 3 errors this diff initially introduced were fixed)

## Patterns check

- Touches the module-registry/offer surface (module-self-registration.md posture preserved: self-registered rows keep working; only bootstrap-registry presence is withdrawn). Registered-mint rule (hub-module-boundary.md) now compile-enforced at one more mint site. No canonical install-path doc statement changes beyond runner's removal; if a workspace-level migration checklist is wanted for the runner retirement (README/patterns mentions outside this repo), that's a `parachute-patterns/migrations/2026-07-01-runner-retirement.md` follow-up — flagging for the reviewer/owner call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB