### PR TITLE
fix(hub): proxy upstream keep-alive — stop burning an ephemeral port per proxied request (hub#738, 0.7.6-rc.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.6-rc.1",
+  "version": "0.7.6-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -15,6 +15,7 @@ import {
   layerOf,
   parseArgs,
   resolveClientIp,
+  stripHopByHopHeaders,
 } from "../hub-server.ts";
 import { setNotesRedirectDisabled } from "../hub-settings.ts";
 import { clearNotesRedirectLogState } from "../notes-redirect.ts";
@@ -5958,6 +5959,153 @@ describe("substrate trust headers — X-Parachute-Layer / X-Parachute-Client-IP 
       expect(body.layer).toBe("tailnet");
     } finally {
       upstream.stop();
+      h.cleanup();
+    }
+  });
+});
+
+describe("stripHopByHopHeaders (hub#738)", () => {
+  test("drops the standard hop-by-hop set", () => {
+    const h = new Headers({
+      connection: "keep-alive",
+      "keep-alive": "timeout=5",
+      "proxy-authorization": "Basic xxx",
+      te: "trailers",
+      "transfer-encoding": "chunked",
+      upgrade: "h2c",
+      authorization: "Bearer keep-me",
+      "content-type": "application/json",
+    });
+    stripHopByHopHeaders(h);
+    expect(h.has("connection")).toBe(false);
+    expect(h.has("keep-alive")).toBe(false);
+    expect(h.has("proxy-authorization")).toBe(false);
+    expect(h.has("te")).toBe(false);
+    expect(h.has("transfer-encoding")).toBe(false);
+    expect(h.has("upgrade")).toBe(false);
+    // End-to-end headers survive.
+    expect(h.get("authorization")).toBe("Bearer keep-me");
+    expect(h.get("content-type")).toBe("application/json");
+  });
+
+  test("drops headers NAMED in the Connection field-value (RFC 9110 §7.6.1)", () => {
+    const h = new Headers({
+      connection: "close, X-Custom-Hop",
+      "x-custom-hop": "should-go",
+      "x-real-header": "should-stay",
+    });
+    stripHopByHopHeaders(h);
+    expect(h.has("connection")).toBe(false);
+    expect(h.has("x-custom-hop")).toBe(false);
+    expect(h.get("x-real-header")).toBe("should-stay");
+  });
+});
+
+describe("proxy upstream keep-alive (hub#738)", () => {
+  const fakeServer = (address: string) => ({ requestIP: () => ({ address }) });
+
+  function writeUpstreamService(h: Harness, port: number): void {
+    writeManifest(
+      {
+        services: [
+          {
+            name: "keepalive-svc",
+            port,
+            paths: ["/keepalive-svc"],
+            health: "/keepalive-svc/health",
+            version: "0.1.0",
+          },
+        ],
+      },
+      h.manifestPath,
+    );
+  }
+
+  test("200 proxied requests reuse a handful of upstream sockets even when the client sends Connection: close", async () => {
+    // Regression for hub#738: the proxy forwarded the client's hop-by-hop
+    // `Connection: close` verbatim, so Bun opened a FRESH ephemeral socket per
+    // proxied request instead of reusing its per-origin pool → 16k+ TIME_WAIT
+    // → host-wide port exhaustion (the 2026-07-02 incident, amplifying an agent
+    // reconciler 401 loop). We count the distinct client (ephemeral) ports the
+    // upstream sees: a working pool reuses one (occasionally a couple); the bug
+    // produced ~N distinct ports.
+    const seenPorts = new Set<number>();
+    const upstream = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (r, server) => {
+        const ip = server.requestIP(r);
+        if (ip) seenPorts.add(ip.port);
+        return new Response("unauthorized", { status: 401 }); // the incident's 401 loop
+      },
+    });
+    const h = makeHarness();
+    try {
+      writeUpstreamService(h, upstream.port as number);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const N = 200;
+      for (let i = 0; i < N; i++) {
+        const res = await fetcher(
+          req("/keepalive-svc/x", { headers: { connection: "close" } }),
+          fakeServer("127.0.0.1"),
+        );
+        await res.arrayBuffer(); // fully drain so the socket returns to the pool
+      }
+      expect(seenPorts.size).toBeLessThanOrEqual(8);
+    } finally {
+      upstream.stop(true);
+      h.cleanup();
+    }
+  });
+
+  test("a client hang-up mid-stream aborts the upstream fetch (socket released, not left streaming to nobody)", async () => {
+    // Without forwarding req.signal, an aborted client left the upstream
+    // streaming its whole body to a gone client and holding the socket. We
+    // forward the signal so the upstream is torn down (cancel() fires or the
+    // enqueue loop errors) instead of running to completion.
+    let tornDown = false;
+    const upstream = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: () =>
+        new Response(
+          new ReadableStream({
+            async start(controller) {
+              try {
+                for (let i = 0; i < 40; i++) {
+                  controller.enqueue(new TextEncoder().encode(`chunk ${i}\n`));
+                  await Bun.sleep(10);
+                }
+                controller.close();
+              } catch {
+                tornDown = true; // enqueue threw after the peer dropped
+              }
+            },
+            cancel() {
+              tornDown = true; // Bun cancelled the source on disconnect
+            },
+          }),
+          { headers: { "content-type": "text/plain" } },
+        ),
+    });
+    const h = makeHarness();
+    try {
+      writeUpstreamService(h, upstream.port as number);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const ac = new AbortController();
+      const res = await fetcher(
+        req("/keepalive-svc/stream", { signal: ac.signal }),
+        fakeServer("127.0.0.1"),
+      );
+      const reader = res.body!.getReader();
+      await reader.read(); // consume one chunk, then hang up
+      ac.abort();
+      // Full stream is 40 * 10ms = 400ms; wait past it. With the signal
+      // forwarded the upstream tears down early; without, it runs to close.
+      await Bun.sleep(700);
+      expect(tornDown).toBe(true);
+    } finally {
+      upstream.stop(true);
       h.cleanup();
     }
   });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -783,6 +783,52 @@ export function wsCapBucketKey(req: Request, peerAddr: string | null): string {
 }
 
 /**
+ * Hop-by-hop headers (RFC 9110 §7.6.1) — connection-scoped, meaningful only
+ * on a single transport hop. An intermediary MUST NOT forward them, and the
+ * hub is exactly such an intermediary between the client and each loopback
+ * module.
+ *
+ * Forwarding a client's `Connection: close` verbatim was the P0 amplifier in
+ * the 2026-07-02 port exhaustion (hub#738): Bun's fetch honors the forwarded
+ * `Connection: close` and opens a FRESH ephemeral socket per proxied request
+ * instead of reusing its per-origin keep-alive pool. A hot client loop then
+ * converts request volume 1:1 into 30s TIME_WAIT entries (macOS: ~16k
+ * ephemeral ports), exhausting the range and taking out all host outbound.
+ * With these stripped, Bun reuses a handful of pooled sockets to each 127.0.0.1
+ * upstream regardless of what the client sends.
+ */
+const HOP_BY_HOP_HEADERS = [
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+] as const;
+
+/**
+ * Delete hop-by-hop headers from an outgoing proxy header bag (mutates in
+ * place). The `Connection` field-value can NAME further headers to drop
+ * (RFC 9110 §7.6.1 — e.g. `Connection: close, X-Custom`), so those tokens are
+ * collected and deleted before the standard set. WebSocket upgrades never
+ * reach the fetch-based proxy (the Bun-native bridge handles them before
+ * dispatch — see `proxyRequest`'s docstring), so dropping `Upgrade`/`Connection`
+ * here only ever touches non-declaring mounts, which see a plain request.
+ */
+export function stripHopByHopHeaders(headers: Headers): void {
+  const connectionValue = headers.get("connection");
+  if (connectionValue) {
+    for (const token of connectionValue.split(",")) {
+      const named = token.trim().toLowerCase();
+      if (named) headers.delete(named);
+    }
+  }
+  for (const name of HOP_BY_HOP_HEADERS) headers.delete(name);
+}
+
+/**
  * Forward a request to a loopback service on `127.0.0.1:<port>`. By default
  * the incoming pathname + query are preserved verbatim; pass `targetPath` to
  * rewrite the path (e.g. when the caller has stripped a mount prefix because
@@ -847,6 +893,12 @@ async function proxyRequest(
   // Host comes from the requester (tailnet FQDN); the loopback target wants
   // its own. Bun's fetch fills it in when omitted.
   headers.delete("host");
+  // Strip hop-by-hop headers before forwarding (RFC 9110 §7.6.1). Critically
+  // this drops a client-supplied `Connection: close`, which Bun's fetch would
+  // otherwise honor by disabling keep-alive and burning a fresh ephemeral
+  // socket per request — the P0 amplifier in hub#738. Bun refills the
+  // connection framing for the upstream hop itself.
+  stripHopByHopHeaders(headers);
   // Force upstreams to reply with uncompressed bodies. The chrome-strip
   // injector (workstream G) buffers + TextDecoders the HTML response to
   // inject the persistent chrome; without this, a gzip- or br-compressed
@@ -887,6 +939,13 @@ async function proxyRequest(
     method: req.method,
     headers,
     redirect: "manual",
+    // Forward the incoming request's abort signal to the upstream hop. When a
+    // client hangs up mid-response, this aborts the loopback fetch so the
+    // upstream stops streaming to a gone client and its socket is released
+    // back to the pool (or closed) instead of running the full body out and
+    // holding the connection — a secondary socket-retention leak alongside the
+    // TIME_WAIT churn (hub#738). `req.signal` is present on Bun.serve requests.
+    signal: req.signal,
   };
   if (req.method !== "GET" && req.method !== "HEAD") {
     init.body = req.body;
@@ -895,6 +954,14 @@ async function proxyRequest(
   try {
     return await fetch(upstream, init);
   } catch (err) {
+    // Client hung up mid-flight: the upstream fetch was aborted via req.signal
+    // (forwarded above), not an upstream failure. The client is gone, so the
+    // response is discarded — don't run the boot-readiness classifier or
+    // render a "module unreachable" page that would misclassify a normal
+    // disconnect. 499 = client closed request (nginx convention).
+    if (req.signal?.aborted) {
+      return new Response(null, { status: 499 });
+    }
     const msg = err instanceof Error ? err.message : String(err);
     // Classify the failure (transient boot-window vs persistent crash) and
     // render either an HTML page or a JSON error per the request's Accept.


### PR DESCRIPTION
## Problem (hub#738)

The module proxy (`proxyRequest` in `src/hub-server.ts`) copied the incoming request headers to the loopback upstream **verbatim**. When a client sent the hop-by-hop `Connection: close` header, Bun's `fetch` honored it and opened a **fresh ephemeral socket per proxied request** instead of reusing its per-origin keep-alive pool — converting any hot client loop 1:1 into 30s `TIME_WAIT` entries.

In the **2026-07-02 port-exhaustion incident** this was the P0 amplifier: it turned the agent reconciler's 401 loop into a host-wide outbound outage (16,642 `TIME_WAIT`, full ephemeral range).

## Root cause (confirmed by repro, not assumed)

Bun **already pools per-origin**. Reproducing the proxy's exact `fetch` init showed 200 sequential requests reuse **1** pooled socket in every case *except* when the forwarded headers carry `Connection: close`, where Bun opens **200** distinct sockets. The bug was forwarding a connection-scoped header that an intermediary must strip (RFC 9110 §7.6.1) — not a missing pool.

## Fix

- **Strip hop-by-hop headers before forwarding** (`Connection` + the headers it names, `Keep-Alive`, `Proxy-Authenticate`/`Authorization`, `TE`, `Trailer`, `Transfer-Encoding`, `Upgrade`). WebSocket upgrades never reach this fetch-based path (the Bun-native bridge handles them pre-dispatch), so stripping `Upgrade`/`Connection` here only ever touches non-declaring mounts.
- **Forward the incoming request's abort signal** to the upstream fetch, so a client hang-up mid-response tears down the upstream instead of leaving it streaming to a gone client and holding the socket (a secondary retention leak, also confirmed by repro: 30/30 aborted requests left the upstream streaming to completion without this). Client-abort returns `499`, not a misclassified boot-readiness proxy error.

## Tests (regression — verified to FAIL without the fix)

Disabling both fixes flips these red (200 distinct ports; upstream never torn down), so they genuinely pin the bug:

- **200 proxied requests with `Connection: close` reuse ≤ 8 upstream sockets** (the repro-as-regression the issue asked for — counts distinct client ephemeral ports the upstream sees).
- **a client hang-up mid-stream tears down the upstream fetch.**
- **unit coverage for `stripHopByHopHeaders`** (standard set + `Connection`-named tokens dropped; end-to-end headers like `Authorization` preserved).

## Gates

- `bun run typecheck` — clean.
- `bun test ./src` — **4128 pass / 1 skip / 0 fail** (baseline 4124; +4 new).
- No new dependencies. WS/SSE proxy semantics unchanged (no SSE handling exists in hub `src`; the change only touches forwarded **request** headers + abort propagation).

Do not merge — pending the mandatory reviewer pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB