### PR TITLE
feat(hub): GET /account/session + 90-day rolling session (hub-parity P1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.6",
+  "version": "0.7.7-rc.7",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-session.test.ts
+++ b/src/__tests__/account-session.test.ts
@@ -1,0 +1,244 @@
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { checkAccountSessionResponse } from "@openparachute/door-contract";
+import { handleAccountSession } from "../account-session.ts";
+import { CSRF_COOKIE_NAME, buildCsrfCookie, generateCsrfToken, parseCsrfCookie } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import {
+  SESSION_COOKIE_NAME,
+  SESSION_SLIDE_THRESHOLD_MS,
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  createSession,
+  findSession,
+} from "../sessions.ts";
+import { createUser } from "../users.ts";
+
+/**
+ * Tests for `GET /account/session` — the same-origin boot oracle (hub-parity
+ * P1, the twin of cloud's `account-session.ts`). Covers:
+ *   - both branches' body shape (signed-out / signed-in).
+ *   - CSRF minted when absent, reused (no re-Set-Cookie) when present — on
+ *     BOTH branches (the G2 anonymous-CSRF invariant).
+ *   - a deleted-user session row falls back to signed-out.
+ *   - the bounded slide: an old-but-live session rolls + re-issues the
+ *     cookie; a fresh session does neither.
+ *   - 405 on non-GET, `cache-control: no-store`, no CORS headers.
+ *   - drift: `checkAccountSessionResponse` reports zero issues against the
+ *     live handler on both branches.
+ */
+const ISSUER = "https://hub.test";
+
+interface Harness {
+  db: Database;
+  cleanup: () => void;
+}
+
+function makeHarness(): Harness {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-session-"));
+  const db = openHubDb(hubDbPath(dir));
+  return {
+    db,
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+let harness: Harness;
+beforeEach(() => {
+  harness = makeHarness();
+});
+afterEach(() => {
+  harness.cleanup();
+});
+
+function getReq(cookie?: string, method = "GET"): Request {
+  return new Request(`${ISSUER}/account/session`, {
+    method,
+    ...(cookie ? { headers: { cookie } } : {}),
+  });
+}
+
+function sessionCookiePair(sid: string): string {
+  return buildSessionCookie(sid, Math.floor(SESSION_TTL_MS / 1000));
+}
+
+describe("handleAccountSession — signed-out branch", () => {
+  test("no cookie at all → {signed_in:false, csrf} + CSRF Set-Cookie minted", async () => {
+    const res = handleAccountSession(getReq(), { db: harness.db });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { signed_in: boolean; csrf: string };
+    expect(body.signed_in).toBe(false);
+    expect(typeof body.csrf).toBe("string");
+    expect(body.csrf.length).toBeGreaterThan(0);
+
+    const setCookie = res.headers.getSetCookie();
+    const csrfSet = setCookie.find((c) => c.includes(CSRF_COOKIE_NAME));
+    expect(csrfSet).toBeDefined();
+    expect(parseCsrfCookie(csrfSet ?? null)).toBe(body.csrf);
+  });
+
+  test("reuses an existing CSRF cookie without re-minting (no Set-Cookie)", async () => {
+    const existing = generateCsrfToken();
+    const cookie = buildCsrfCookie(existing).split(";")[0] ?? "";
+    const res = handleAccountSession(getReq(cookie), { db: harness.db });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { signed_in: boolean; csrf: string };
+    expect(body.signed_in).toBe(false);
+    expect(body.csrf).toBe(existing);
+    expect(res.headers.get("set-cookie")).toBeNull();
+  });
+
+  test("a session cookie naming a deleted user → signed-out", async () => {
+    // The on-disk FK normally guards against a session outliving its user, so
+    // forge the orphaned row directly with `PRAGMA foreign_keys=OFF` (the
+    // `api-account.test.ts` precedent) — simulating a delete-user-via-SQL-shell
+    // race, not something reachable through the app's own APIs.
+    const sessionId = "test-orphaned-session-id-base64url";
+    harness.db.exec("PRAGMA foreign_keys = OFF");
+    try {
+      harness.db
+        .prepare("INSERT INTO sessions (id, user_id, expires_at, created_at) VALUES (?, ?, ?, ?)")
+        .run(
+          sessionId,
+          "nonexistent-user-uuid",
+          new Date(Date.now() + SESSION_TTL_MS).toISOString(),
+          new Date().toISOString(),
+        );
+    } finally {
+      harness.db.exec("PRAGMA foreign_keys = ON");
+    }
+    const cookie = sessionCookiePair(sessionId);
+    const res = handleAccountSession(getReq(cookie), { db: harness.db });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { signed_in: boolean };
+    expect(body.signed_in).toBe(false);
+  });
+
+  test("drift: checkAccountSessionResponse reports zero issues (signed-out)", async () => {
+    const res = handleAccountSession(getReq(), { db: harness.db });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(checkAccountSessionResponse(body, { signedIn: false })).toEqual([]);
+  });
+});
+
+describe("handleAccountSession — signed-in branch", () => {
+  test("username always present; no email when the user row has none", async () => {
+    const user = await createUser(harness.db, "operator", "pw", { passwordChanged: true });
+    const session = createSession(harness.db, { userId: user.id });
+    const res = handleAccountSession(getReq(sessionCookiePair(session.id)), { db: harness.db });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.signed_in).toBe(true);
+    expect(body.username).toBe("operator");
+    expect(body.email).toBeUndefined();
+    expect(body.account_created_at).toBe(user.createdAt);
+    expect(body.password_change_required).toBeUndefined();
+  });
+
+  test("email present when the user row has one", async () => {
+    const user = await createUser(harness.db, "withmail", "pw", {
+      passwordChanged: true,
+      email: "friend@example.com",
+    });
+    const session = createSession(harness.db, { userId: user.id });
+    const res = handleAccountSession(getReq(sessionCookiePair(session.id)), { db: harness.db });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.email).toBe("friend@example.com");
+    expect(body.username).toBe("withmail");
+  });
+
+  test("password_change_required:true for a not-yet-rotated (passwordChanged:false) user", async () => {
+    // createUser defaults passwordChanged to false — the admin-created-user
+    // posture (force-redirect on first sign-in).
+    const user = await createUser(harness.db, "temp", "pw");
+    const session = createSession(harness.db, { userId: user.id });
+    const res = handleAccountSession(getReq(sessionCookiePair(session.id)), { db: harness.db });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.signed_in).toBe(true);
+    expect(body.password_change_required).toBe(true);
+  });
+
+  test("mints CSRF when absent even on the signed-in branch", async () => {
+    const user = await createUser(harness.db, "operator2", "pw", { passwordChanged: true });
+    const session = createSession(harness.db, { userId: user.id });
+    const res = handleAccountSession(getReq(sessionCookiePair(session.id)), { db: harness.db });
+    const body = (await res.json()) as { csrf: string };
+    expect(typeof body.csrf).toBe("string");
+    expect(body.csrf.length).toBeGreaterThan(0);
+    const setCookie = res.headers.getSetCookie();
+    expect(setCookie.some((c) => c.includes(CSRF_COOKIE_NAME))).toBe(true);
+  });
+
+  test("drift: checkAccountSessionResponse reports zero issues (signed-in)", async () => {
+    const user = await createUser(harness.db, "driftcheck", "pw", { passwordChanged: true });
+    const session = createSession(harness.db, { userId: user.id });
+    const res = handleAccountSession(getReq(sessionCookiePair(session.id)), { db: harness.db });
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(checkAccountSessionResponse(body, { signedIn: true })).toEqual([]);
+  });
+});
+
+describe("handleAccountSession — bounded slide", () => {
+  test("an old-but-live session (within the slide threshold of expiry) rolls + re-issues the cookie", async () => {
+    const user = await createUser(harness.db, "slider", "pw", { passwordChanged: true });
+    const t0 = new Date();
+    // Created far enough in the past that remaining life < TTL - threshold.
+    const createdAt = new Date(
+      t0.getTime() - (SESSION_TTL_MS - SESSION_SLIDE_THRESHOLD_MS + 60_000),
+    );
+    const session = createSession(harness.db, { userId: user.id, now: () => createdAt });
+    const originalExpiry = new Date(session.expiresAt).getTime();
+
+    const res = handleAccountSession(getReq(sessionCookiePair(session.id)), { db: harness.db });
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.getSetCookie();
+    const sessionSet = setCookie.find((c) => c.includes(SESSION_COOKIE_NAME));
+    expect(sessionSet).toBeDefined();
+    expect(sessionSet).toContain("HttpOnly");
+    expect(sessionSet).toContain("SameSite=Lax");
+
+    const found = findSession(harness.db, session.id);
+    expect(new Date(found?.expiresAt ?? 0).getTime()).toBeGreaterThan(originalExpiry);
+  });
+
+  test("a fresh session does NOT slide — no session Set-Cookie, no DB write", async () => {
+    const user = await createUser(harness.db, "fresh", "pw", { passwordChanged: true });
+    const session = createSession(harness.db, { userId: user.id });
+    const originalExpiry = session.expiresAt;
+
+    const res = handleAccountSession(getReq(sessionCookiePair(session.id)), { db: harness.db });
+    expect(res.status).toBe(200);
+    const setCookie = res.headers.getSetCookie();
+    expect(setCookie.some((c) => c.includes(SESSION_COOKIE_NAME))).toBe(false);
+
+    const found = findSession(harness.db, session.id);
+    expect(found?.expiresAt).toBe(originalExpiry);
+  });
+});
+
+describe("handleAccountSession — method + headers", () => {
+  test("405 on POST", async () => {
+    const res = handleAccountSession(getReq(undefined, "POST"), { db: harness.db });
+    expect(res.status).toBe(405);
+    expect(res.headers.get("allow")).toBe("GET");
+  });
+
+  test("cache-control: no-store on the 200 path", async () => {
+    const res = handleAccountSession(getReq(), { db: harness.db });
+    expect(res.headers.get("cache-control")).toBe("no-store");
+  });
+
+  test("no access-control-allow-origin (same-origin only, no CORS)", async () => {
+    const req = new Request(`${ISSUER}/account/session`, {
+      headers: { origin: "https://evil.example" },
+    });
+    const res = handleAccountSession(req, { db: harness.db });
+    expect(res.headers.get("access-control-allow-origin")).toBeNull();
+  });
+});

--- a/src/__tests__/admin-handlers.test.ts
+++ b/src/__tests__/admin-handlers.test.ts
@@ -603,4 +603,29 @@ describe("handleAdminLogoutPost (#113)", () => {
     expect(res.headers.get("location")).toBe("/login");
     expect(res.headers.get("set-cookie") ?? "").toContain("parachute_hub_session=;");
   });
+
+  // App-wire pin (hub-parity P1, §8-M4): the app's `logout()` posts form-
+  // encoded, not JSON (`parachute-app/src/lib/account/client.ts:246-258`:
+  // `content-type: application/x-www-form-urlencoded`, body
+  // `new URLSearchParams({ __csrf: csrf }).toString()`, credentials included).
+  // No hub code changed for this — the existing formData()-based handler
+  // already accepts exactly this shape; this test freezes the byte-shape so a
+  // future refactor of the handler can't silently drop form-body support out
+  // from under the app.
+  test("app-wire pin — form-encoded body matching client.ts's exact logout() shape", async () => {
+    const cookie = await cookieForUser(harness.db, "appuser", "pw");
+    const sid = cookie.match(/parachute_hub_session=([^;]+)/)?.[1] ?? "";
+    const req = new Request("http://hub.test/logout", {
+      method: "POST",
+      headers: {
+        cookie,
+        "content-type": "application/x-www-form-urlencoded",
+      },
+      body: new URLSearchParams({ [CSRF_FIELD_NAME]: TEST_CSRF }).toString(),
+    });
+    const res = await handleAdminLogoutPost(harness.db, req);
+    expect(res.status).toBe(302);
+    expect(res.headers.get("location")).toBe("/login");
+    expect(findSession(harness.db, sid)).toBeNull();
+  });
 });

--- a/src/__tests__/sessions.test.ts
+++ b/src/__tests__/sessions.test.ts
@@ -5,13 +5,15 @@ import { join } from "node:path";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
   SESSION_COOKIE_NAME,
-  SESSION_MAX_LIFETIME_MS,
+  SESSION_SLIDE_THRESHOLD_MS,
+  SESSION_TTL_MS,
   buildSessionClearCookie,
   buildSessionCookie,
   createSession,
   deleteSession,
   findSession,
   parseSessionCookie,
+  shouldSlideSession,
   touchSession,
 } from "../sessions.ts";
 import { createUser } from "../users.ts";
@@ -57,11 +59,11 @@ describe("createSession + findSession", () => {
     try {
       const epoch = new Date("2026-01-01T00:00:00Z");
       const s = createSession(db, { userId, now: () => epoch });
-      // Past TTL (24h).
-      const later = new Date(epoch.getTime() + 25 * 3600 * 1000);
+      // Past TTL (90 days).
+      const later = new Date(epoch.getTime() + SESSION_TTL_MS + 3600 * 1000);
       expect(findSession(db, s.id, () => later)).toBeNull();
       // Still valid one second before expiry.
-      const justBefore = new Date(epoch.getTime() + 24 * 3600 * 1000 - 1000);
+      const justBefore = new Date(epoch.getTime() + SESSION_TTL_MS - 1000);
       expect(findSession(db, s.id, () => justBefore)?.id).toBe(s.id);
     } finally {
       cleanup();
@@ -78,60 +80,64 @@ describe("touchSession (sliding renewal)", () => {
     try {
       const t0 = new Date("2026-01-01T00:00:00Z");
       const s = createSession(db, { userId, now: () => t0 });
-      // Original expiry: t0 + 24h.
-      expect(new Date(s.expiresAt).getTime()).toBe(t0.getTime() + DAY);
-      // Touch 1h later → expiry becomes (t0 + 1h) + 24h.
+      // Original expiry: t0 + 90d.
+      expect(new Date(s.expiresAt).getTime()).toBe(t0.getTime() + SESSION_TTL_MS);
+      // Touch 1h later → expiry becomes (t0 + 1h) + 90d.
       const t1 = new Date(t0.getTime() + HOUR);
       touchSession(db, s.id, () => t1);
       const found = findSession(db, s.id, () => t1);
-      expect(new Date(found?.expiresAt ?? 0).getTime()).toBe(t1.getTime() + DAY);
+      expect(new Date(found?.expiresAt ?? 0).getTime()).toBe(t1.getTime() + SESSION_TTL_MS);
     } finally {
       cleanup();
     }
   });
 
-  test("a touched session outlives the ORIGINAL 24h expiry", async () => {
+  test("a touched session outlives the ORIGINAL 90d expiry", async () => {
     const { db, userId, cleanup } = await makeDb();
     try {
       const t0 = new Date("2026-01-01T00:00:00Z");
       const s = createSession(db, { userId, now: () => t0 });
-      // Activity at +12h slides expiry to +36h.
-      touchSession(db, s.id, () => new Date(t0.getTime() + 12 * HOUR));
-      // At +30h — PAST the original +24h — the session is still alive.
-      const at30h = new Date(t0.getTime() + 30 * HOUR);
-      expect(findSession(db, s.id, () => at30h)?.id).toBe(s.id);
+      // Activity at +45d slides expiry to +135d.
+      touchSession(db, s.id, () => new Date(t0.getTime() + 45 * DAY));
+      // At +100d — PAST the original +90d — the session is still alive.
+      const at100d = new Date(t0.getTime() + 100 * DAY);
+      expect(findSession(db, s.id, () => at100d)?.id).toBe(s.id);
     } finally {
       cleanup();
     }
   });
 
-  test("an UNtouched session still expires at the original 24h", async () => {
+  test("an UNtouched session still expires at the original 90d", async () => {
     const { db, userId, cleanup } = await makeDb();
     try {
       const t0 = new Date("2026-01-01T00:00:00Z");
       const s = createSession(db, { userId, now: () => t0 });
-      // No touch — at +25h it's gone (today's absolute-TTL behavior preserved
-      // for idle / closed tabs that stop re-minting).
-      const at25h = new Date(t0.getTime() + 25 * HOUR);
-      expect(findSession(db, s.id, () => at25h)).toBeNull();
+      // No touch — one day past the 90d TTL it's gone (idle / closed tabs
+      // that stop re-minting still lapse at the full TTL).
+      const past = new Date(t0.getTime() + SESSION_TTL_MS + DAY);
+      expect(findSession(db, s.id, () => past)).toBeNull();
     } finally {
       cleanup();
     }
   });
 
-  test("caps at created_at + SESSION_MAX_LIFETIME_MS (sliding can't run forever)", async () => {
+  test("NO ceiling (Q4) — an actively-touched session rolls forward indefinitely", async () => {
+    // The old SESSION_MAX_LIFETIME_MS (30d) absolute cap is gone: repeatedly
+    // touching a session keeps sliding its expiry to now + 90d with no upper
+    // bound, matching cloud's rolling posture (an idle session still lapses
+    // at the TTL; an active one never does).
     const { db, userId, cleanup } = await makeDb();
     try {
       const t0 = new Date("2026-01-01T00:00:00Z");
       const s = createSession(db, { userId, now: () => t0 });
-      const ceiling = t0.getTime() + SESSION_MAX_LIFETIME_MS;
-      // A touch near the ceiling would slide to now + 24h, but the cap pins it.
-      const nearCeiling = new Date(ceiling - HOUR); // raw slide would be ceiling + 23h
-      touchSession(db, s.id, () => nearCeiling);
-      const found = findSession(db, s.id, () => nearCeiling);
-      expect(new Date(found?.expiresAt ?? 0).getTime()).toBe(ceiling);
-      // Past the ceiling the session is dead even though it was just "active".
-      expect(findSession(db, s.id, () => new Date(ceiling + 1000))).toBeNull();
+      // Touch well past where the old 30-day ceiling would have pinned it.
+      const farOut = new Date(t0.getTime() + 200 * DAY);
+      touchSession(db, s.id, () => farOut);
+      const found = findSession(db, s.id, () => farOut);
+      expect(new Date(found?.expiresAt ?? 0).getTime()).toBe(farOut.getTime() + SESSION_TTL_MS);
+      // Still alive nearly 90 more days out, right up to the fresh slide's TTL.
+      const stillAlive = new Date(farOut.getTime() + SESSION_TTL_MS - DAY);
+      expect(findSession(db, s.id, () => stillAlive)?.id).toBe(s.id);
     } finally {
       cleanup();
     }
@@ -141,6 +147,47 @@ describe("touchSession (sliding renewal)", () => {
     const { db, cleanup } = await makeDb();
     try {
       expect(() => touchSession(db, "no-such-session")).not.toThrow();
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("shouldSlideSession (bounded slide, G3 twin)", () => {
+  test("false for a freshly-created session (full TTL remaining)", async () => {
+    const { db, userId, cleanup } = await makeDb();
+    try {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      const s = createSession(db, { userId, now: () => t0 });
+      expect(shouldSlideSession(s, () => t0)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("false just before crossing the slide threshold", async () => {
+    const { db, userId, cleanup } = await makeDb();
+    try {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      const s = createSession(db, { userId, now: () => t0 });
+      // Elapsed just UNDER the threshold (30d) → remaining life still above
+      // (TTL - threshold) → not yet due to slide.
+      const justBefore = new Date(t0.getTime() + SESSION_SLIDE_THRESHOLD_MS - 1000);
+      expect(shouldSlideSession(s, () => justBefore)).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("true once remaining life drops below the slide threshold", async () => {
+    const { db, userId, cleanup } = await makeDb();
+    try {
+      const t0 = new Date("2026-01-01T00:00:00Z");
+      const s = createSession(db, { userId, now: () => t0 });
+      // Elapsed just OVER the threshold (30d) → remaining life below
+      // (TTL - threshold) → due to slide.
+      const justAfter = new Date(t0.getTime() + SESSION_SLIDE_THRESHOLD_MS + 1000);
+      expect(shouldSlideSession(s, () => justAfter)).toBe(true);
     } finally {
       cleanup();
     }

--- a/src/account-session.ts
+++ b/src/account-session.ts
@@ -1,0 +1,132 @@
+/**
+ * `GET /account/session` — the same-origin boot oracle (hub-parity P1; the
+ * hub's twin of cloud `account-session.ts`). Returns `{ signed_in, csrf, ... }`
+ * so the same-origin `parachute-app` — served at the hub's own origin — can
+ * (a) decide whether to render the signed-in UI or the sign-in ceremony, and
+ * (b) echo `csrf` back as `__csrf` on its next same-origin `POST /account/token`
+ * mint (C2). The CSRF cookie is `HttpOnly` (csrf.ts), so the SPA can't read it
+ * directly; this hands the token over the same way a server-rendered form's
+ * hidden input does.
+ *
+ * PUBLIC — no Bearer, no scope gate. It drives the `parachute_hub_session`
+ * cookie directly, same as `/api/me`: a client with no account Bearer yet has
+ * nothing else to authenticate a read with, and this endpoint IS the
+ * bootstrap. Mounted ABOVE the force-change-password gate (hub-server.ts
+ * CHOKE POINT 1) — it's a pure state oracle, not a mutating surface, so a
+ * pre-rotation user must still be able to read it (the app needs `signed_in` +
+ * `csrf` to drive the rotation ceremony itself, not get walled off before it
+ * can even ask). `POST /account/token` stays BELOW the gate — a pre-rotation
+ * user hits its 403 `force_change_password` there, and the app is expected to
+ * weather that (P4).
+ *
+ * SAME-ORIGIN ONLY, by design — mirrors cloud's posture exactly: the response
+ * is CREDENTIALED (it reflects the session cookie and sets the CSRF cookie),
+ * so it carries NO CORS headers. A cross-origin caller simply gets no
+ * `access-control-allow-origin`, so the browser blocks it from reading the
+ * body — intended, not an oversight.
+ */
+import type { Database } from "bun:sqlite";
+import { ensureCsrfToken } from "./csrf.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
+import {
+  SESSION_TTL_MS,
+  buildSessionCookie,
+  findActiveSession,
+  shouldSlideSession,
+  touchSession,
+} from "./sessions.ts";
+import { getUserById } from "./users.ts";
+
+export interface AccountSessionDeps {
+  db: Database;
+}
+
+/** Matches the `/account/*` 405 shape (`account-api.ts`'s `methodNotAllowed`)
+ * — same `{error, message}` body + `Allow` header, kept local to this file
+ * per the one-handler-one-file convention (`api-me.ts`, `account-token.ts`). */
+function methodNotAllowed(allow: string): Response {
+  return new Response(JSON.stringify({ error: "method_not_allowed", message: `use ${allow}` }), {
+    status: 405,
+    headers: { "content-type": "application/json", allow },
+  });
+}
+
+/**
+ * A credentialed JSON reply that can carry MULTIPLE Set-Cookie headers (the
+ * CSRF mint and the session slide's re-issue can coincide — a plain
+ * `Record`-keyed header init can't hold two `set-cookie` values). NO CORS
+ * headers (see the module note); `no-store` so a back/forward navigation
+ * never replays a stale csrf/session state. Mirrors cloud's `sessionJson`.
+ */
+function sessionJson(body: unknown, cookies: readonly string[]): Response {
+  const headers = new Headers({ "content-type": "application/json", "cache-control": "no-store" });
+  for (const c of cookies) headers.append("set-cookie", c);
+  return new Response(JSON.stringify(body), { status: 200, headers });
+}
+
+export function handleAccountSession(req: Request, deps: AccountSessionDeps): Response {
+  if (req.method !== "GET") return methodNotAllowed("GET");
+
+  // CSRF token for BOTH branches (G2 — anonymous CSRF; the piece `api-me.ts`
+  // lacks, since it mints only when signed in). ensureCsrfToken reuses an
+  // existing CSRF cookie or mints one (setCookie only when it minted) — it
+  // works WITHOUT a session and authorizes NOTHING alone (it's one half of a
+  // double-submit that also needs the matching cookie + same-origin + a live
+  // session at the mint gate it protects). Returning it on the signed-OUT
+  // branch lets the app run the sign-in moment in-app.
+  const csrf = ensureCsrfToken(req);
+  const cookies: string[] = [];
+  if (csrf.setCookie) cookies.push(csrf.setCookie);
+
+  // findActiveSession is the single chokepoint: it refuses an expired row (a
+  // logged-out row is gone outright). Nothing below rolls or reads a
+  // dead/absent session.
+  const session = findActiveSession(deps.db, req);
+  if (!session) {
+    return sessionJson({ signed_in: false, csrf: csrf.token }, cookies);
+  }
+
+  // Bounded slide (the G3 twin, and the reason NOT to call bare
+  // `touchSession` unconditionally here): this endpoint is POLLED — the
+  // app's `/check-email` screen hits it every few seconds while it waits for
+  // a magic-link-style click — so sliding only past
+  // `SESSION_SLIDE_THRESHOLD_MS` of remaining life bounds the write (and the
+  // cookie re-issue) to ~once per threshold per session, not per request.
+  if (shouldSlideSession(session)) {
+    touchSession(deps.db, session.id);
+    cookies.push(
+      buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000), {
+        secure: isHttpsRequest(req),
+      }),
+    );
+  }
+
+  const user = getUserById(deps.db, session.userId);
+  if (!user) {
+    // Session row points at a deleted user — treat as signed-out (the
+    // `api-me.ts` precedent) rather than surface a stale identity. Any slide
+    // cookie computed above still rides along; it's harmless (the row is
+    // about to be orphaned regardless) and keeping the branch simple beats
+    // special-casing a cookie rollback for a should-never-happen state.
+    return sessionJson({ signed_in: false, csrf: csrf.token }, cookies);
+  }
+
+  return sessionJson(
+    {
+      signed_in: true,
+      csrf: csrf.token,
+      // users.email is null-by-history (migration v15) — username is always
+      // present, email only when the row has one (B2 signup capture).
+      username: user.username,
+      ...(user.email ? { email: user.email } : {}),
+      account_created_at: user.createdAt,
+      // HUB EXTRA — additive, not part of the door-contract pin
+      // (`checkAccountSessionResponse` tolerates extra fields): lets the app
+      // hop a temp-password user straight to the change-password ceremony
+      // instead of hitting the force-change-password 403 wall on their next
+      // `/account/*` call.
+      ...(user.passwordChanged === false ? { password_change_required: true } : {}),
+    },
+    cookies,
+  );
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -114,6 +114,13 @@
  *                                                 (hub#473; reached after a correct
  *                                                 password for a 2FA-enrolled user)
  *   /logout                       (POST)       → end admin session
+ *   /account/session               (GET)        → same-origin boot oracle {signed_in,
+ *                                                 csrf,...} (hub-parity P1); cookie-gated,
+ *                                                 NOT Bearer — mounted ABOVE the
+ *                                                 force-change-password gate below (a pure
+ *                                                 state oracle, so a pre-rotation user can
+ *                                                 still read it to drive the rotation
+ *                                                 ceremony itself)
  *   /account/change-password      (GET + POST) → user self-service change-password
  *                                                 (force-redirect target for users
  *                                                 with password_changed=false; also
@@ -122,7 +129,8 @@
  *                                                 + the per-vault proxy is hard-gated
  *                                                 per-request on password_changed===true
  *                                                 (forceChangePasswordGate); only this
- *                                                 route and /logout stay reachable
+ *                                                 route, /logout, and /account/session
+ *                                                 (P1, also above the gate) stay reachable
  *                                                 pre-rotation.
  *   /account/token                (POST)       → cookie→account-bearer mint (App
  *                                                 campaign Phase 2 H1): session cookie →
@@ -190,6 +198,7 @@ import {
   handleAccountSetVaultCaps,
   requireAnyScope,
 } from "./account-api.ts";
+import { type AccountSessionDeps, handleAccountSession } from "./account-session.ts";
 import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
 import { handleAccountToken } from "./account-token.ts";
 import { handleAccountVaultAdminTokenPost } from "./account-vault-admin-token.ts";
@@ -3744,6 +3753,20 @@ export function hubFetch(
         if (req.method === "GET") return handleAccountChangePasswordGet(req, accountDeps);
         if (req.method === "POST") return handleAccountChangePasswordPost(req, accountDeps);
         return new Response("method not allowed", { status: 405 });
+      }
+
+      // /account/session — the same-origin boot oracle (hub-parity P1). A
+      // PURE STATE ORACLE, not a mutating surface, so it is mounted ABOVE the
+      // force-change-password gate immediately below: a pre-rotation user
+      // must still be able to read `{signed_in, csrf}` to drive the rotation
+      // ceremony itself, rather than get walled off before it can even ask.
+      // `/account/token` (below the gate) stays gated — a pre-rotation user
+      // hits its 403 `force_change_password` there instead. See
+      // `account-session.ts`.
+      if (pathname === "/account/session") {
+        if (!getDb) return dbNotConfigured();
+        const sessionDeps: AccountSessionDeps = { db: getDb() };
+        return handleAccountSession(req, sessionDeps);
       }
 
       // Per-request force-change-password gate (P0-1 / hub#469). CHOKE POINT 1:

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -4,12 +4,18 @@
  * with that cookie skip the login form and go straight to consent.
  *
  * Stored in `sessions` (one row per active session), so logout / forced
- * revocation is just a delete. Sessions are SLIDING: `expires_at` starts at
- * `created_at + SESSION_TTL_MS`, and {@link touchSession} pushes it forward on
- * genuine activity (the admin SPA re-mints `/admin/host-admin-token` every
- * ~10 min while a tab is open). An idle session — no more mints — still
- * expires at the original 24h mark, and {@link SESSION_MAX_LIFETIME_MS} caps
- * total life so sliding can't keep a left-open tab alive forever.
+ * revocation is just a delete. Sessions are ROLLING (hub-parity P1, Q4 —
+ * adopts cloud's posture): `expires_at` starts at `created_at + SESSION_TTL_MS`
+ * (90 days), and {@link touchSession} pushes it forward on genuine activity
+ * (the admin SPA re-mints `/admin/host-admin-token` every ~10 min while a tab
+ * is open; `GET /account/session`, the app's boot/poll oracle, slides once it
+ * crosses {@link SESSION_SLIDE_THRESHOLD_MS} of its life — see
+ * `account-session.ts`). There is NO absolute ceiling: an ACTIVELY-used
+ * session rolls forward indefinitely, while an idle one (no more touches)
+ * still lapses at the 90-day mark. Was 24h sliding / 30d hard cap through
+ * 2026-07; the cap is gone — the kill switches that bound a rolling session
+ * are logout (deletes the row), the admin screen-lock (idle PIN), and
+ * (P6-era) per-user delete, not a lifetime ceiling.
  *
  * The cookie value is the session id directly. It's a 32-byte base64url
  * random; collision is statistically impossible. No HMAC needed because the
@@ -20,16 +26,25 @@ import type { Database } from "bun:sqlite";
 import { randomBytes } from "node:crypto";
 
 export const SESSION_COOKIE_NAME = "parachute_hub_session";
-export const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
+/**
+ * Session lifetime — 90 days (hub-parity P1, Q4: adopts cloud's rolling
+ * posture). A session (and its cookie Max-Age) lasts 90 days from its last
+ * slide; {@link findSession} still expires it hard past this, and logout
+ * deletes the row outright. Was 24h (sliding, 30d hard cap) prior to this PR.
+ */
+export const SESSION_TTL_MS = 90 * 24 * 60 * 60 * 1000;
 
 /**
- * Absolute ceiling on a session's total lifetime, independent of sliding
- * renewal. Sliding ({@link touchSession}) keeps an active console signed in,
- * but a left-open-but-idle tab whose background polls keep re-minting must
- * still be force-logged-out eventually — this caps life at
- * `created_at + SESSION_MAX_LIFETIME_MS` so renewal can't extend forever.
+ * Roll a session forward once it has been used past this much of its life
+ * (30 days) — so an ACTIVE session stays alive indefinitely, while an idle one
+ * still expires at the full 90-day TTL. Callers that slide on every touch
+ * (the admin SPA's host-admin-token re-mint) don't need this threshold; it's
+ * for a POLLING caller like `GET /account/session` (the app's `/check-email`
+ * screen hits it every few seconds) that must NOT rewrite the row on every
+ * request — see `shouldSlideSession` there. Mirrors cloud's
+ * `SESSION_REFRESH_THRESHOLD_MS` (`workers/identity/src/sessions.ts`).
  */
-export const SESSION_MAX_LIFETIME_MS = 30 * 24 * 60 * 60 * 1000;
+export const SESSION_SLIDE_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
 
 export interface Session {
   id: string;
@@ -91,35 +106,53 @@ export function findSession(
 }
 
 /**
- * Slide a session's expiry forward to `now + SESSION_TTL_MS`, capped at
- * `created_at + SESSION_MAX_LIFETIME_MS`. No-op when the session doesn't exist.
+ * Slide a session's expiry forward to `now + SESSION_TTL_MS`. No-op when the
+ * session doesn't exist. NO ceiling (hub-parity P1, Q4) — cloud's posture,
+ * adopted here: an ACTIVELY-used session rolls forward forever; a closed tab
+ * / idle client (no more touches) still expires `SESSION_TTL_MS` after its
+ * last activity. The old absolute cap (`SESSION_MAX_LIFETIME_MS`, 30d) is
+ * removed — the bounds on a rolling session are logout, the admin
+ * screen-lock, and (P6-era) per-user delete, not a lifetime ceiling.
  *
- * This is what makes sessions sliding rather than fixed-24h: the admin SPA
- * re-mints `/admin/host-admin-token` roughly every ~10 min while a tab is open,
- * and each successful mint calls this — so an actively-used console isn't
- * hard-logged-out at the 24h mark, while a closed tab (no more mints) still
- * expires 24h after its last activity. The ceiling bounds a left-open-but-idle
- * tab (background polls keep re-minting) so sliding can't run forever.
+ * This is what makes sessions sliding rather than fixed-TTL: the admin SPA
+ * re-mints `/admin/host-admin-token` roughly every ~10 min while a tab is
+ * open, and each successful mint calls this unconditionally; `GET
+ * /account/session` (the app's boot/poll oracle) instead calls this only
+ * past `SESSION_SLIDE_THRESHOLD_MS` of remaining life (bounded slide — see
+ * `account-session.ts`), since it's polled every few seconds and an
+ * unconditional touch there would rewrite the row on every poll.
  *
  * Monotonic in practice: the production wall clock only moves forward, so the
- * slid value never undershoots a previously-written expiry; once it reaches the
- * ceiling it stays pinned there. (The write is unconditional — it does not read
- * the current expiry — so an injected backward `now` in tests would shorten the
- * session: a conservative failure mode, not a security issue.) `now` is
- * injectable for tests, matching {@link findSession}.
+ * slid value never undershoots a previously-written expiry. (The write is
+ * unconditional — it does not read the current expiry — so an injected
+ * backward `now` in tests would shorten the session: a conservative failure
+ * mode, not a security issue.) `now` is injectable for tests, matching
+ * {@link findSession}.
  */
 export function touchSession(db: Database, id: string, now: () => Date = () => new Date()): void {
   const row = db.query<Row, [string]>("SELECT * FROM sessions WHERE id = ?").get(id);
   if (!row) return;
-  const nowMs = now().getTime();
-  const slidMs = nowMs + SESSION_TTL_MS;
-  const ceilingMs = new Date(row.created_at).getTime() + SESSION_MAX_LIFETIME_MS;
-  const newExpiresAt = new Date(Math.min(slidMs, ceilingMs)).toISOString();
+  const newExpiresAt = new Date(now().getTime() + SESSION_TTL_MS).toISOString();
   db.prepare("UPDATE sessions SET expires_at = ? WHERE id = ?").run(newExpiresAt, id);
 }
 
 export function deleteSession(db: Database, id: string): void {
   db.prepare("DELETE FROM sessions WHERE id = ?").run(id);
+}
+
+/**
+ * Should this live session be rolled forward? True once it has been used past
+ * {@link SESSION_SLIDE_THRESHOLD_MS} of its life — i.e. its remaining life has
+ * dropped below `SESSION_TTL_MS - SESSION_SLIDE_THRESHOLD_MS`. A
+ * freshly-created/-slid session is NOT slid; one that's crossed the threshold
+ * is. Pure — the caller (`account-session.ts`'s bounded slide, the G3 twin of
+ * cloud's `shouldSlideSession`) does the write ({@link touchSession}) + cookie
+ * re-issue only when this returns true, bounding both to ~once per threshold
+ * per session even under frequent polling.
+ */
+export function shouldSlideSession(session: Session, now: () => Date = () => new Date()): boolean {
+  const remainingMs = new Date(session.expiresAt).getTime() - now().getTime();
+  return remainingMs < SESSION_TTL_MS - SESSION_SLIDE_THRESHOLD_MS;
 }
 
 /**

--- a/src/sessions.ts
+++ b/src/sessions.ts
@@ -13,9 +13,12 @@
  * `account-session.ts`). There is NO absolute ceiling: an ACTIVELY-used
  * session rolls forward indefinitely, while an idle one (no more touches)
  * still lapses at the 90-day mark. Was 24h sliding / 30d hard cap through
- * 2026-07; the cap is gone — the kill switches that bound a rolling session
- * are logout (deletes the row), the admin screen-lock (idle PIN), and
- * (P6-era) per-user delete, not a lifetime ceiling.
+ * 2026-07; the cap is gone. The ONLY thing that terminates a session row today
+ * is logout (which deletes it). Note what does NOT: the admin screen-lock gates
+ * token MINTS (it does not touch or expire the session row), and per-user
+ * session revocation does not exist yet (P6-era). So an actively-used session
+ * — including a stolen cookie — currently lives on until 90 idle days or an
+ * explicit logout; a per-user revoke lever is the standing gap to close.
  *
  * The cookie value is the session id directly. It's a 32-byte base64url
  * random; collision is statistically impossible. No HMAC needed because the


### PR DESCRIPTION
## Summary

Implements **P1** of the hub-parity build plan: `GET /account/session` (the same-origin boot oracle both doors serve) + the Q4-approved 90-day rolling session.

- **NEW `src/account-session.ts`** — `handleAccountSession(req, {db})`, the hub's twin of cloud's `account-session.ts`:
  - Non-GET → 405 (matches `account-api.ts`'s `methodNotAllowed` shape).
  - `ensureCsrfToken` on **both** branches (G2 anonymous-CSRF — signed-out still gets `csrf`).
  - No session / deleted-user session → `{signed_in:false, csrf}`.
  - Signed-in → `{signed_in:true, csrf, username, ...(email?{email}:{}), account_created_at, ...(passwordChanged===false?{password_change_required:true}:{})}` — `username` always (hub's `users.email` is null-by-history).
  - **Bounded slide** (poll-safe — the app's `/check-email` screen polls this every few seconds): slides only once the session is within `SESSION_TTL_MS - SESSION_SLIDE_THRESHOLD_MS` of expiry, then `touchSession` + re-issues the cookie.
  - `content-type: application/json`, `cache-control: no-store`, cookies via `Headers.append` (CSRF mint + session slide can coincide), **no CORS headers** (credentialed same-origin).

- **`src/sessions.ts` (Q4)** — `SESSION_TTL_MS` 24h → 90d; **removed** `SESSION_MAX_LIFETIME_MS` and the ceiling clamp in `touchSession` (an active session now rolls forever; an idle one still lapses at 90d — cloud's posture); added `SESSION_SLIDE_THRESHOLD_MS` (30d) and an exported `shouldSlideSession` pure helper (mirrors cloud's).

- **`src/hub-server.ts`** — mounts `/account/session` **above** the force-change-password gate (CHOKE POINT 1) — it's a pure state oracle, so a pre-rotation user can still read it to drive the rotation ceremony itself. `/account/token` stays below the gate (unchanged — a pre-rotation user hits its 403 there). Updated the header route table with the new row + note.

- **Logout: no code change** — added an app-wire pin test only (`admin-handlers.test.ts`): POST `/logout` with `content-type: application/x-www-form-urlencoded`, body `__csrf=<token>`, matching cookie → 302 `/login` + session cleared. This is byte-for-byte what `parachute-app/src/lib/account/client.ts`'s `logout()` sends; the existing `formData()`-based handler already accepts it unchanged.

## Tests

- New `src/__tests__/account-session.test.ts` (14 tests): both branches' body shape, CSRF mint/reuse (no re-Set-Cookie), deleted-user session → signed-out, bounded slide (old session slides + re-issues cookie; fresh session doesn't), 405 on POST, `cache-control: no-store`, no `access-control-allow-origin`, and a drift assertion — `checkAccountSessionResponse(body, {signedIn})` `toEqual([])` on both branches (door-contract 0.4.0, already on `main`).
- Updated `src/__tests__/sessions.test.ts`: the 24h/30d-cap-specific tests rewritten for the 90d/no-ceiling model; added a `shouldSlideSession` describe block.
- Added the logout app-wire pin test to `src/__tests__/admin-handlers.test.ts`.
- Grepped every test under `src/__tests__/` for `SESSION_TTL_MS`/`SESSION_MAX_LIFETIME_MS`: everywhere else builds cookies dynamically off the imported `SESSION_TTL_MS` constant (or passes an arbitrary literal `Max-Age` unrelated to the real session-expiry logic), so only `sessions.ts`'s own test needed literal-value edits.

## Gate counts (literal)

- `bun run typecheck` — clean, zero errors.
- `bun test ./src` (canonical hub gate) — **4211 pass, 1 skip, 0 fail, 39338 expect() calls, across 161 files.**
- `bunx biome check .` — **19 errors, 6 warnings** — verified byte-identical to `origin/main`'s baseline (stashed the diff and re-ran; same 19/6, none in any file this PR touches). Zero new findings introduced.
- rc bump: `0.7.7-rc.6` → `0.7.7-rc.7`.

## Flag for reviewer

The session-TTL change (`SESSION_TTL_MS` 24h → 90d, no more absolute ceiling) applies to **every** hub session, including the **admin console** session — not just the new account-session endpoint. This is deliberate and Q4-approved (re-grounding pass, hub-parity build plan) but is a real behavior change worth an explicit look: an admin console tab, once actively used, now never hard-expires (previously capped at 30 days regardless of activity).

## Deviations from the brief

None found — verified the brief's file:line references (`account-api.ts`'s `methodNotAllowed` shape, `csrf.ts`'s `ensureCsrfToken`, `sessions.ts`'s `findActiveSession`/`touchSession`, `hub-server.ts`'s CHOKE POINT 1 at the force-change-password gate, `users.ts`'s `User.email`/`passwordChanged`) against the actual hub `main` tree and they all matched. One implementation choice beyond the brief's literal text: added an exported `shouldSlideSession(session, now)` pure helper to `sessions.ts` (mirroring cloud's own exported helper) rather than inlining the bounded-slide condition directly in `account-session.ts` — this keeps the two doors' session modules structurally parallel and made the threshold boundary independently unit-testable.

Per the task instructions: **not merged, no tag pushed, nothing deployed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB