### PR TITLE
feat(door-contract): extract shared OAuth-issuer + /account/* contract (Phase A)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,12 @@ jobs:
         # runtime hub resolves depcheck via the `bun`→src export condition, so
         # this is only needed for the type-level resolution.
         run: bun run --cwd packages/depcheck build
+      - name: build door-contract
+        # Same reason as depcheck: hub's `tsc` typecheck + the door-contract
+        # parity test resolve `@openparachute/door-contract` from its built
+        # `dist/`. The frozen-lockfile install doesn't build it, so build it
+        # explicitly before typecheck + tests.
+        run: bun run --cwd packages/door-contract build
       - name: typecheck
         run: bun run typecheck
       - name: hub tests
@@ -90,6 +96,11 @@ jobs:
         # Same rationale — depcheck is consumed by hub, so a regression here
         # would break hub too. Cheap to run on every tag.
         run: bun test ./packages/depcheck/src
+      - name: door-contract tests
+        # The shared OAuth-issuer + /account/* contract corpus (consumed
+        # test-only by hub's door-contract-parity suite; the hosted cloud door
+        # adopts it in Phase B). Cheap; gates the contract on every tag.
+        run: bun test ./packages/door-contract/src
 
   publish-hub-npm:
     name: publish hub to npm

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ WORKDIR /app
 COPY package.json bun.lock ./
 COPY packages/scope-guard/package.json packages/scope-guard/
 COPY packages/depcheck/package.json packages/depcheck/
+COPY packages/door-contract/package.json packages/door-contract/
 COPY web/ui/package.json web/ui/bun.lock web/ui/
 
 # Install with the lockfile pinned. `--frozen-lockfile` matches CI; the

--- a/bun.lock
+++ b/bun.lock
@@ -6,13 +6,14 @@
       "name": "@openparachute/hub",
       "dependencies": {
         "@node-rs/argon2": "^2.0.2",
-        "@openparachute/depcheck": "0.1.0-rc.1",
+        "@openparachute/depcheck": "0.1.1",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode": "^1.5.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
+        "@openparachute/door-contract": "workspace:*",
         "@types/bun": "latest",
         "@types/qrcode": "^1.5.6",
       },
@@ -22,14 +23,21 @@
     },
     "packages/depcheck": {
       "name": "@openparachute/depcheck",
-      "version": "0.1.0-rc.1",
+      "version": "0.1.1",
+      "peerDependencies": {
+        "typescript": "^5",
+      },
+    },
+    "packages/door-contract": {
+      "name": "@openparachute/door-contract",
+      "version": "0.1.0",
       "peerDependencies": {
         "typescript": "^5",
       },
     },
     "packages/scope-guard": {
       "name": "@openparachute/scope-guard",
-      "version": "0.4.0-rc.2",
+      "version": "0.5.0",
       "dependencies": {
         "jose": "^6.2.2",
       },
@@ -98,6 +106,8 @@
     "@node-rs/argon2-win32-x64-msvc": ["@node-rs/argon2-win32-x64-msvc@2.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw=="],
 
     "@openparachute/depcheck": ["@openparachute/depcheck@workspace:packages/depcheck"],
+
+    "@openparachute/door-contract": ["@openparachute/door-contract@workspace:packages/door-contract"],
 
     "@openparachute/scope-guard": ["@openparachute/scope-guard@workspace:packages/scope-guard"],
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.2",
+  "version": "0.7.7-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -28,8 +28,10 @@
   "scripts": {
     "start": "bun src/cli.ts",
     "build:depcheck": "[ ! -f packages/depcheck/package.json ] || [ -f packages/depcheck/dist/index.js ] || bun run --cwd packages/depcheck build",
-    "prepare": "bun run build:depcheck",
-    "pretest": "bun run build:depcheck",
+    "build:door-contract": "[ ! -f packages/door-contract/package.json ] || [ -f packages/door-contract/dist/index.js ] || bun run --cwd packages/door-contract build",
+    "build:packages": "bun run build:depcheck && bun run build:door-contract",
+    "prepare": "bun run build:packages",
+    "pretest": "bun run build:packages",
     "test": "bun test ./src",
     "lint": "biome check .",
     "lint:fix": "biome check --write .",
@@ -40,6 +42,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
+    "@openparachute/door-contract": "workspace:*",
     "@types/bun": "latest",
     "@types/qrcode": "^1.5.6"
   },

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -1,0 +1,19 @@
+# @openparachute/door-contract
+
+## 0.1.0
+
+Initial extraction (Cloud+Hub shared-core campaign, parachute-cloud#116,
+Phase A). The shared OAuth-issuer + `/account/*` door contract, previously
+duplicated across the self-host hub and the hosted cloud:
+
+- token wire constants (`ACCESS_TOKEN_TTL_SECONDS`, `REFRESH_TOKEN_TTL_MS`,
+  `REFRESH_GRACE_MS`, `TOKEN_TYPE`, `SIGNING_ALG`) + `AccessTokenClaims` /
+  `TokenResponse` types;
+- the `account:<id>:<verb>` scope grammar + `hasAccountScope`;
+- RFC 8414 / 9728 discovery-doc vectors;
+- the `/account/*` route table + request/response types;
+- the shared conformance corpus (`check*` helpers).
+
+Consumed test-only by the hub in this release (drift-detector parity test);
+runtime adoption in both doors + cloud conformance-suite adoption follow in
+Phase B.

--- a/packages/door-contract/README.md
+++ b/packages/door-contract/README.md
@@ -1,0 +1,54 @@
+# @openparachute/door-contract
+
+The Parachute **door contract** — the OAuth-issuer + `/account/*` wire types,
+constants, and conformance vectors that **both doors** implement:
+
+- the **self-host hub** (`@openparachute/hub`, Bun) and
+- the **hosted cloud** (`@openparachute/cloud`, Cloudflare Workers).
+
+Cloud's job is to "reproduce the hub's issuer contract exactly." Today that
+contract is duplicated: the token TTL/grace constants, the discovery-doc shape,
+the token claim set, the account scope grammar, and the `/account/*` route table
+each exist twice, kept in sync only by prose comments and two separate test
+suites. This package is where "exactly" is written down **once**.
+
+Sibling to [`@openparachute/scope-guard`](../scope-guard), which owns the
+resource-server side (JWT validation + the vault scope matcher). `door-contract`
+owns the **door/issuer** side.
+
+## What's in here
+
+| Module | Contract |
+|---|---|
+| `tokens.ts` | `ACCESS_TOKEN_TTL_SECONDS`, `REFRESH_TOKEN_TTL_MS`, `REFRESH_GRACE_MS`, `TOKEN_TYPE`, `SIGNING_ALG` + `AccessTokenClaims` / `TokenResponse` |
+| `scopes.ts` | the `account:<id>:<verb>` grammar (`admin ⊇ read`) + `hasAccountScope` |
+| `discovery.ts` | RFC 8414 / 9728 metadata vectors: `expected*Metadata(issuer, …)` |
+| `account-contract.ts` | the `/account/*` route table (`ACCOUNT_ROUTES`) + request/response types |
+| `conformance.ts` | the shared corpus + `check*` helpers a door's suite drives against its live handlers |
+
+## Usage — a door's conformance suite
+
+```ts
+import { checkAuthorizationServerMetadata } from "@openparachute/door-contract";
+
+const res = await app.fetch(new Request(`${ISSUER}/.well-known/oauth-authorization-server`));
+const md = await res.json();
+expect(checkAuthorizationServerMetadata(md, ISSUER, ADVERTISED_SCOPES)).toEqual([]);
+```
+
+## Design
+
+- **Pure.** No runtime dependencies — no `jose`, no D1/SQLite. Data, types, and
+  pure functions only. Each door keeps its own (forked) runtime; only the
+  *contract* is shared.
+- **Drift-detected.** Each door ships a parity test asserting its live runtime
+  values equal the canon here. A real contract change happens here, and the
+  parity tests then force each door to follow — the mechanism that keeps the two
+  issuers from silently diverging.
+- **`.js` relative imports.** Resolved to `.ts` by bun + bundler consumers;
+  keeps a future NodeNext/npm build a mechanical flip (the scope-guard #225
+  lesson).
+
+## License
+
+AGPL-3.0.

--- a/packages/door-contract/package.json
+++ b/packages/door-contract/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@openparachute/door-contract",
+  "version": "0.1.0",
+  "description": "The Parachute door contract: shared OAuth-issuer + /account/* wire types, constants, and conformance vectors that both doors (self-host hub + hosted cloud) implement.",
+  "license": "AGPL-3.0",
+  "type": "module",
+  "publishConfig": {
+    "access": "public"
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "//": "exports MUST match scope-guard/depcheck: NO `bun`→src condition. npm does not honor publishConfig.exports, so a `bun`→src condition would ship in the published package and Bun consumers (hub) would resolve src/index.ts which the tarball doesn't include (files: dist only) → 'Cannot find module'. dist is built locally + shipped, so `import`→dist resolves under both Bun and Node. (Caught on the depcheck rc.1→rc.2 deploy.)",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/ParachuteComputer/parachute-hub.git",
+    "directory": "packages/door-contract"
+  },
+  "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "bun run build",
+    "test": "bun test src",
+    "typecheck": "tsc --noEmit"
+  },
+  "peerDependencies": {
+    "typescript": "^5"
+  }
+}

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  ACCOUNT_ROUTES,
+  ACCOUNT_SELF_ADMIN_SCOPE,
+  ACCOUNT_SELF_READ_SCOPE,
+  REFRESH_GRACE_MS,
+  REFRESH_TOKEN_TTL_MS,
+  TOKEN_TYPE,
+  accountScope,
+  checkAuthorizationServerMetadata,
+  checkProtectedResourceMetadata,
+  checkTokenResponseInvariants,
+  expectedAuthorizationServerMetadata,
+  expectedProtectedResourceMetadata,
+  hasAccountScope,
+  parseAccountScope,
+} from "../index.js";
+
+// The corpus is pinned as the single source of truth. These values are what
+// each door currently duplicates; if a real contract change is intended, it
+// changes HERE and each door's parity test then forces the door to follow.
+describe("token constants", () => {
+  test("pin the wire values both doors mint against", () => {
+    expect(ACCESS_TOKEN_TTL_SECONDS).toBe(900);
+    expect(REFRESH_TOKEN_TTL_MS).toBe(2_592_000_000);
+    expect(REFRESH_GRACE_MS).toBe(30_000);
+    expect(TOKEN_TYPE).toBe("Bearer");
+  });
+});
+
+describe("account scope grammar", () => {
+  test("canonical self scopes match the builder", () => {
+    expect(ACCOUNT_SELF_ADMIN_SCOPE).toBe(accountScope("self", "admin"));
+    expect(ACCOUNT_SELF_READ_SCOPE).toBe(accountScope("self", "read"));
+  });
+
+  test("parse rejects non-account and malformed scopes", () => {
+    expect(parseAccountScope("account:self:admin")).toEqual({ id: "self", verb: "admin" });
+    expect(parseAccountScope("account:u_123:read")).toEqual({ id: "u_123", verb: "read" });
+    expect(parseAccountScope("account:admin")).toBeNull(); // 2-part
+    expect(parseAccountScope("vault:work:read")).toBeNull(); // wrong resource
+    expect(parseAccountScope("account:self:write")).toBeNull(); // no write rung
+    expect(parseAccountScope("account::read")).toBeNull(); // empty id
+  });
+
+  test("admin ⊇ read, and a different id never matches", () => {
+    expect(hasAccountScope(["account:self:admin"], "self", "read")).toBe(true);
+    expect(hasAccountScope(["account:self:admin"], "self", "admin")).toBe(true);
+    expect(hasAccountScope(["account:self:read"], "self", "admin")).toBe(false);
+    expect(hasAccountScope(["account:u_1:admin"], "u_2", "read")).toBe(false);
+    expect(hasAccountScope(["vault:x:admin"], "self", "read")).toBe(false);
+  });
+});
+
+describe("discovery vectors", () => {
+  const iss = "https://cloud.parachute.computer";
+  const scopes = ["vault:read", "vault:write"];
+
+  test("authorization-server metadata derives endpoints from the issuer", () => {
+    const md = expectedAuthorizationServerMetadata(iss, scopes);
+    expect(md.issuer).toBe(iss);
+    expect(md.authorization_endpoint).toBe(`${iss}/oauth/authorize`);
+    expect(md.token_endpoint).toBe(`${iss}/oauth/token`);
+    expect(md.jwks_uri).toBe(`${iss}/.well-known/jwks.json`);
+    expect(md.response_types_supported).toEqual(["code"]);
+    expect(md.grant_types_supported).toEqual(["authorization_code", "refresh_token"]);
+    expect(md.code_challenge_methods_supported).toEqual(["S256"]);
+    expect(md.token_endpoint_auth_methods_supported).toEqual(["none", "client_secret_post"]);
+    expect(md.scopes_supported).toEqual(scopes);
+  });
+
+  test("checkAuthorizationServerMetadata reports zero issues for a conformant door", () => {
+    const md = expectedAuthorizationServerMetadata(iss, scopes);
+    expect(checkAuthorizationServerMetadata(md, iss, scopes)).toEqual([]);
+  });
+
+  test("checkAuthorizationServerMetadata catches drift", () => {
+    const md = {
+      ...expectedAuthorizationServerMetadata(iss, scopes),
+      grant_types_supported: ["authorization_code"],
+    };
+    const issues = checkAuthorizationServerMetadata(md, iss, scopes);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("grant_types_supported");
+  });
+
+  test("protected-resource metadata + its checker", () => {
+    const md = expectedProtectedResourceMetadata(iss);
+    expect(md.resource).toBe(iss);
+    expect(md.authorization_servers).toEqual([iss]);
+    expect(md.bearer_methods_supported).toEqual(["header"]);
+    expect(checkProtectedResourceMetadata(md, iss)).toEqual([]);
+  });
+});
+
+describe("token-response invariants", () => {
+  test("a conformant body passes", () => {
+    const body = {
+      access_token: "x.y.z",
+      token_type: "Bearer",
+      expires_in: 900,
+      scope: "vault:default:read",
+    };
+    expect(checkTokenResponseInvariants(body, "vault:default:read")).toEqual([]);
+  });
+
+  test("wrong ttl / type / scope / empty token each surface", () => {
+    expect(
+      checkTokenResponseInvariants(
+        { access_token: "t", token_type: "bearer", expires_in: 900, scope: "s" },
+        "s",
+      ).length,
+    ).toBe(1);
+    expect(
+      checkTokenResponseInvariants(
+        { access_token: "t", token_type: "Bearer", expires_in: 3600, scope: "s" },
+        "s",
+      ).length,
+    ).toBe(1);
+    expect(
+      checkTokenResponseInvariants(
+        { access_token: "t", token_type: "Bearer", expires_in: 900, scope: "other" },
+        "s",
+      ).length,
+    ).toBe(1);
+    expect(
+      checkTokenResponseInvariants(
+        { access_token: "", token_type: "Bearer", expires_in: 900, scope: "s" },
+        "s",
+      ).length,
+    ).toBe(1);
+  });
+});
+
+describe("account route table", () => {
+  test("every route is well-formed and scope-gated", () => {
+    expect(ACCOUNT_ROUTES.length).toBeGreaterThan(0);
+    for (const r of ACCOUNT_ROUTES) {
+      expect(r.path.startsWith("/account")).toBe(true);
+      expect(["read", "admin"]).toContain(r.scope);
+      expect(["GET", "POST", "DELETE", "PUT"]).toContain(r.method);
+    }
+  });
+
+  test("mutations require admin, reads require read", () => {
+    const byKey = (m: string, p: string) =>
+      ACCOUNT_ROUTES.find((r) => r.method === m && r.path === p);
+    expect(byKey("POST", "/account/vaults")?.scope).toBe("admin");
+    expect(byKey("DELETE", "/account/vaults/<name>")?.scope).toBe("admin");
+    expect(byKey("GET", "/account/vaults")?.scope).toBe("read");
+  });
+});

--- a/packages/door-contract/src/account-contract.ts
+++ b/packages/door-contract/src/account-contract.ts
@@ -1,0 +1,109 @@
+/**
+ * The normalized `/account/*` door contract — the route table both doors mount
+ * (self-host hub H2 `src/account-api.ts`, hosted cloud C3
+ * `workers/identity/src/account-api.ts`). Today the contract lives only in prose
+ * in each file; this is the machine-readable spec both twins can assert against.
+ *
+ * Auth posture: `Authorization: Bearer <account token>`; every route gates on an
+ * account scope (`read` for GETs, `admin` for mutations) via the grammar in
+ * `scopes.ts`. The account id comes from the TOKEN, never a request body — a
+ * token for account A can only ever act on account A's vaults.
+ */
+
+import type { AccountVerb } from "./scopes.js";
+
+/** One row of the `/account/*` contract. `path` is a template (`<name>` slot). */
+export interface AccountRoute {
+  method: "GET" | "POST" | "DELETE" | "PUT";
+  path: string;
+  /** The minimum account verb the route requires. */
+  scope: AccountVerb;
+  summary: string;
+}
+
+/**
+ * The `/account/*` route table. Both doors wrap their own machinery behind these
+ * routes; the shape here is the contract, not an implementation.
+ */
+export const ACCOUNT_ROUTES: readonly AccountRoute[] = [
+  {
+    method: "GET",
+    path: "/account",
+    scope: "read",
+    summary: "Account bootstrap (id, email, door).",
+  },
+  {
+    method: "GET",
+    path: "/account/vaults",
+    scope: "read",
+    summary: "List the account's vaults + usage.",
+  },
+  {
+    method: "POST",
+    path: "/account/vaults",
+    scope: "admin",
+    summary: "Create a vault (plan vault-count capped).",
+  },
+  {
+    method: "DELETE",
+    path: "/account/vaults/<name>",
+    scope: "admin",
+    summary: "Delete a vault the account owns.",
+  },
+  {
+    method: "POST",
+    path: "/account/vaults/<name>/token",
+    scope: "admin",
+    summary: "Mint a per-vault access token for an owned vault.",
+  },
+  {
+    method: "GET",
+    path: "/account/vaults/<name>/caps",
+    scope: "read",
+    summary: "Read a vault's storage caps.",
+  },
+  {
+    method: "PUT",
+    path: "/account/vaults/<name>/caps",
+    scope: "admin",
+    summary: "Set a vault's storage caps.",
+  },
+] as const;
+
+/** The public capabilities descriptor served at `/.well-known/parachute-account`. */
+export interface ParachuteAccountDescriptor {
+  /** The account door's issuer origin. */
+  issuer: string;
+  /** Which door this is. */
+  door: "hub" | "cloud";
+  /** The `/account/*` routes this door mounts. */
+  account_endpoint: string;
+}
+
+/** A vault as returned by `GET /account/vaults`. */
+export interface AccountVaultSummary {
+  name: string;
+  url: string;
+  /** Bytes used, when the door tracks usage (cloud's daily rollup); omitted otherwise. */
+  used_bytes?: number;
+  /** The vault's cap in bytes, when set. */
+  cap_bytes?: number;
+}
+
+/** `POST /account/vaults` request body. */
+export interface CreateVaultRequest {
+  name: string;
+}
+
+/** `POST /account/vaults/<name>/token` request body — scope narrowed to the one vault. */
+export interface MintVaultTokenRequest {
+  /** Requested verb; the mint validates it against the account's ownership. */
+  verb: "read" | "write" | "admin";
+}
+
+/** `GET /account` bootstrap body. */
+export interface AccountBootstrap {
+  id: string;
+  email?: string;
+  door: "hub" | "cloud";
+}

--- a/packages/door-contract/src/conformance.ts
+++ b/packages/door-contract/src/conformance.ts
@@ -1,0 +1,93 @@
+/**
+ * The unified conformance corpus — the X1 twin-suite content, as ONE shared
+ * body both doors' conformance suites import (the D11 follow-on).
+ *
+ * Today the hosted door has a 1048-line `conformance.test.ts` with the expected
+ * wire values inlined as `expect()` literals, and the self-host door asserts the
+ * same behaviors scattered across its own suites. Neither shares the VECTORS.
+ * This module is those vectors: runtime-agnostic data + assertion helpers a door
+ * calls against its own live `fetch(app)`. Extend it with every contract
+ * endpoint; a door's suite that drives it inherits the drift protection.
+ */
+
+import { ACCOUNT_ROUTES, type AccountRoute } from "./account-contract.js";
+import {
+  type AuthorizationServerMetadata,
+  type ProtectedResourceMetadata,
+  expectedAuthorizationServerMetadata,
+  expectedProtectedResourceMetadata,
+} from "./discovery.js";
+import { ACCESS_TOKEN_TTL_SECONDS, TOKEN_TYPE } from "./tokens.js";
+
+/** A named discrepancy between a door's live output and the contract. */
+export interface ConformanceIssue {
+  vector: string;
+  detail: string;
+}
+
+/**
+ * Assert a door's authorization-server metadata equals the contract for its
+ * `issuer` + advertised `scopesSupported`. Returns the list of discrepancies
+ * (empty = conformant) so a suite can assert `toEqual([])` with readable output.
+ */
+export function checkAuthorizationServerMetadata(
+  actual: Partial<AuthorizationServerMetadata>,
+  issuer: string,
+  scopesSupported: readonly string[],
+): ConformanceIssue[] {
+  const expected = expectedAuthorizationServerMetadata(issuer, scopesSupported);
+  return diffFields("oauth-authorization-server", expected, actual);
+}
+
+/** Assert a door's protected-resource metadata equals the contract. */
+export function checkProtectedResourceMetadata(
+  actual: Partial<ProtectedResourceMetadata>,
+  issuer: string,
+): ConformanceIssue[] {
+  const expected = expectedProtectedResourceMetadata(issuer);
+  return diffFields("oauth-protected-resource", expected, actual);
+}
+
+/**
+ * Invariants a `POST /oauth/token` success body must satisfy, independent of the
+ * runtime that produced it. `scope` is caller-supplied (the granted scope).
+ */
+export function checkTokenResponseInvariants(
+  actual: Record<string, unknown>,
+  grantedScope: string,
+): ConformanceIssue[] {
+  const issues: ConformanceIssue[] = [];
+  const push = (detail: string) => issues.push({ vector: "token-response", detail });
+  if (actual.token_type !== TOKEN_TYPE)
+    push(`token_type must be "${TOKEN_TYPE}", got ${JSON.stringify(actual.token_type)}`);
+  if (actual.expires_in !== ACCESS_TOKEN_TTL_SECONDS)
+    push(
+      `expires_in must be ${ACCESS_TOKEN_TTL_SECONDS}, got ${JSON.stringify(actual.expires_in)}`,
+    );
+  if (actual.scope !== grantedScope)
+    push(
+      `scope must echo the granted scope ${JSON.stringify(grantedScope)}, got ${JSON.stringify(actual.scope)}`,
+    );
+  if (typeof actual.access_token !== "string" || actual.access_token.length === 0)
+    push("access_token must be a non-empty string");
+  return issues;
+}
+
+/** The `/account/*` route vectors — the contract every door mounts. */
+export const ACCOUNT_ROUTE_VECTORS: readonly AccountRoute[] = ACCOUNT_ROUTES;
+
+function diffFields<T extends object>(
+  vector: string,
+  expected: T,
+  actual: Partial<T>,
+): ConformanceIssue[] {
+  const issues: ConformanceIssue[] = [];
+  const expectedRec = expected as Record<string, unknown>;
+  const actualRec = actual as Record<string, unknown>;
+  for (const key of Object.keys(expectedRec)) {
+    const e = JSON.stringify(expectedRec[key]);
+    const a = JSON.stringify(actualRec[key]);
+    if (e !== a) issues.push({ vector, detail: `${key}: expected ${e}, got ${a}` });
+  }
+  return issues;
+}

--- a/packages/door-contract/src/discovery.ts
+++ b/packages/door-contract/src/discovery.ts
@@ -1,0 +1,71 @@
+/**
+ * OAuth discovery-document contract (RFC 8414 authorization-server metadata +
+ * RFC 9728 protected-resource metadata).
+ *
+ * Both doors serve `/.well-known/oauth-authorization-server` and
+ * `/.well-known/oauth-protected-resource` with a byte-identical shape (self-host
+ * hub `src/oauth-handlers.ts`, hosted cloud `workers/identity/src/oauth-metadata.ts`).
+ * The supported-value arrays and the endpoint layout are the same for both; the
+ * only per-door variable is the issuer origin. `expected*Metadata(issuer)`
+ * returns the canonical object a door MUST emit — the vector its conformance
+ * suite asserts its live `/.well-known/*` response against.
+ */
+
+export const RESPONSE_TYPES_SUPPORTED = ["code"] as const;
+export const GRANT_TYPES_SUPPORTED = ["authorization_code", "refresh_token"] as const;
+export const CODE_CHALLENGE_METHODS_SUPPORTED = ["S256"] as const;
+export const TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED = ["none", "client_secret_post"] as const;
+export const BEARER_METHODS_SUPPORTED = ["header"] as const;
+
+export interface AuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  revocation_endpoint: string;
+  jwks_uri: string;
+  response_types_supported: string[];
+  grant_types_supported: string[];
+  code_challenge_methods_supported: string[];
+  token_endpoint_auth_methods_supported: string[];
+  scopes_supported: string[];
+}
+
+export interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  bearer_methods_supported: string[];
+}
+
+/**
+ * The RFC 8414 authorization-server metadata a door must emit for `issuer`.
+ * `scopes_supported` is door-advertised (RFC 8414 §2 — advertise only what a
+ * client may request), so it is a parameter: pass the door's advertised list.
+ */
+export function expectedAuthorizationServerMetadata(
+  issuer: string,
+  scopesSupported: readonly string[],
+): AuthorizationServerMetadata {
+  return {
+    issuer,
+    authorization_endpoint: `${issuer}/oauth/authorize`,
+    token_endpoint: `${issuer}/oauth/token`,
+    registration_endpoint: `${issuer}/oauth/register`,
+    revocation_endpoint: `${issuer}/oauth/revoke`,
+    jwks_uri: `${issuer}/.well-known/jwks.json`,
+    response_types_supported: [...RESPONSE_TYPES_SUPPORTED],
+    grant_types_supported: [...GRANT_TYPES_SUPPORTED],
+    code_challenge_methods_supported: [...CODE_CHALLENGE_METHODS_SUPPORTED],
+    token_endpoint_auth_methods_supported: [...TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED],
+    scopes_supported: [...scopesSupported],
+  };
+}
+
+/** The RFC 9728 protected-resource metadata a door must emit for `issuer`. */
+export function expectedProtectedResourceMetadata(issuer: string): ProtectedResourceMetadata {
+  return {
+    resource: issuer,
+    authorization_servers: [issuer],
+    bearer_methods_supported: [...BEARER_METHODS_SUPPORTED],
+  };
+}

--- a/packages/door-contract/src/index.ts
+++ b/packages/door-contract/src/index.ts
@@ -1,0 +1,74 @@
+/**
+ * @openparachute/door-contract
+ *
+ * The Parachute *door contract*: the OAuth-issuer + `/account/*` wire types,
+ * constants, and conformance vectors that BOTH doors implement — the self-host
+ * hub (`@openparachute/hub`, Bun) and the hosted cloud (`@openparachute/cloud`,
+ * Cloudflare Workers). Cloud "reproduces the hub's issuer contract exactly";
+ * this package is where "exactly" is written down once instead of twice.
+ *
+ * Sibling to `@openparachute/scope-guard` (which owns resource-server JWT
+ * validation + the vault scope matcher). This package owns the DOOR side: the
+ * issuer's advertised shape, token constants, the account scope grammar, and the
+ * shared conformance corpus.
+ *
+ * Pure data + types + pure functions — no runtime dependencies, no `jose`, no
+ * D1/SQLite. A door imports the constants/types at runtime and drives the
+ * conformance helpers from its test suite against its own live handlers.
+ *
+ * Relative imports carry `.js` extensions (resolved back to `.ts` by bundler +
+ * bun consumers) so a future NodeNext/npm build stays a mechanical flip — the
+ * `@openparachute/scope-guard` convention, see its #225.
+ */
+
+export {
+  ACCESS_TOKEN_TTL_SECONDS,
+  REFRESH_TOKEN_TTL_MS,
+  REFRESH_GRACE_MS,
+  TOKEN_TYPE,
+  SIGNING_ALG,
+  type AccessTokenClaims,
+  type TokenResponse,
+} from "./tokens.js";
+
+export {
+  type AccountVerb,
+  ACCOUNT_VERB_RANK,
+  ACCOUNT_SELF_ID,
+  ACCOUNT_SELF_ADMIN_SCOPE,
+  ACCOUNT_SELF_READ_SCOPE,
+  isAccountVerb,
+  accountScope,
+  parseAccountScope,
+  hasAccountScope,
+} from "./scopes.js";
+
+export {
+  RESPONSE_TYPES_SUPPORTED,
+  GRANT_TYPES_SUPPORTED,
+  CODE_CHALLENGE_METHODS_SUPPORTED,
+  TOKEN_ENDPOINT_AUTH_METHODS_SUPPORTED,
+  BEARER_METHODS_SUPPORTED,
+  type AuthorizationServerMetadata,
+  type ProtectedResourceMetadata,
+  expectedAuthorizationServerMetadata,
+  expectedProtectedResourceMetadata,
+} from "./discovery.js";
+
+export {
+  type AccountRoute,
+  ACCOUNT_ROUTES,
+  type ParachuteAccountDescriptor,
+  type AccountVaultSummary,
+  type CreateVaultRequest,
+  type MintVaultTokenRequest,
+  type AccountBootstrap,
+} from "./account-contract.js";
+
+export {
+  type ConformanceIssue,
+  checkAuthorizationServerMetadata,
+  checkProtectedResourceMetadata,
+  checkTokenResponseInvariants,
+  ACCOUNT_ROUTE_VECTORS,
+} from "./conformance.js";

--- a/packages/door-contract/src/scopes.ts
+++ b/packages/door-contract/src/scopes.ts
@@ -1,0 +1,71 @@
+/**
+ * The account-door scope grammar — `account:<id>:<verb>`, `admin ⊇ read`.
+ *
+ * Both doors gate their `/account/*` surface on this grammar and re-implement it
+ * separately today: the self-host hub pins `<id>` to the `self` sentinel
+ * (account ≡ box, `src/scope-explanations.ts`), the hosted cloud uses the
+ * per-user account id (`workers/identity/src/account-auth.ts` with its own
+ * `AccountVerb` + `ACCOUNT_VERB_RANK`). The grammar and the verb ladder are
+ * identical; this is the shared definition.
+ *
+ * This is the account-scope sibling of `@openparachute/scope-guard`'s vault
+ * scope matcher — kept here (not there) because it's part of the door/account
+ * contract, not the resource-server JWT-validation surface scope-guard owns.
+ */
+
+/** The two-rung account verb ladder. */
+export type AccountVerb = "read" | "admin";
+
+/** `admin ⊇ read`. */
+export const ACCOUNT_VERB_RANK: Record<AccountVerb, number> = { read: 0, admin: 1 };
+
+/** The self-host account sentinel — on a hub the account IS the box. */
+export const ACCOUNT_SELF_ID = "self";
+
+/** `account:self:admin` — the self-host canonical admin scope. */
+export const ACCOUNT_SELF_ADMIN_SCOPE = "account:self:admin";
+/** `account:self:read` — the self-host canonical read scope. */
+export const ACCOUNT_SELF_READ_SCOPE = "account:self:read";
+
+export function isAccountVerb(s: string): s is AccountVerb {
+  return s === "read" || s === "admin";
+}
+
+/** Build the `account:<id>:<verb>` scope string. */
+export function accountScope(id: string, verb: AccountVerb): string {
+  return `account:${id}:${verb}`;
+}
+
+/**
+ * Parse an `account:<id>:<verb>` scope. Returns `null` for anything that is not
+ * exactly a 3-part account scope with a known verb (a 2-part `account:admin`, a
+ * vault scope, a malformed string) — mirrors both doors' decomposition.
+ */
+export function parseAccountScope(scope: string): { id: string; verb: AccountVerb } | null {
+  const parts = scope.split(":");
+  if (parts.length !== 3) return null;
+  const [resource, id, verb] = parts as [string, string, string];
+  if (resource !== "account" || id.length === 0 || !isAccountVerb(verb)) return null;
+  return { id, verb };
+}
+
+/**
+ * Does the granted scope set satisfy `verb` on `accountId`? `admin` satisfies a
+ * `read` requirement; a scope for a different `<id>` never matches. Identical to
+ * cloud's `hasAccountScope` and the semantics the hub's exact-string gate
+ * assumes (`account:self:admin` covers `account:self:read`).
+ */
+export function hasAccountScope(
+  granted: readonly string[],
+  accountId: string,
+  verb: AccountVerb,
+): boolean {
+  const reqRank = ACCOUNT_VERB_RANK[verb];
+  for (const s of granted) {
+    const d = parseAccountScope(s);
+    if (!d) continue;
+    if (d.id !== accountId) continue;
+    if (ACCOUNT_VERB_RANK[d.verb] >= reqRank) return true;
+  }
+  return false;
+}

--- a/packages/door-contract/src/tokens.ts
+++ b/packages/door-contract/src/tokens.ts
@@ -1,0 +1,71 @@
+/**
+ * Token wire constants + shapes — the single source of truth both doors mint
+ * against.
+ *
+ * These values are currently duplicated byte-for-byte in each door's issuer
+ * (self-host hub `src/jwt-sign.ts`, hosted cloud `workers/identity/src/tokens.ts`).
+ * They live here so the two can converge on ONE definition; until each door
+ * imports them at runtime (plan Phase B), a parity test in each door asserts its
+ * local literal still equals the canon here (the drift detector).
+ */
+
+/** Access-token lifetime. RS256 JWT, `exp = iat + ACCESS_TOKEN_TTL_SECONDS`. */
+export const ACCESS_TOKEN_TTL_SECONDS = 15 * 60;
+
+/** Opaque refresh-token lifetime (registry-row `expires_at`). */
+export const REFRESH_TOKEN_TTL_MS = 30 * 24 * 60 * 60 * 1000;
+
+/**
+ * One-generation rotation grace window (hub#685). A refresh of the immediately-
+ * previous (just-rotated) token within this window is a benign concurrent/retried
+ * refresh — the family converges onto the live tip instead of being revoked.
+ * Anything older, or any replay past the window, still revokes the family.
+ */
+export const REFRESH_GRACE_MS = 30_000;
+
+/** The `token_type` every token response carries. */
+export const TOKEN_TYPE = "Bearer";
+
+/** The JWS `alg` both issuers sign with, advertised in JWKS (`RS256`). */
+export const SIGNING_ALG = "RS256";
+
+/**
+ * The access-token claim set both issuers emit. Registered claims (`sub`, `iss`,
+ * `aud`, `iat`, `exp`, `jti`) plus the Parachute-specific `scope` (space-joined),
+ * `client_id`, and `vault_scope` (the narrowed vault-name list, `[]` for
+ * unnamed/admin).
+ */
+export interface AccessTokenClaims {
+  /** Space-joined granted scopes. */
+  scope: string;
+  /** The client the token was issued to (DCR id or a first-party sentinel). */
+  client_id: string;
+  /** Narrowed vault names; `[]` when unnamed or admin. */
+  vault_scope: string[];
+  /** Subject — the user/account id. */
+  sub: string;
+  /** Issuer origin. */
+  iss: string;
+  /** Audience — the resource this token is spendable against. */
+  aud: string;
+  iat: number;
+  exp: number;
+  /** JWT id — the revocation + refresh-family key. */
+  jti: string;
+}
+
+/**
+ * The `POST /oauth/token` success body. `services` is the discovery catalog
+ * (resource → URL); `vault` is the app-client convenience field, emitted only
+ * when the granted scopes name exactly one vault.
+ */
+export interface TokenResponse {
+  access_token: string;
+  refresh_token?: string;
+  token_type: typeof TOKEN_TYPE;
+  /** Always `ACCESS_TOKEN_TTL_SECONDS`. */
+  expires_in: number;
+  scope: string;
+  services?: Record<string, { url: string }>;
+  vault?: string;
+}

--- a/packages/door-contract/tsconfig.json
+++ b/packages/door-contract/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false,
+    "allowImportingTsExtensions": false,
+    "verbatimModuleSyntax": false,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/src/__tests__/door-contract-parity.test.ts
+++ b/src/__tests__/door-contract-parity.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ACCESS_TOKEN_TTL_SECONDS as CONTRACT_ACCESS_TTL,
+  ACCOUNT_SELF_ADMIN_SCOPE as CONTRACT_ACCOUNT_ADMIN,
+  ACCOUNT_SELF_READ_SCOPE as CONTRACT_ACCOUNT_READ,
+  REFRESH_GRACE_MS as CONTRACT_REFRESH_GRACE,
+  REFRESH_TOKEN_TTL_MS as CONTRACT_REFRESH_TTL,
+  hasAccountScope,
+} from "@openparachute/door-contract";
+import { ACCESS_TOKEN_TTL_SECONDS, REFRESH_GRACE_MS, REFRESH_TOKEN_TTL_MS } from "../jwt-sign.ts";
+import { ACCOUNT_SELF_ADMIN_SCOPE, ACCOUNT_SELF_READ_SCOPE } from "../scope-explanations.ts";
+
+/**
+ * Drift detector for the shared door contract (Cloud+Hub shared-core campaign,
+ * parachute-cloud#116, Phase A). The hub's issuer constants + account-scope
+ * strings are duplicated in `@openparachute/door-contract` (the hosted cloud
+ * door duplicates them too). These assertions bind the hub's LIVE runtime values
+ * to the shared canon — no runtime code path is changed by this test, but any
+ * future divergence between the hub's issuer and the shared contract fails here,
+ * forcing the change through the shared package (and thus the cloud twin).
+ *
+ * When the hub adopts the contract at runtime (Phase B — `jwt-sign.ts` imports
+ * these constants instead of re-declaring them), these become identity checks;
+ * until then they are the guardrail.
+ */
+describe("door-contract parity — token constants", () => {
+  test("the hub's issuer TTL/grace equal the shared contract", () => {
+    expect(ACCESS_TOKEN_TTL_SECONDS).toBe(CONTRACT_ACCESS_TTL);
+    expect(REFRESH_TOKEN_TTL_MS).toBe(CONTRACT_REFRESH_TTL);
+    expect(REFRESH_GRACE_MS).toBe(CONTRACT_REFRESH_GRACE);
+  });
+});
+
+describe("door-contract parity — account scopes", () => {
+  test("the hub's account scope strings equal the shared contract", () => {
+    expect(ACCOUNT_SELF_ADMIN_SCOPE).toBe(CONTRACT_ACCOUNT_ADMIN);
+    expect(ACCOUNT_SELF_READ_SCOPE).toBe(CONTRACT_ACCOUNT_READ);
+  });
+
+  test("the shared checker agrees with the hub's admin⊇read intent", () => {
+    // The hub's `/account/*` gate treats `account:self:admin` as satisfying a
+    // read requirement (scope-explanations.ts). The shared checker must too.
+    expect(hasAccountScope([ACCOUNT_SELF_ADMIN_SCOPE], "self", "read")).toBe(true);
+    expect(hasAccountScope([ACCOUNT_SELF_READ_SCOPE], "self", "admin")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

First safe step of the **Cloud + Hub shared-core merge** (Aaron's call: "Yes to cloud + hub shared core, one repo"). Campaign: **parachute-cloud#116**.

Extracts the genuinely-shared, currently-**duplicated** door contract into a new pure-TypeScript workspace package **`@openparachute/door-contract`** (sibling to `scope-guard`) — the single source of truth for the OAuth-issuer + `/account/*` wire contract both doors implement.

### The duplication this closes (receipts)
Two independent issuer implementations, kept in sync only by prose + two test suites:
- **Token constants — byte-identical, defined twice:** `ACCESS_TOKEN_TTL_SECONDS`/`REFRESH_TOKEN_TTL_MS`/`REFRESH_GRACE_MS` in hub `src/jwt-sign.ts` **and** cloud `workers/identity/src/tokens.ts`.
- **Discovery doc (RFC 8414/9728) — same shape built twice:** hub `oauth-handlers.ts` vs cloud `oauth-metadata.ts`.
- **Access-token claim set — identical:** `{scope, client_id, vault_scope, sub, iss, iat, exp, aud, jti}`.
- **Account scope grammar — twice:** `account:self:*` (hub `scope-explanations.ts`) vs cloud's `account:<id>:*` + its own verb ladder (`account-auth.ts`).
- **`/account/*` route table** (H2/C3 twins) — lives only in prose in each door.
- **Conformance corpus** — cloud has a 1048-line `conformance.test.ts`; hub's equivalent is scattered. No shared vectors. This unifies them (the X1 twin-suite content → one corpus; the D11 follow-on).

### The package (pure data/types/functions, zero runtime deps)
`tokens.ts` · `scopes.ts` · `discovery.ts` · `account-contract.ts` · `conformance.ts` (the `check*` helpers a door's suite drives against its live `app.fetch`).

## Wiring — test-only, deploy-neutral
- Hub consumes it via a **`workspace:*` devDependency** (devDeps are **not** installed by npm consumers of `@openparachute/hub`; the published `files` list excludes `packages/` — the hub npm package + runtime are unchanged).
- New `src/__tests__/door-contract-parity.test.ts` asserts the hub's **live** runtime constants + account-scope strings **equal** the shared canon — a **drift detector** that makes the corpus load-bearing **without touching any runtime code path**.
- **Cloud is untouched in this PR.** Cloud adoption (its `conformance.test.ts` imports the shared vectors; both doors import the constants at runtime) is **Phase B**.

## Reversible
Delete the package + the parity test + the devDep line + the CI step + the rc bump. No runtime behavior changes in either door.

## Verification
- `door-contract` package: **12 pass** (`bun test ./packages/door-contract/src`).
- hub parity: **3 pass** (`bun test ./src/__tests__/door-contract-parity.test.ts`).
- **Positive control:** injecting drift into the contract (16*60 vs 15*60) **fails** the parity test; restoring **passes** — the detector is not vacuous.
- `bun run typecheck` clean · `biome check` clean.
- Full `bun test ./src` **deferred to CI** — the hub lifecycle suites can launchctl-boot the live daemon on the author's box; CI (Linux) runs it safely.
- New CI step `bun test ./packages/door-contract/src` added to `release.yml`.

## Notes for the reviewer
- `bun.lock` is the fresh-install output; it also reconciles two **pre-existing** stale workspace-version lines (`depcheck` 0.1.0-rc.1→0.1.1, `scope-guard` 0.4.0-rc.2→0.5.0) to match those packages' on-disk `package.json` versions.
- `.js` relative imports inside the package are intentional (resolve to `.ts` for bun/bundler consumers; keeps a future NodeNext/npm build a mechanical flip — the scope-guard #225 lesson).
- The full migration plan (target monorepo shape, history-preserving `git subtree` merge, deploy-neutrality, phased sequence) accompanies this step and is shared with the campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB