### PR TITLE
feat(hub): account scope + POST /account/token mint (H1, campaign #116)

### DIFF
--- a/docs/contracts/oauth-scopes.md
+++ b/docs/contracts/oauth-scopes.md
@@ -37,6 +37,8 @@ Parachute OAuth tokens carry **whitespace-separated scope strings**
 | `surface:<name>:read` | Fetch/clone the named surface's hub-hosted git repo (Surface Git Transport) |
 | `surface:<name>:write` | Push to the named surface's repo (write ⊇ read at the git endpoint) |
 | `surface:admin` | surface-host module admin — the hub↔surface-host notify bearer + the credential endpoint |
+| `account:<id>:read` | Read the account: list the owner's vaults, read their caps/usage (Parachute App campaign, Phase 2 — the `/account/*` door contract). Cookie-minted only via `POST /account/token`; **not requestable** from third-party clients. On self-host `<id>` is the sentinel `self` (account ≡ box). |
+| `account:<id>:admin` | Every account mutation: create/delete/import vaults, mint per-vault tokens, set caps. `admin ⊇ read`. Cookie-minted only via `POST /account/token`; **not requestable**. |
 
 Third-party modules declare their own namespace (`my-service:read`, etc.)
 and the hub renders consent for those scopes the same way.
@@ -57,6 +59,7 @@ enforced by the agent daemon. See
 ```
 admin ⊇ write ⊇ read       (vault)
 write ⊇ read               (surface:<name>, at the git endpoint)
+admin ⊇ read               (account:<id>, at the /account/* validator)
 ```
 
 - `vault:<name>:admin` satisfies any check for `vault:<name>:write` or

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.6",
+  "version": "0.7.7-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-token.test.ts
+++ b/src/__tests__/account-token.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Tests for `POST /account/token` — the cookie→account-bearer mint (Parachute
+ * App campaign, Phase 2 H1). Covers:
+ *   - 405 on a non-POST method.
+ *   - 401 when no admin session cookie is present (unauthenticated → refused).
+ *   - 401 when the cookie names a deleted session.
+ *   - 403 csrf_failed when the double-submit CSRF token is missing / mismatched.
+ *   - 403 not_admin when a signed-in non-first-admin (friend) hits the endpoint.
+ *   - 200 mint carrying the superset {account:self:admin, parachute:host:admin,
+ *     parachute:host:auth}, aud="account", validating against the hub's keys.
+ *   - scope-guard admin ⊇ read: account:self:read is inherited by the minted
+ *     account:self:admin (the RS-side check the `/account/*` validator runs).
+ *   - the superset actually unlocks a host-admin-gated endpoint (requireScope
+ *     accepts parachute:host:admin even though aud="account" — SCOPE-b).
+ *   - sliding session renewal on the success path.
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+// The `/account/*` validator (H2 / cloud) hand-rolls its scope check via
+// scope-guard's hasScope — hub never imports scope-guard at runtime (the
+// issuer/validator boundary), but the test asserts the RS-side inheritance
+// the account grammar must satisfy. Same relative import as account-setup.test.
+import { hasScope } from "../../packages/scope-guard/src/scope.ts";
+import {
+  ACCOUNT_TOKEN_AUDIENCE,
+  ACCOUNT_TOKEN_TTL_SECONDS,
+  handleAccountToken,
+} from "../account-token.ts";
+import { requireScope } from "../admin-auth.ts";
+import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { ACCOUNT_SELF_ADMIN_SCOPE, ACCOUNT_SELF_READ_SCOPE } from "../scope-explanations.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  createSession,
+  deleteSession,
+  findSession,
+} from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-token-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+/**
+ * Build a first-admin session + a matching CSRF token pair. Returns the cookie
+ * header (session + csrf) and the CSRF token to place in the JSON body — the
+ * double-submit both halves must agree on.
+ */
+async function withAdminSession(): Promise<{
+  cookie: string;
+  csrf: string;
+  userId: string;
+}> {
+  const user = await createUser(harness.db, "operator", "operator-passphrase");
+  const session = createSession(harness.db, { userId: user.id });
+  const csrf = generateCsrfToken();
+  const cookie = [
+    buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)).split(";")[0],
+    buildCsrfCookie(csrf).split(";")[0],
+  ].join("; ");
+  return { cookie, csrf, userId: user.id };
+}
+
+/** Seed an admin + a second non-admin friend; return the friend's cookie/csrf. */
+async function withFriendSession(): Promise<{ cookie: string; csrf: string }> {
+  await createUser(harness.db, "admin", "admin-passphrase");
+  const friend = await createUser(harness.db, "alice", "alice-passphrase", { allowMulti: true });
+  const session = createSession(harness.db, { userId: friend.id });
+  const csrf = generateCsrfToken();
+  const cookie = [
+    buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)).split(";")[0],
+    buildCsrfCookie(csrf).split(";")[0],
+  ].join("; ");
+  return { cookie, csrf };
+}
+
+function postReq(cookie: string, body: Record<string, unknown>): Request {
+  return new Request(`${ISSUER}/account/token`, {
+    method: "POST",
+    headers: { cookie, "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("handleAccountToken", () => {
+  test("405 on GET", async () => {
+    const { cookie } = await withAdminSession();
+    const req = new Request(`${ISSUER}/account/token`, { headers: { cookie } });
+    const res = await handleAccountToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(405);
+  });
+
+  test("401 when no session cookie is present (unauthenticated → refused)", async () => {
+    // No session AND no CSRF: the session gate fires first, so the refusal is a
+    // clean 401 rather than a CSRF 403.
+    const req = postReq("", { [CSRF_FIELD_NAME]: "anything" });
+    const res = await handleAccountToken(req, { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(401);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("unauthenticated");
+  });
+
+  test("401 when the cookie names a deleted session", async () => {
+    const { cookie, csrf } = await withAdminSession();
+    const sid = cookie.match(/parachute_hub_session=([^;]+)/)?.[1] ?? "";
+    deleteSession(harness.db, sid);
+    const res = await handleAccountToken(postReq(cookie, { [CSRF_FIELD_NAME]: csrf }), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(401);
+  });
+
+  test("403 csrf_failed when the CSRF token is absent from the body", async () => {
+    const { cookie } = await withAdminSession();
+    rotateSigningKey(harness.db);
+    const res = await handleAccountToken(postReq(cookie, {}), { db: harness.db, issuer: ISSUER });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("csrf_failed");
+  });
+
+  test("403 csrf_failed when the body token doesn't match the cookie token", async () => {
+    const { cookie } = await withAdminSession();
+    rotateSigningKey(harness.db);
+    // A well-formed but wrong token (never the cookie's value).
+    const res = await handleAccountToken(
+      postReq(cookie, { [CSRF_FIELD_NAME]: generateCsrfToken() }),
+      { db: harness.db, issuer: ISSUER },
+    );
+    expect(res.status).toBe(403);
+    expect(((await res.json()) as { error: string }).error).toBe("csrf_failed");
+  });
+
+  test("403 not_admin when a signed-in friend (non-first-admin) mints", async () => {
+    // Privesc closure: a valid friend session + valid CSRF must still be
+    // refused — the account superset carries host:admin + host:auth, which a
+    // non-admin must never hold. The gate keys off first-admin (account ≡ box).
+    const { cookie, csrf } = await withFriendSession();
+    rotateSigningKey(harness.db);
+    const res = await handleAccountToken(postReq(cookie, { [CSRF_FIELD_NAME]: csrf }), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(403);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("not_admin");
+    expect(body.error_description).toContain("/account/");
+  });
+
+  test("200 mints the account superset with aud=account, validating against the hub keys", async () => {
+    const { cookie, csrf, userId } = await withAdminSession();
+    rotateSigningKey(harness.db);
+    const res = await handleAccountToken(postReq(cookie, { [CSRF_FIELD_NAME]: csrf }), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("cache-control")).toBe("no-store");
+
+    const body = (await res.json()) as {
+      token: string;
+      expires_at: string;
+      scopes: string[];
+      aud: string;
+    };
+    // The superset (SCOPE-b): account scope + the host superset.
+    expect(body.scopes).toEqual([
+      "account:self:admin",
+      "parachute:host:admin",
+      "parachute:host:auth",
+    ]);
+    expect(body.aud).toBe(ACCOUNT_TOKEN_AUDIENCE);
+
+    // TTL is roughly the 10-min window.
+    const skew = new Date(body.expires_at).getTime() - Date.now();
+    expect(skew).toBeGreaterThan((ACCOUNT_TOKEN_TTL_SECONDS - 30) * 1000);
+    expect(skew).toBeLessThan((ACCOUNT_TOKEN_TTL_SECONDS + 30) * 1000);
+
+    // JWT verifies against the hub's own signing key + issuer, and carries the
+    // explicit account audience (SCOPE-a).
+    const validated = await validateAccessToken(harness.db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(userId);
+    expect(validated.payload.iss).toBe(ISSUER);
+    expect(validated.payload.aud).toBe(ACCOUNT_TOKEN_AUDIENCE);
+    const scopes = ((validated.payload as { scope?: string }).scope ?? "").split(/\s+/);
+    expect(scopes).toContain("account:self:admin");
+    expect(scopes).toContain("parachute:host:admin");
+    expect(scopes).toContain("parachute:host:auth");
+  });
+
+  test("scope-guard: account:self:read is inherited by the minted account:self:admin", async () => {
+    // The `/account/*` validator (H2 / cloud) hand-rolls admin ⊇ read via
+    // scope-guard. The minted token carries account:self:admin; a read-gated
+    // account endpoint must accept it, an admin-gated one too, and neither a
+    // different account id nor an unrelated resource must match.
+    const { cookie, csrf } = await withAdminSession();
+    rotateSigningKey(harness.db);
+    const res = await handleAccountToken(postReq(cookie, { [CSRF_FIELD_NAME]: csrf }), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    const { scopes } = (await res.json()) as { scopes: string[] };
+
+    expect(hasScope(scopes, ACCOUNT_SELF_ADMIN_SCOPE)).toBe(true);
+    expect(hasScope(scopes, ACCOUNT_SELF_READ_SCOPE)).toBe(true); // admin ⊇ read
+    // A different account id must NOT be satisfied (name-pinned inheritance).
+    expect(hasScope(scopes, "account:other:read")).toBe(false);
+    // account:self:admin must never satisfy a vault scope.
+    expect(hasScope(scopes, "vault:self:read")).toBe(false);
+  });
+
+  test("the minted superset unlocks a host-admin-gated endpoint (SCOPE-b, aud not pinned)", async () => {
+    // requireScope validates signature + iss + the scope claim but does NOT pin
+    // aud, so the aud="account" token is accepted on the host-scoped surfaces
+    // (POST /vaults, /api/auth/*) it wraps — no existing gate needs rewiring.
+    const { cookie, csrf } = await withAdminSession();
+    rotateSigningKey(harness.db);
+    const res = await handleAccountToken(postReq(cookie, { [CSRF_FIELD_NAME]: csrf }), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    const { token } = (await res.json()) as { token: string };
+
+    const bearerReq = new Request(`${ISSUER}/vaults`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    });
+    const ctx = await requireScope(harness.db, bearerReq, "parachute:host:admin", ISSUER);
+    expect(ctx.scopes).toContain("account:self:admin");
+    expect(ctx.audience).toBe(ACCOUNT_TOKEN_AUDIENCE);
+  });
+
+  test("200 slides the session expiry forward and re-issues the cookie", async () => {
+    const user = await createUser(harness.db, "operator", "operator-passphrase");
+    const twelveHoursAgo = new Date(Date.now() - 12 * 60 * 60 * 1000);
+    const session = createSession(harness.db, { userId: user.id, now: () => twelveHoursAgo });
+    const originalExpiry = new Date(session.expiresAt).getTime();
+    const csrf = generateCsrfToken();
+    const cookie = [
+      buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000)).split(";")[0],
+      buildCsrfCookie(csrf).split(";")[0],
+    ].join("; ");
+    rotateSigningKey(harness.db);
+
+    const res = await handleAccountToken(postReq(cookie, { [CSRF_FIELD_NAME]: csrf }), {
+      db: harness.db,
+      issuer: ISSUER,
+    });
+    expect(res.status).toBe(200);
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain("parachute_hub_session=");
+    expect(setCookie).toContain("HttpOnly");
+    expect(setCookie).toContain("Secure"); // ISSUER is https
+    expect(setCookie).toContain("SameSite=Lax");
+    expect(setCookie.toLowerCase()).not.toContain("domain=");
+
+    const found = findSession(harness.db, session.id);
+    expect(new Date(found?.expiresAt ?? 0).getTime()).toBeGreaterThan(originalExpiry);
+  });
+});

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -22,6 +22,9 @@ describe("SCOPE_EXPLANATIONS", () => {
       "agent:send",
       "hub:admin",
       "parachute:host:admin",
+      // Account scopes (Parachute App campaign, Phase 2).
+      "account:self:admin",
+      "account:self:read",
     ];
     for (const s of expected) {
       expect(SCOPE_EXPLANATIONS[s]).toBeDefined();
@@ -156,6 +159,14 @@ describe("NON_REQUESTABLE_SCOPES (#96)", () => {
     expect(NON_REQUESTABLE_SCOPES.has("scribe:admin")).toBe(true);
   });
 
+  test("contains the account scopes (App campaign Phase 2 — cookie-minted only)", () => {
+    // account:self:{admin,read} are minted exclusively by POST /account/token
+    // (cookie→bearer), never via /oauth/authorize — a third-party app pointed at
+    // the hub AS must not be able to consent its way to account authority.
+    expect(NON_REQUESTABLE_SCOPES.has("account:self:admin")).toBe(true);
+    expect(NON_REQUESTABLE_SCOPES.has("account:self:read")).toBe(true);
+  });
+
   test("every non-requestable scope is a known first-party scope", () => {
     for (const s of NON_REQUESTABLE_SCOPES) {
       expect(FIRST_PARTY_SCOPES).toContain(s);
@@ -193,6 +204,17 @@ describe("isRequestableScope", () => {
     expect(isRequestableScope("vault:default:admin")).toBe(true);
     expect(isRequestableScope("vault:work:admin")).toBe(true);
     expect(isRequestableScope("vault:my-techne_2:admin")).toBe(true);
+  });
+
+  test("account scopes are non-requestable (cookie-minted only, App campaign)", () => {
+    expect(isRequestableScope("account:self:admin")).toBe(false);
+    expect(isRequestableScope("account:self:read")).toBe(false);
+    // explainScope resolves them (direct SCOPE_EXPLANATIONS keys) with the
+    // right levels, so scopeIsAdmin recognizes the admin form.
+    expect(explainScope("account:self:admin")?.level).toBe("admin");
+    expect(explainScope("account:self:read")?.level).toBe("read");
+    expect(scopeIsAdmin("account:self:admin")).toBe(true);
+    expect(scopeIsAdmin("account:self:read")).toBe(false);
   });
 
   test("host-level operator scopes stay non-requestable", () => {

--- a/src/account-token.ts
+++ b/src/account-token.ts
@@ -1,0 +1,200 @@
+/**
+ * `POST /account/token` — exchange a valid admin session cookie for a
+ * short-lived JWT carrying the ACCOUNT credential: the superset
+ *
+ *   { account:self:admin, parachute:host:admin, parachute:host:auth }
+ *
+ * with `aud="account"`. This is the self-host door's half of the Parachute App
+ * campaign's `/account/*` contract (Phase 2, H1) — the same shape the cloud
+ * door mints from its own session cookie.
+ *
+ * Why a SUPERSET (SCOPE-b). The account bearer must drive both the net-new
+ * `/account/*` REST surface (H2, gated on `account:self:admin`) AND — on a
+ * single-operator self-host box — the EXISTING hub admin endpoints it wraps
+ * (`POST /vaults`, `/api/auth/*`, caps), all gated on `parachute:host:admin` /
+ * `parachute:host:auth` via `requireScope`. Carrying all three scopes means no
+ * existing hub endpoint needs rewiring: `requireScope` checks the scope claim +
+ * signature + `iss` and does NOT pin `aud` (admin-auth.ts), so the `aud="account"`
+ * token validates unchanged on the host-scoped surfaces. This is the "relabel a
+ * semantics that ships" path — it reuses the `admin-host-admin-token.ts` mint
+ * and adds the `account:self:admin` string on top of the host superset.
+ *
+ * Why `aud="account"` (SCOPE-a). The account token is minted with an explicit
+ * `aud="account"` (not the `inferAudience` fallback) so the `/account/*`
+ * validator can pin the audience and a vault RS's strict `aud=vault.<name>`
+ * check refuses it outright — an account token can never be spent as a vault
+ * token.
+ *
+ * Authorization — the same spine as `/admin/host-admin-token`:
+ *   1. **Session.** A valid, unexpired `parachute_hub_session` cookie (set by
+ *      `/login` after a password check). No session → 401.
+ *   2. **CSRF.** Unlike the GET host-admin mint, this is a POST that performs a
+ *      privileged mint, so it carries the double-submit CSRF token
+ *      (`__csrf` in the JSON body, same `verifyCsrfToken` as `/api/account/*`).
+ *      Missing/mismatched → 403. The hub-server dispatcher additionally applies
+ *      the strict same-origin Origin belt (`assertSameOriginForCookieMutation`)
+ *      before this handler runs — belt-and-suspenders on the cookie path.
+ *   3. **First-admin gate.** A valid session is necessary but NOT sufficient: it
+ *      must belong to the hub admin (earliest-created user row). Without this a
+ *      signed-in friend account could mint a full host-admin superset — a
+ *      privesc. On a single-operator box first-admin ≡ the account ≡ the box
+ *      (the ratified "operator ≡ account ≡ box"), so the first-admin gate is the
+ *      account gate. Non-first-admin session → 403.
+ *   4. **Admin screen-lock.** When the optional idle-lock PIN is set and this
+ *      session isn't in an unlock window, refuse (423) — same as the host-admin
+ *      mint (the account token is at least as powerful, so it inherits the gate).
+ *
+ * Statelessness + revocation (SCOPE-d). Like the host-admin token, the account
+ * token is deliberately NOT persisted in the `tokens` table — no registry row,
+ * no per-jti revocation. It is short-lived (10 min) and re-minted from the live
+ * session; revocation is by logout (kills the cookie → no re-mint) plus the
+ * read-time session-expiry chokepoint. A stateless mint avoids a DB write on
+ * every re-mint.
+ */
+import type { Database } from "bun:sqlite";
+import { HOST_ADMIN_SCOPES } from "./admin-host-admin-token.ts";
+import { lockedResponse, requireUnlocked } from "./admin-lock.ts";
+import { CSRF_FIELD_NAME, verifyCsrfToken } from "./csrf.ts";
+import { signAccessToken } from "./jwt-sign.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
+import { ACCOUNT_SELF_ADMIN_SCOPE } from "./scope-explanations.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  findSession,
+  parseSessionCookie,
+  touchSession,
+} from "./sessions.ts";
+import { isFirstAdmin } from "./users.ts";
+
+/** Short TTL — page-snapshot threats can't carry the token forever. Matches the
+ * host-admin mint's 10-min window; the app re-mints when it's about to lapse. */
+export const ACCOUNT_TOKEN_TTL_SECONDS = 10 * 60;
+/** Explicit account audience (SCOPE-a) — pinned by the `/account/*` validator;
+ * a vault RS's strict `aud=vault.<name>` check refuses it. */
+export const ACCOUNT_TOKEN_AUDIENCE = "account";
+/** First-party browser client id for the account credential (matches the
+ * `parachute-account` id the friend vault-token mints already use). */
+export const ACCOUNT_TOKEN_CLIENT_ID = "parachute-account";
+/** The superset the account bearer carries (SCOPE-b): the account scope plus
+ * the host superset, so the same token drives both the `/account/*` surface and
+ * the host-scoped endpoints it wraps without rewiring any existing gate. */
+export const ACCOUNT_TOKEN_SCOPES = [ACCOUNT_SELF_ADMIN_SCOPE, ...HOST_ADMIN_SCOPES] as const;
+
+export interface MintAccountTokenDeps {
+  db: Database;
+  /** Hub origin — written into JWT `iss`. */
+  issuer: string;
+}
+
+export async function handleAccountToken(
+  req: Request,
+  deps: MintAccountTokenDeps,
+): Promise<Response> {
+  if (req.method !== "POST") {
+    return jsonError(405, "method_not_allowed", "use POST");
+  }
+
+  // Gate 1 — session. No identity, no mint.
+  const sid = parseSessionCookie(req.headers.get("cookie"));
+  const session = sid ? findSession(deps.db, sid) : null;
+  if (!session || !sid) {
+    return jsonError(401, "unauthenticated", "no admin session — sign in at /login first");
+  }
+
+  // Gate 2 — CSRF double-submit. This is a POST mint, so a cross-site forged
+  // submission must be refused before any privileged work. The token rides the
+  // JSON body's `__csrf` field, same shape + helper as `/api/account/*`. The
+  // dispatcher's Origin belt already ran; this is the double-submit half.
+  const csrfToken = await readCsrfToken(req);
+  if (!verifyCsrfToken(req, csrfToken)) {
+    return jsonError(403, "csrf_failed", "missing or invalid CSRF token");
+  }
+
+  // Gate 3 — first-admin. A friend account (non-first-admin) holds a valid
+  // session but must not mint the account superset (host:admin + host:auth is a
+  // full-admin privesc). On a single-operator box first-admin ≡ the account, so
+  // this gate IS the account gate. Mirror the host-admin mint's 403 shape.
+  if (!isFirstAdmin(deps.db, session.userId)) {
+    return jsonError(
+      403,
+      "not_admin",
+      "account token mint is restricted to the hub admin — your account home is at /account/",
+    );
+  }
+
+  // Gate 4 — admin screen-lock (optional, off by default). When a lock PIN is
+  // set AND this session isn't within an unlock window, refuse. Same PURE-CHECK
+  // posture as the host-admin mint: it does NOT slide the idle window (sliding
+  // is heartbeat-only), so a background re-mint can't keep an idle tab unlocked.
+  if (!requireUnlocked(deps.db, sid).ok) {
+    return lockedResponse();
+  }
+
+  const minted = await signAccessToken(deps.db, {
+    sub: session.userId,
+    scopes: [...ACCOUNT_TOKEN_SCOPES],
+    audience: ACCOUNT_TOKEN_AUDIENCE,
+    clientId: ACCOUNT_TOKEN_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds: ACCOUNT_TOKEN_TTL_SECONDS,
+    // No per-user vault pin — the account bearer talks to hub-scoped account +
+    // provisioning endpoints, not a single vault. Empty `vault_scope` is the
+    // "no per-user restriction" sentinel, matching the host-admin mint.
+    vaultScope: [],
+  });
+
+  // Sliding session renewal — a successful mint pushes the session's expiry
+  // forward and re-issues the cookie with the EXACT attributes creation uses,
+  // so an app re-minting ~every 10 min keeps the operator signed in without
+  // broadening the cookie. Identical to the host-admin mint.
+  touchSession(deps.db, sid);
+  const sessionCookie = buildSessionCookie(sid, Math.floor(SESSION_TTL_MS / 1000), {
+    secure: isHttpsRequest(req),
+  });
+
+  return new Response(
+    JSON.stringify({
+      token: minted.token,
+      expires_at: minted.expiresAt,
+      scopes: ACCOUNT_TOKEN_SCOPES,
+      aud: ACCOUNT_TOKEN_AUDIENCE,
+    }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        // No browser cache — the token rotates per-mint; a stale 200 from a
+        // back/forward navigation could hand the app a long-expired JWT.
+        "cache-control": "no-store",
+        "set-cookie": sessionCookie,
+      },
+    },
+  );
+}
+
+/**
+ * Pull the double-submit CSRF token from the JSON request body's `__csrf`
+ * field. Tolerant of an absent/malformed body (returns null → the verify
+ * fails closed with a 403), matching `readJsonBody` + `checkCsrf` in
+ * `api-account-2fa.ts`.
+ */
+async function readCsrfToken(req: Request): Promise<string | null> {
+  try {
+    const body = (await req.json()) as unknown;
+    if (body && typeof body === "object") {
+      const token = (body as Record<string, unknown>)[CSRF_FIELD_NAME];
+      return typeof token === "string" ? token : null;
+    }
+  } catch {
+    // Empty or non-JSON body — no token.
+  }
+  return null;
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return new Response(JSON.stringify({ error, error_description: description }), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -116,6 +116,13 @@
  *                                                 (forceChangePasswordGate); only this
  *                                                 route and /logout stay reachable
  *                                                 pre-rotation.
+ *   /account/token                (POST)       → cookie→account-bearer mint (App
+ *                                                 campaign Phase 2 H1): session cookie →
+ *                                                 short-lived JWT carrying the account
+ *                                                 superset {account:self:admin,
+ *                                                 parachute:host:admin, parachute:host:auth}
+ *                                                 aud="account"; first-admin-gated,
+ *                                                 CSRF + same-origin belt; stateless
  *   /account/2fa                  (GET + POST) → user self-service 2FA enroll/disenroll
  *                                                 (hub#473; QR + backup codes)
  *   /account/vault-token/<name>   (POST)       → friend mints a scoped
@@ -164,6 +171,7 @@ import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import pkg from "../package.json" with { type: "json" };
 import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
+import { handleAccountToken } from "./account-token.ts";
 import { handleAccountVaultAdminTokenPost } from "./account-vault-admin-token.ts";
 import { handleAccountVaultTokenPost } from "./account-vault-token.ts";
 import {
@@ -3719,6 +3727,27 @@ export function hubFetch(
       if (getDb && (pathname === "/account" || pathname.startsWith("/account/"))) {
         const gate = forceChangePasswordGate(getDb(), req);
         if (gate) return gate;
+      }
+
+      // /account/token — cookie→account-bearer mint (Parachute App campaign,
+      // Phase 2 H1). POST-only. Exchanges the `parachute_hub_session` cookie for
+      // a short-lived JWT carrying the account superset
+      // {account:self:admin, parachute:host:admin, parachute:host:auth} with
+      // aud="account" — the same-origin app's bootstrap into holding the account
+      // credential (it never touches /oauth/authorize, so never hits consent).
+      // First-admin-gated (account ≡ box), CSRF double-submit + the same-origin
+      // Origin belt below. Stateless (no tokens row); revocation = logout.
+      if (pathname === "/account/token") {
+        if (!getDb) return dbNotConfigured();
+        // Origin belt (hub#632 posture): a cookie-authed POST mint gets the
+        // strict same-origin check as defense-in-depth over the body's CSRF
+        // token. A Bearer-authed caller (none expected here) would bypass the
+        // belt but still fail the cookie-only session gate inside the handler.
+        {
+          const rejected = assertSameOriginForCookieMutation(req, oauthDeps(req).hubBoundOrigins());
+          if (rejected) return rejected;
+        }
+        return handleAccountToken(req, { db: getDb(), issuer: oauthDeps(req).issuer });
       }
 
       // /account/2fa — user self-service TOTP 2FA enroll / disenroll (hub#473).

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -112,7 +112,33 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
     label: "Administer vaults on this host (create, configure, delete).",
     level: "admin",
   },
+  // Account scopes (Parachute App campaign, Phase 2 — the `/account/*` door
+  // contract). `account:<id>:admin` authorizes every account mutation
+  // (create/delete/import vaults, mint per-vault tokens, set caps); `:read`
+  // authorizes the read side (list vaults, read caps/usage). On a self-host
+  // hub `<id>` is the sentinel `self` (account ≡ box). These are minted ONLY
+  // by the cookie→bearer `POST /account/token` exchange, NEVER via the public
+  // OAuth flow — they're in NON_REQUESTABLE_SCOPES below, like the host scopes.
+  // Listed here (a) so `NON_REQUESTABLE_SCOPES ⊆ FIRST_PARTY_SCOPES` holds and
+  // (b) so scope-guard's `admin ⊇ read` inheritance recognizes the grammar
+  // (`account:self:admin` satisfies `account:self:read`).
+  "account:self:admin": {
+    label:
+      "Manage your Parachute account — create, delete, and configure your vaults, and mint access tokens for them.",
+    level: "admin",
+  },
+  "account:self:read": {
+    label: "View your Parachute account — list your vaults and read their settings and usage.",
+    level: "read",
+  },
 };
+
+/** Account scope strings (Parachute App campaign, Phase 2). Exported so the
+ * `POST /account/token` mint and the `/account/*` route gates reference the
+ * canonical constants rather than re-literaling the strings. `self` is the
+ * self-host account sentinel (account ≡ box). */
+export const ACCOUNT_SELF_ADMIN_SCOPE = "account:self:admin";
+export const ACCOUNT_SELF_READ_SCOPE = "account:self:read";
 
 /**
  * Sorted list of every first-party scope the hub recognizes. Used as the
@@ -170,6 +196,13 @@ export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
   // Service-admin scopes: operator-only, never requestable via /oauth/authorize.
   "hub:admin",
   "scribe:admin",
+  // Account scopes (Parachute App campaign, Phase 2): cookie-minted only via
+  // `POST /account/token`, NEVER OAuth-requestable. A third-party app pointed
+  // at the hub AS must not be able to consent its way to account authority
+  // (create/delete vaults, mint per-vault tokens) — the account credential is
+  // exclusively the same-origin app's cookie→bearer exchange.
+  ACCOUNT_SELF_ADMIN_SCOPE,
+  ACCOUNT_SELF_READ_SCOPE,
 ]);
 
 /**


### PR DESCRIPTION
Phase 2 (the door contract) **H1** — the self-host door's half of the Parachute App campaign's `/account/*` credential seam. Builds the account scope vocabulary + the cookie→bearer mint that bootstraps the same-origin app into holding the account credential. Does **not** build the `/account/*` REST endpoints (that's H2).

Refs: campaign #116, `plan/PHASE-2-BREAKDOWN.md` §2 (scope tier) / §4 (credential) + the H1 row. Ratified decisions honored: **SCOPE-a** (explicit `aud="account"`), **SCOPE-b** (superset token, no existing endpoint rewired), **SCOPE-d** (stateless + short-TTL; revocation = logout).

## What lands

- **Scope vocabulary** (`scope-explanations.ts`): adds `account:self:admin` + `account:self:read` to `SCOPE_EXPLANATIONS` and to `NON_REQUESTABLE_SCOPES`. Account scopes are **cookie-minted only** — a third-party app pointed at the hub AS can't consent its way to account authority. scope-guard's generic `admin ⊇ read` (`hasScope`) already recognizes the `account:<id>` grammar (resource `account`, name `self`, verb rank) — **no scope-guard change**. Exports `ACCOUNT_SELF_ADMIN_SCOPE` / `ACCOUNT_SELF_READ_SCOPE` for reuse.
- **`POST /account/token`** (new `account-token.ts` + `hub-server.ts` route): exchanges the `parachute_hub_session` cookie for a short-lived (10 min) bearer carrying the superset `{account:self:admin, parachute:host:admin, parachute:host:auth}`, `aud="account"`. Reuses the `admin-host-admin-token.ts` mint machinery + `HOST_ADMIN_SCOPES`. **First-admin-gated** (account ≡ box), **POST + CSRF** double-submit (`__csrf` in JSON body, same helper as `/api/account/*`), plus the dispatcher's same-origin Origin belt (`assertSameOriginForCookieMutation`). Stateless — no `tokens` registry row; revocation is logout.

### Why the superset validates on host endpoints (SCOPE-b)
`requireScope` (`admin-auth.ts`) checks the scope claim + `iss` + signature but **does not pin `aud`** — so the `aud="account"` token is accepted unchanged on the `parachute:host:admin`-gated surfaces H2 wraps (`POST /vaults`, `/api/auth/*`, caps). No existing gate needs rewiring. A test asserts this directly.

## Auth-critical review points
- **CSRF**: double-submit token verified (`verifyCsrfToken`) **and** the same-origin Origin belt applied at the route — belt-and-suspenders, matching `/api/account/*`.
- **First-admin gate kept**: a signed-in non-admin friend (valid session + valid CSRF) still gets `403 not_admin` — the superset carries host:admin, which a non-admin must never hold.
- **`aud="account"` explicit** so a vault RS's strict `aud=vault.<name>` check refuses it; scope-guard test asserts `account:self:admin` never satisfies a `vault:*` scope.

## Gates
- `bun test ./src`: **4171 pass / 1 skip / 0 fail** (158 files). New `account-token.test.ts` = 10 tests; `scope-explanations.test.ts` gains account coverage.
- `bun run typecheck`: clean. `biome check`: clean.

Live-verify (cookie → `POST /account/token` → decode claims) is the ★ staging-soak step for the merge decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB