### PR TITLE
feat(door-contract): account-door descriptor + conformance helper (C4-A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.3",
+  "version": "0.7.7-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -1,5 +1,16 @@
 # @openparachute/door-contract
 
+## 0.2.0
+
+C4 (Parachute App campaign, parachute-cloud#116) — the account-door descriptor.
+Extends `ParachuteAccountDescriptor` (served at `GET /.well-known/parachute-account`)
+with `signup_path`, `app_client_id`, `capabilities` (`AccountCapabilities`), and
+`plans` (`AccountPlanSummary[]`) so a client learns where to sign up, which
+first-party client to use, what the door can do, and its plan ladder without
+hardcoding. Adds the `checkAccountDescriptor(actual, {issuer, door})` conformance
+helper (mirrors `checkAuthorizationServerMetadata`) so both doors' descriptors
+are pinned. Additive; no breaking changes.
+
 ## 0.1.0
 
 Initial extraction (Cloud+Hub shared-core campaign, parachute-cloud#116,

--- a/packages/door-contract/package.json
+++ b/packages/door-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/door-contract",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "The Parachute door contract: shared OAuth-issuer + /account/* wire types, constants, and conformance vectors that both doors (self-host hub + hosted cloud) implement.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -8,6 +8,7 @@ import {
   REFRESH_TOKEN_TTL_MS,
   TOKEN_TYPE,
   accountScope,
+  checkAccountDescriptor,
   checkAuthorizationServerMetadata,
   checkProtectedResourceMetadata,
   checkTokenResponseInvariants,
@@ -16,6 +17,16 @@ import {
   hasAccountScope,
   parseAccountScope,
 } from "../index.js";
+
+const CONFORMANT_DESCRIPTOR = {
+  issuer: "https://cloud.parachute.computer",
+  door: "cloud" as const,
+  account_endpoint: "https://cloud.parachute.computer/account",
+  signup_path: "/signup",
+  app_client_id: "parachute-app",
+  capabilities: { vault_create: true, vault_rename: false, vault_delete: false },
+  plans: [{ id: "entry", name: "Entry", vaults: 1, price_month: 1 }],
+};
 
 // The corpus is pinned as the single source of truth. These values are what
 // each door currently duplicates; if a real contract change is intended, it
@@ -149,5 +160,45 @@ describe("account route table", () => {
     expect(byKey("POST", "/account/vaults")?.scope).toBe("admin");
     expect(byKey("DELETE", "/account/vaults/<name>")?.scope).toBe("admin");
     expect(byKey("GET", "/account/vaults")?.scope).toBe("read");
+  });
+});
+
+describe("parachute-account descriptor (C4)", () => {
+  const expected = { issuer: "https://cloud.parachute.computer", door: "cloud" as const };
+
+  test("a conformant descriptor reports zero issues", () => {
+    expect(checkAccountDescriptor(CONFORMANT_DESCRIPTOR, expected)).toEqual([]);
+  });
+
+  test("account_endpoint must derive from the issuer", () => {
+    const bad = { ...CONFORMANT_DESCRIPTOR, account_endpoint: "https://elsewhere.example/account" };
+    const issues = checkAccountDescriptor(bad, expected);
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("account_endpoint");
+  });
+
+  test("issuer / door / signup_path / app_client_id / capabilities / plans are all pinned", () => {
+    expect(
+      checkAccountDescriptor({ ...CONFORMANT_DESCRIPTOR, issuer: "https://evil.example" }, expected)
+        .length,
+    ).toBe(1); // issuer (account_endpoint is checked vs the EXPECTED issuer)
+    expect(checkAccountDescriptor({ ...CONFORMANT_DESCRIPTOR, door: "hub" }, expected).length).toBe(
+      1,
+    );
+    expect(
+      checkAccountDescriptor({ ...CONFORMANT_DESCRIPTOR, signup_path: "signup" }, expected).length,
+    ).toBe(1); // not absolute
+    expect(
+      checkAccountDescriptor({ ...CONFORMANT_DESCRIPTOR, app_client_id: "" }, expected).length,
+    ).toBe(1);
+    expect(
+      checkAccountDescriptor(
+        { ...CONFORMANT_DESCRIPTOR, capabilities: { vault_create: true, vault_delete: false } },
+        expected,
+      ).length,
+    ).toBe(1); // missing vault_rename boolean
+    expect(
+      checkAccountDescriptor({ ...CONFORMANT_DESCRIPTOR, plans: "nope" }, expected).length,
+    ).toBe(1);
   });
 });

--- a/packages/door-contract/src/account-contract.ts
+++ b/packages/door-contract/src/account-contract.ts
@@ -70,14 +70,55 @@ export const ACCOUNT_ROUTES: readonly AccountRoute[] = [
   },
 ] as const;
 
-/** The public capabilities descriptor served at `/.well-known/parachute-account`. */
+/** One plan/tier the door advertises (cloud's `PLAN_SPECS`; empty for self-host). */
+export interface AccountPlanSummary {
+  /** Stable plan id (e.g. `"entry"`). */
+  id: string;
+  /** Human label (e.g. `"Entry"`). */
+  name: string;
+  /** Max vaults this plan allows. */
+  vaults: number;
+  /** Monthly price in whole USD; `0`/omitted = free or self-host. */
+  price_month?: number;
+}
+
+/** Which account-lifecycle operations the door's `/account/*` API supports. */
+export interface AccountCapabilities {
+  /** `POST /account/vaults` creates a vault. */
+  vault_create: boolean;
+  /**
+   * A vault's canonical name can change after creation. Cloud: `false` — the
+   * vault `name` is the immutable global slug / DO address / URL (a future
+   * rename would set a separate mutable display name, never the slug).
+   */
+  vault_rename: boolean;
+  /** `DELETE /account/vaults/<name>` tears a vault down (cloud v1: `false`). */
+  vault_delete: boolean;
+}
+
+/**
+ * The public descriptor served at `GET /.well-known/parachute-account` — the
+ * door's self-description a client fetches to learn where to sign up, where the
+ * account API lives, which first-party client to use, and what the door can do.
+ * Both doors serve their own instance (cloud advertises `signup_path:"/signup"`,
+ * the self-host hub `"/account/setup"`); clients read `signup_path` etc. rather
+ * than hardcoding. Public + wildcard-CORS, no auth.
+ */
 export interface ParachuteAccountDescriptor {
-  /** The account door's issuer origin. */
+  /** The account door's issuer origin (no trailing slash). */
   issuer: string;
   /** Which door this is. */
   door: "hub" | "cloud";
-  /** The `/account/*` routes this door mounts. */
+  /** The `/account/*` API base — always `${issuer}/account`. */
   account_endpoint: string;
+  /** Where a brand-new user begins sign-up (cloud `"/signup"`, hub `"/account/setup"`). */
+  signup_path: string;
+  /** The reserved first-party `client_id` a native app should use (cloud `"parachute-app"`). */
+  app_client_id: string;
+  /** Which account-lifecycle operations this door supports. */
+  capabilities: AccountCapabilities;
+  /** The plan/tier ladder this door offers (empty for self-host). */
+  plans: AccountPlanSummary[];
 }
 
 /** A vault as returned by `GET /account/vaults`. */

--- a/packages/door-contract/src/conformance.ts
+++ b/packages/door-contract/src/conformance.ts
@@ -73,6 +73,46 @@ export function checkTokenResponseInvariants(
   return issues;
 }
 
+/**
+ * Validate a door's `GET /.well-known/parachute-account` descriptor. Door-specific
+ * values (`signup_path`, `app_client_id`, `plans`) are the door's own; this pins
+ * the SHAPE + the cross-field invariants BOTH doors must hold: `issuer`/`door`
+ * match the caller's expected pair, `account_endpoint` is derived (`${issuer}/account`),
+ * `signup_path` is an absolute path, `app_client_id` is present, `capabilities`
+ * carries the three booleans, and `plans` is an array.
+ */
+export function checkAccountDescriptor(
+  actual: Record<string, unknown>,
+  expected: { issuer: string; door: "hub" | "cloud" },
+): ConformanceIssue[] {
+  const issues: ConformanceIssue[] = [];
+  const push = (detail: string) => issues.push({ vector: "parachute-account", detail });
+  if (actual.issuer !== expected.issuer)
+    push(`issuer must be ${JSON.stringify(expected.issuer)}, got ${JSON.stringify(actual.issuer)}`);
+  if (actual.door !== expected.door)
+    push(`door must be ${JSON.stringify(expected.door)}, got ${JSON.stringify(actual.door)}`);
+  const wantEndpoint = `${expected.issuer}/account`;
+  if (actual.account_endpoint !== wantEndpoint)
+    push(
+      `account_endpoint must be ${JSON.stringify(wantEndpoint)}, got ${JSON.stringify(actual.account_endpoint)}`,
+    );
+  if (typeof actual.signup_path !== "string" || !actual.signup_path.startsWith("/"))
+    push(`signup_path must be an absolute path, got ${JSON.stringify(actual.signup_path)}`);
+  if (typeof actual.app_client_id !== "string" || actual.app_client_id.length === 0)
+    push("app_client_id must be a non-empty string");
+  const caps = actual.capabilities;
+  if (typeof caps !== "object" || caps === null) {
+    push("capabilities must be an object");
+  } else {
+    for (const k of ["vault_create", "vault_rename", "vault_delete"] as const) {
+      if (typeof (caps as Record<string, unknown>)[k] !== "boolean")
+        push(`capabilities.${k} must be a boolean`);
+    }
+  }
+  if (!Array.isArray(actual.plans)) push("plans must be an array");
+  return issues;
+}
+
 /** The `/account/*` route vectors — the contract every door mounts. */
 export const ACCOUNT_ROUTE_VECTORS: readonly AccountRoute[] = ACCOUNT_ROUTES;
 

--- a/packages/door-contract/src/index.ts
+++ b/packages/door-contract/src/index.ts
@@ -59,6 +59,8 @@ export {
   type AccountRoute,
   ACCOUNT_ROUTES,
   type ParachuteAccountDescriptor,
+  type AccountPlanSummary,
+  type AccountCapabilities,
   type AccountVaultSummary,
   type CreateVaultRequest,
   type MintVaultTokenRequest,
@@ -70,5 +72,6 @@ export {
   checkAuthorizationServerMetadata,
   checkProtectedResourceMetadata,
   checkTokenResponseInvariants,
+  checkAccountDescriptor,
   ACCOUNT_ROUTE_VECTORS,
 } from "./conformance.js";


### PR DESCRIPTION
## What

**C4 part A** of the Parachute App campaign (**parachute-cloud#116**) — the shared TYPE + conformance vector for the account door's `GET /.well-known/parachute-account` descriptor, in `@openparachute/door-contract`. This is the door-contract half; the cloud identity worker serves its instance in the **sibling cloud PR (C4-B)**, and the self-host hub serves its twin (advertising `/account/setup`, hub#748) in a follow-up.

## Changes (additive, no breaking)
- **`ParachuteAccountDescriptor`** gains `signup_path`, `app_client_id`, `capabilities` (`AccountCapabilities`: `vault_create`/`vault_rename`/`vault_delete`), and `plans` (`AccountPlanSummary[]`) — so a client learns where to sign up, which first-party client to use, what the door can do, and its plan ladder without hardcoding. `capabilities.vault_rename` documents the immutable-name reality (cloud: `false` — the vault name is the global slug / DO address / URL).
- **`checkAccountDescriptor(actual, {issuer, door})`** — the conformance helper (mirrors `checkAuthorizationServerMetadata`) pinning the shape + cross-field invariants: `account_endpoint === ${issuer}/account`, absolute `signup_path`, present `app_client_id`, the three capability booleans, `plans` is an array. Both doors' conformance suites import it.

## Versions
`@openparachute/door-contract` 0.1.0 → **0.2.0**; hub rc.3 → **rc.4**.

## Sequence
**Merge this before the cloud C4-B PR** — cloud CI clones `parachute-hub@main` + builds door-contract's dist, so it needs `checkAccountDescriptor` on hub main to resolve.

## Verification
- door-contract package: **15 pass** (was 12) — `bun test ./packages/door-contract/src`
- hub `bun run typecheck` clean · `biome check` clean · dist rebuilt (`checkAccountDescriptor` present in `index.js`/`index.d.ts`)
- `bun install --frozen-lockfile` passes (workspace-member version is informational in the lock, same as depcheck/scope-guard).
- Full `bun test ./src` deferred to CI (the hub lifecycle suites can launchctl-boot the live daemon on the author's box).

Design: `scratchpad/design-phase/plan/C4-C5-DESIGN.md` §4a/§8. No runtime behavior change — a type + a test helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB