### PR TITLE
feat(hub): /account/* REST facade + capabilities descriptor (H2, campaign #116)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.1",
+  "version": "0.7.7-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -1,0 +1,511 @@
+import type { Database } from "bun:sqlite";
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  handleAccountCapabilities,
+  handleAccountCreateVault,
+  handleAccountGetVaultCaps,
+  handleAccountListVaults,
+  handleAccountMintVaultToken,
+  handleAccountRoot,
+  handleAccountSetVaultCaps,
+} from "../account-api.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken, validateAccessToken } from "../jwt-sign.ts";
+import { upsertService } from "../services-manifest.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+import { getVaultCap } from "../vault-caps.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+const HOST_ADMIN_SCOPE = "parachute:host:admin";
+const ACCOUNT_ADMIN_SCOPE = "account:self:admin";
+const ACCOUNT_READ_SCOPE = "account:self:read";
+
+type RunResult = { exitCode: number; stdout: string; stderr: string };
+
+/** Mirror of the `parachute-vault create --json` stdout shape (see admin-vaults.test). */
+function vaultCreateJson(
+  name: string,
+  token = `hubjwt.${name}.access`,
+  tokenGuidance?: string,
+): string {
+  return JSON.stringify({
+    name,
+    token,
+    ...(tokenGuidance ? { token_guidance: tokenGuidance } : {}),
+    paths: {
+      vault_dir: `/home/test/.parachute/vault/${name}`,
+      vault_db: `/home/test/.parachute/vault/${name}/vault.db`,
+      vault_config: `/home/test/.parachute/vault/${name}/config.yaml`,
+    },
+    set_as_default: false,
+  });
+}
+
+interface Harness {
+  db: Database;
+  dir: string;
+  manifestPath: string;
+  cleanup: () => void;
+}
+
+function makeHarness(vaultNames: string[] = ["beta", "personal"]): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-api-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const manifestPath = join(dir, "services.json");
+  const paths = vaultNames.map((n) => `/vault/${n}`);
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      services: [
+        { name: "parachute-vault", port: 4101, paths, health: "/health", version: "0.4.2" },
+      ],
+    }),
+  );
+  return {
+    db,
+    dir,
+    manifestPath,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+function deps(
+  h: Harness,
+  extra: Partial<{ runCommand: (cmd: readonly string[]) => Promise<RunResult> }> = {},
+) {
+  return { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath, ...extra };
+}
+
+async function bearer(h: Harness, scopes: string[], sub = "operator-user"): Promise<string> {
+  const minted = await signAccessToken(h.db, {
+    sub,
+    scopes,
+    audience: "account",
+    clientId: "parachute-hub-spa",
+    issuer: ISSUER,
+    ttlSeconds: 600,
+  });
+  return minted.token;
+}
+
+function withBearer(path: string, token: string | null, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers ?? {});
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return new Request(`${ISSUER}${path}`, { ...init, headers });
+}
+
+function jsonReq(path: string, token: string, method: string, body?: unknown): Request {
+  const init: RequestInit = { method };
+  if (body !== undefined) {
+    init.body = JSON.stringify(body);
+    init.headers = { "content-type": "application/json" };
+  }
+  return withBearer(path, token, init);
+}
+
+// ===========================================================================
+// GET /.well-known/parachute-account — the capabilities descriptor
+// ===========================================================================
+describe("handleAccountCapabilities", () => {
+  test("descriptor is public and reports the self-host door honestly", async () => {
+    const res = handleAccountCapabilities(new Request(`${ISSUER}/.well-known/parachute-account`), {
+      issuer: `${ISSUER}/`,
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.door).toBe("self-host");
+    expect(body.issuer).toBe(ISSUER); // trailing slash trimmed
+    const features = body.features as Record<string, unknown>;
+    expect(features.billing).toBe(false); // no billing on self-host
+    expect(features.plans).toEqual([]);
+    expect(features.vault_create).toBe(true);
+    expect(features.vault_delete).toBe(true);
+    expect(features.modules).toBe(true);
+    expect(features.expose).toBe(true);
+    expect(body.caps_writable).toBe(true);
+    expect((body.limits as Record<string, unknown>).vaults_max).toBeNull();
+  });
+
+  test("405 on non-GET", () => {
+    const res = handleAccountCapabilities(
+      new Request(`${ISSUER}/.well-known/parachute-account`, { method: "POST" }),
+      { issuer: ISSUER },
+    );
+    expect(res.status).toBe(405);
+  });
+});
+
+// ===========================================================================
+// Auth gates (shared shape across the surface)
+// ===========================================================================
+describe("account API — auth gates", () => {
+  test("401 with no Authorization header", async () => {
+    const h = makeHarness();
+    try {
+      const res = await handleAccountListVaults(withBearer("/account/vaults", null), deps(h));
+      expect(res.status).toBe(401);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 when the token carries neither account:self:* nor host:admin", async () => {
+    const h = makeHarness();
+    try {
+      const token = await bearer(h, ["vault:beta:read"]);
+      const res = await handleAccountListVaults(withBearer("/account/vaults", token), deps(h));
+      expect(res.status).toBe(403);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a plain parachute:host:admin token is accepted (H1-independent)", async () => {
+    const h = makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const res = await handleAccountListVaults(withBearer("/account/vaults", token), deps(h));
+      expect(res.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("an account:self:admin token is accepted", async () => {
+    const h = makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountListVaults(withBearer("/account/vaults", token), deps(h));
+      expect(res.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("account:self:read is accepted on reads but rejected (403) on mutations", async () => {
+    const h = makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const read = await handleAccountListVaults(withBearer("/account/vaults", token), deps(h));
+      expect(read.status).toBe(200);
+      const write = await handleAccountCreateVault(
+        jsonReq("/account/vaults", token, "POST", { name: "nope" }),
+        deps(h),
+      );
+      expect(write.status).toBe(403);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// GET /account/vaults — list
+// ===========================================================================
+describe("handleAccountListVaults", () => {
+  test("lists every registered vault with url + version + caps", async () => {
+    const h = makeHarness(["alpha", "beta"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountListVaults(withBearer("/account/vaults", token), deps(h));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        vaults: Array<{
+          name: string;
+          url: string;
+          version: string;
+          caps: { cap_bytes: number | null };
+        }>;
+      };
+      const names = body.vaults.map((v) => v.name).sort();
+      expect(names).toEqual(["alpha", "beta"]);
+      const alpha = body.vaults.find((v) => v.name === "alpha");
+      expect(alpha?.url).toBe(`${ISSUER}/vault/alpha`);
+      expect(alpha?.version).toBe("0.4.2");
+      expect(alpha?.caps.cap_bytes).toBeNull();
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// POST /account/vaults — create (returns a ready-to-use vault token)
+// ===========================================================================
+describe("handleAccountCreateVault", () => {
+  test("201 returns the vault token + services block on a fresh create", async () => {
+    const h = makeHarness(["default"]);
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work", "hubjwt.work.access"), stderr: "" };
+      };
+      const res = await handleAccountCreateVault(
+        jsonReq("/account/vaults", token, "POST", { name: "work" }),
+        deps(h, { runCommand }),
+      );
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as {
+        name: string;
+        url: string;
+        vault_token: string;
+        services: Record<string, { url: string; version: string }>;
+      };
+      expect(body.name).toBe("work");
+      expect(body.url).toBe(`${ISSUER}/vault/work`);
+      expect(body.vault_token).toBe("hubjwt.work.access");
+      expect(body.services["vault:work"]?.url).toBe(`${ISSUER}/vault/work`);
+      expect(body.services["vault:work"]?.version).toBe("0.4.2");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("empty vault_token + token_guidance flow through so the app can fall back", async () => {
+    const h = makeHarness(["default"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return {
+          exitCode: 0,
+          stdout: vaultCreateJson("work", "", "no hub origin reachable to mint against"),
+          stderr: "",
+        };
+      };
+      const res = await handleAccountCreateVault(
+        jsonReq("/account/vaults", token, "POST", { name: "work" }),
+        deps(h, { runCommand }),
+      );
+      expect(res.status).toBe(201);
+      const body = (await res.json()) as { vault_token: string; token_guidance?: string };
+      expect(body.vault_token).toBe("");
+      expect(body.token_guidance).toBe("no hub origin reachable to mint against");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 invalid_name on a missing name", async () => {
+    const h = makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountCreateVault(
+        jsonReq("/account/vaults", token, "POST", {}),
+        deps(h),
+      );
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toBe("invalid_name");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// POST /account/vaults/<name>/token — per-vault token mint
+// ===========================================================================
+describe("handleAccountMintVaultToken", () => {
+  test("mints a vault token with aud=vault.<name> and default read+write scope", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountMintVaultToken(
+        withBearer("/account/vaults/field-notes/token", token, { method: "POST" }),
+        "field-notes",
+        deps(h),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as {
+        vault_token: string;
+        expires_at: string;
+        services: Record<string, { url: string }>;
+      };
+      expect(body.vault_token.length).toBeGreaterThan(0);
+      expect(body.services["vault:field-notes"]?.url).toBe(`${ISSUER}/vault/field-notes`);
+      const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
+      expect(validated.payload.aud).toBe("vault.field-notes");
+      expect(validated.payload.scope).toBe("vault:field-notes:read vault:field-notes:write");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("honors an explicit scopes list", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountMintVaultToken(
+        jsonReq("/account/vaults/field-notes/token", token, "POST", {
+          scopes: ["vault:field-notes:read"],
+        }),
+        "field-notes",
+        deps(h),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { vault_token: string };
+      const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
+      expect(validated.payload.scope).toBe("vault:field-notes:read");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("404 when the vault does not exist", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountMintVaultToken(
+        withBearer("/account/vaults/ghost/token", token, { method: "POST" }),
+        "ghost",
+        deps(h),
+      );
+      expect(res.status).toBe(404);
+      expect(((await res.json()) as { error: string }).error).toBe("vault_not_found");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("400 invalid_scope when a requested scope names another vault", async () => {
+    const h = makeHarness(["field-notes", "other"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountMintVaultToken(
+        jsonReq("/account/vaults/field-notes/token", token, "POST", {
+          scopes: ["vault:other:read"],
+        }),
+        "field-notes",
+        deps(h),
+      );
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toBe("invalid_scope");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// GET / PUT /account/vaults/<name>/caps
+// ===========================================================================
+describe("account caps", () => {
+  test("GET reports null cap for an uncapped vault; PUT sets it; GET reflects", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const adminTok = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const readTok = await bearer(h, [ACCOUNT_READ_SCOPE]);
+
+      const get0 = await handleAccountGetVaultCaps(
+        withBearer("/account/vaults/field-notes/caps", readTok),
+        "field-notes",
+        deps(h),
+      );
+      expect(get0.status).toBe(200);
+      expect(
+        ((await get0.json()) as { caps: { cap_bytes: number | null } }).caps.cap_bytes,
+      ).toBeNull();
+
+      const put = await handleAccountSetVaultCaps(
+        jsonReq("/account/vaults/field-notes/caps", adminTok, "PUT", { cap_bytes: 1048576 }),
+        "field-notes",
+        deps(h),
+      );
+      expect(put.status).toBe(200);
+      expect(getVaultCap(h.db, "field-notes")?.capBytes).toBe(1048576);
+
+      const get1 = await handleAccountGetVaultCaps(
+        withBearer("/account/vaults/field-notes/caps", readTok),
+        "field-notes",
+        deps(h),
+      );
+      expect(((await get1.json()) as { caps: { cap_bytes: number | null } }).caps.cap_bytes).toBe(
+        1048576,
+      );
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PUT 400 on a non-positive cap", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountSetVaultCaps(
+        jsonReq("/account/vaults/field-notes/caps", token, "PUT", { cap_bytes: 0 }),
+        "field-notes",
+        deps(h),
+      );
+      expect(res.status).toBe(400);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET 404 for an unknown vault", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountGetVaultCaps(
+        withBearer("/account/vaults/ghost/caps", token),
+        "ghost",
+        deps(h),
+      );
+      expect(res.status).toBe(404);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// ===========================================================================
+// GET /account — bootstrap
+// ===========================================================================
+describe("handleAccountRoot", () => {
+  test("returns account_id=self, door=self-host, and the operator email", async () => {
+    const h = makeHarness();
+    try {
+      const user = await createUser(h.db, "operator", "any-password", {
+        allowMulti: true,
+        passwordChanged: true,
+        email: "op@example.com",
+      });
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE], user.id);
+      const res = await handleAccountRoot(withBearer("/account", token), deps(h));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { account_id: string; email: string | null; door: string };
+      expect(body.account_id).toBe("self");
+      expect(body.door).toBe("self-host");
+      expect(body.email).toBe("op@example.com");
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -1,0 +1,632 @@
+/**
+ * `/account/*` — the Bearer-gated account-door REST facade (Phase 2, H2).
+ *
+ * This is the self-host door's slice of the normalized `/account/*` contract
+ * both doors mount (the hosted cloud door mounts the twin). It is deliberately
+ * a THIN FACADE over machinery the hub already ships — it does NOT reimplement
+ * vault provisioning, deletion, per-vault token minting, or caps. Each handler
+ * wraps the existing core:
+ *
+ *   POST   /account/vaults              → `provisionVault` (admin-vaults.ts)
+ *   GET    /account/vaults              → services.json vault enumeration + caps
+ *   DELETE /account/vaults/<name>       → `handleDeleteVault` (wired in hub-server)
+ *   POST   /account/vaults/<name>/token → `signAccessToken` (the same mint the
+ *                                          friend-facing /account/vault-token
+ *                                          surface uses, bearer-gated instead of
+ *                                          cookie-gated)
+ *   GET    /account/vaults/<name>/caps  → `getVaultCap` (vault-caps.ts)
+ *   PUT    /account/vaults/<name>/caps  → `setVaultCap` (vault-caps.ts)
+ *   GET    /account                     → account bootstrap (id/email/door)
+ *   GET    /.well-known/parachute-account → the public capabilities descriptor
+ *
+ * Auth posture: `Authorization: Bearer` + scope, adopting the hub's admin shape
+ * (NOT the console session-cookie + CSRF + HTML-form shape). Mutations accept
+ * `account:self:admin` OR `parachute:host:admin`; reads additionally accept
+ * `account:self:read`. Per PLAN-DECISION SCOPE-b the hub's account token is a
+ * SUPERSET that carries both the `account:self:*` string AND the host scopes,
+ * so the wrapped cores (which still gate on `parachute:host:admin`) accept it
+ * unchanged and this facade works whether or not the H1 scope-registry PR has
+ * landed — a plain host-admin token is always sufficient.
+ *
+ * On self-host the account IS the box (operator ≡ account ≡ box): the account
+ * id is the sentinel `self`, and the operator owns every vault, so the
+ * ownership gate the cloud twin runs per-vault is trivially satisfied here.
+ */
+import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULT_TOKEN_TTL_SECONDS } from "./account-home-ui.ts";
+import {
+  type AdminAuthContext,
+  AdminAuthError,
+  adminAuthErrorResponse,
+  extractBearerToken,
+} from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE, provisionVault } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { inferAudience } from "./jwt-audience.ts";
+import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import { ACCOUNT_SELF_ADMIN_SCOPE, ACCOUNT_SELF_READ_SCOPE } from "./scope-explanations.ts";
+import { readManifestLenient } from "./services-manifest.ts";
+import { getUserById } from "./users.ts";
+import { getVaultCap, setVaultCap } from "./vault-caps.ts";
+import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
+import { isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
+
+// The `account:self:{admin,read}` scope strings are defined once in
+// scope-explanations.ts (H1, #746) — the same registry that makes them
+// non-OAuth-requestable — and imported here so the two never drift.
+/** client_id stamped on per-vault tokens this surface mints + their registry rows. */
+const ACCOUNT_API_CLIENT_ID = "parachute-account";
+
+/**
+ * Scopes that satisfy a `/account/*` MUTATION. The account superset token
+ * carries `account:self:admin`; a plain operator/host-admin token carries
+ * `parachute:host:admin`. Either is accepted so H2 works independent of H1's
+ * merge order (SCOPE-b).
+ */
+const ADMIN_SCOPES: readonly string[] = [ACCOUNT_SELF_ADMIN_SCOPE, HOST_ADMIN_SCOPE];
+/** Scopes that satisfy a `/account/*` READ. `admin ⊇ read`, spelled explicitly
+ * because the hub's `requireScope` does an exact-string membership check (no
+ * inheritance expansion at validate time). */
+const READ_SCOPES: readonly string[] = [
+  ACCOUNT_SELF_READ_SCOPE,
+  ACCOUNT_SELF_ADMIN_SCOPE,
+  HOST_ADMIN_SCOPE,
+];
+
+export interface AccountApiDeps {
+  db: Database;
+  /** Hub origin — JWT `iss` validation, response URLs, and minted-token `iss`. */
+  issuer: string;
+  /**
+   * SET of origins the hub answers on (loopback ∪ expose-state ∪ platform ∪
+   * per-request `issuer`), built via `buildHubBoundOrigins`. The bearer's `iss`
+   * is validated against THIS set rather than the single `issuer` so a
+   * credential minted under a still-valid prior origin keeps working across an
+   * origin switch (hub#516 parity). Absent → falls back to `[issuer]`.
+   */
+  knownIssuers?: readonly string[];
+  /** Override services.json path. Defaults to `~/.parachute/services.json`. */
+  manifestPath?: string;
+  /** Test seam for the clock (mint + registry row). */
+  now?: () => Date;
+  /** Test seam threaded into `provisionVault` so create can be exercised
+   * without spawning the real `parachute-vault create` binary. */
+  runCommand?: (cmd: readonly string[]) => Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store" },
+  });
+}
+
+function methodNotAllowed(allow: string): Response {
+  return new Response(JSON.stringify({ error: "method_not_allowed", message: `use ${allow}` }), {
+    status: 405,
+    headers: { "content-type": "application/json", allow },
+  });
+}
+
+/**
+ * Validate a presented bearer token and assert it carries ANY of `acceptable`.
+ * Mirrors `requireScope` (admin-auth.ts) exactly — same signature-first
+ * validation, same `iss`-∈-set relaxation, same claim surfacing — but matches
+ * a SET of scopes rather than a single required one, so `/account/*` can accept
+ * `account:self:*` OR `parachute:host:admin`. Throws `AdminAuthError` (401/403);
+ * callers translate via `adminAuthErrorResponse`.
+ */
+export async function requireAnyScope(
+  db: Database,
+  req: Request,
+  acceptable: readonly string[],
+  expectedIssuer: string | readonly string[],
+): Promise<AdminAuthContext> {
+  const token = extractBearerToken(req);
+  let validated: Awaited<ReturnType<typeof validateAccessToken>>;
+  try {
+    validated = await validateAccessToken(db, token, expectedIssuer);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new AdminAuthError(401, `invalid token: ${msg}`);
+  }
+  const sub = typeof validated.payload.sub === "string" ? validated.payload.sub : null;
+  if (!sub) throw new AdminAuthError(401, "token missing required `sub` claim");
+  const scopeClaim = (validated.payload as { scope?: unknown }).scope;
+  const scopes =
+    typeof scopeClaim === "string" ? scopeClaim.split(/\s+/).filter((s) => s.length > 0) : [];
+  if (!acceptable.some((s) => scopes.includes(s))) {
+    throw new AdminAuthError(403, `token missing one of required scopes: ${acceptable.join(", ")}`);
+  }
+  const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
+  const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
+  const aud = typeof validated.payload.aud === "string" ? validated.payload.aud : undefined;
+  return { sub, scopes, clientId, audience: aud };
+}
+
+/** Scope set for a `/account/*` mutation (create / delete / mint / set-caps). */
+export const ACCOUNT_MUTATION_SCOPES = ADMIN_SCOPES;
+/** Scope set for a `/account/*` read (list / get-caps / bootstrap). */
+export const ACCOUNT_READ_SCOPES = READ_SCOPES;
+
+interface VaultMeta {
+  name: string;
+  url: string;
+  version: string;
+}
+
+/**
+ * Enumerate every servable vault from services.json with its canonical URL +
+ * version. Mirrors `findExistingVault`'s enumeration in admin-vaults.ts (same
+ * `isVaultEntry` filter, same empty-paths skip #478, same `vaultInstanceNameFor`
+ * name derivation, same `new URL(path, base)` URL build as `buildEntry`) so the
+ * account list agrees with the well-known vaults[] fan-out and the create path.
+ */
+function listVaultsWithMeta(manifestPath: string, issuer: string): VaultMeta[] {
+  const base = issuer.replace(/\/$/, "");
+  const out: VaultMeta[] = [];
+  let manifest: ReturnType<typeof readManifestLenient>;
+  try {
+    manifest = readManifestLenient(manifestPath);
+  } catch {
+    return out;
+  }
+  for (const svc of manifest.services) {
+    if (!isVaultEntry(svc)) continue;
+    if (svc.paths.length === 0) continue; // #478: installed-but-no-instance
+    for (const path of svc.paths) {
+      const name = vaultInstanceNameFor(svc.name, path);
+      const url = new URL(path, `${base}/`).toString();
+      out.push({ name, url, version: svc.version });
+    }
+  }
+  return out;
+}
+
+function servicesBlock(meta: VaultMeta): Record<string, { url: string; version: string }> {
+  return { [`vault:${meta.name}`]: { url: meta.url, version: meta.version } };
+}
+
+// ---------------------------------------------------------------------------
+// GET /.well-known/parachute-account — public capabilities descriptor
+// ---------------------------------------------------------------------------
+
+/**
+ * The self-host door descriptor. Public, no auth — it is what lets the app
+ * render honestly per door (D2): `billing:false` + `plans:[]` means the app
+ * shows no billing/upgrade UI on self-host; `caps_writable:true` means the
+ * operator can PUT caps freely (the cloud twin is plan-derived → false).
+ *
+ * `import`/`export` describe the self-host DOOR's portability capability
+ * (which it has). The `/account/vaults/<name>/export` + `/account/vaults/import`
+ * REST endpoints are a follow-on to this PR (H2 ships the vault-lifecycle +
+ * caps core); the flags stay true because the door supports portability.
+ */
+export function handleAccountCapabilities(req: Request, deps: { issuer: string }): Response {
+  if (req.method !== "GET") return methodNotAllowed("GET");
+  const descriptor = {
+    door: "self-host",
+    issuer: deps.issuer.replace(/\/$/, ""),
+    account_token: { endpoint: "/account/token", method: "POST", scheme: "cookie" },
+    features: {
+      vault_create: true,
+      vault_delete: true,
+      import: true,
+      export: true,
+      billing: false,
+      plans: [] as string[],
+      modules: true,
+      expose: true,
+    },
+    caps_writable: true,
+    limits: { vaults_max: null as number | null },
+  };
+  return json(200, descriptor);
+}
+
+// ---------------------------------------------------------------------------
+// GET /account — account bootstrap
+// ---------------------------------------------------------------------------
+
+/** `{ account_id, email, door }`. On self-host the account id is `self`. */
+export async function handleAccountRoot(req: Request, deps: AccountApiDeps): Promise<Response> {
+  if (req.method !== "GET") return methodNotAllowed("GET");
+  let ctx: AdminAuthContext;
+  try {
+    ctx = await requireAnyScope(deps.db, req, READ_SCOPES, deps.knownIssuers ?? [deps.issuer]);
+  } catch (err) {
+    return adminAuthErrorResponse(err);
+  }
+  const user = getUserById(deps.db, ctx.sub);
+  return json(200, {
+    account_id: "self",
+    email: user?.email ?? null,
+    door: "self-host",
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GET /account/vaults — list
+// ---------------------------------------------------------------------------
+
+export async function handleAccountListVaults(
+  req: Request,
+  deps: AccountApiDeps,
+): Promise<Response> {
+  if (req.method !== "GET") return methodNotAllowed("GET");
+  try {
+    await requireAnyScope(deps.db, req, READ_SCOPES, deps.knownIssuers ?? [deps.issuer]);
+  } catch (err) {
+    return adminAuthErrorResponse(err);
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const vaults = listVaultsWithMeta(manifestPath, deps.issuer).map((v) => {
+    const cap = getVaultCap(deps.db, v.name);
+    return {
+      name: v.name,
+      url: v.url,
+      version: v.version,
+      caps: { cap_bytes: cap?.capBytes ?? null },
+    };
+  });
+  return json(200, { vaults });
+}
+
+// ---------------------------------------------------------------------------
+// POST /account/vaults — create (returns a ready-to-use vault token)
+// ---------------------------------------------------------------------------
+
+interface NameBody {
+  ok: true;
+  name: string;
+}
+interface BodyErr {
+  ok: false;
+  status: number;
+  error: string;
+  message: string;
+}
+
+async function parseNameBody(req: Request): Promise<NameBody | BodyErr> {
+  const ctype = req.headers.get("content-type") ?? "";
+  if (!ctype.toLowerCase().includes("application/json")) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: "Content-Type must be application/json",
+    };
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: `invalid JSON body: ${msg}`,
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: "request body must be a JSON object",
+    };
+  }
+  const name = (raw as Record<string, unknown>).name;
+  if (typeof name !== "string" || name.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_name",
+      message: '"name" must be a non-empty string',
+    };
+  }
+  return { ok: true, name };
+}
+
+/**
+ * Create a vault and return a ready-to-use vault token (the hinge, D2): the app
+ * lands the user IN the vault with zero extra round-trips. Wraps the auth-free
+ * `provisionVault` core (this facade already ran the scope gate). The hub's
+ * create already mints a `vault:<name>:admin` token; post-`pvt_*`-DROP that
+ * token can be `""` when no hub origin was reachable — the response forwards
+ * whatever the vault minted (+ `token_guidance`), and the app falls back to
+ * `POST /account/vaults/<name>/token` on an empty `vault_token` (risk #5).
+ */
+export async function handleAccountCreateVault(
+  req: Request,
+  deps: AccountApiDeps,
+): Promise<Response> {
+  if (req.method !== "POST") return methodNotAllowed("POST");
+  try {
+    await requireAnyScope(deps.db, req, ADMIN_SCOPES, deps.knownIssuers ?? [deps.issuer]);
+  } catch (err) {
+    return adminAuthErrorResponse(err);
+  }
+  const parsed = await parseNameBody(req);
+  if (!parsed.ok) return json(parsed.status, { error: parsed.error, message: parsed.message });
+
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const provisioned = await provisionVault(parsed.name, {
+    issuer: deps.issuer,
+    manifestPath,
+    ...(deps.runCommand ? { runCommand: deps.runCommand } : {}),
+  });
+  if (!provisioned.ok) {
+    const error = provisioned.status === 400 ? "invalid_name" : "server_error";
+    return json(provisioned.status, { error, message: provisioned.message });
+  }
+
+  const entry = provisioned.entry;
+  const meta: VaultMeta = { name: entry.name, url: entry.url, version: entry.version };
+  const body: {
+    name: string;
+    url: string;
+    vault_token: string;
+    token_guidance?: string;
+    services: Record<string, { url: string; version: string }>;
+  } = {
+    name: entry.name,
+    url: entry.url,
+    vault_token: provisioned.createJson?.token ?? "",
+    ...(provisioned.createJson?.token_guidance
+      ? { token_guidance: provisioned.createJson.token_guidance }
+      : {}),
+    services: servicesBlock(meta),
+  };
+  // 201 on a fresh create; 200 on an idempotent re-POST of an existing vault
+  // (no fresh token — `vault_token` is "" and the app mints via /token).
+  return json(provisioned.created ? 201 : 200, body);
+}
+
+// ---------------------------------------------------------------------------
+// POST /account/vaults/<name>/token — per-vault token mint
+// ---------------------------------------------------------------------------
+
+const MINTABLE_VERBS = new Set(["read", "write", "admin"]);
+
+interface ScopesBody {
+  ok: true;
+  scopes: string[];
+}
+
+/**
+ * Parse + validate the requested `scopes`. Each must be `vault:<name>:<verb>`
+ * for THIS vault with a mintable verb. Omitted / empty → default read+write.
+ */
+async function parseScopesBody(req: Request, vaultName: string): Promise<ScopesBody | BodyErr> {
+  const defaultScopes = [`vault:${vaultName}:read`, `vault:${vaultName}:write`];
+  const ctype = req.headers.get("content-type") ?? "";
+  // A body is optional; a token mint with no body defaults to read+write.
+  if (!ctype.toLowerCase().includes("application/json")) {
+    return { ok: true, scopes: defaultScopes };
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch {
+    return { ok: true, scopes: defaultScopes };
+  }
+  if (!raw || typeof raw !== "object") return { ok: true, scopes: defaultScopes };
+  const requested = (raw as Record<string, unknown>).scopes;
+  if (requested === undefined || requested === null) return { ok: true, scopes: defaultScopes };
+  if (!Array.isArray(requested) || requested.some((s) => typeof s !== "string")) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: '"scopes" must be an array of strings',
+    };
+  }
+  const scopes = requested as string[];
+  if (scopes.length === 0) return { ok: true, scopes: defaultScopes };
+  for (const s of scopes) {
+    const parts = s.split(":");
+    if (
+      parts.length !== 3 ||
+      parts[0] !== "vault" ||
+      parts[1] !== vaultName ||
+      !MINTABLE_VERBS.has(parts[2] ?? "")
+    ) {
+      return {
+        ok: false,
+        status: 400,
+        error: "invalid_scope",
+        message: `scope "${s}" must be vault:${vaultName}:{read|write|admin}`,
+      };
+    }
+  }
+  return { ok: true, scopes };
+}
+
+export async function handleAccountMintVaultToken(
+  req: Request,
+  vaultName: string,
+  deps: AccountApiDeps,
+): Promise<Response> {
+  if (req.method !== "POST") return methodNotAllowed("POST");
+  let ctx: AdminAuthContext;
+  try {
+    ctx = await requireAnyScope(deps.db, req, ADMIN_SCOPES, deps.knownIssuers ?? [deps.issuer]);
+  } catch (err) {
+    return adminAuthErrorResponse(err);
+  }
+  if (!VAULT_NAME_CHARSET_RE.test(vaultName)) {
+    return json(400, {
+      error: "invalid_name",
+      message: `"${vaultName}" is not a valid vault name`,
+    });
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const meta = listVaultsWithMeta(manifestPath, deps.issuer).find((v) => v.name === vaultName);
+  if (!meta) {
+    return json(404, { error: "vault_not_found", message: `no vault named "${vaultName}"` });
+  }
+  const parsed = await parseScopesBody(req, vaultName);
+  if (!parsed.ok) return json(parsed.status, { error: parsed.error, message: parsed.message });
+
+  const scopes = parsed.scopes;
+  const audience = inferAudience(scopes); // → vault.<name>
+  const minted = await signAccessToken(deps.db, {
+    sub: ctx.sub,
+    scopes,
+    audience,
+    clientId: ACCOUNT_API_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds: ACCOUNT_VAULT_TOKEN_TTL_SECONDS,
+    vaultScope: [vaultName],
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+  // Registry row so the operator token registry + revocation list attribute it.
+  // Anchor to the subject's user_id only when it names a real user row (an
+  // operator token's `sub` may be the "operator" sentinel, which is not a
+  // `users` row — pass it as `subject` but omit `user_id` to avoid a dangling FK).
+  const subjectIsUser = getUserById(deps.db, ctx.sub) !== null;
+  recordTokenMint(deps.db, {
+    jti: minted.jti,
+    createdVia: "cli_mint",
+    subject: ctx.sub,
+    ...(subjectIsUser ? { userId: ctx.sub } : {}),
+    clientId: ACCOUNT_API_CLIENT_ID,
+    scopes,
+    expiresAt: minted.expiresAt,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+
+  return json(200, {
+    vault_token: minted.token,
+    expires_at: minted.expiresAt,
+    services: servicesBlock(meta),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GET / PUT /account/vaults/<name>/caps
+// ---------------------------------------------------------------------------
+
+export async function handleAccountGetVaultCaps(
+  req: Request,
+  vaultName: string,
+  deps: AccountApiDeps,
+): Promise<Response> {
+  if (req.method !== "GET") return methodNotAllowed("GET");
+  try {
+    await requireAnyScope(deps.db, req, READ_SCOPES, deps.knownIssuers ?? [deps.issuer]);
+  } catch (err) {
+    return adminAuthErrorResponse(err);
+  }
+  if (!VAULT_NAME_CHARSET_RE.test(vaultName)) {
+    return json(400, {
+      error: "invalid_name",
+      message: `"${vaultName}" is not a valid vault name`,
+    });
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const meta = listVaultsWithMeta(manifestPath, deps.issuer).find((v) => v.name === vaultName);
+  if (!meta) {
+    return json(404, { error: "vault_not_found", message: `no vault named "${vaultName}"` });
+  }
+  const cap = getVaultCap(deps.db, vaultName);
+  return json(200, {
+    name: vaultName,
+    caps: {
+      cap_bytes: cap?.capBytes ?? null,
+      created_at: cap?.createdAt ?? null,
+      updated_at: cap?.updatedAt ?? null,
+    },
+    caps_writable: true,
+  });
+}
+
+interface CapBody {
+  ok: true;
+  cap_bytes: number;
+}
+
+async function parseCapBody(req: Request): Promise<CapBody | BodyErr> {
+  const ctype = req.headers.get("content-type") ?? "";
+  if (!ctype.toLowerCase().includes("application/json")) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: "Content-Type must be application/json",
+    };
+  }
+  let raw: unknown;
+  try {
+    raw = await req.json();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: `invalid JSON body: ${msg}`,
+    };
+  }
+  if (!raw || typeof raw !== "object") {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: "request body must be a JSON object",
+    };
+  }
+  const capBytes = (raw as Record<string, unknown>).cap_bytes;
+  if (typeof capBytes !== "number" || !Number.isInteger(capBytes) || capBytes <= 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: "invalid_request",
+      message: '"cap_bytes" must be a positive integer number of bytes',
+    };
+  }
+  return { ok: true, cap_bytes: capBytes };
+}
+
+export async function handleAccountSetVaultCaps(
+  req: Request,
+  vaultName: string,
+  deps: AccountApiDeps,
+): Promise<Response> {
+  if (req.method !== "PUT") return methodNotAllowed("PUT");
+  try {
+    await requireAnyScope(deps.db, req, ADMIN_SCOPES, deps.knownIssuers ?? [deps.issuer]);
+  } catch (err) {
+    return adminAuthErrorResponse(err);
+  }
+  if (!VAULT_NAME_CHARSET_RE.test(vaultName)) {
+    return json(400, {
+      error: "invalid_name",
+      message: `"${vaultName}" is not a valid vault name`,
+    });
+  }
+  const manifestPath = deps.manifestPath ?? SERVICES_MANIFEST_PATH;
+  const meta = listVaultsWithMeta(manifestPath, deps.issuer).find((v) => v.name === vaultName);
+  if (!meta) {
+    return json(404, { error: "vault_not_found", message: `no vault named "${vaultName}"` });
+  }
+  const parsed = await parseCapBody(req);
+  if (!parsed.ok) return json(parsed.status, { error: parsed.error, message: parsed.message });
+
+  const cap = setVaultCap(deps.db, vaultName, parsed.cap_bytes);
+  return json(200, {
+    name: vaultName,
+    caps: { cap_bytes: cap.capBytes, created_at: cap.createdAt, updated_at: cap.updatedAt },
+    caps_writable: true,
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -33,6 +33,7 @@
  *   /.well-known/parachute.json                → built dynamically from services.json
  *   /.well-known/parachute-revocation.json     → revoked-jti list (hub#212 Phase 1)
  *   /.well-known/jwks.json                     → JWKS from hub.db
+ *   /.well-known/parachute-account             → account-door capabilities descriptor (public, H2)
  *   /.well-known/oauth-authorization-server    → RFC 8414 metadata (issuer, endpoints)
  *
  *   # OAuth issuer.
@@ -49,6 +50,13 @@
  *                                                 tokens/grants/user_vaults/invites/
  *                                                 connections sweep, CLI remove,
  *                                                 supervisor restart)
+ *   # /account/* — the Bearer-gated account-door REST facade (Phase 2, H2).
+ *   # account:self:admin OR parachute:host:admin (mutations); +:read (reads).
+ *   /account                      (GET)        → account bootstrap {id,email,door} (Bearer only)
+ *   /account/vaults               (GET/POST)   → list / create vault (create returns vault_token)
+ *   /account/vaults/<name>        (DELETE)     → teardown (wraps /vaults/<name> cascade)
+ *   /account/vaults/<name>/token  (POST)       → per-vault scoped token mint
+ *   /account/vaults/<name>/caps   (GET/PUT)    → read / set the storage cap
  *   /admin/host-admin-token       (GET)        → SPA bearer mint (cookie-gated)
  *   /admin/vault-admin-token/<n>  (GET)        → per-vault bearer mint (cookie-gated)
  *   /admin/agent-token            (GET)        → agent UI bearer mint (cookie-gated)
@@ -170,6 +178,18 @@ import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import pkg from "../package.json" with { type: "json" };
+import {
+  ACCOUNT_MUTATION_SCOPES,
+  type AccountApiDeps,
+  handleAccountCapabilities,
+  handleAccountCreateVault,
+  handleAccountGetVaultCaps,
+  handleAccountListVaults,
+  handleAccountMintVaultToken,
+  handleAccountRoot,
+  handleAccountSetVaultCaps,
+  requireAnyScope,
+} from "./account-api.ts";
 import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
 import { handleAccountToken } from "./account-token.ts";
 import { handleAccountVaultAdminTokenPost } from "./account-vault-admin-token.ts";
@@ -180,6 +200,7 @@ import {
   handleOAuthGrantCallback,
 } from "./admin-agent-grants.ts";
 import { handleAgentToken } from "./admin-agent-token.ts";
+import { adminAuthErrorResponse } from "./admin-auth.ts";
 import { handleApproveClient, handleDeleteClient, handleGetClient } from "./admin-clients.ts";
 import {
   type ConnectionsDeps,
@@ -2820,6 +2841,24 @@ export function hubFetch(
         return new Response(res.body, { status: res.status, headers: merged });
       }
 
+      // GET /.well-known/parachute-account — the account-door capabilities
+      // descriptor (Phase 2, H2). Public, no auth, wildcard CORS (the app pulls
+      // it cross-origin to render honestly per door: billing:false + plans:[] on
+      // self-host means no upgrade UI). See account-api.handleAccountCapabilities.
+      if (pathname === "/.well-known/parachute-account") {
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        const res = handleAccountCapabilities(req, { issuer: oauthDeps(req).issuer });
+        const merged = new Headers(res.headers);
+        for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+        return new Response(res.body, { status: res.status, headers: merged });
+      }
+
       // OAuth surface — every handler return is wrapped in `applyCorsHeaders`
       // so third-party SPAs can fetch these endpoints cross-origin (the entire
       // point of OAuth DCR: arbitrary SPAs register → authorize → exchange
@@ -3803,6 +3842,114 @@ export function hubFetch(
           db,
           hubOrigin,
           ...(managementUrl !== undefined ? { managementUrl } : {}),
+        });
+      }
+
+      // ====================================================================
+      // /account/* — the Bearer-gated account-door REST facade (Phase 2, H2).
+      // The normalized account API both doors mount (the hosted cloud door
+      // mounts the twin). Bearer-authed, machine-to-machine — no session
+      // cookie — so these precede the session-cookie `/account/vault-token/`
+      // + `/account/` HTML routes below. Mutations accept account:self:admin
+      // OR parachute:host:admin; reads also accept account:self:read. See
+      // `account-api.ts`.
+      // ====================================================================
+      if (pathname === "/account/vaults") {
+        if (!getDb) return dbNotConfigured();
+        const accountDeps: AccountApiDeps = {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
+          manifestPath,
+        };
+        if (req.method === "GET") return handleAccountListVaults(req, accountDeps);
+        if (req.method === "POST") return handleAccountCreateVault(req, accountDeps);
+        return new Response("method not allowed", { status: 405 });
+      }
+      if (pathname.startsWith("/account/vaults/")) {
+        if (!getDb) return dbNotConfigured();
+        const rest = pathname.slice("/account/vaults/".length);
+        const accountDeps: AccountApiDeps = {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
+          manifestPath,
+        };
+        // POST /account/vaults/<name>/token — per-vault scoped token mint.
+        if (rest.endsWith("/token")) {
+          const name = decodeURIComponent(rest.slice(0, -"/token".length));
+          return handleAccountMintVaultToken(req, name, accountDeps);
+        }
+        // GET/PUT /account/vaults/<name>/caps — read / set the storage cap.
+        if (rest.endsWith("/caps")) {
+          const name = decodeURIComponent(rest.slice(0, -"/caps".length));
+          if (req.method === "GET") return handleAccountGetVaultCaps(req, name, accountDeps);
+          if (req.method === "PUT") return handleAccountSetVaultCaps(req, name, accountDeps);
+          return new Response("method not allowed", { status: 405 });
+        }
+        // DELETE /account/vaults/<name> — teardown via the full identity
+        // cascade. Gate with the account-scope set here (accept account:self:admin
+        // OR parachute:host:admin), then delegate to `handleDeleteVault`, which
+        // re-gates parachute:host:admin — the superset account token carries it,
+        // so this is belt-and-suspenders, not a second authorization.
+        if (req.method === "DELETE") {
+          const name = decodeURIComponent(rest);
+          if (!name || name.includes("/")) return new Response("not found", { status: 404 });
+          try {
+            await requireAnyScope(
+              getDb(),
+              req,
+              ACCOUNT_MUTATION_SCOPES,
+              oauthDeps(req).hubBoundOrigins(),
+            );
+          } catch (err) {
+            return adminAuthErrorResponse(err);
+          }
+          const services = readManifestLenient(manifestPath).services;
+          const agentEntry = findServiceByShort(services, "agent");
+          const agentOrigin = agentEntry ? `http://127.0.0.1:${agentEntry.port}` : null;
+          const resolveVaultOrigin = (vaultName: string): string | null => {
+            const match = findVaultUpstream(
+              readManifestLenient(manifestPath).services,
+              `/vault/${vaultName}`,
+            );
+            return match ? `http://127.0.0.1:${match.port}` : null;
+          };
+          const supervisor = deps?.supervisor;
+          return handleDeleteVault(req, name, {
+            db: getDb(),
+            issuer: oauthDeps(req).issuer,
+            knownIssuers: oauthDeps(req).hubBoundOrigins(),
+            manifestPath,
+            connectionsStorePath:
+              deps?.connectionsStorePath ?? join(CONFIG_DIR, "connections.json"),
+            agentOrigin,
+            resolveVaultOrigin,
+            resolveModuleOrigin: makeResolveModuleOrigin(manifestPath),
+            ...(supervisor
+              ? {
+                  restartVaultModule: async () => {
+                    await supervisor.restart("vault");
+                  },
+                }
+              : {}),
+          });
+        }
+        return new Response("method not allowed", { status: 405 });
+      }
+      // GET /account (Bearer) — account bootstrap {account_id,email,door}. Only
+      // intercepts when an Authorization header is present, so the cookie-authed
+      // HTML account home at `/account`/`/account/` below stays unaffected.
+      if (
+        (pathname === "/account" || pathname === "/account/") &&
+        req.headers.get("authorization")
+      ) {
+        if (!getDb) return dbNotConfigured();
+        return handleAccountRoot(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
+          manifestPath,
         });
       }
 


### PR DESCRIPTION
## H2 — the hub's `/account/*` REST surface (Parachute App campaign, cloud#116, Phase 2)

The self-host door's slice of the normalized `/account/*` contract both doors mount (§1 of the Phase-2 breakdown). A thin **Bearer-gated facade** over machinery the hub already ships — no vault-provision / delete / mint / caps logic is reimplemented.

### Endpoints
| Route | Scope | Wraps |
|---|---|---|
| `GET /.well-known/parachute-account` | public | net-new descriptor |
| `GET /account` | read | `getUserById` (bootstrap `{account_id:"self", email, door:"self-host"}`) |
| `GET /account/vaults` | read | services.json enumeration + `getVaultCap` |
| `POST /account/vaults` | admin | `provisionVault` → returns a ready-to-use `vault_token` |
| `DELETE /account/vaults/<name>` | admin | `handleDeleteVault` (the full identity cascade) |
| `POST /account/vaults/<name>/token` | admin | `signAccessToken` (same mint as the friend `/account/vault-token` surface, bearer-gated) |
| `GET/PUT /account/vaults/<name>/caps` | read / admin | `getVaultCap` / `setVaultCap` |

### Capabilities descriptor (drives honest per-door UI, D2)
```jsonc
{ "door": "self-host",
  "issuer": "<hub origin>",
  "account_token": { "endpoint": "/account/token", "method": "POST", "scheme": "cookie" },
  "features": { "vault_create": true, "vault_delete": true, "import": true, "export": true,
                "billing": false, "plans": [], "modules": true, "expose": true },
  "caps_writable": true,
  "limits": { "vaults_max": null } }
```

### Auth posture
Mutations accept `account:self:admin` **OR** `parachute:host:admin`; reads also accept `account:self:read`. Per **PLAN-DECISION SCOPE-b** the hub account token is a SUPERSET carrying both the `account:self:*` string and the host scopes, so the wrapped cores (still `parachute:host:admin`-gated) accept it unchanged.

### H1 dependency
**H1 (`ag-h1-hub-account`) is NOT merged to main yet** (a concurrent session is building it). H2 is written to work regardless of merge order: every endpoint is gated on `parachute:host:admin` **OR** `account:self:admin`, and the wrapped cores require `host:admin` — which the H1 superset token always carries. A plain host-admin token is sufficient today; once H1 lands, the `account:self:*` scope strings become mintable + non-requestable. **Sequence H1 before H2.** Version bumped `0.7.6 → 0.7.7-rc.2` (H1 takes rc.1) — may need a rebump depending on merge order.

### Gates
- `bun test ./src` — **4178 pass, 1 skip, 0 fail** (incl. new `account-api.test.ts`, 19 tests)
- `bun run typecheck` — clean
- Full `hubFetch` routing smoke — descriptor 200 / no-auth 401 / wrong-scope 403 / host:admin 200 on list+mint+bootstrap+caps; the cookie-authed HTML `/account/` home is unaffected (Bearer routes only intercept when an `Authorization` header is present)
- Live hub health unchanged across the full run (the `launchctl-guard` hub#535 fix held)

### Scope notes for the orchestrator
- **`door` value:** used `"self-host"` per the H2 brief (§1's hub example literally says `"hub"`; the cloud twin will use `"cloud"`). Reconcile with C4 — the descriptor `door` is a wire field the twin mirrors.
- **`plans: []`** (per brief) vs §1's `plans: null` — used `[]`.
- **import/export:** the descriptor `features.import/export` describe the door's portability capability (true); the `/account/vaults/<name>/export` + `/account/vaults/import` REST endpoints are **deferred** (not in the H2 core list) — a small follow-on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB