### PR TITLE
feat(door-contract): optional vault_url_template on the account descriptor (PR-2A)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.4",
+  "version": "0.7.7-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @openparachute/door-contract
 
+## 0.3.0
+
+Adds the optional `vault_url_template` field to `ParachuteAccountDescriptor` — a
+`{name}`-placeholder template a client substitutes to preview a vault's address
+pre-creation, door-agnostically (cloud has both path + subdomain forms, so only
+the door can render the right one). `checkAccountDescriptor` validates it only
+when present (must be a string containing `{name}`). Additive; no breaking change.
+
 ## 0.2.0
 
 C4 (Parachute App campaign, parachute-cloud#116) — the account-door descriptor.

--- a/packages/door-contract/package.json
+++ b/packages/door-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/door-contract",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "The Parachute door contract: shared OAuth-issuer + /account/* wire types, constants, and conformance vectors that both doors (self-host hub + hosted cloud) implement.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -201,4 +201,23 @@ describe("parachute-account descriptor (C4)", () => {
       checkAccountDescriptor({ ...CONFORMANT_DESCRIPTOR, plans: "nope" }, expected).length,
     ).toBe(1);
   });
+
+  test("vault_url_template is OPTIONAL but must carry {name} when present", () => {
+    // Omitted → still conformant (the CONFORMANT_DESCRIPTOR has none).
+    expect(checkAccountDescriptor(CONFORMANT_DESCRIPTOR, expected)).toEqual([]);
+    // Present + valid → conformant.
+    expect(
+      checkAccountDescriptor(
+        { ...CONFORMANT_DESCRIPTOR, vault_url_template: "https://u.parachute.computer/vault/{name}" },
+        expected,
+      ),
+    ).toEqual([]);
+    // Present without the {name} placeholder → one issue.
+    const bad = checkAccountDescriptor(
+      { ...CONFORMANT_DESCRIPTOR, vault_url_template: "https://u.parachute.computer/vault/" },
+      expected,
+    );
+    expect(bad.length).toBe(1);
+    expect(bad[0]?.detail).toContain("vault_url_template");
+  });
 });

--- a/packages/door-contract/src/account-contract.ts
+++ b/packages/door-contract/src/account-contract.ts
@@ -119,6 +119,15 @@ export interface ParachuteAccountDescriptor {
   capabilities: AccountCapabilities;
   /** The plan/tier ladder this door offers (empty for self-host). */
   plans: AccountPlanSummary[];
+  /**
+   * A vault-URL template with a literal `{name}` PLACEHOLDER the client
+   * substitutes to preview a vault's address pre-creation ("it will live at …")
+   * — door-agnostic, so a client never hardcodes cloud's path form vs a hub's.
+   * NOT a base prefix: cloud serves both path (`…/vault/{name}`) and subdomain
+   * (`{name}.<base>`) shapes, so only the door can render the right template.
+   * Optional (a door that can't express one omits it).
+   */
+  vault_url_template?: string;
 }
 
 /** A vault as returned by `GET /account/vaults`. */

--- a/packages/door-contract/src/conformance.ts
+++ b/packages/door-contract/src/conformance.ts
@@ -110,6 +110,12 @@ export function checkAccountDescriptor(
     }
   }
   if (!Array.isArray(actual.plans)) push("plans must be an array");
+  // Optional: a door MAY omit `vault_url_template`, but when present it must be a
+  // string carrying the literal `{name}` placeholder (it's a template, not a URL).
+  if (actual.vault_url_template !== undefined) {
+    if (typeof actual.vault_url_template !== "string" || !actual.vault_url_template.includes("{name}"))
+      push('vault_url_template, when present, must be a string containing "{name}"');
+  }
   return issues;
 }
 


### PR DESCRIPTION
## What
**PR-2A** (hub half of PR-2) — adds the optional **`vault_url_template`** field to `ParachuteAccountDescriptor` in `@openparachute/door-contract`: a `{name}`-**placeholder** template a client substitutes to preview a vault's address pre-creation ("it will live at …/vault/<name>"), door-agnostically. NOT a base prefix — cloud serves both path (`…/vault/{name}`) and subdomain (`{name}.<base>`) shapes, so only the door can render the right template.

`checkAccountDescriptor` validates it **only when present** (must be a string containing `{name}`); omitting it stays conformant.

## Versions
`@openparachute/door-contract` 0.2.0 → **0.3.0**; hub rc.4 → **rc.5**. Additive, no breaking change.

## Sequence
**Merge before the cloud PR-2B** (which serves the field) — cloud CI clones `parachute-hub@main` + builds door-contract's dist, so the type must be on hub main to resolve.

## Verification
door-contract **16 pass** (+1: optional-but-`{name}`-required); hub `bun run typecheck` + `biome` clean; dist rebuilt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB