### PR TITLE
feat(door-contract): 0.4.0 — the auth block + session/token wire canon (hub-parity P0)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.5",
+  "version": "0.7.7-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -27,6 +27,24 @@ requests default to `vault:<name>:{read,write}`, every entry must be exactly
 `vault:<name>:{read|write|admin}`, results are de-duplicated. Additive to the
 type surface; no existing call signature changes.
 
+Review-fold (P0 review):
+- `validateVaultScopes` now returns `{ ok: false; reason: "invalid_request" |
+  "invalid_scope" }` on rejection (was a bare `{ ok: false }`) — the `reason`
+  carries the door's wire error code so a door adopting the shared validator
+  (P2/P3) keeps its exact HTTP error without re-deriving the split
+  (`invalid_request` = non-array / non-string entry; `invalid_scope` =
+  well-formed string naming the wrong resource/vault/verb, matching hub's
+  `parseScopesBody`). New `VaultScopesReason` type. Nothing consumes the
+  validator yet, so this is pure additive design.
+- `ACCOUNT_ERROR_CODES` was born incomplete; added the codes both doors already
+  emit but the pin missed: `account_suspended`, `not_found` (cloud),
+  `method_not_allowed`, `server_error` (hub). Now the real union.
+- Hardened the new conformance checkers: `checkAccountSessionResponse` requires
+  `email`/`username` to be a string when present (not merely present);
+  `checkVaultTokenMintResponse` requires the `vault:<name>` services entry to
+  carry a string `url`; `isParseableTimestamp` now enforces true ISO-8601
+  (rejecting `Date.parse`-lenient locale strings like `"January 1, 2026"`).
+
 ## 0.3.0
 
 Adds the optional `vault_url_template` field to `ParachuteAccountDescriptor` — a

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -1,5 +1,32 @@
 # @openparachute/door-contract
 
+## 0.4.0
+
+The auth block + the session/token wire canon (hub-parity P0). `signup_path` and
+`app_client_id` on `ParachuteAccountDescriptor` move from required to OPTIONAL
+(a door advertises each only when it applies — hub's `signup_path` only while an
+active public invite exists (Q2), a door with no reserved native client omits
+`app_client_id`); `checkAccountDescriptor` validates both only when present. Adds
+`AccountAuthDescriptor` (`methods`, `signin_path`) + optional `auth` on the
+descriptor — drives the app's front-door branch (magic-link form vs a
+ceremony-hop to the door's own sign-in page); optional in 0.4.0 so cloud@main
+keeps typechecking pre-P3, required from 0.5.0. `AccountRoute` gains
+`optional?: boolean`; `GET /account` and the `/account/vaults/<name>/caps`
+routes are now marked optional in `ACCOUNT_ROUTES` (hub-only — cloud routes
+`GET /account` to its SPA shell and derives caps from plan, not a per-vault
+knob). New wire types written down once from the app's pinned shapes:
+`AccountSessionResponse` (`GET /account/session`), `AccountTokenMintResponse`
+(`POST /account/token`), `VaultTokenMintResponse`
+(`POST /account/vaults/<name>/token`) — each with a matching `check*`
+conformance helper. `ACCOUNT_ERROR_CODES` pins the shared `/account/*` error
+vocabulary both doors already mirror. New `vault-scopes.ts`:
+`validateVaultScopes(requested, vaultName)`, the ONE shared scope-shape
+validator replacing hub's `parseScopesBody` scope logic and cloud's local
+`validateVaultScopes` (cross-repo derived-key lesson) — absent/null/empty
+requests default to `vault:<name>:{read,write}`, every entry must be exactly
+`vault:<name>:{read|write|admin}`, results are de-duplicated. Additive to the
+type surface; no existing call signature changes.
+
 ## 0.3.0
 
 Adds the optional `vault_url_template` field to `ParachuteAccountDescriptor` — a

--- a/packages/door-contract/README.md
+++ b/packages/door-contract/README.md
@@ -23,7 +23,8 @@ owns the **door/issuer** side.
 | `tokens.ts` | `ACCESS_TOKEN_TTL_SECONDS`, `REFRESH_TOKEN_TTL_MS`, `REFRESH_GRACE_MS`, `TOKEN_TYPE`, `SIGNING_ALG` + `AccessTokenClaims` / `TokenResponse` |
 | `scopes.ts` | the `account:<id>:<verb>` grammar (`admin ⊇ read`) + `hasAccountScope` |
 | `discovery.ts` | RFC 8414 / 9728 metadata vectors: `expected*Metadata(issuer, …)` |
-| `account-contract.ts` | the `/account/*` route table (`ACCOUNT_ROUTES`) + request/response types |
+| `account-contract.ts` | the `/account/*` route table (`ACCOUNT_ROUTES`) + request/response types, the `AccountAuthDescriptor` block, and `ACCOUNT_ERROR_CODES` |
+| `vault-scopes.ts` | `validateVaultScopes(requested, vaultName)` — the shared per-vault-mint scope validator |
 | `conformance.ts` | the shared corpus + `check*` helpers a door's suite drives against its live handlers |
 
 ## Usage — a door's conformance suite

--- a/packages/door-contract/package.json
+++ b/packages/door-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/door-contract",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "The Parachute door contract: shared OAuth-issuer + /account/* wire types, constants, and conformance vectors that both doors (self-host hub + hosted cloud) implement.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
+  ACCOUNT_ERROR_CODES,
   ACCOUNT_ROUTES,
   ACCOUNT_SELF_ADMIN_SCOPE,
   ACCOUNT_SELF_READ_SCOPE,
@@ -9,13 +10,17 @@ import {
   TOKEN_TYPE,
   accountScope,
   checkAccountDescriptor,
+  checkAccountSessionResponse,
+  checkAccountTokenMintResponse,
   checkAuthorizationServerMetadata,
   checkProtectedResourceMetadata,
   checkTokenResponseInvariants,
+  checkVaultTokenMintResponse,
   expectedAuthorizationServerMetadata,
   expectedProtectedResourceMetadata,
   hasAccountScope,
   parseAccountScope,
+  validateVaultScopes,
 } from "../index.js";
 
 const CONFORMANT_DESCRIPTOR = {
@@ -208,7 +213,10 @@ describe("parachute-account descriptor (C4)", () => {
     // Present + valid → conformant.
     expect(
       checkAccountDescriptor(
-        { ...CONFORMANT_DESCRIPTOR, vault_url_template: "https://u.parachute.computer/vault/{name}" },
+        {
+          ...CONFORMANT_DESCRIPTOR,
+          vault_url_template: "https://u.parachute.computer/vault/{name}",
+        },
         expected,
       ),
     ).toEqual([]);
@@ -219,5 +227,298 @@ describe("parachute-account descriptor (C4)", () => {
     );
     expect(bad.length).toBe(1);
     expect(bad[0]?.detail).toContain("vault_url_template");
+  });
+
+  test("signup_path / app_client_id are OPTIONAL (P0) — absent is still conformant", () => {
+    const { signup_path, app_client_id, ...withoutOptionalFields } = CONFORMANT_DESCRIPTOR;
+    expect(checkAccountDescriptor(withoutOptionalFields, expected)).toEqual([]);
+  });
+
+  test("signup_path, when present, must still be an absolute path", () => {
+    const issues = checkAccountDescriptor(
+      { ...CONFORMANT_DESCRIPTOR, signup_path: "signup" },
+      expected,
+    );
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("signup_path");
+  });
+
+  test("app_client_id, when present, must still be non-empty", () => {
+    const issues = checkAccountDescriptor(
+      { ...CONFORMANT_DESCRIPTOR, app_client_id: "" },
+      expected,
+    );
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("app_client_id");
+  });
+
+  test("auth is OPTIONAL (P0) — absent is conformant, present + valid is conformant", () => {
+    const { signup_path, app_client_id, ...base } = CONFORMANT_DESCRIPTOR;
+    expect(checkAccountDescriptor(base, expected)).toEqual([]);
+    expect(
+      checkAccountDescriptor(
+        { ...base, auth: { methods: ["magic_link"], signin_path: "/login" } },
+        expected,
+      ),
+    ).toEqual([]);
+  });
+
+  test("auth, when present, pins methods + signin_path", () => {
+    const { signup_path, app_client_id, ...base } = CONFORMANT_DESCRIPTOR;
+    expect(
+      checkAccountDescriptor({ ...base, auth: { methods: [], signin_path: "/login" } }, expected)
+        .length,
+    ).toBe(1); // empty methods
+    expect(
+      checkAccountDescriptor(
+        { ...base, auth: { methods: ["carrier_pigeon"], signin_path: "/login" } },
+        expected,
+      ).length,
+    ).toBe(1); // unknown method
+    expect(
+      checkAccountDescriptor(
+        { ...base, auth: { methods: ["password"], signin_path: "login" } },
+        expected,
+      ).length,
+    ).toBe(1); // not absolute
+    expect(checkAccountDescriptor({ ...base, auth: "nope" }, expected).length).toBe(1); // not an object
+  });
+});
+
+describe("account route table — optional flag (P0)", () => {
+  test("GET /account and the caps routes are marked optional (hub-only)", () => {
+    const byKey = (m: string, p: string) =>
+      ACCOUNT_ROUTES.find((r) => r.method === m && r.path === p);
+    expect(byKey("GET", "/account")?.optional).toBe(true);
+    expect(byKey("GET", "/account/vaults/<name>/caps")?.optional).toBe(true);
+    expect(byKey("PUT", "/account/vaults/<name>/caps")?.optional).toBe(true);
+  });
+
+  test("the core vault-lifecycle routes are NOT optional — every door mounts them", () => {
+    const byKey = (m: string, p: string) =>
+      ACCOUNT_ROUTES.find((r) => r.method === m && r.path === p);
+    expect(byKey("GET", "/account/vaults")?.optional).toBeUndefined();
+    expect(byKey("POST", "/account/vaults")?.optional).toBeUndefined();
+    expect(byKey("DELETE", "/account/vaults/<name>")?.optional).toBeUndefined();
+    expect(byKey("POST", "/account/vaults/<name>/token")?.optional).toBeUndefined();
+  });
+});
+
+describe("ACCOUNT_ERROR_CODES", () => {
+  test("pins the shared /account/* error vocabulary", () => {
+    expect(ACCOUNT_ERROR_CODES).toEqual([
+      "invalid_request",
+      "invalid_name",
+      "reserved",
+      "vault_taken",
+      "not_owner",
+      "vault_not_found",
+      "vault_limit_reached",
+      "invalid_scope",
+      "not_implemented",
+      "insufficient_scope",
+      "invalid_token",
+      "unauthenticated",
+      "csrf_failed",
+      "foreign_origin",
+      "force_change_password",
+    ]);
+  });
+});
+
+describe("checkAccountSessionResponse (P0)", () => {
+  test("signed-out: a conformant body reports zero issues", () => {
+    expect(
+      checkAccountSessionResponse({ signed_in: false, csrf: "tok" }, { signedIn: false }),
+    ).toEqual([]);
+  });
+
+  test("signed-out: csrf must still be present (the G2 anonymous-CSRF invariant)", () => {
+    const issues = checkAccountSessionResponse({ signed_in: false, csrf: "" }, { signedIn: false });
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("csrf");
+  });
+
+  test("signed-out: an identity field leaking through is an issue", () => {
+    const issues = checkAccountSessionResponse(
+      { signed_in: false, csrf: "tok", username: "leaked" },
+      { signedIn: false },
+    );
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("username");
+  });
+
+  test("signed-in: a conformant body (username, no email) reports zero issues", () => {
+    expect(
+      checkAccountSessionResponse(
+        {
+          signed_in: true,
+          csrf: "tok",
+          username: "aaron",
+          account_created_at: "2026-01-01T00:00:00Z",
+        },
+        { signedIn: true },
+      ),
+    ).toEqual([]);
+  });
+
+  test("signed-in: a conformant body (email, no username) also reports zero issues", () => {
+    expect(
+      checkAccountSessionResponse(
+        { signed_in: true, csrf: "tok", email: "a@example.com" },
+        { signedIn: true },
+      ),
+    ).toEqual([]);
+  });
+
+  test("signed-in: neither email nor username present is an issue", () => {
+    const issues = checkAccountSessionResponse(
+      { signed_in: true, csrf: "tok" },
+      { signedIn: true },
+    );
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("email/username");
+  });
+
+  test("signed-in: a non-ISO account_created_at is an issue", () => {
+    const issues = checkAccountSessionResponse(
+      { signed_in: true, csrf: "tok", username: "aaron", account_created_at: "not-a-date" },
+      { signedIn: true },
+    );
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("account_created_at");
+  });
+
+  test("signed_in mismatched against the expected branch is an issue", () => {
+    const issues = checkAccountSessionResponse(
+      { signed_in: true, csrf: "tok", username: "aaron" },
+      { signedIn: false },
+    );
+    expect(issues.some((i) => i.detail.includes("signed_in"))).toBe(true);
+  });
+});
+
+describe("checkAccountTokenMintResponse (P0)", () => {
+  const GREEN = {
+    token: "t.o.k",
+    expires_at: "2026-01-01T00:15:00Z",
+    scopes: ["account:self:admin"],
+    aud: "account",
+  };
+
+  test("a conformant body reports zero issues", () => {
+    expect(checkAccountTokenMintResponse(GREEN)).toEqual([]);
+  });
+
+  test("empty token is an issue", () => {
+    expect(checkAccountTokenMintResponse({ ...GREEN, token: "" }).length).toBe(1);
+  });
+
+  test("non-ISO expires_at is an issue (future-ness is NOT pinned — clock-free)", () => {
+    expect(checkAccountTokenMintResponse({ ...GREEN, expires_at: "whenever" }).length).toBe(1);
+    // A timestamp in the PAST still passes — only parseability is pinned.
+    expect(checkAccountTokenMintResponse({ ...GREEN, expires_at: "2000-01-01T00:00:00Z" })).toEqual(
+      [],
+    );
+  });
+
+  test("empty scopes array is an issue", () => {
+    expect(checkAccountTokenMintResponse({ ...GREEN, scopes: [] }).length).toBe(1);
+  });
+
+  test("wrong aud is an issue", () => {
+    expect(checkAccountTokenMintResponse({ ...GREEN, aud: "vault.default" }).length).toBe(1);
+  });
+});
+
+describe("checkVaultTokenMintResponse (P0)", () => {
+  const GREEN = {
+    vault_token: "v.t.k",
+    expires_at: "2026-01-01T00:15:00Z",
+    services: { "vault:moss": { url: "https://example.com/vault/moss" } },
+  };
+
+  test("a conformant body reports zero issues", () => {
+    expect(checkVaultTokenMintResponse(GREEN, "moss")).toEqual([]);
+  });
+
+  test("empty vault_token is an issue", () => {
+    expect(checkVaultTokenMintResponse({ ...GREEN, vault_token: "" }, "moss").length).toBe(1);
+  });
+
+  test("non-ISO expires_at is an issue", () => {
+    expect(checkVaultTokenMintResponse({ ...GREEN, expires_at: "whenever" }, "moss").length).toBe(
+      1,
+    );
+  });
+
+  test("services missing the vault:<name> key is an issue", () => {
+    expect(
+      checkVaultTokenMintResponse({ ...GREEN, services: { "vault:other": { url: "x" } } }, "moss")
+        .length,
+    ).toBe(1);
+  });
+});
+
+describe("validateVaultScopes (P0)", () => {
+  test("absent (undefined) defaults to read+write", () => {
+    expect(validateVaultScopes(undefined, "moss")).toEqual({
+      ok: true,
+      scopes: ["vault:moss:read", "vault:moss:write"],
+    });
+  });
+
+  test("null defaults to read+write", () => {
+    expect(validateVaultScopes(null, "moss")).toEqual({
+      ok: true,
+      scopes: ["vault:moss:read", "vault:moss:write"],
+    });
+  });
+
+  test("empty array defaults to read+write", () => {
+    expect(validateVaultScopes([], "moss")).toEqual({
+      ok: true,
+      scopes: ["vault:moss:read", "vault:moss:write"],
+    });
+  });
+
+  test("a valid single-scope request round-trips", () => {
+    expect(validateVaultScopes(["vault:moss:admin"], "moss")).toEqual({
+      ok: true,
+      scopes: ["vault:moss:admin"],
+    });
+  });
+
+  test("duplicate entries are de-duplicated", () => {
+    expect(validateVaultScopes(["vault:moss:read", "vault:moss:read"], "moss")).toEqual({
+      ok: true,
+      scopes: ["vault:moss:read"],
+    });
+  });
+
+  test("a foreign vault name rejects the whole request", () => {
+    expect(validateVaultScopes(["vault:other:read"], "moss")).toEqual({ ok: false });
+  });
+
+  test("a non-vault resource (account:*) rejects the whole request", () => {
+    expect(validateVaultScopes(["account:self:admin"], "moss")).toEqual({ ok: false });
+  });
+
+  test("an unknown verb rejects the whole request", () => {
+    expect(validateVaultScopes(["vault:moss:execute"], "moss")).toEqual({ ok: false });
+  });
+
+  test("a non-string entry rejects the whole request", () => {
+    expect(validateVaultScopes([123], "moss")).toEqual({ ok: false });
+  });
+
+  test("a non-array, non-nullish value rejects the whole request", () => {
+    expect(validateVaultScopes("vault:moss:read", "moss")).toEqual({ ok: false });
+  });
+
+  test("one bad entry among good ones rejects the WHOLE request (no partial grant)", () => {
+    expect(validateVaultScopes(["vault:moss:read", "vault:other:read"], "moss")).toEqual({
+      ok: false,
+    });
   });
 });

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -322,7 +322,23 @@ describe("ACCOUNT_ERROR_CODES", () => {
       "csrf_failed",
       "foreign_origin",
       "force_change_password",
+      "account_suspended",
+      "method_not_allowed",
+      "not_found",
+      "server_error",
     ]);
+  });
+
+  test("carries the codes each door actually emits (the union, not a subset)", () => {
+    // Regression against the born-incomplete pin the P0 review caught.
+    for (const code of [
+      "account_suspended", // cloud
+      "method_not_allowed", // hub
+      "not_found", // cloud
+      "server_error", // hub
+    ] as const) {
+      expect(ACCOUNT_ERROR_CODES).toContain(code);
+    }
   });
 });
 
@@ -380,9 +396,37 @@ describe("checkAccountSessionResponse (P0)", () => {
     expect(issues[0]?.detail).toContain("email/username");
   });
 
+  test("signed-in: a non-string email (present but not a string) is an issue", () => {
+    const issues = checkAccountSessionResponse(
+      { signed_in: true, csrf: "tok", email: 42 },
+      { signedIn: true },
+    );
+    expect(issues.some((i) => i.detail.includes("email"))).toBe(true);
+  });
+
+  test("signed-in: a null username (present but not a string) is an issue", () => {
+    const issues = checkAccountSessionResponse(
+      { signed_in: true, csrf: "tok", username: null },
+      { signedIn: true },
+    );
+    // null is present (!== undefined) but not a string → the non-string check flags it.
+    expect(issues.some((i) => i.detail.includes("username"))).toBe(true);
+  });
+
   test("signed-in: a non-ISO account_created_at is an issue", () => {
     const issues = checkAccountSessionResponse(
       { signed_in: true, csrf: "tok", username: "aaron", account_created_at: "not-a-date" },
+      { signedIn: true },
+    );
+    expect(issues.length).toBe(1);
+    expect(issues[0]?.detail).toContain("account_created_at");
+  });
+
+  test("signed-in: a Date.parse-able but non-ISO account_created_at is an issue (strict ISO-8601)", () => {
+    // "January 1, 2026" is Date.parse-able but not ISO-8601 — the tightened
+    // checker must reject it, where the old bare-Date.parse checker passed it.
+    const issues = checkAccountSessionResponse(
+      { signed_in: true, csrf: "tok", username: "aaron", account_created_at: "January 1, 2026" },
       { signedIn: true },
     );
     expect(issues.length).toBe(1);
@@ -458,6 +502,17 @@ describe("checkVaultTokenMintResponse (P0)", () => {
         .length,
     ).toBe(1);
   });
+
+  test("the vault:<name> entry present but without a string url is an issue", () => {
+    // {} conforms to the key-presence check but violates the type's `url: string`.
+    expect(
+      checkVaultTokenMintResponse({ ...GREEN, services: { "vault:moss": {} } }, "moss").length,
+    ).toBe(1);
+    expect(
+      checkVaultTokenMintResponse({ ...GREEN, services: { "vault:moss": { url: 42 } } }, "moss")
+        .length,
+    ).toBe(1);
+  });
 });
 
 describe("validateVaultScopes (P0)", () => {
@@ -496,29 +551,53 @@ describe("validateVaultScopes (P0)", () => {
     });
   });
 
-  test("a foreign vault name rejects the whole request", () => {
-    expect(validateVaultScopes(["vault:other:read"], "moss")).toEqual({ ok: false });
+  // The rejection `reason` carries each door's wire error code — a well-formed
+  // scope string that names the wrong resource/vault/verb is `invalid_scope`;
+  // a structurally-broken value (non-array, or a non-string entry) is
+  // `invalid_request`. This split preserves hub's `parseScopesBody` semantics.
+  test("a foreign vault name rejects with invalid_scope", () => {
+    expect(validateVaultScopes(["vault:other:read"], "moss")).toEqual({
+      ok: false,
+      reason: "invalid_scope",
+    });
   });
 
-  test("a non-vault resource (account:*) rejects the whole request", () => {
-    expect(validateVaultScopes(["account:self:admin"], "moss")).toEqual({ ok: false });
+  test("a non-vault resource (account:*) rejects with invalid_scope", () => {
+    expect(validateVaultScopes(["account:self:admin"], "moss")).toEqual({
+      ok: false,
+      reason: "invalid_scope",
+    });
   });
 
-  test("an unknown verb rejects the whole request", () => {
-    expect(validateVaultScopes(["vault:moss:execute"], "moss")).toEqual({ ok: false });
+  test("an unknown verb rejects with invalid_scope", () => {
+    expect(validateVaultScopes(["vault:moss:execute"], "moss")).toEqual({
+      ok: false,
+      reason: "invalid_scope",
+    });
   });
 
-  test("a non-string entry rejects the whole request", () => {
-    expect(validateVaultScopes([123], "moss")).toEqual({ ok: false });
+  test("a malformed (wrong part-count) scope string rejects with invalid_scope", () => {
+    expect(validateVaultScopes(["vault:moss"], "moss")).toEqual({
+      ok: false,
+      reason: "invalid_scope",
+    });
   });
 
-  test("a non-array, non-nullish value rejects the whole request", () => {
-    expect(validateVaultScopes("vault:moss:read", "moss")).toEqual({ ok: false });
+  test("a non-string entry rejects with invalid_request", () => {
+    expect(validateVaultScopes([123], "moss")).toEqual({ ok: false, reason: "invalid_request" });
+  });
+
+  test("a non-array, non-nullish value rejects with invalid_request", () => {
+    expect(validateVaultScopes("vault:moss:read", "moss")).toEqual({
+      ok: false,
+      reason: "invalid_request",
+    });
   });
 
   test("one bad entry among good ones rejects the WHOLE request (no partial grant)", () => {
     expect(validateVaultScopes(["vault:moss:read", "vault:other:read"], "moss")).toEqual({
       ok: false,
+      reason: "invalid_scope",
     });
   });
 });

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -594,6 +594,16 @@ describe("validateVaultScopes (P0)", () => {
     });
   });
 
+  test("a mixed array (a wrong scope BEFORE a non-string) is invalid_request, not invalid_scope", () => {
+    // Byte-exact with hub's whole-array non-string pre-scan: a non-string entry
+    // ANYWHERE makes the request invalid_request even if a bad-but-well-formed
+    // scope string sits earlier. Guards P2/P3 adoption against an error-code flip.
+    expect(validateVaultScopes(["vault:other:read", 123], "moss")).toEqual({
+      ok: false,
+      reason: "invalid_request",
+    });
+  });
+
   test("one bad entry among good ones rejects the WHOLE request (no partial grant)", () => {
     expect(validateVaultScopes(["vault:moss:read", "vault:other:read"], "moss")).toEqual({
       ok: false,

--- a/packages/door-contract/src/account-contract.ts
+++ b/packages/door-contract/src/account-contract.ts
@@ -238,11 +238,12 @@ export interface VaultTokenMintResponse {
 }
 
 /**
- * The shared `/account/*` error vocabulary. Auth-gate failures use
- * `{error, error_description}` (OAuth-style, matching the token endpoint);
- * resource-level failures use `{error, message}`. Both doors already
- * deliberately mirror this list (hub `account-api.ts` header, cloud
- * `account-api.ts:82-96`) — pinned here so it can't silently drift.
+ * The shared `/account/*` error vocabulary — the UNION of codes both doors
+ * actually emit on the account surface (verified against hub `account-api.ts`
+ * and cloud `workers/identity/src/account-api.ts`), not an aspirational subset.
+ * Auth-gate failures use `{error, error_description}` (OAuth-style, matching the
+ * token endpoint); resource-level failures use `{error, message}`. When a door
+ * adds a new code, add it here in the same PR so this stays the real union.
  */
 export const ACCOUNT_ERROR_CODES = [
   "invalid_request",
@@ -260,6 +261,11 @@ export const ACCOUNT_ERROR_CODES = [
   "csrf_failed",
   "foreign_origin",
   "force_change_password",
+  // Emitted today but missing from the original pin (found by the P0 review):
+  "account_suspended", // cloud — suspended account hits any /account/* route
+  "method_not_allowed", // hub — wrong verb on an account route
+  "not_found", // cloud — unknown /account/vaults/<name> subroute
+  "server_error", // hub — vault provisioning failed for a non-name reason
 ] as const;
 
 /** One member of {@link ACCOUNT_ERROR_CODES}. */

--- a/packages/door-contract/src/account-contract.ts
+++ b/packages/door-contract/src/account-contract.ts
@@ -19,6 +19,12 @@ export interface AccountRoute {
   /** The minimum account verb the route requires. */
   scope: AccountVerb;
   summary: string;
+  /**
+   * When `true`, this route is not mounted by every door — a door may omit it
+   * without breaking the contract (e.g. it's superseded, or the door's
+   * equivalent lives elsewhere). Absent/`false` = every door mounts this route.
+   */
+  optional?: boolean;
 }
 
 /**
@@ -31,6 +37,10 @@ export const ACCOUNT_ROUTES: readonly AccountRoute[] = [
     path: "/account",
     scope: "read",
     summary: "Account bootstrap (id, email, door).",
+    // Optional: hub-only. Cloud routes a browser GET /account to the SPA
+    // shell (the app's Account screen), not a worker JSON handler (#146) — the
+    // app bootstraps via GET /account/session + GET /account/summary instead.
+    optional: true,
   },
   {
     method: "GET",
@@ -61,12 +71,17 @@ export const ACCOUNT_ROUTES: readonly AccountRoute[] = [
     path: "/account/vaults/<name>/caps",
     scope: "read",
     summary: "Read a vault's storage caps.",
+    // Optional: hub-only. Cloud's caps are plan-derived (no per-vault storage
+    // cap knob to read back) — there is nothing for cloud to mount here.
+    optional: true,
   },
   {
     method: "PUT",
     path: "/account/vaults/<name>/caps",
     scope: "admin",
     summary: "Set a vault's storage caps.",
+    // Optional: hub-only, same reason as the GET above.
+    optional: true,
   },
 ] as const;
 
@@ -97,6 +112,17 @@ export interface AccountCapabilities {
 }
 
 /**
+ * How a person signs IN at this door — drives the app's front-door branch
+ * (magic-link email form vs a ceremony-hop card to the door's own sign-in page).
+ */
+export interface AccountAuthDescriptor {
+  /** Sign-in methods, most-preferred first. */
+  methods: ("magic_link" | "password")[];
+  /** Absolute path of the door's sign-in ceremony; honors `?next=<path>`. */
+  signin_path: string;
+}
+
+/**
  * The public descriptor served at `GET /.well-known/parachute-account` — the
  * door's self-description a client fetches to learn where to sign up, where the
  * account API lives, which first-party client to use, and what the door can do.
@@ -111,10 +137,26 @@ export interface ParachuteAccountDescriptor {
   door: "hub" | "cloud";
   /** The `/account/*` API base — always `${issuer}/account`. */
   account_endpoint: string;
-  /** Where a brand-new user begins sign-up (cloud `"/signup"`, hub `"/account/setup"`). */
-  signup_path: string;
-  /** The reserved first-party `client_id` a native app should use (cloud `"parachute-app"`). */
-  app_client_id: string;
+  /**
+   * How a person signs IN at this door. Optional in 0.4.0 so cloud@main keeps
+   * typechecking while it lands its own twin (P3); P7 flips this required once
+   * both doors serve it.
+   */
+  auth?: AccountAuthDescriptor;
+  /**
+   * Present only when the door currently offers self-serve signup (cloud:
+   * always, `/signup`; hub: only while an active multi-use public invite
+   * exists — Q2). Absent = no self-serve path right now (an operator-shared
+   * link is the only way in).
+   */
+  signup_path?: string;
+  /**
+   * The reserved first-party `client_id` a native app should use (cloud
+   * `"parachute-app"`). The hosted flow never OAuths its home door (C4-C5
+   * §7.6); retained for cross-origin native clients that do. Optional because
+   * a door with no such reserved client has nothing to advertise here.
+   */
+  app_client_id?: string;
   /** Which account-lifecycle operations this door supports. */
   capabilities: AccountCapabilities;
   /** The plan/tier ladder this door offers (empty for self-host). */
@@ -157,3 +199,68 @@ export interface AccountBootstrap {
   email?: string;
   door: "hub" | "cloud";
 }
+
+/**
+ * `GET /account/session` — the same-origin boot oracle (both doors). Public
+ * per-request state check the app polls on first load (and while it waits for
+ * a magic-link click); NOT gated on the account Bearer — it drives the cookie
+ * session directly.
+ */
+export interface AccountSessionResponse {
+  signed_in: boolean;
+  /** Anonymous-capable CSRF (G2) — present on BOTH branches. */
+  csrf: string;
+  /**
+   * Signed-in branch. Cloud always has email; hub email is nullable-by-history
+   * (`users.email`, migration v15) so hub sends `username` and email-when-present.
+   */
+  email?: string;
+  username?: string;
+  account_created_at?: string;
+}
+
+/**
+ * `POST /account/token` success (both doors; NOT RFC-6749 — deliberate: this is
+ * the account-scoped credential a same-origin session mints, not an OAuth grant).
+ */
+export interface AccountTokenMintResponse {
+  token: string;
+  expires_at: string;
+  scopes: string[];
+  aud: "account";
+}
+
+/** `POST /account/vaults/<name>/token` success (both doors). */
+export interface VaultTokenMintResponse {
+  vault_token: string;
+  expires_at: string;
+  services: Record<string, { url: string; version?: string }>;
+}
+
+/**
+ * The shared `/account/*` error vocabulary. Auth-gate failures use
+ * `{error, error_description}` (OAuth-style, matching the token endpoint);
+ * resource-level failures use `{error, message}`. Both doors already
+ * deliberately mirror this list (hub `account-api.ts` header, cloud
+ * `account-api.ts:82-96`) — pinned here so it can't silently drift.
+ */
+export const ACCOUNT_ERROR_CODES = [
+  "invalid_request",
+  "invalid_name",
+  "reserved",
+  "vault_taken",
+  "not_owner",
+  "vault_not_found",
+  "vault_limit_reached",
+  "invalid_scope",
+  "not_implemented",
+  "insufficient_scope",
+  "invalid_token",
+  "unauthenticated",
+  "csrf_failed",
+  "foreign_origin",
+  "force_change_password",
+] as const;
+
+/** One member of {@link ACCOUNT_ERROR_CODES}. */
+export type AccountErrorCode = (typeof ACCOUNT_ERROR_CODES)[number];

--- a/packages/door-contract/src/conformance.ts
+++ b/packages/door-contract/src/conformance.ts
@@ -154,9 +154,18 @@ export function checkAccountDescriptor(
   return issues;
 }
 
-/** `true` when `value` is a string `Date.parse` can turn into a real instant. */
+/**
+ * `true` when `value` is a real ISO-8601 instant — a `T`-separated date-time
+ * with a `Z` or numeric offset, as both doors emit via `Date.toISOString()`.
+ * Deliberately STRICTER than bare `Date.parse` (which accepts "Jan 1 2026" and
+ * other locale strings): the wire contract is ISO-8601, so the checker enforces
+ * ISO-8601 rather than whatever a given JS engine's `Date.parse` tolerates.
+ */
+const ISO_8601_INSTANT_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/;
 function isParseableTimestamp(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+  return (
+    typeof value === "string" && ISO_8601_INSTANT_RE.test(value) && !Number.isNaN(Date.parse(value))
+  );
 }
 
 /**
@@ -189,6 +198,10 @@ export function checkAccountSessionResponse(
   } else {
     if (actual.email === undefined && actual.username === undefined)
       push("at least one of email/username must be present when signed in");
+    for (const k of ["email", "username"] as const) {
+      if (actual[k] !== undefined && typeof actual[k] !== "string")
+        push(`${k}, when present, must be a string, got ${JSON.stringify(actual[k])}`);
+    }
     if (actual.account_created_at !== undefined && !isParseableTimestamp(actual.account_created_at))
       push(
         `account_created_at, when present, must be ISO-8601-parseable, got ${JSON.stringify(actual.account_created_at)}`,
@@ -239,6 +252,14 @@ export function checkVaultTokenMintResponse(
   const key = `vault:${vaultName}`;
   if (typeof services !== "object" || services === null || !(key in services)) {
     push(`services must be an object carrying the key ${JSON.stringify(key)}`);
+  } else {
+    const entry = (services as Record<string, unknown>)[key];
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      typeof (entry as Record<string, unknown>).url !== "string"
+    )
+      push(`services[${JSON.stringify(key)}] must carry a string "url"`);
   }
   return issues;
 }

--- a/packages/door-contract/src/conformance.ts
+++ b/packages/door-contract/src/conformance.ts
@@ -73,13 +73,18 @@ export function checkTokenResponseInvariants(
   return issues;
 }
 
+const AUTH_METHODS = new Set(["magic_link", "password"]);
+
 /**
  * Validate a door's `GET /.well-known/parachute-account` descriptor. Door-specific
- * values (`signup_path`, `app_client_id`, `plans`) are the door's own; this pins
- * the SHAPE + the cross-field invariants BOTH doors must hold: `issuer`/`door`
- * match the caller's expected pair, `account_endpoint` is derived (`${issuer}/account`),
- * `signup_path` is an absolute path, `app_client_id` is present, `capabilities`
- * carries the three booleans, and `plans` is an array.
+ * values (`signup_path`, `app_client_id`, `auth`, `plans`) are the door's own; this
+ * pins the SHAPE + the cross-field invariants BOTH doors must hold: `issuer`/`door`
+ * match the caller's expected pair, `account_endpoint` is derived
+ * (`${issuer}/account`), `capabilities` carries the three booleans, and `plans` is
+ * an array. `signup_path`, `app_client_id`, `auth`, and `vault_url_template` are all
+ * OPTIONAL fields (0.4.0) — each is validated only WHEN PRESENT, so a door that
+ * omits one (hub with no active public invite, a door with no reserved native
+ * client) still conforms.
  */
 export function checkAccountDescriptor(
   actual: Record<string, unknown>,
@@ -96,10 +101,37 @@ export function checkAccountDescriptor(
     push(
       `account_endpoint must be ${JSON.stringify(wantEndpoint)}, got ${JSON.stringify(actual.account_endpoint)}`,
     );
-  if (typeof actual.signup_path !== "string" || !actual.signup_path.startsWith("/"))
-    push(`signup_path must be an absolute path, got ${JSON.stringify(actual.signup_path)}`);
-  if (typeof actual.app_client_id !== "string" || actual.app_client_id.length === 0)
-    push("app_client_id must be a non-empty string");
+  // Optional: signup_path is present only while the door currently offers
+  // self-serve signup (Q2). When present, must be an absolute path.
+  if (actual.signup_path !== undefined) {
+    if (typeof actual.signup_path !== "string" || !actual.signup_path.startsWith("/"))
+      push(
+        `signup_path, when present, must be an absolute path, got ${JSON.stringify(actual.signup_path)}`,
+      );
+  }
+  // Optional: app_client_id is present only when the door has a reserved
+  // first-party native-client id to advertise.
+  if (actual.app_client_id !== undefined) {
+    if (typeof actual.app_client_id !== "string" || actual.app_client_id.length === 0)
+      push("app_client_id, when present, must be a non-empty string");
+  }
+  // Optional (0.4.0 — required from 0.5.0 once both doors serve it): the
+  // sign-in-method block that drives the app's front-door branch.
+  if (actual.auth !== undefined) {
+    const auth = actual.auth;
+    if (typeof auth !== "object" || auth === null) {
+      push("auth, when present, must be an object");
+    } else {
+      const a = auth as Record<string, unknown>;
+      if (!Array.isArray(a.methods) || a.methods.length === 0) {
+        push("auth.methods, when present, must be a non-empty array");
+      } else if (!a.methods.every((m) => typeof m === "string" && AUTH_METHODS.has(m))) {
+        push('auth.methods entries must each be "magic_link" or "password"');
+      }
+      if (typeof a.signin_path !== "string" || !a.signin_path.startsWith("/"))
+        push(`auth.signin_path must be an absolute path, got ${JSON.stringify(a.signin_path)}`);
+    }
+  }
   const caps = actual.capabilities;
   if (typeof caps !== "object" || caps === null) {
     push("capabilities must be an object");
@@ -113,8 +145,100 @@ export function checkAccountDescriptor(
   // Optional: a door MAY omit `vault_url_template`, but when present it must be a
   // string carrying the literal `{name}` placeholder (it's a template, not a URL).
   if (actual.vault_url_template !== undefined) {
-    if (typeof actual.vault_url_template !== "string" || !actual.vault_url_template.includes("{name}"))
+    if (
+      typeof actual.vault_url_template !== "string" ||
+      !actual.vault_url_template.includes("{name}")
+    )
       push('vault_url_template, when present, must be a string containing "{name}"');
+  }
+  return issues;
+}
+
+/** `true` when `value` is a string `Date.parse` can turn into a real instant. */
+function isParseableTimestamp(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0 && !Number.isNaN(Date.parse(value));
+}
+
+/**
+ * Validate a door's `GET /account/session` body against
+ * {@link AccountSessionResponse} — the same-origin boot oracle both doors serve.
+ * Pins: `signed_in` matches `expected.signedIn`; `csrf` is a non-empty string on
+ * BOTH branches (the G2 anonymous-CSRF invariant — a client must be able to grab
+ * a CSRF token before it has ever signed in); when signed OUT, none of
+ * `email`/`username`/`account_created_at` are present (a stale/spoofed identity
+ * leak); when signed IN, at least one of `email`/`username` is present, and
+ * `account_created_at`, when present, is ISO-8601-parseable.
+ */
+export function checkAccountSessionResponse(
+  actual: Record<string, unknown>,
+  expected: { signedIn: boolean },
+): ConformanceIssue[] {
+  const issues: ConformanceIssue[] = [];
+  const push = (detail: string) => issues.push({ vector: "account-session", detail });
+  if (actual.signed_in !== expected.signedIn)
+    push(
+      `signed_in must be ${JSON.stringify(expected.signedIn)}, got ${JSON.stringify(actual.signed_in)}`,
+    );
+  if (typeof actual.csrf !== "string" || actual.csrf.length === 0)
+    push("csrf must be a non-empty string on both the signed-in and signed-out branches");
+  if (!expected.signedIn) {
+    for (const k of ["email", "username", "account_created_at"] as const) {
+      if (actual[k] !== undefined)
+        push(`${k} must be absent when signed out, got ${JSON.stringify(actual[k])}`);
+    }
+  } else {
+    if (actual.email === undefined && actual.username === undefined)
+      push("at least one of email/username must be present when signed in");
+    if (actual.account_created_at !== undefined && !isParseableTimestamp(actual.account_created_at))
+      push(
+        `account_created_at, when present, must be ISO-8601-parseable, got ${JSON.stringify(actual.account_created_at)}`,
+      );
+  }
+  return issues;
+}
+
+/**
+ * Validate a door's `POST /account/token` success body against
+ * {@link AccountTokenMintResponse}. `expires_at` is checked for ISO-parseability
+ * only — NOT "in the future" (clock-free vectors: a fixture built with a fixed
+ * `now` shouldn't flake against wall-clock time).
+ */
+export function checkAccountTokenMintResponse(actual: Record<string, unknown>): ConformanceIssue[] {
+  const issues: ConformanceIssue[] = [];
+  const push = (detail: string) => issues.push({ vector: "account-token-mint", detail });
+  if (typeof actual.token !== "string" || actual.token.length === 0)
+    push("token must be a non-empty string");
+  if (!isParseableTimestamp(actual.expires_at))
+    push(`expires_at must be ISO-8601-parseable, got ${JSON.stringify(actual.expires_at)}`);
+  if (
+    !Array.isArray(actual.scopes) ||
+    actual.scopes.length === 0 ||
+    !actual.scopes.every((s) => typeof s === "string")
+  )
+    push("scopes must be a non-empty array of strings");
+  if (actual.aud !== "account") push(`aud must be "account", got ${JSON.stringify(actual.aud)}`);
+  return issues;
+}
+
+/**
+ * Validate a door's `POST /account/vaults/<name>/token` success body against
+ * {@link VaultTokenMintResponse}. `services` must carry the `vault:<vaultName>`
+ * key (both doors key their services catalog this way).
+ */
+export function checkVaultTokenMintResponse(
+  actual: Record<string, unknown>,
+  vaultName: string,
+): ConformanceIssue[] {
+  const issues: ConformanceIssue[] = [];
+  const push = (detail: string) => issues.push({ vector: "vault-token-mint", detail });
+  if (typeof actual.vault_token !== "string" || actual.vault_token.length === 0)
+    push("vault_token must be a non-empty string");
+  if (!isParseableTimestamp(actual.expires_at))
+    push(`expires_at must be ISO-8601-parseable, got ${JSON.stringify(actual.expires_at)}`);
+  const services = actual.services;
+  const key = `vault:${vaultName}`;
+  if (typeof services !== "object" || services === null || !(key in services)) {
+    push(`services must be an object carrying the key ${JSON.stringify(key)}`);
   }
   return issues;
 }

--- a/packages/door-contract/src/index.ts
+++ b/packages/door-contract/src/index.ts
@@ -58,6 +58,7 @@ export {
 export {
   type AccountRoute,
   ACCOUNT_ROUTES,
+  type AccountAuthDescriptor,
   type ParachuteAccountDescriptor,
   type AccountPlanSummary,
   type AccountCapabilities,
@@ -65,7 +66,17 @@ export {
   type CreateVaultRequest,
   type MintVaultTokenRequest,
   type AccountBootstrap,
+  type AccountSessionResponse,
+  type AccountTokenMintResponse,
+  type VaultTokenMintResponse,
+  ACCOUNT_ERROR_CODES,
+  type AccountErrorCode,
 } from "./account-contract.js";
+
+export {
+  type VaultScopesResult,
+  validateVaultScopes,
+} from "./vault-scopes.js";
 
 export {
   type ConformanceIssue,
@@ -73,5 +84,8 @@ export {
   checkProtectedResourceMetadata,
   checkTokenResponseInvariants,
   checkAccountDescriptor,
+  checkAccountSessionResponse,
+  checkAccountTokenMintResponse,
+  checkVaultTokenMintResponse,
   ACCOUNT_ROUTE_VECTORS,
 } from "./conformance.js";

--- a/packages/door-contract/src/vault-scopes.ts
+++ b/packages/door-contract/src/vault-scopes.ts
@@ -22,8 +22,21 @@
 /** The three verbs mintable on a per-vault token. */
 const MINTABLE_VAULT_VERBS = new Set(["read", "write", "admin"]);
 
-/** A conformant scopes array, or the sentinel rejection. */
-export type VaultScopesResult = { ok: true; scopes: string[] } | { ok: false };
+/**
+ * Why a scopes request was rejected — carries the door's wire error code so a
+ * door adopting this validator keeps its exact HTTP error without re-deriving
+ * the split (hub's `parseScopesBody` distinguishes these two today):
+ *   - `invalid_request` — the value is structurally wrong: not an array, or an
+ *     entry that isn't a string. "You sent me garbage."
+ *   - `invalid_scope` — every entry is a string, but at least one isn't
+ *     `vault:<vaultName>:{read|write|admin}`. "Well-formed, but not mintable here."
+ */
+export type VaultScopesReason = "invalid_request" | "invalid_scope";
+
+/** A conformant scopes array, or the sentinel rejection with its wire reason. */
+export type VaultScopesResult =
+  | { ok: true; scopes: string[] }
+  | { ok: false; reason: VaultScopesReason };
 
 /**
  * Validate a requested `scopes` value against `vaultName`. `requested` is
@@ -34,18 +47,18 @@ export function validateVaultScopes(requested: unknown, vaultName: string): Vaul
   if (requested === undefined || requested === null) {
     return { ok: true, scopes: defaultVaultScopes(vaultName) };
   }
-  if (!Array.isArray(requested)) return { ok: false };
+  if (!Array.isArray(requested)) return { ok: false, reason: "invalid_request" };
   if (requested.length === 0) {
     return { ok: true, scopes: defaultVaultScopes(vaultName) };
   }
   const scopes = new Set<string>();
   for (const s of requested) {
-    if (typeof s !== "string") return { ok: false };
+    if (typeof s !== "string") return { ok: false, reason: "invalid_request" };
     const parts = s.split(":");
-    if (parts.length !== 3) return { ok: false };
+    if (parts.length !== 3) return { ok: false, reason: "invalid_scope" };
     const [resource, name, verb] = parts as [string, string, string];
     if (resource !== "vault" || name !== vaultName || !MINTABLE_VAULT_VERBS.has(verb)) {
-      return { ok: false };
+      return { ok: false, reason: "invalid_scope" };
     }
     scopes.add(s);
   }

--- a/packages/door-contract/src/vault-scopes.ts
+++ b/packages/door-contract/src/vault-scopes.ts
@@ -1,0 +1,57 @@
+/**
+ * The shared vault-scope validator for a per-vault token mint
+ * (`POST /account/vaults/<name>/token`) — the ONE implementation replacing the
+ * two that grew independently: hub's `parseScopesBody` (`account-api.ts`, the
+ * scope-shape part) and cloud's local `validateVaultScopes`
+ * (`workers/identity/src/account-api.ts`). Pure, no runtime dependencies — the
+ * cross-repo derived-key lesson: reconcile behavior in ONE place both doors
+ * import, don't keep two impls in sync by hand.
+ *
+ * Pinned semantics (reconciles the two doors' prior behavior):
+ *   - `undefined` / `null` / `[]` (absent, explicit null, or an empty array) →
+ *     the default read+write pair for the vault (hub's prior lenient reading —
+ *     hub is the door with real users today; cloud's prior `[]` → reject
+ *     changes to match in P3).
+ *   - Every entry must be exactly `vault:<vaultName>:{read|write|admin}` for
+ *     THIS vault name — a different vault, a non-vault resource
+ *     (`account:*`), an unknown verb, or a non-string entry all reject the
+ *     WHOLE request (`{ ok: false }`), never a partial scope list.
+ *   - The result is de-duplicated (cloud's prior `Set` behavior).
+ */
+
+/** The three verbs mintable on a per-vault token. */
+const MINTABLE_VAULT_VERBS = new Set(["read", "write", "admin"]);
+
+/** A conformant scopes array, or the sentinel rejection. */
+export type VaultScopesResult = { ok: true; scopes: string[] } | { ok: false };
+
+/**
+ * Validate a requested `scopes` value against `vaultName`. `requested` is
+ * `unknown` because it comes straight off a parsed JSON body — the caller
+ * hasn't type-narrowed it yet.
+ */
+export function validateVaultScopes(requested: unknown, vaultName: string): VaultScopesResult {
+  if (requested === undefined || requested === null) {
+    return { ok: true, scopes: defaultVaultScopes(vaultName) };
+  }
+  if (!Array.isArray(requested)) return { ok: false };
+  if (requested.length === 0) {
+    return { ok: true, scopes: defaultVaultScopes(vaultName) };
+  }
+  const scopes = new Set<string>();
+  for (const s of requested) {
+    if (typeof s !== "string") return { ok: false };
+    const parts = s.split(":");
+    if (parts.length !== 3) return { ok: false };
+    const [resource, name, verb] = parts as [string, string, string];
+    if (resource !== "vault" || name !== vaultName || !MINTABLE_VAULT_VERBS.has(verb)) {
+      return { ok: false };
+    }
+    scopes.add(s);
+  }
+  return { ok: true, scopes: [...scopes] };
+}
+
+function defaultVaultScopes(vaultName: string): string[] {
+  return [`vault:${vaultName}:read`, `vault:${vaultName}:write`];
+}

--- a/packages/door-contract/src/vault-scopes.ts
+++ b/packages/door-contract/src/vault-scopes.ts
@@ -47,13 +47,20 @@ export function validateVaultScopes(requested: unknown, vaultName: string): Vaul
   if (requested === undefined || requested === null) {
     return { ok: true, scopes: defaultVaultScopes(vaultName) };
   }
-  if (!Array.isArray(requested)) return { ok: false, reason: "invalid_request" };
+  // Whole-array structural check FIRST (byte-exact with hub's `parseScopesBody`,
+  // which does `!Array.isArray || requested.some(non-string)` before the per-entry
+  // scope loop): a non-array, or ANY non-string entry, is `invalid_request` — even
+  // when a well-formed-but-wrong scope string sits earlier in the array. Without
+  // this pre-scan a mixed array like `["vault:other:read", 123]` would positionally
+  // report `invalid_scope`, flipping hub's wire code on adoption (P2/P3).
+  if (!Array.isArray(requested) || requested.some((s) => typeof s !== "string")) {
+    return { ok: false, reason: "invalid_request" };
+  }
   if (requested.length === 0) {
     return { ok: true, scopes: defaultVaultScopes(vaultName) };
   }
   const scopes = new Set<string>();
-  for (const s of requested) {
-    if (typeof s !== "string") return { ok: false, reason: "invalid_request" };
+  for (const s of requested as string[]) {
     const parts = s.split(":");
     if (parts.length !== 3) return { ok: false, reason: "invalid_scope" };
     const [resource, name, verb] = parts as [string, string, string];


### PR DESCRIPTION
## Summary

**P0 of the hub-parity build playbook** — the foundation both P1 (hub H3
`GET /account/session`), P2 (hub descriptor twin), and P3 (cloud auth-block
adoption) depend on. Pure additions to `packages/door-contract/` — no runtime
behavior changes to either door in this PR.

- `signup_path` / `app_client_id` on `ParachuteAccountDescriptor`: required →
  **optional**. Hub only advertises `signup_path` while an active public
  invite exists (Q2); a door with no reserved native client omits
  `app_client_id`. `checkAccountDescriptor` validates each **only when
  present**.
- New `AccountAuthDescriptor { methods, signin_path }` + optional `auth?` on
  the descriptor — drives the app's front-door branch (magic-link form vs a
  ceremony-hop to the door's sign-in page). Optional in 0.4.0 so cloud@main
  keeps typechecking pre-P3; flips required in 0.5.0 once both doors serve it.
- `AccountRoute` gains `optional?: boolean`; `GET /account` and the
  `/account/vaults/<name>/caps` routes are marked optional in `ACCOUNT_ROUTES`
  (hub-only — cloud routes `GET /account` to its SPA shell per #146; caps are
  plan-derived on cloud, nothing to mount).
- New wire types, written down once from the app's already-pinned shapes:
  `AccountSessionResponse`, `AccountTokenMintResponse`,
  `VaultTokenMintResponse` — each with a matching `check*` conformance helper.
  `ACCOUNT_ERROR_CODES` pins the shared `/account/*` error vocabulary both
  doors already mirror.
- New `src/vault-scopes.ts`: `validateVaultScopes(requested, vaultName)` — the
  ONE shared scope-shape validator that will replace hub's `parseScopesBody`
  scope logic and cloud's local `validateVaultScopes` (P2/P3 wire it in; not
  swapped in this PR). Pinned semantics: `undefined`/`null`/`[]` → default
  `vault:<name>:{read,write}`; every entry must be exactly
  `vault:<name>:{read|write|admin}` for *this* vault or the **whole** request
  rejects (no partial grant); result de-duplicated.
- door-contract `0.3.0 → 0.4.0` (additive; no existing call signatures
  changed). Hub `rc.5 → rc.6`, matching the #749/#750/#751 precedent of
  bumping the sub-package and the root hub version together.

**⚠ Load-bearing constraint honored:** cloud's CI clones `parachute-hub@main`
as a sibling and builds door-contract from it — every new descriptor field is
optional in the type, `checkAccountDescriptor` validates new fields only when
present, and no existing call signature changed. Verified live against the
cloud checkout (see Test plan).

## Interpretation calls (flagging for review)

1. **Root hub `package.json` rc bump**: the brief said "rc bump on the hub
   package.json per governance" — I verified this against the actual
   precedent (PRs #749/#750/#751, the three prior door-contract-only PRs),
   which each bumped *both* the door-contract sub-package version *and* the
   root hub rc by one. Followed that precedent (`rc.5 → rc.6`) rather than
   leaving the root version untouched.
2. **`checkVaultTokenMintResponse`'s `services` key check**: the brief said
   "carrying key `vault:<vaultName>`" — confirmed against both doors' actual
   `services` catalog builders (hub `servicesBlock`, cloud
   `buildServicesCatalog`) that the key format is exactly `` `vault:${name}` ``
   before pinning it in the checker.
3. Everything else (route-optional flags, the `auth` shape, the error-code
   list, `validateVaultScopes`' pinned semantics) followed the brief's spec
   directly.

## Test plan

- [x] `bun test packages/door-contract/src` — **52 pass, 0 fail, 128 expect()
      calls** (green + red fixture per pinned invariant on every new checker;
      `validateVaultScopes` table; descriptor checker with/without
      `auth`/`signup_path`/`app_client_id`).
- [x] `bun run typecheck` (door-contract package) — clean.
- [x] `bun run typecheck` (hub root) — clean.
- [x] `bun test` — full hub suite **excluding** `lifecycle`/`uninstall`/`migrate*`
      suites (they can boot the live daemon, per workspace guidance): **4084
      pass, 1 skip, 0 fail across 156 files**.
- [x] `bunx biome check` — clean (auto-fixed two line-length wraps).
- [x] **Cross-repo cloud-sibling verification (the critical green-cloud
      proof):** rebuilt door-contract's `dist`, then in
      `parachute-cloud`: `bun install` (re-copies the `file:` sibling) →
      `cd workers/identity && bun run typecheck` (clean) →
      `bunx vitest run` — **682 pass across 29 test files**, including the
      existing descriptor conformance test. Cloud@main stays green against
      this sibling.

## Not in this PR (by design — P0 is contract-only)

- Hub doesn't yet serve `GET /account/session` (P1) or the descriptor twin
  (P2, `checkAccountDescriptor` currently fails against hub's live ad-hoc
  shape — expected, tracked).
- Cloud doesn't yet serve its `auth` block or adopt the shared
  `validateVaultScopes` (P3).
- `parseScopesBody` (hub) and `validateVaultScopes` (cloud) are NOT yet swapped
  for the shared implementation — that's P2/P3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB