### PR TITLE
release: hub 0.7.6 (@latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.6-rc.4",
+  "version": "0.7.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Promote the tested rc.4 chain to stable **0.7.6** (published @latest on the `v0.7.6` tag). Same commit already passed the release gate when published @rc. Version-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)