### PR TITLE
feat(hub): loopback-hijack detection — /health instance nonce + self-probe + doctor check (hub#737, 0.7.6-rc.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.6-rc.2",
+  "version": "0.7.6-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/doctor.test.ts
+++ b/src/__tests__/doctor.test.ts
@@ -753,3 +753,134 @@ describe("doctor --fix — canonical-port repair (confirm-gated, idempotent, non
     }
   });
 });
+
+describe("doctor — loopback-hijack check (hub#737)", () => {
+  test("no hub-instance.json → PASS (benign; the Hub check owns 'down') — #717", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      // No instance file seeded, no seams overridden — defaults read the empty
+      // sandbox and short-circuit before any real network/lsof.
+      const { code, checks } = await runDoctor(h, healthyDeps());
+      expect(byName(checks, "loopback-hijack")?.status).toBe("pass");
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("loopback nonce matches ours + single listener → PASS", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({
+          readInstanceRecord: () => ({ instance: "n1", pid: 1, port: 1939, startedAt: "" }),
+          probeLoopbackInstance: async () => ({ reachable: true, status: 200, instance: "n1" }),
+          countHubListeners: () => 1,
+        }),
+      );
+      const c = byName(checks, "loopback-hijack");
+      expect(c?.status).toBe("pass");
+      expect(c?.detail).toContain("instance nonce");
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("loopback nonce MISMATCH → FAIL with lsof/orb remediation + incident ref", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({
+          readInstanceRecord: () => ({ instance: "ours", pid: 1, port: 1939, startedAt: "" }),
+          probeLoopbackInstance: async () => ({
+            reachable: true,
+            status: 200,
+            instance: "rogue-hub",
+          }),
+          countHubListeners: () => 2,
+        }),
+      );
+      const c = byName(checks, "loopback-hijack");
+      expect(c?.status).toBe("fail");
+      expect(c?.detail).toContain("rogue-hub");
+      expect(c?.detail).toContain("2 listeners");
+      expect(c?.detail).toContain("hub#737");
+      expect(c?.fix).toContain("lsof -nP -iTCP:1939 -sTCP:LISTEN");
+      expect(c?.fix).toContain("orb list");
+      expect(code).toBe(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("foreign process answering with NO nonce → FAIL (the OrbStack container-hub shape)", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { checks } = await runDoctor(
+        h,
+        healthyDeps({
+          readInstanceRecord: () => ({ instance: "ours", pid: 1, port: 1939, startedAt: "" }),
+          probeLoopbackInstance: async () => ({ reachable: true, status: 200 }),
+          countHubListeners: () => undefined, // lsof indeterminate — still FAILs on the nonce alone
+        }),
+      );
+      const c = byName(checks, "loopback-hijack");
+      expect(c?.status).toBe("fail");
+      expect(c?.detail).toContain("foreign process");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("nonce matches but a SECOND listener exists → WARN (latent shadow, not FAIL)", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { code, checks } = await runDoctor(
+        h,
+        healthyDeps({
+          readInstanceRecord: () => ({ instance: "n1", pid: 1, port: 1939, startedAt: "" }),
+          probeLoopbackInstance: async () => ({ reachable: true, status: 200, instance: "n1" }),
+          countHubListeners: () => 2,
+        }),
+      );
+      const c = byName(checks, "loopback-hijack");
+      expect(c?.status).toBe("warn");
+      expect(c?.detail).toContain("2 listeners");
+      // WARN never fails the exit code.
+      expect(code).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("record present but loopback unreachable → PASS (defers to the Hub check)", async () => {
+    const h = makeHarness();
+    try {
+      seedCurrentManifest(h.manifestPath);
+      seedOperatorToken(h.configDir);
+      const { checks } = await runDoctor(
+        h,
+        healthyDeps({
+          readInstanceRecord: () => ({ instance: "n1", pid: 1, port: 1939, startedAt: "" }),
+          probeLoopbackInstance: async () => ({ reachable: false }),
+        }),
+      );
+      expect(byName(checks, "loopback-hijack")?.status).toBe("pass");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/hub-instance.test.ts
+++ b/src/__tests__/hub-instance.test.ts
@@ -8,6 +8,7 @@ import {
   type SelfProbeState,
   armHubSelfProbe,
   classifyLoopback,
+  clearHubInstanceFile,
   generateInstanceNonce,
   hijackAlertMessage,
   hubInstancePath,
@@ -75,6 +76,20 @@ describe("nonce + instance file", () => {
       expect(readHubInstanceFile(configDir)).toBeNull(); // malformed
       writeFileSync(hubInstancePath(configDir), JSON.stringify({ port: 1939 }));
       expect(readHubInstanceFile(configDir)).toBeNull(); // no instance field
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("clearHubInstanceFile removes the file (graceful-shutdown hygiene) + no-ops when absent", () => {
+    const { configDir, cleanup } = makeDir();
+    try {
+      writeHubInstanceFile(record(), { configDir });
+      expect(readHubInstanceFile(configDir)).not.toBeNull();
+      clearHubInstanceFile(configDir);
+      expect(readHubInstanceFile(configDir)).toBeNull();
+      // Idempotent — clearing an already-absent file must not throw.
+      expect(() => clearHubInstanceFile(configDir)).not.toThrow();
     } finally {
       cleanup();
     }

--- a/src/__tests__/hub-instance.test.ts
+++ b/src/__tests__/hub-instance.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  type HubInstanceRecord,
+  type LoopbackProbe,
+  type SelfProbeState,
+  armHubSelfProbe,
+  classifyLoopback,
+  generateInstanceNonce,
+  hijackAlertMessage,
+  hubInstancePath,
+  probeLoopbackInstance,
+  readHubInstanceFile,
+  writeHubInstanceFile,
+} from "../hub-instance.ts";
+
+/**
+ * hub#737 loopback-hijack detection. The nonce file is the linchpin — an
+ * external process learns THIS hub's true identity from disk, then compares it
+ * to what a (possibly hijacked) loopback /health returns. Every side effect
+ * (fs, network) is exercised against a tmp dir / injected fetch.
+ */
+
+function makeDir(): { configDir: string; cleanup: () => void } {
+  const dir = mkdtempSync(join(tmpdir(), "parachute-instance-test-"));
+  return { configDir: dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
+}
+
+function record(over: Partial<HubInstanceRecord> = {}): HubInstanceRecord {
+  return {
+    instance: "nonce-1",
+    pid: 4242,
+    port: 1939,
+    startedAt: "2026-07-02T00:00:00.000Z",
+    ...over,
+  };
+}
+
+describe("nonce + instance file", () => {
+  test("generateInstanceNonce yields distinct UUID-shaped values", () => {
+    const a = generateInstanceNonce();
+    const b = generateInstanceNonce();
+    expect(a).not.toBe(b);
+    expect(a).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
+  });
+
+  test("write → read round-trips the record (incl. selfProbe)", () => {
+    const { configDir, cleanup } = makeDir();
+    try {
+      const sp: SelfProbeState = {
+        status: "ok",
+        checkedAt: "2026-07-02T00:01:00.000Z",
+      };
+      expect(writeHubInstanceFile(record({ selfProbe: sp }), { configDir })).toBe(true);
+      const back = readHubInstanceFile(configDir);
+      expect(back?.instance).toBe("nonce-1");
+      expect(back?.port).toBe(1939);
+      expect(back?.pid).toBe(4242);
+      expect(back?.selfProbe?.status).toBe("ok");
+      // Written 0644 (world-readable diagnostic aid, not a secret).
+      const raw = readFileSync(hubInstancePath(configDir), "utf8");
+      expect(raw.endsWith("\n")).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("read returns null on absent / malformed / instance-less files", () => {
+    const { configDir, cleanup } = makeDir();
+    try {
+      expect(readHubInstanceFile(configDir)).toBeNull(); // absent
+      writeFileSync(hubInstancePath(configDir), "not json{");
+      expect(readHubInstanceFile(configDir)).toBeNull(); // malformed
+      writeFileSync(hubInstancePath(configDir), JSON.stringify({ port: 1939 }));
+      expect(readHubInstanceFile(configDir)).toBeNull(); // no instance field
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("write failure is swallowed (returns false, logs) — never throws", () => {
+    const logs: string[] = [];
+    // An un-writable path (a file where a dir must be) forces the mkdir/write to
+    // fail; the helper must degrade, not throw.
+    const { configDir, cleanup } = makeDir();
+    try {
+      const filePath = join(configDir, "blocker");
+      writeFileSync(filePath, "x");
+      const ok = writeHubInstanceFile(record(), {
+        configDir: join(filePath, "nested"),
+        log: (l) => logs.push(l),
+      });
+      expect(ok).toBe(false);
+      expect(logs.length).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("classifyLoopback", () => {
+  test("unreachable when the probe didn't answer", () => {
+    expect(classifyLoopback("n1", { reachable: false })).toBe("unreachable");
+  });
+  test("ok when the returned instance matches ours", () => {
+    expect(classifyLoopback("n1", { reachable: true, status: 200, instance: "n1" })).toBe("ok");
+  });
+  test("hijacked when a different instance answers", () => {
+    expect(classifyLoopback("n1", { reachable: true, status: 200, instance: "n2" })).toBe(
+      "hijacked",
+    );
+  });
+  test("hijacked when a reachable process carries NO instance (old/foreign hub)", () => {
+    expect(classifyLoopback("n1", { reachable: true, status: 200 })).toBe("hijacked");
+  });
+});
+
+describe("probeLoopbackInstance", () => {
+  test("extracts instance + isHub from a well-formed /health body", async () => {
+    const fetchFn = (async () =>
+      new Response(JSON.stringify({ service: "parachute-hub", instance: "xyz" }), {
+        status: 200,
+      })) as unknown as typeof fetch;
+    const out = await probeLoopbackInstance(1939, { fetchFn });
+    expect(out).toEqual({ reachable: true, status: 200, instance: "xyz", isHub: true });
+  });
+
+  test("reachable-but-junk body → reachable with no instance (foreign server shape)", async () => {
+    const fetchFn = (async () =>
+      new Response("<html>not a hub</html>", { status: 200 })) as unknown as typeof fetch;
+    const out = await probeLoopbackInstance(1939, { fetchFn });
+    expect(out.reachable).toBe(true);
+    expect(out.instance).toBeUndefined();
+    expect(out.isHub).toBeUndefined();
+  });
+
+  test("network error → not reachable, never throws", async () => {
+    const fetchFn = (async () => {
+      throw new Error("ECONNREFUSED");
+    }) as unknown as typeof fetch;
+    const out = await probeLoopbackInstance(1939, { fetchFn });
+    expect(out).toEqual({ reachable: false });
+  });
+});
+
+describe("armHubSelfProbe", () => {
+  /** A probe stub that returns a fixed LoopbackProbe. */
+  function fixedProbe(p: LoopbackProbe): (port: number) => Promise<LoopbackProbe> {
+    return async () => p;
+  }
+
+  test("ok verdict: writes state, stays quiet (no loud log)", async () => {
+    const logs: string[] = [];
+    const states: SelfProbeState[] = [];
+    const probe = armHubSelfProbe(
+      { port: 1939, nonce: "n1", record: record() },
+      {
+        probe: fixedProbe({ reachable: true, status: 200, instance: "n1" }),
+        writeState: (s) => states.push(s),
+        log: (l) => logs.push(l),
+        setIntervalFn: () => 0,
+      },
+    );
+    const verdict = await probe.probeOnce();
+    expect(verdict).toBe("ok");
+    expect(logs).toEqual([]);
+    expect(states.at(-1)?.status).toBe("ok");
+  });
+
+  test("hijacked verdict: LOUD alert on EVERY probe + observedInstance persisted", async () => {
+    const logs: string[] = [];
+    const states: SelfProbeState[] = [];
+    const probe = armHubSelfProbe(
+      { port: 1939, nonce: "n1", record: record() },
+      {
+        probe: fixedProbe({ reachable: true, status: 200, instance: "rogue-9" }),
+        writeState: (s) => states.push(s),
+        log: (l) => logs.push(l),
+        setIntervalFn: () => 0,
+      },
+    );
+    expect(await probe.probeOnce()).toBe("hijacked");
+    expect(await probe.probeOnce()).toBe("hijacked");
+    // Repeated verbatim — a hijack is a standing emergency, not a one-shot.
+    expect(logs.length).toBe(2);
+    expect(logs[0]).toContain("LOOPBACK HIJACK");
+    expect(logs[0]).toContain("lsof -nP -iTCP:1939");
+    expect(states.at(-1)?.observedInstance).toBe("rogue-9");
+    expect(states.at(-1)?.status).toBe("hijacked");
+  });
+
+  test("unreachable verdict: logs ONCE per state change, not per tick", async () => {
+    const logs: string[] = [];
+    const probe = armHubSelfProbe(
+      { port: 1939, nonce: "n1", record: record() },
+      {
+        probe: fixedProbe({ reachable: false }),
+        writeState: () => {},
+        log: (l) => logs.push(l),
+        setIntervalFn: () => 0,
+      },
+    );
+    await probe.probeOnce();
+    await probe.probeOnce();
+    expect(logs.length).toBe(1); // second consecutive unreachable is silent
+    expect(logs[0]).toContain("did not answer");
+  });
+
+  test("recovery: hijacked → ok logs a single 'cleared' line", async () => {
+    const logs: string[] = [];
+    let current: LoopbackProbe = { reachable: true, status: 200, instance: "rogue" };
+    const probe = armHubSelfProbe(
+      { port: 1939, nonce: "n1", record: record() },
+      {
+        probe: async () => current,
+        writeState: () => {},
+        log: (l) => logs.push(l),
+        setIntervalFn: () => 0,
+      },
+    );
+    expect(await probe.probeOnce()).toBe("hijacked");
+    current = { reachable: true, status: 200, instance: "n1" };
+    expect(await probe.probeOnce()).toBe("ok");
+    expect(logs.length).toBe(2);
+    expect(logs[1]).toContain("Hijack cleared");
+  });
+
+  test("stop() clears the interval handle", () => {
+    let cleared: unknown;
+    const probe = armHubSelfProbe(
+      { port: 1939, nonce: "n1", record: record() },
+      {
+        probe: fixedProbe({ reachable: true, instance: "n1" }),
+        writeState: () => {},
+        setIntervalFn: () => "the-handle",
+        clearIntervalFn: (h) => {
+          cleared = h;
+        },
+      },
+    );
+    probe.stop();
+    expect(cleared).toBe("the-handle");
+  });
+
+  test("default writeState patches selfProbe into the real instance file", async () => {
+    const { configDir, cleanup } = makeDir();
+    try {
+      const rec = record();
+      writeHubInstanceFile(rec, { configDir });
+      const probe = armHubSelfProbe(
+        { port: 1939, nonce: "n1", record: rec, configDir },
+        {
+          probe: fixedProbe({ reachable: true, status: 200, instance: "someone-else" }),
+          log: () => {},
+          setIntervalFn: () => 0,
+        },
+      );
+      await probe.probeOnce();
+      const back = readHubInstanceFile(configDir);
+      expect(back?.selfProbe?.status).toBe("hijacked");
+      expect(back?.instance).toBe("nonce-1"); // base record preserved
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("hijackAlertMessage", () => {
+  test("names the observed instance + the diagnosis commands + incident ref", () => {
+    const msg = hijackAlertMessage(1939, "rogue-42");
+    expect(msg).toContain("instance=rogue-42");
+    expect(msg).toContain("lsof -nP -iTCP:1939 -sTCP:LISTEN");
+    expect(msg).toContain("orb list");
+    expect(msg).toContain("hub#737");
+  });
+  test("degrades gracefully when the foreign process carries no nonce", () => {
+    const msg = hijackAlertMessage(1939);
+    expect(msg).toContain("no hub instance nonce");
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -140,6 +140,27 @@ describe("hubFetch routing", () => {
     }
   });
 
+  test("/health echoes the instance nonce when set, omits it when absent (hub#737)", async () => {
+    const h = makeHarness();
+    try {
+      // With a nonce threaded in, /health carries it as `instance`.
+      const withNonce = (await (
+        await hubFetch(h.dir, { instanceNonce: "nonce-abc-123" })(req("/health"))
+      ).json()) as { service: string; instance?: string };
+      expect(withNonce.service).toBe("parachute-hub");
+      expect(withNonce.instance).toBe("nonce-abc-123");
+
+      // Without one (DB-less / dev entrypoint), the field is omitted — additive,
+      // so no strict /health consumer breaks.
+      const withoutNonce = (await (await hubFetch(h.dir, {})(req("/health"))).json()) as {
+        instance?: string;
+      };
+      expect(withoutNonce.instance).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("/health surfaces db:error:path-gone when the proactive probe sees a wiped path (#610)", async () => {
     // The ghost-fd lie: SELECT 1 still succeeds against the unlinked inode, so
     // probeDbLiveness alone would report ok. probeDbPath stat()s the PATH and

--- a/src/__tests__/status-supervisor.test.ts
+++ b/src/__tests__/status-supervisor.test.ts
@@ -689,6 +689,36 @@ describe("status — loopback-hijack override (hub#737)", () => {
     }
   });
 
+  test("hub down + STALE hijacked verdict on disk → NO phantom hijack, normal down-hub row", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      // A hard-killed hub can leave a stale `hijacked` verdict in hub-instance.json
+      // (it's only cleared on a graceful stop). With nothing answering loopback
+      // (hubHealthy=false), status must render the ordinary down-hub row, not a
+      // phantom LOOPBACK HIJACK warning.
+      const opts = supervisorOpts(configDir, path, {
+        managerState: { state: "inactive" },
+        hubHealthy: false,
+        readInstanceState: () => ({
+          status: "hijacked",
+          checkedAt: "2026-07-02T00:00:00.000Z",
+          observedInstance: "rogue-from-a-past-run",
+        }),
+      });
+      const code = await status({ ...opts, print: (l) => lines.push(l) });
+      const out = lines.join("\n");
+      expect(out).not.toContain("LOOPBACK HIJACK");
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toMatch(/\binactive\b/);
+      // An inactive hub is `skipped` (expected-stopped), so exit 0 — the point is
+      // simply that no phantom hijack was injected on top of the normal row.
+      expect(code).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
   test("selfProbe ok leaves a healthy hub row untouched (active)", async () => {
     const { path, configDir, cleanup } = makeTempPath();
     try {

--- a/src/__tests__/status-supervisor.test.ts
+++ b/src/__tests__/status-supervisor.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { status } from "../commands/status.ts";
+import type { SelfProbeState } from "../hub-instance.ts";
 import type { HubUnitDeps, HubUnitStateResult } from "../hub-unit.ts";
 import {
   type ModuleStatesResult,
@@ -86,6 +87,12 @@ interface SupervisorArmOpts {
    * network; specific tests override to mark a module live.
    */
   probeModuleHealth?: (port: number, health: string) => Promise<boolean>;
+  /**
+   * Loopback-hijack self-probe verdict read off `hub-instance.json` (hub#737).
+   * Defaults to "no verdict on disk" (undefined) so existing tests are
+   * unaffected; the hijack tests inject a `hijacked` / `ok` verdict.
+   */
+  readInstanceState?: (configDir: string) => SelfProbeState | undefined;
 }
 
 /** Drive `status` through the supervisor arm with fully stubbed seams. */
@@ -104,6 +111,7 @@ function supervisorOpts(configDir: string, path: string, o: SupervisorArmOpts) {
         (async () => o.moduleStates ?? { supervisorAvailable: true, modules: [] }),
       probeModuleHealth: o.probeModuleHealth ?? (async () => false),
       openDb: fakeOpenDb as unknown as (configDir: string) => import("bun:sqlite").Database,
+      readInstanceState: o.readInstanceState ?? (() => undefined),
     },
   };
 }
@@ -651,3 +659,77 @@ describe("status — Phase 3c supervisor arm: module rows", () => {
 // manager + supervisor. The supervisor-path readout is exercised throughout the
 // suites above; a box with no hub unit degrades gracefully (manager `no-unit` /
 // `/health` down → inactive rows), which the hub-row + module-row suites cover.
+
+describe("status — loopback-hijack override (hub#737)", () => {
+  test("selfProbe hijacked flips the hub row to failing despite a healthy /health", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const opts = supervisorOpts(configDir, path, {
+        // The rogue answers /health 200, so the raw liveness probe says healthy —
+        // the on-disk self-probe verdict is what corrects the row.
+        managerState: { state: "active" },
+        hubHealthy: true,
+        moduleStates: { supervisorAvailable: true, modules: [] },
+        readInstanceState: () => ({
+          status: "hijacked",
+          checkedAt: "2026-07-02T00:00:00.000Z",
+          observedInstance: "rogue-hub",
+        }),
+      });
+      const code = await status({ ...opts, print: (l) => lines.push(l) });
+      expect(code).toBe(1);
+      const out = lines.join("\n");
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toMatch(/\bfailing\b/);
+      expect(out).toContain("LOOPBACK HIJACK on :1939");
+      expect(out).toMatch(/lsof -nP -iTCP:1939 -sTCP:LISTEN/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("selfProbe ok leaves a healthy hub row untouched (active)", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      const opts = supervisorOpts(configDir, path, {
+        managerState: { state: "active" },
+        hubHealthy: true,
+        moduleStates: { supervisorAvailable: true, modules: [] },
+        readInstanceState: () => ({
+          status: "ok",
+          checkedAt: "2026-07-02T00:00:00.000Z",
+        }),
+      });
+      const code = await status({ ...opts, print: (l) => lines.push(l) });
+      expect(code).toBe(0);
+      const hubLine = lines.find((l) => l.includes("parachute-hub (internal)"));
+      expect(hubLine).toMatch(/\bactive\b/);
+      expect(lines.join("\n")).not.toContain("LOOPBACK HIJACK");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("no self-probe verdict on disk → no override (default read returns undefined)", async () => {
+    const { path, configDir, cleanup } = makeTempPath();
+    try {
+      const lines: string[] = [];
+      // No readInstanceState override + no file on disk → the default reader
+      // returns undefined and the row is unchanged.
+      const code = await status({
+        ...supervisorOpts(configDir, path, {
+          managerState: { state: "active" },
+          hubHealthy: true,
+          moduleStates: { supervisorAvailable: true, modules: [] },
+        }),
+        print: (l) => lines.push(l),
+      });
+      expect(code).toBe(0);
+      expect(lines.join("\n")).not.toContain("LOOPBACK HIJACK");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/commands/doctor.ts
+++ b/src/commands/doctor.ts
@@ -54,6 +54,13 @@ import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { type ExposeState, readExposeState } from "../expose-state.ts";
 import { HUB_SVC, readHubPort } from "../hub-control.ts";
 import {
+  HIJACK_INCIDENT_REF,
+  type HubInstanceRecord,
+  type LoopbackProbe,
+  probeLoopbackInstance,
+  readHubInstanceFile,
+} from "../hub-instance.ts";
+import {
   HUB_UNIT_DEFAULT_PORT,
   type HubUnitDeps,
   type HubUnitStateResult,
@@ -157,6 +164,25 @@ export interface DoctorDeps {
    * readline; tests inject a canned answer.
    */
   readLine?: (prompt: string) => Promise<string>;
+  /**
+   * Loopback-hijack check (hub#737): read THIS hub's on-disk identity
+   * (`hub-instance.json`, written by the running `serve`). Default
+   * {@link readHubInstanceFile}; tests inject a fixture record (or null).
+   */
+  readInstanceRecord?: (configDir: string) => HubInstanceRecord | null;
+  /**
+   * Loopback-hijack check: probe `127.0.0.1:<port>/health` and read its
+   * `instance`. Default {@link probeLoopbackInstance}; tests inject the
+   * matched / mismatched / unreachable outcomes.
+   */
+  probeLoopbackInstance?: (port: number) => Promise<LoopbackProbe>;
+  /**
+   * Loopback-hijack check: count LISTEN sockets on the hub port (a second
+   * listener is the OrbStack-shadow fingerprint). Default shells `lsof`;
+   * returns `undefined` when it can't determine a count (lsof absent / errored)
+   * so the check degrades to the instance comparison alone. Tests inject a count.
+   */
+  countHubListeners?: (port: number) => number | undefined;
 }
 
 export interface DoctorOpts {
@@ -217,6 +243,33 @@ async function defaultProbePublicHealth(origin: string): Promise<boolean> {
   }
 }
 
+/**
+ * Count LISTEN sockets on `port` via `lsof`. A hijack shows TWO (this hub's
+ * wildcard bind + the shadowing process's specific loopback bind). Bounded +
+ * best-effort: returns `undefined` on any failure (lsof absent, non-zero exit,
+ * unparseable) so the check degrades to the instance-comparison signal alone
+ * rather than false-flagging. Counts DISTINCT pids across the LISTEN rows.
+ */
+function defaultCountHubListeners(port: number): number | undefined {
+  try {
+    const proc = Bun.spawnSync(["lsof", "-nP", `-iTCP:${port}`, "-sTCP:LISTEN", "-FpP"], {
+      stdout: "pipe",
+      stderr: "ignore",
+    });
+    // lsof exits non-zero when there are zero matches — that's a real "0", not
+    // an error. Only treat a missing binary (spawn failure) as indeterminate.
+    if (proc.exitCode !== 0 && (proc.stdout?.length ?? 0) === 0) return 0;
+    const text = new TextDecoder().decode(proc.stdout ?? new Uint8Array());
+    const pids = new Set<string>();
+    for (const line of text.split("\n")) {
+      if (line.startsWith("p")) pids.add(line.slice(1));
+    }
+    return pids.size;
+  } catch {
+    return undefined;
+  }
+}
+
 /** Both ends of the pipe must be a TTY for an interactive confirm to make sense. */
 function defaultIsInteractive(): boolean {
   return Boolean(process.stdin.isTTY && process.stdout.isTTY);
@@ -243,6 +296,9 @@ interface ResolvedDeps {
   now: () => Date;
   isInteractive: () => boolean;
   readLine: (prompt: string) => Promise<string>;
+  readInstanceRecord: (configDir: string) => HubInstanceRecord | null;
+  probeLoopbackInstance: (port: number) => Promise<LoopbackProbe>;
+  countHubListeners: (port: number) => number | undefined;
 }
 
 function resolveDeps(d: DoctorDeps | undefined): ResolvedDeps {
@@ -257,6 +313,9 @@ function resolveDeps(d: DoctorDeps | undefined): ResolvedDeps {
     now: d?.now ?? (() => new Date()),
     isInteractive: d?.isInteractive ?? defaultIsInteractive,
     readLine: d?.readLine ?? defaultReadLine,
+    readInstanceRecord: d?.readInstanceRecord ?? readHubInstanceFile,
+    probeLoopbackInstance: d?.probeLoopbackInstance ?? probeLoopbackInstance,
+    countHubListeners: d?.countHubListeners ?? defaultCountHubListeners,
   };
 }
 
@@ -334,6 +393,110 @@ async function checkHubReachable(configDir: string, deps: ResolvedDeps): Promise
     status: "fail",
     detail: `hub is not running — nothing answered /health on http://127.0.0.1:${port}`,
     fix,
+  };
+}
+
+/**
+ * Loopback-hijack detection (hub#737) — the 2026-07-02 P0's root trigger. This
+ * hub binds `*:<port>` (wildcard); a foreign process that grabs a SPECIFIC
+ * `127.0.0.1:<port>` bind (classically an OrbStack VM auto-forwarding the port)
+ * WINS all loopback traffic, so every module's JWKS/API call silently reaches
+ * the wrong hub. Detection compares THIS hub's on-disk identity nonce
+ * (`hub-instance.json`, written by `serve`) to what a loopback `/health`
+ * actually returns:
+ *   - no instance file → the running hub predates nonce detection, or isn't
+ *     running under `serve` (the Hub check owns "down") → PASS (benign info,
+ *     never a false FAIL per #717).
+ *   - loopback not answering → defer to the Hub check → PASS (info).
+ *   - loopback nonce === ours → loopback reaches THIS hub. A second LISTEN on
+ *     the port (lsof) is a latent shadow → WARN; a single listener → PASS.
+ *   - loopback nonce ≠ ours (or missing) → ACTIVE HIJACK → FAIL with the exact
+ *     lsof/orb remediation + the incident reference. Detect-only (no `--fix`).
+ * Never throws — every read is bounded + degrades to a benign verdict.
+ */
+async function checkLoopbackHijack(configDir: string, deps: ResolvedDeps): Promise<CheckResult> {
+  const port = readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT;
+  const title = `No loopback hijack on :${port}`;
+
+  let record: HubInstanceRecord | null = null;
+  try {
+    record = deps.readInstanceRecord(configDir);
+  } catch {
+    record = null;
+  }
+  if (!record) {
+    return {
+      name: "loopback-hijack",
+      title,
+      status: "pass",
+      detail:
+        "no hub-instance.json — the running hub predates loopback-nonce detection or isn't running under `parachute serve` (see the Hub check)",
+    };
+  }
+
+  let probe: LoopbackProbe;
+  try {
+    probe = await deps.probeLoopbackInstance(port);
+  } catch {
+    probe = { reachable: false };
+  }
+  if (!probe.reachable) {
+    return {
+      name: "loopback-hijack",
+      title,
+      status: "pass",
+      detail: `loopback /health on 127.0.0.1:${port} didn't answer — nothing to compare (the Hub check covers a down hub)`,
+    };
+  }
+
+  // Reachable but a DIFFERENT identity answers → active hijack.
+  if (probe.instance !== record.instance) {
+    let listeners: number | undefined;
+    try {
+      listeners = deps.countHubListeners(port);
+    } catch {
+      listeners = undefined;
+    }
+    const who = probe.instance
+      ? `a different hub (instance ${probe.instance})`
+      : "a foreign process (its /health carries no hub instance nonce)";
+    const listenerNote =
+      listeners !== undefined && listeners > 1
+        ? ` lsof shows ${listeners} listeners on the port.`
+        : "";
+    return {
+      name: "loopback-hijack",
+      title,
+      status: "fail",
+      detail: `loopback 127.0.0.1:${port} is answered by ${who}, NOT this hub (instance ${record.instance}) — module JWKS/API calls are reaching the wrong hub.${listenerNote} Incident: ${HIJACK_INCIDENT_REF}`,
+      fix: `lsof -nP -iTCP:${port} -sTCP:LISTEN  # find the shadow; then \`orb list\` and stop any VM auto-forwarding ${port}`,
+    };
+  }
+
+  // Loopback reaches us. A second listener is a latent shadow that could win the
+  // next reboot — WARN so the operator clears it before it flips to a FAIL.
+  let listeners: number | undefined;
+  try {
+    listeners = deps.countHubListeners(port);
+  } catch {
+    listeners = undefined;
+  }
+  if (listeners !== undefined && listeners > 1) {
+    return {
+      name: "loopback-hijack",
+      title,
+      status: "warn",
+      detail: `loopback reaches this hub, but lsof shows ${listeners} listeners on :${port} — a second bind is a latent shadow that could win loopback after a restart`,
+      fix: `lsof -nP -iTCP:${port} -sTCP:LISTEN  # identify + stop the extra listener (e.g. \`orb list\`)`,
+    };
+  }
+  return {
+    name: "loopback-hijack",
+    title,
+    status: "pass",
+    detail: `loopback 127.0.0.1:${port}/health returns this hub's instance nonce${
+      listeners === 1 ? " (single listener)" : ""
+    }`,
   };
 }
 
@@ -1017,7 +1180,8 @@ async function runChecks(
   const hub = await checkHubReachable(configDir, deps);
   const hubHealthy = hub.status === "pass";
 
-  const [modules, bins, exposure] = await Promise.all([
+  const [hijack, modules, bins, exposure] = await Promise.all([
+    checkLoopbackHijack(configDir, deps),
     checkModulesAlive(manifest, hubHealthy, deps),
     checkModuleBins(manifest, deps),
     checkExposure(configDir, deps),
@@ -1032,7 +1196,7 @@ async function runChecks(
   const add = (group: Group, checks: CheckResult[]) => {
     for (const c of checks) grouped.push({ ...c, group });
   };
-  add("Hub", [hub]);
+  add("Hub", [hub, hijack]);
   add("Modules", [...modules, ...bins]);
   add("Configuration", [manifestCheck, portDrift, operator]);
   add("Migration", migration);
@@ -1208,8 +1372,7 @@ async function fixPortDrift(
   const canonicalByName = new Map(drifted.map((d) => [d.name, d.canonical]));
   const next = {
     services: parsed.services.map((row) => {
-      const canonical =
-        typeof row.name === "string" ? canonicalByName.get(row.name) : undefined;
+      const canonical = typeof row.name === "string" ? canonicalByName.get(row.name) : undefined;
       return canonical === undefined ? row : { ...row, port: canonical };
     }),
   };

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -36,6 +36,13 @@ import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { readExposeState } from "../expose-state.ts";
 import { createDbHolder, defaultStatInode, startDbPathLivenessTimer } from "../hub-db-liveness.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  type HubInstanceRecord,
+  type HubSelfProbe,
+  armHubSelfProbe,
+  generateInstanceNonce,
+  writeHubInstanceFile,
+} from "../hub-instance.ts";
 import { hubFetch } from "../hub-server.ts";
 import { getHubOrigin } from "../hub-settings.ts";
 import { writeHubFile } from "../hub.ts";
@@ -513,6 +520,13 @@ export async function serve(opts: ServeOpts = {}): Promise<{
 
   const supervisor = opts.supervisor ?? new Supervisor();
 
+  // Per-boot instance nonce (hub#737). Minted BEFORE the listener so it can be
+  // threaded into `/health`; written to disk AFTER a successful bind (below) so
+  // a bind failure never leaves a stale identity file. It's the linchpin of
+  // loopback-hijack detection: `/health` echoes it, and external tools compare
+  // the disk copy to what a loopback `/health` actually returns.
+  const instanceNonce = generateInstanceNonce();
+
   // Claim the hub port FIRST — before booting a single supervised module. If
   // another hub/supervisor already owns it, `Bun.serve` throws here and we
   // exit immediately. The prior order (boot modules, *then* bind) let a
@@ -534,6 +548,7 @@ export async function serve(opts: ServeOpts = {}): Promise<{
           probeDbPath: () => dbHolder.probePath(),
           issuer,
           loopbackPort: port,
+          instanceNonce,
           supervisor,
         }),
       }),
@@ -542,6 +557,38 @@ export async function serve(opts: ServeOpts = {}): Promise<{
     const conflict = hubPortConflictMessage(err, port);
     if (conflict) throw new Error(conflict);
     throw err;
+  }
+
+  // We own the listener now — record this process's identity on disk (0644) so
+  // `parachute status` / `parachute doctor` can detect a loopback hijack by
+  // comparing this nonce to what a loopback `/health` returns. Best-effort:
+  // a write failure only degrades external detection, never blocks the hub.
+  const instanceRecord: HubInstanceRecord = {
+    instance: instanceNonce,
+    pid: process.pid,
+    port,
+    startedAt: new Date().toISOString(),
+  };
+  writeHubInstanceFile(instanceRecord, { configDir: CONFIG_DIR, log });
+
+  // Arm the loopback self-probe (hub#737): an immediate check right after the
+  // bind catches a hijack that's ALREADY present at boot (the OrbStack VM that
+  // relaunched at reboot and grabbed 127.0.0.1:<port> before us), then a
+  // low-frequency re-probe catches one that appears later. It logs loudly on a
+  // mismatch and records the verdict into hub-instance.json for external tools.
+  // Skipped alongside module boot in tests (`skipModuleBoot`) so the test path
+  // never spawns a real 5-minute timer / loopback fetch.
+  let selfProbe: HubSelfProbe | undefined;
+  if (!opts.skipModuleBoot) {
+    selfProbe = armHubSelfProbe(
+      { port, nonce: instanceNonce, record: instanceRecord, configDir: CONFIG_DIR },
+      { log },
+    );
+    // Fire the startup check without blocking serve's return — a hijack present
+    // at boot surfaces within the probe's bounded timeout, not on the next tick.
+    // `probeOnce` is non-throwing in production, but guard the floating promise
+    // against ever surfacing as an unhandled rejection.
+    void selfProbe.probeOnce().catch(() => {});
   }
 
   log(
@@ -618,6 +665,7 @@ export async function serve(opts: ServeOpts = {}): Promise<{
       for (const state of supervisor.list()) {
         await supervisor.stop(state.short);
       }
+      selfProbe?.stop();
       livenessTimer.stop();
       await server.stop();
       dbHolder.get().close();

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -40,6 +40,7 @@ import {
   type HubInstanceRecord,
   type HubSelfProbe,
   armHubSelfProbe,
+  clearHubInstanceFile,
   generateInstanceNonce,
   writeHubInstanceFile,
 } from "../hub-instance.ts";
@@ -668,6 +669,9 @@ export async function serve(opts: ServeOpts = {}): Promise<{
       selfProbe?.stop();
       livenessTimer.stop();
       await server.stop();
+      // Clear our on-disk identity so a cleanly-stopped hub leaves no stale
+      // self-probe verdict for `status` / `doctor` to read (hub#737 review).
+      clearHubInstanceFile(CONFIG_DIR);
       dbHolder.get().close();
     },
   };

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -690,13 +690,21 @@ async function buildSupervisorRows(args: BuildSupervisorRowsArgs): Promise<Statu
   // reads `active`), so trust the running serve's own on-disk self-probe verdict
   // instead — read from disk, never over the hijacked loopback. A `hijacked`
   // verdict flips the row to `failing` with the loud, actionable note.
+  //
+  // GATED ON `hubHealthy` (review fix): the instance file is written per-boot
+  // and only cleared on a *graceful* stop, so a hard-killed hub can leave a
+  // stale `hijacked` verdict on disk. `hubHealthy` is true exactly when
+  // SOMETHING is answering the loopback port right now — which is precisely the
+  // live-hijack condition (the rogue keeps answering 200), so gating here never
+  // suppresses a real hijack, but it does keep a stopped hub (nothing answering)
+  // from rendering a phantom hijack over its normal down-hub row.
   let selfProbe: SelfProbeState | undefined;
   try {
     selfProbe = sup.readInstanceState(configDir);
   } catch {
     selfProbe = undefined;
   }
-  if (selfProbe?.status === "hijacked") {
+  if (hubHealthy && selfProbe?.status === "hijacked") {
     hub.stateLabel = "failing";
     hub.healthy = false;
     hub.skipped = false;

--- a/src/commands/status.ts
+++ b/src/commands/status.ts
@@ -2,6 +2,7 @@ import type { Database } from "bun:sqlite";
 import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from "../config.ts";
 import { readHubPort } from "../hub-control.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { type SelfProbeState, readHubInstanceFile } from "../hub-instance.ts";
 import {
   HUB_UNIT_DEFAULT_PORT,
   type HubUnitDeps,
@@ -90,6 +91,16 @@ export interface StatusOpts {
     openDb?: (configDir: string) => Database;
     /** Loopback hub base URL override (default derives from the hub port). */
     baseUrl?: string;
+    /**
+     * Read the running serve process's last loopback self-probe verdict from
+     * `hub-instance.json` (hub#737). Read from DISK, not over loopback — during
+     * a hijack the loopback /health (and the module-ops API) reach the WRONG
+     * hub, so the on-disk verdict the real serve wrote is the only trustworthy
+     * source. A `hijacked` verdict overrides the hub row (which would otherwise
+     * read `active` off the rogue's 200). Default {@link readHubInstanceFile}'s
+     * `selfProbe`; tests inject a state (or undefined).
+     */
+    readInstanceState?: (configDir: string) => SelfProbeState | undefined;
   };
 }
 
@@ -386,6 +397,7 @@ interface ResolvedStatusSupervisor {
   probeModuleHealth: (port: number, health: string) => Promise<boolean>;
   openDb: (configDir: string) => Database;
   baseUrl: string | undefined;
+  readInstanceState: (configDir: string) => SelfProbeState | undefined;
 }
 
 /**
@@ -402,6 +414,8 @@ function resolveStatusSupervisor(opts: StatusOpts["supervisor"]): ResolvedStatus
     probeModuleHealth: opts?.probeModuleHealth ?? defaultProbeModuleHealth,
     openDb: opts?.openDb ?? ((configDir) => openHubDb(hubDbPath(configDir))),
     baseUrl: opts?.baseUrl,
+    readInstanceState:
+      opts?.readInstanceState ?? ((configDir) => readHubInstanceFile(configDir)?.selfProbe),
   };
 }
 
@@ -671,8 +685,27 @@ async function buildSupervisorRows(args: BuildSupervisorRowsArgs): Promise<Statu
     port,
     hubHealthy,
   });
+  // Loopback-hijack override (hub#737). During a hijack the loopback `/health`
+  // the hub row's liveness probe hit belongs to the ROGUE hub (a 200 → the row
+  // reads `active`), so trust the running serve's own on-disk self-probe verdict
+  // instead — read from disk, never over the hijacked loopback. A `hijacked`
+  // verdict flips the row to `failing` with the loud, actionable note.
+  let selfProbe: SelfProbeState | undefined;
+  try {
+    selfProbe = sup.readInstanceState(configDir);
+  } catch {
+    selfProbe = undefined;
+  }
+  if (selfProbe?.status === "hijacked") {
+    hub.stateLabel = "failing";
+    hub.healthy = false;
+    hub.skipped = false;
+    hub.healthDetail = "loopback hijacked — /health answered by a foreign process";
+    hub.managerNote = `LOOPBACK HIJACK on :${port} — module JWKS/API calls are NOT reaching this hub. Run \`parachute doctor\` and \`lsof -nP -iTCP:${port} -sTCP:LISTEN\`.`;
+  }
   // If the degraded-read note never landed on a module row (empty manifest),
-  // surface it on the hub row so the operator still sees the actionable hint.
+  // surface it on the hub row so the operator still sees the actionable hint —
+  // unless the hijack note already claimed it (the hijack is the bigger signal).
   if (moduleReadNote && !hub.managerNote) hub.managerNote = moduleReadNote;
   rows.push(hub);
   return rows;

--- a/src/hub-instance.ts
+++ b/src/hub-instance.ts
@@ -1,0 +1,344 @@
+/**
+ * Hub instance identity + loopback-hijack detection (hub#737).
+ *
+ * ## The incident this defends against (2026-07-02 P0)
+ *
+ * The hub binds `*:1939` (INADDR_ANY / `0.0.0.0`). An OrbStack Linux machine
+ * auto-forwarded ITS port 1939 onto the host as a SPECIFIC bind on
+ * `127.0.0.1:1939` — and a specific loopback bind WINS over a wildcard bind for
+ * all loopback traffic. Every module's JWKS/API call to `127.0.0.1:1939`
+ * silently reached the WRONG hub (a fresh container DB → empty JWKS, no admin),
+ * so every hub-JWT validation failed `no applicable key found in the JWKS` and
+ * the ecosystem 401-looped for hours. `lsof -nP -i :1939` showed two LISTENs;
+ * the tell was `/health` reporting the container's version, not the checkout's.
+ *
+ * ## The primitive: a per-process instance nonce
+ *
+ * Each `parachute serve` process generates a random nonce at boot, (a) exposes
+ * it as `instance` in `/health`, and (b) writes it to
+ * `~/.parachute/hub-instance.json` (0644). That file is the linchpin: an
+ * EXTERNAL process (`parachute status`, `parachute doctor`) can learn THIS
+ * hub's true identity from disk WITHOUT traversing the (possibly hijacked)
+ * loopback — then compare it to what a loopback `GET /health` actually returns.
+ * A mismatch means another process owns `127.0.0.1:<port>`.
+ *
+ * The in-process self-probe (armed by `serve`) compares its own in-memory nonce
+ * to the loopback `/health` it fetches, logs loudly on mismatch, and records the
+ * verdict back into the same file's `selfProbe` field so external tools surface
+ * the serve process's own authoritative reading without re-probing.
+ *
+ * Every side effect (fs, network probe) is behind an injectable seam so the
+ * whole module runs deterministically in tests with no real network / disk.
+ */
+
+import { randomUUID } from "node:crypto";
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { CONFIG_DIR } from "./config.ts";
+
+/** The public incident reference operators grep for. */
+export const HIJACK_INCIDENT_REF = "hub#737 / team-vault Log/2026-07-02-port-exhaustion-incident";
+
+/** Self-probe verdicts. `ok` = loopback reaches us; `hijacked` = someone else owns loopback. */
+export type SelfProbeStatus = "ok" | "hijacked" | "unreachable";
+
+/**
+ * The serve process's own most-recent loopback self-probe reading, persisted
+ * into the instance file so external readers (`status`) see the authoritative
+ * verdict without re-probing the (possibly hijacked) loopback themselves.
+ */
+export interface SelfProbeState {
+  status: SelfProbeStatus;
+  /** ISO timestamp of the reading. */
+  checkedAt: string;
+  /** The `instance` the loopback `/health` actually returned (present on a `hijacked` reading). */
+  observedInstance?: string;
+  /** One-line human detail (loud message on a hijack; the probe error class on unreachable). */
+  detail?: string;
+}
+
+/** The `~/.parachute/hub-instance.json` record. */
+export interface HubInstanceRecord {
+  /** Per-process random nonce (`crypto.randomUUID`) minted at serve boot. */
+  instance: string;
+  /** The serve process PID (informational — helps an operator map the file to a process). */
+  pid: number;
+  /** The port this serve bound. */
+  port: number;
+  /** ISO timestamp of serve boot. */
+  startedAt: string;
+  /** Last self-probe reading, patched in by the running serve process. */
+  selfProbe?: SelfProbeState;
+}
+
+/** Mint a fresh per-process nonce. */
+export function generateInstanceNonce(): string {
+  return randomUUID();
+}
+
+/** Path to the instance file under a config dir (default `~/.parachute`). */
+export function hubInstancePath(configDir: string = CONFIG_DIR): string {
+  return join(configDir, "hub-instance.json");
+}
+
+/**
+ * Atomically write the instance record (tmp + rename, 0644). Best-effort: a
+ * write failure must NEVER take the hub down — the file is a diagnostic aid, not
+ * a load-bearing runtime dependency. Returns true on success.
+ */
+export function writeHubInstanceFile(
+  record: HubInstanceRecord,
+  opts: { configDir?: string; log?: (line: string) => void } = {},
+): boolean {
+  const path = hubInstancePath(opts.configDir);
+  try {
+    const dir = dirname(path);
+    if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
+    const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
+    writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o644 });
+    renameSync(tmp, path);
+    return true;
+  } catch (err) {
+    opts.log?.(
+      `parachute serve: could not write ${path} (${err instanceof Error ? err.message : String(err)}); loopback-hijack detection for external tools is degraded, hub start continues.`,
+    );
+    return false;
+  }
+}
+
+/**
+ * Read + validate the instance file. Returns null on absence / unreadable /
+ * malformed — a missing file is the benign "no nonce-aware serve wrote one yet"
+ * state, never an error.
+ */
+export function readHubInstanceFile(configDir: string = CONFIG_DIR): HubInstanceRecord | null {
+  const path = hubInstancePath(configDir);
+  let raw: unknown;
+  try {
+    raw = JSON.parse(readFileSync(path, "utf8"));
+  } catch {
+    return null;
+  }
+  if (!raw || typeof raw !== "object") return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.instance !== "string" || r.instance.length === 0) return null;
+  if (typeof r.port !== "number") return null;
+  const rec: HubInstanceRecord = {
+    instance: r.instance,
+    pid: typeof r.pid === "number" ? r.pid : -1,
+    port: r.port,
+    startedAt: typeof r.startedAt === "string" ? r.startedAt : "",
+  };
+  const sp = r.selfProbe;
+  if (sp && typeof sp === "object") {
+    const s = sp as Record<string, unknown>;
+    if (s.status === "ok" || s.status === "hijacked" || s.status === "unreachable") {
+      const state: SelfProbeState = {
+        status: s.status,
+        checkedAt: typeof s.checkedAt === "string" ? s.checkedAt : "",
+      };
+      if (typeof s.observedInstance === "string") state.observedInstance = s.observedInstance;
+      if (typeof s.detail === "string") state.detail = s.detail;
+      rec.selfProbe = state;
+    }
+  }
+  return rec;
+}
+
+/** The result of probing a loopback `/health`. */
+export interface LoopbackProbe {
+  /** The socket answered at all (any HTTP status). */
+  reachable: boolean;
+  /** HTTP status, when reachable. */
+  status?: number;
+  /** The `instance` field of the JSON body, when present + parseable. */
+  instance?: string;
+  /** True when the body self-identifies as a parachute hub (`service: "parachute-hub"`). */
+  isHub?: boolean;
+}
+
+/**
+ * Probe `http://127.0.0.1:<port>/health` and extract the instance identity.
+ * Bounded (default 1.5s); never throws — a network error is `{ reachable: false }`.
+ */
+export async function probeLoopbackInstance(
+  port: number,
+  opts: { timeoutMs?: number; fetchFn?: typeof fetch } = {},
+): Promise<LoopbackProbe> {
+  const fetchFn = opts.fetchFn ?? fetch;
+  try {
+    const res = await fetchFn(`http://127.0.0.1:${port}/health`, {
+      signal: AbortSignal.timeout(opts.timeoutMs ?? 1500),
+    });
+    const out: LoopbackProbe = { reachable: true, status: res.status };
+    try {
+      const body = (await res.json()) as Record<string, unknown>;
+      if (typeof body.instance === "string") out.instance = body.instance;
+      if (body.service === "parachute-hub") out.isHub = true;
+    } catch {
+      // A non-JSON / unparseable body still counts as "reachable" — a foreign
+      // process answering the port with junk is exactly the hijack shape.
+    }
+    return out;
+  } catch {
+    return { reachable: false };
+  }
+}
+
+/**
+ * Classify a loopback probe against our TRUE nonce.
+ *   - not reachable                → `unreachable` (we bound, but loopback refused/timed out — suspicious but soft).
+ *   - reachable, instance === ours → `ok`.
+ *   - reachable, instance !== ours → `hijacked` (a DIFFERENT process owns loopback: another hub, or a foreign
+ *     server answering `/health` with no/other instance — the OrbStack-shadow class).
+ */
+export function classifyLoopback(ourNonce: string, probe: LoopbackProbe): SelfProbeStatus {
+  if (!probe.reachable) return "unreachable";
+  if (probe.instance === ourNonce) return "ok";
+  return "hijacked";
+}
+
+/**
+ * The LOUD, structured hijack alert. Names the class + the exact diagnosis
+ * commands + the incident reference so an operator scanning logs can act
+ * immediately. Repeated verbatim on every probe while mismatched (by design —
+ * a single line scrolls away; a hijack is a standing emergency).
+ */
+export function hijackAlertMessage(port: number, observedInstance?: string): string {
+  const observed = observedInstance
+    ? `a DIFFERENT hub (instance=${observedInstance})`
+    : "a foreign process (no hub instance nonce in its /health)";
+  return [
+    `parachute serve: LOOPBACK HIJACK on 127.0.0.1:${port} — this hub bound the port but loopback /health is answered by ${observed}.`,
+    "  Loopback traffic (module JWKS/API calls, CLI probes) is NOT reaching this hub — every hub-JWT validation downstream will fail.",
+    `  A specific 127.0.0.1:${port} bind (commonly an OrbStack/container port-forward) wins over this hub's wildcard bind.`,
+    `  Diagnose:  lsof -nP -iTCP:${port} -sTCP:LISTEN   (expect ONE listener — this hub)`,
+    `             orb list   (stop/delete any VM auto-forwarding ${port}, e.g. a leftover smoke-test machine)`,
+    `  Incident:  ${HIJACK_INCIDENT_REF}`,
+  ].join("\n");
+}
+
+/** The softer "we're listening but loopback didn't answer" note (logged once per state change). */
+export function unreachableNote(port: number): string {
+  return `parachute serve: loopback /health on 127.0.0.1:${port} did not answer, yet this hub is bound — transient, or another process is interfering with loopback. Watching (will re-probe).`;
+}
+
+// ---------------------------------------------------------------------------
+// Self-probe timer (armed by `serve` after the listener is up)
+// ---------------------------------------------------------------------------
+
+export interface HubSelfProbe {
+  /** Stop the interval. */
+  stop(): void;
+  /** Run exactly one probe now (used for the immediate startup check + tests). */
+  probeOnce(): Promise<SelfProbeStatus>;
+  /** The most recent in-memory verdict (tests). */
+  getState(): SelfProbeState | undefined;
+}
+
+export interface HubSelfProbeDeps<H = unknown> {
+  /** Poll cadence in ms. Default 300_000 (5 min) — a safety net, not a hot path. */
+  intervalMs?: number;
+  /** Loopback probe (default {@link probeLoopbackInstance}). */
+  probe?: (port: number) => Promise<LoopbackProbe>;
+  /** Persist the verdict (default: patch the instance file's `selfProbe`). */
+  writeState?: (state: SelfProbeState) => void;
+  /** Loud log sink (default `console.error`). */
+  log?: (line: string) => void;
+  /** Clock seam (default `() => new Date()`). */
+  now?: () => Date;
+  /** Injectable scheduler (default `setInterval`). Tests drive ticks manually. */
+  setIntervalFn?: (cb: () => void, ms: number) => H;
+  /** Injectable clear (default `clearInterval`). */
+  clearIntervalFn?: (handle: H) => void;
+}
+
+/**
+ * Arm the loopback self-probe. On each tick (and on the immediate startup
+ * `probeOnce`) it fetches loopback `/health`, compares the returned instance to
+ * OUR nonce, logs per the incident-severity rules, and persists the verdict:
+ *
+ *   - `hijacked`   → LOUD structured alert EVERY tick (standing emergency), verdict persisted.
+ *   - `unreachable`→ softer note, logged ONLY on a state change (avoid a spinning log on a flaky loopback).
+ *   - `ok`         → recovery line logged once when clearing a prior non-ok verdict.
+ *
+ * The verdict is written to the instance file's `selfProbe` field so external
+ * tools (`status`) read the authoritative reading without re-probing the
+ * hijacked loopback. Overlapping ticks are guarded (a slow probe never stacks).
+ * The interval is `unref`'d so it never keeps the event loop alive on its own.
+ */
+export function armHubSelfProbe<H = ReturnType<typeof setInterval>>(
+  args: { port: number; nonce: string; record: HubInstanceRecord; configDir?: string },
+  deps: HubSelfProbeDeps<H> = {},
+): HubSelfProbe {
+  const { port, nonce, record } = args;
+  const intervalMs = deps.intervalMs ?? 300_000;
+  const probe = deps.probe ?? probeLoopbackInstance;
+  const log = deps.log ?? ((line: string) => console.error(line));
+  const now = deps.now ?? (() => new Date());
+  const writeState =
+    deps.writeState ??
+    ((state: SelfProbeState) =>
+      writeHubInstanceFile(
+        { ...record, selfProbe: state },
+        { ...(args.configDir !== undefined ? { configDir: args.configDir } : {}), log },
+      ));
+  const setIntervalFn =
+    deps.setIntervalFn ?? ((cb: () => void, ms: number) => setInterval(cb, ms) as unknown as H);
+  const clearIntervalFn =
+    deps.clearIntervalFn ??
+    ((h: H) => clearInterval(h as unknown as ReturnType<typeof setInterval>));
+
+  let last: SelfProbeState | undefined;
+  let inFlight = false;
+
+  async function probeOnce(): Promise<SelfProbeStatus> {
+    if (inFlight) return last?.status ?? "ok";
+    inFlight = true;
+    try {
+      const result = await probe(port);
+      const status = classifyLoopback(nonce, result);
+      const state: SelfProbeState = { status, checkedAt: now().toISOString() };
+      if (status === "hijacked") {
+        if (result.instance !== undefined) state.observedInstance = result.instance;
+        state.detail = hijackAlertMessage(port, result.instance);
+        // LOUD every tick — a hijack is a standing emergency, not a one-shot notice.
+        log(state.detail);
+      } else if (status === "unreachable") {
+        state.detail = unreachableNote(port);
+        if (last?.status !== "unreachable") log(state.detail);
+      } else {
+        // ok — announce recovery once when clearing a prior non-ok verdict.
+        if (last && last.status !== "ok") {
+          log(
+            `parachute serve: loopback /health on 127.0.0.1:${port} is back to this hub (instance=${nonce}). Hijack cleared.`,
+          );
+        }
+      }
+      last = state;
+      try {
+        writeState(state);
+      } catch {
+        // Persisting the verdict is best-effort; the loud log already fired.
+      }
+      return status;
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  const handle = setIntervalFn(() => {
+    void probeOnce();
+  }, intervalMs);
+  (handle as { unref?: () => void }).unref?.();
+
+  return {
+    stop() {
+      clearIntervalFn(handle);
+    },
+    probeOnce,
+    getState() {
+      return last;
+    },
+  };
+}

--- a/src/hub-instance.ts
+++ b/src/hub-instance.ts
@@ -32,7 +32,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { CONFIG_DIR } from "./config.ts";
 
@@ -91,18 +91,39 @@ export function writeHubInstanceFile(
   opts: { configDir?: string; log?: (line: string) => void } = {},
 ): boolean {
   const path = hubInstancePath(opts.configDir);
+  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
   try {
     const dir = dirname(path);
     if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-    const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
     writeFileSync(tmp, `${JSON.stringify(record, null, 2)}\n`, { mode: 0o644 });
     renameSync(tmp, path);
     return true;
   } catch (err) {
+    // Don't leave a half-written tmp behind if the rename (or write) failed.
+    try {
+      if (existsSync(tmp)) rmSync(tmp, { force: true });
+    } catch {
+      // Best-effort cleanup — nothing more we can do.
+    }
     opts.log?.(
       `parachute serve: could not write ${path} (${err instanceof Error ? err.message : String(err)}); loopback-hijack detection for external tools is degraded, hub start continues.`,
     );
     return false;
+  }
+}
+
+/**
+ * Remove the instance file (best-effort). Called on graceful shutdown so a
+ * cleanly-stopped hub doesn't leave a stale identity/self-probe verdict on disk
+ * for `status` / `doctor` to read as a phantom. A hard kill (SIGKILL) can't run
+ * this — the readers additionally gate on live hub liveness, so a leftover file
+ * from a hard kill never surfaces as a false hijack.
+ */
+export function clearHubInstanceFile(configDir: string = CONFIG_DIR): void {
+  try {
+    rmSync(hubInstancePath(configDir), { force: true });
+  } catch {
+    // Best-effort — a missing / unremovable file is not worth surfacing.
   }
 }
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1329,6 +1329,17 @@ export interface HubFetchDeps {
    */
   loopbackPort?: number;
   /**
+   * This serve process's per-boot instance nonce (hub#737). When present it's
+   * echoed as `instance` in `/health` so an external reader can tell whether a
+   * loopback `/health` actually reached THIS hub or a foreign process that has
+   * shadowed the port (the OrbStack loopback-hijack class). `serve` mints it,
+   * writes it to `~/.parachute/hub-instance.json`, and threads it here; absent
+   * on the DB-less / test / `bun src/hub-server.ts` paths, where `/health`
+   * simply omits the field (additive — no consumer parses `/health` for
+   * `instance` strictly).
+   */
+  instanceNonce?: string;
+  /**
    * Test seam for reading `expose-state.json`'s `hubOrigin`. Production reads
    * the operator's `~/.parachute/expose-state.json` via `readExposeState`;
    * tests inject a fake to drive tailnet/funnel origins into the bound set
@@ -2381,7 +2392,17 @@ export function hubFetch(
           }
         }
         return new Response(
-          JSON.stringify({ status: "ok", service: "parachute-hub", version: pkg.version, db }),
+          JSON.stringify({
+            status: "ok",
+            service: "parachute-hub",
+            version: pkg.version,
+            db,
+            // Per-boot instance nonce (hub#737): lets an external reader detect a
+            // loopback hijack (foreign process shadowing 127.0.0.1:<port>) by
+            // comparing this to the nonce serve wrote to hub-instance.json.
+            // Omitted when unset (DB-less / test / dev-entrypoint paths).
+            ...(deps?.instanceNonce ? { instance: deps.instanceNonce } : {}),
+          }),
           {
             headers: {
               "content-type": "application/json",


### PR DESCRIPTION
Closes hub#737. The **2026-07-02 P0's root trigger**: the hub binds `*:1939` (wildcard); an OrbStack VM auto-forwarded `127.0.0.1:1939` as a **specific** bind that wins over the wildcard for all loopback traffic. Every module's JWKS/API call silently reached the wrong (fresh, empty-JWKS) hub → a 9-hour ecosystem-wide 401 storm + ephemeral-port exhaustion. `lsof` showed two LISTENs; `/health` reporting the container's version was the tell.

## What this ships (detection — portable across every ordering + platform)

**1. Instance nonce in `/health`** — each `serve` process mints `crypto.randomUUID()` at boot, echoes it as an additive `instance` field in `/health` (omitted when unset, so no strict consumer breaks — verified none parse it strictly), and writes it to `~/.parachute/hub-instance.json` (0644). That file is the linchpin: an **external** process learns THIS hub's true identity from disk *without* traversing the (possibly hijacked) loopback.

**2. Startup + 5-min self-probe** (`armHubSelfProbe`, armed in `serve` after the bind) — compares its in-memory nonce to what a loopback `/health` returns:
- **hijacked** (loopback answered by a different/no nonce) → LOUD structured alert on **every** tick (standing emergency), naming the class + `lsof -nP -iTCP:<port> -sTCP:LISTEN` + `orb list` + the incident ref. Verdict persisted to the instance file.
- **unreachable** (bound but loopback refused) → softer note, logged **once per state change**.
- **recovery** → single "cleared" line.
- An immediate probe fires right after the bind, so a hijack already present at boot surfaces within the bounded timeout, not on the next tick.

**3. `parachute status`** reads the serve-written verdict **off disk** (not over the hijacked loopback, where its own liveness probe would read `active` off the rogue's 200) and flips the hub row to `failing` with a loud note on a hijack.

**4. `parachute doctor` — new `loopback-hijack` check** (Hub group, detect-only, no `--fix`):
| Condition | Verdict |
|---|---|
| no instance file / loopback unreachable | PASS (benign — #717 no-false-positive rule; Hub check owns "down") |
| loopback nonce == ours, 1 listener | PASS |
| loopback nonce == ours, ≥2 listeners | WARN (latent shadow that could win a reboot) |
| loopback nonce ≠ ours (or missing) | **FAIL** with the `lsof`/`orb` remediation + incident ref |

Listener count via `lsof`, best-effort (indeterminate → degrades to the nonce comparison alone).

## Item 4 (optional hardening) — investigated, **SKIPPED**

Empirically (macOS): a process CAN co-hold `0.0.0.0:P` + a specific `127.0.0.1:P`, and holding the specific bind **does** block a later rogue specific bind (even `reusePort`). BUT: when both listeners are in-process the **specific bind wins loopback**, so a naive guard with a stub handler would **steal loopback from the real hub — self-inflicting the exact outage**. A correct guard needs a second full `Bun.serve` sharing `hubFetch` + the WS bridge + the connection tracker, only helps when the hub boots **before** the rogue, and Linux/container `SO_REUSEADDR` semantics differ. That's the ">30min / gets complicated / could conflict" case the issue says to skip. Detection (above) is strictly more portable and catches **all** orderings at startup. Recommend the guard as a separate hardening PR if desired.

## Gates
- `bun run typecheck`: clean
- `bun test ./src`: **4157 pass / 1 skip / 0 fail** (+29 over the 4128 baseline: 19 hub-instance, 6 doctor, 3 status, 1 hub-server)
- `biome check`: clean on changed files
- **Live-verified** on a sandboxed `PARACHUTE_HOME` + test port (never the live `:1939` hub): `/health` carries the nonce; `hub-instance.json` written with matching nonce + startup self-probe `ok`; `doctor` clean→PASS (real `lsof` counted 1 listener) and a simulated nonce mismatch→FAIL with the full remediation (real loopback fetch vs real file read).

Do not merge — reviewer pass pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB

---

## Review fold (head `25ddf61`)

Folded the PR #740 reviewer findings:
- **MUST (status phantom-hijack):** the hijack override is now gated on `hubHealthy === true`, so a hard-killed hub that left a stale `hijacked` verdict on disk no longer renders a phantom "LOOPBACK HIJACK" over its normal down-hub row. `hubHealthy` is true exactly when something is answering the loopback port (the live-hijack condition), so a real hijack is never suppressed. Added a regression test (hubHealthy=false + stale hijacked verdict → no hijack message).
- **Shutdown hygiene:** `serve` now clears `hub-instance.json` on graceful stop (SIGTERM → `clearHubInstanceFile`); live-verified the file is removed on SIGTERM.
- **nit:** `writeHubInstanceFile` unlinks its `.tmp` file if the write/rename throws.
- **Guard-socket hardening (item 4):** filed as follow-up **#741** with the full macOS/Linux `SO_REUSEADDR` rationale.

Gates after fold: typecheck clean; `bun test ./src` **4159 pass / 1 skip / 0 fail**; biome clean.
