### PR TITLE
feat(hub): Bearer scheme-casing unification + door-contract live conformance (contracts-brief H1, 0.7.7-rc.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.7-rc.12] - 2026-07-17
+
+Contracts-brief H1 (cross-door contract-parity program, hub wave) — distinct from campaign #116's "H1" (merged #746). Bearer scheme-casing unification + the hub half of the door-contract live conformance suite + a shape-inconsistency catalog.
+
+### Changed
+
+- **Bearer scheme is now case-insensitive at every remaining hub call site** (RFC 7235 §2.1 — the auth-scheme token is case-insensitive; the token itself is passed verbatim, never case-folded). Converts the last 12 case-sensitive `startsWith("Bearer ")` sites (`api-hub-upgrade.ts`, `api-tokens.ts`, `api-revoke-token.ts`, `api-settings-root-redirect.ts`, `api-modules.ts` ×2, `api-modules-ops.ts`, `api-mint-token.ts`, `api-settings-hub-origin.ts`, `admin-surfaces.ts`, `admin-connections.ts` ×2, `audience-gate.ts`) to a case-insensitive `/^Bearer\s+/i` scheme test, keeping each site's existing extraction/error flow otherwise byte-identical — parity with parachute-vault's V1.4 and parachute-cloud's C1.3, which made the same change on their doors. `module-ops-client.ts`'s stale comment (claiming receivers parse the scheme-cased prefix) is corrected. The hub already had a documented case-insensitive helper (`extractBearerToken`, `admin-auth.ts`) for a subset of routes; this closes the gap on the rest.
+
+### Added
+
+- **Door-contract live-handler conformance — hub half of X1.** Wires 5 more of `@openparachute/door-contract`'s conformance checkers to REAL hub handler responses (joining the 2 already wired): `checkTokenResponseInvariants` against a live `POST /oauth/token` success body, `checkAuthorizationServerMetadata` against the live `/.well-known/oauth-authorization-server` handler, `checkProtectedResourceMetadata` against the live `/.well-known/oauth-protected-resource` handler (RFC 9728 — the hub DOES serve this, closes hub#393), `checkAccountTokenMintResponse` against the live `POST /account/token` handler, and `checkVaultTokenMintResponse` against the live `POST /account/vaults/<name>/token` handler. All 7 checkers in the package are now wired on the hub side — none deferred.
+- **`/account/*` error-shape contract pinned (not changed).** Representative tests across `account-token.ts`, `account-session.ts`, and `account-api.ts` pin the CURRENT wire shape: auth-gate failures emit `{error, error_description}`, resource-level failures emit `{error, message}`, and emitted error codes are checked against door-contract's `ACCOUNT_ERROR_CODES` union. A handful of shape inconsistencies were found and deliberately left unpinned/unfixed — see the PR body's decisions-needed section (`account-token.ts`'s 405 vs `account-session.ts`'s 405 disagree on shape; `account-token.ts`'s `not_admin` code isn't yet in the shared vocabulary; `api-revocation-list.ts` emits `{error}` alone).
+
 ## [0.7.7-rc.10] - 2026-07-11
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.11",
+  "version": "0.7.7-rc.12",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkAccountDescriptor, validateVaultScopes } from "@openparachute/door-contract";
+import {
+  ACCOUNT_ERROR_CODES,
+  checkAccountDescriptor,
+  checkVaultTokenMintResponse,
+  validateVaultScopes,
+} from "@openparachute/door-contract";
 import {
   handleAccountCapabilities,
   handleAccountCreateVault,
@@ -376,6 +381,13 @@ describe("account API — auth gates", () => {
     try {
       const res = await handleAccountListVaults(withBearer("/account/vaults", null), deps(h));
       expect(res.status).toBe(401);
+      // H1.3 — pin the CURRENT shape: auth-gate failures on /account/* emit
+      // {error, error_description} (door-contract account-contract.ts:244-246),
+      // via the shared `adminAuthErrorResponse` translator.
+      const body = (await res.json()) as { error: string; error_description: string };
+      expect(body.error).toBe("invalid_token");
+      expect(typeof body.error_description).toBe("string");
+      expect(ACCOUNT_ERROR_CODES as readonly string[]).toContain(body.error);
     } finally {
       h.cleanup();
     }
@@ -387,6 +399,10 @@ describe("account API — auth gates", () => {
       const token = await bearer(h, ["vault:beta:read"]);
       const res = await handleAccountListVaults(withBearer("/account/vaults", token), deps(h));
       expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string; error_description: string };
+      expect(body.error).toBe("insufficient_scope");
+      expect(typeof body.error_description).toBe("string");
+      expect(ACCOUNT_ERROR_CODES as readonly string[]).toContain(body.error);
     } finally {
       h.cleanup();
     }
@@ -594,6 +610,10 @@ describe("handleAccountMintVaultToken", () => {
       };
       expect(body.vault_token.length).toBeGreaterThan(0);
       expect(body.services["vault:field-notes"]?.url).toBe(`${ISSUER}/vault/field-notes`);
+      // H1.2 — door-contract conformance against the live
+      // `POST /account/vaults/<name>/token` success body (V1.4/C1.4 twin
+      // coverage, hub half).
+      expect(checkVaultTokenMintResponse(body, "field-notes")).toEqual([]);
       const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
       expect(validated.payload.aud).toBe("vault.field-notes");
       expect(validated.payload.scope).toBe("vault:field-notes:read vault:field-notes:write");
@@ -632,7 +652,14 @@ describe("handleAccountMintVaultToken", () => {
         deps(h),
       );
       expect(res.status).toBe(404);
-      expect(((await res.json()) as { error: string }).error).toBe("vault_not_found");
+      const body = (await res.json()) as { error: string; message: string };
+      expect(body.error).toBe("vault_not_found");
+      // H1.3 — pin the CURRENT shape: resource-level failures on /account/*
+      // emit {error, message} (door-contract account-contract.ts:244-246) —
+      // distinct from the auth-gate's {error, error_description} above.
+      expect(typeof body.message).toBe("string");
+      expect(body.message.length).toBeGreaterThan(0);
+      expect(ACCOUNT_ERROR_CODES as readonly string[]).toContain(body.error);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-session.test.ts
+++ b/src/__tests__/account-session.test.ts
@@ -3,7 +3,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { checkAccountSessionResponse } from "@openparachute/door-contract";
+import { ACCOUNT_ERROR_CODES, checkAccountSessionResponse } from "@openparachute/door-contract";
 import { handleAccountSession } from "../account-session.ts";
 import { CSRF_COOKIE_NAME, buildCsrfCookie, generateCsrfToken, parseCsrfCookie } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
@@ -227,6 +227,14 @@ describe("handleAccountSession — method + headers", () => {
     const res = handleAccountSession(getReq(undefined, "POST"), { db: harness.db });
     expect(res.status).toBe(405);
     expect(res.headers.get("allow")).toBe("GET");
+    // H1.3 — pin the CURRENT shape: resource-level failures on /account/*
+    // emit {error, message} (door-contract account-contract.ts:244-246). This
+    // is account-session.ts's own `methodNotAllowed`, distinct from
+    // account-token.ts's {error, error_description} 405 (see H1.1/H1.3 PR
+    // notes — a decisions-needed inconsistency, not fixed here).
+    const body = (await res.json()) as { error: string; message: string };
+    expect(body).toEqual({ error: "method_not_allowed", message: "use GET" });
+    expect(ACCOUNT_ERROR_CODES as readonly string[]).toContain(body.error);
   });
 
   test("cache-control: no-store on the 200 path", async () => {

--- a/src/__tests__/account-token.test.ts
+++ b/src/__tests__/account-token.test.ts
@@ -19,6 +19,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { ACCOUNT_ERROR_CODES, checkAccountTokenMintResponse } from "@openparachute/door-contract";
 // The `/account/*` validator (H2 / cloud) hand-rolls its scope check via
 // scope-guard's hasScope — hub never imports scope-guard at runtime (the
 // issuer/validator boundary), but the test asserts the RS-side inheritance
@@ -118,6 +119,14 @@ describe("handleAccountToken", () => {
     const req = new Request(`${ISSUER}/account/token`, { headers: { cookie } });
     const res = await handleAccountToken(req, { db: harness.db, issuer: ISSUER });
     expect(res.status).toBe(405);
+    // H1.3 — pin the CURRENT shape: account-token.ts emits {error,
+    // error_description} uniformly (its own local `jsonError`), including for
+    // this 405 — DIFFERENT from account-session.ts's 405, which emits {error,
+    // message} (see that file's test). A decisions-needed inconsistency
+    // across /account/*, not fixed here.
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body).toEqual({ error: "method_not_allowed", error_description: "use POST" });
+    expect(ACCOUNT_ERROR_CODES as readonly string[]).toContain(body.error);
   });
 
   test("401 when no session cookie is present (unauthenticated → refused)", async () => {
@@ -126,8 +135,13 @@ describe("handleAccountToken", () => {
     const req = postReq("", { [CSRF_FIELD_NAME]: "anything" });
     const res = await handleAccountToken(req, { db: harness.db, issuer: ISSUER });
     expect(res.status).toBe(401);
-    const body = (await res.json()) as { error: string };
+    const body = (await res.json()) as { error: string; error_description: string };
     expect(body.error).toBe("unauthenticated");
+    // H1.3 — pin the CURRENT shape: auth-gate failures on /account/* emit
+    // {error, error_description} (door-contract account-contract.ts:244-246).
+    expect(typeof body.error_description).toBe("string");
+    expect(body.error_description.length).toBeGreaterThan(0);
+    expect(ACCOUNT_ERROR_CODES as readonly string[]).toContain(body.error);
   });
 
   test("401 when the cookie names a deleted session", async () => {
@@ -146,8 +160,11 @@ describe("handleAccountToken", () => {
     rotateSigningKey(harness.db);
     const res = await handleAccountToken(postReq(cookie, {}), { db: harness.db, issuer: ISSUER });
     expect(res.status).toBe(403);
-    const body = (await res.json()) as { error: string };
+    const body = (await res.json()) as { error: string; error_description: string };
     expect(body.error).toBe("csrf_failed");
+    // H1.3 — pin the {error, error_description} shape + ACCOUNT_ERROR_CODES membership.
+    expect(typeof body.error_description).toBe("string");
+    expect(ACCOUNT_ERROR_CODES as readonly string[]).toContain(body.error);
   });
 
   test("403 csrf_failed when the body token doesn't match the cookie token", async () => {
@@ -176,6 +193,10 @@ describe("handleAccountToken", () => {
     const body = (await res.json()) as { error: string; error_description: string };
     expect(body.error).toBe("not_admin");
     expect(body.error_description).toContain("/account/");
+    // H1.3 — DECISIONS-NEEDED (cataloged, not fixed here): "not_admin" is a
+    // real emitted /account/* error code but is NOT a member of door-contract's
+    // ACCOUNT_ERROR_CODES union — a gap in the shared vocabulary. See the PR
+    // body's decisions-needed section rather than asserting membership here.
   });
 
   test("200 mints the account superset with aud=account, validating against the hub keys", async () => {
@@ -201,6 +222,9 @@ describe("handleAccountToken", () => {
       "parachute:host:auth",
     ]);
     expect(body.aud).toBe(ACCOUNT_TOKEN_AUDIENCE);
+    // H1.2 — door-contract conformance against the live `POST /account/token`
+    // success body (V1.4/C1.4 twin coverage, hub half).
+    expect(checkAccountTokenMintResponse(body)).toEqual([]);
 
     // TTL is roughly the 10-min window.
     const skew = new Date(body.expires_at).getTime() - Date.now();

--- a/src/__tests__/admin-connections-credentials.test.ts
+++ b/src/__tests__/admin-connections-credentials.test.ts
@@ -556,6 +556,26 @@ describe("credential connection — renewal (proof of possession)", () => {
     expect(rec.provisioned.mintedJtis).toEqual([out.credential.jti!]);
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const { fetchImpl, calls } = mockFetch({ "POST /api/credential": () => ok({ ok: true }) });
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const cred = await provision(deps, calls);
+
+    const res = await handleConnections(
+      new Request(`http://127.0.0.1/admin/connections/${cred.connection_id}/renew`, {
+        method: "POST",
+        headers: { authorization: `bearer ${cred.token}` },
+      }),
+      `/${cred.connection_id}/renew`,
+      deps,
+    );
+    expect(res.status).toBe(200);
+    const out = (await res.json()) as { ok: boolean; credential: DeliveredCredential };
+    expect(out.ok).toBe(true);
+    expect(out.credential.op).toBe("renewed");
+  });
+
   test("renewed credential can renew again (the chain extends)", async () => {
     const { fetchImpl, calls } = mockFetch({ "POST /api/credential": () => ok({ ok: true }) });
     const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
@@ -939,6 +959,27 @@ describe("credential connection — claim/reconcile (surface#113)", () => {
     expect(readConnections(harness.storePath)[0]!.provisioned.mintedJtis).toEqual([
       out.credential.jti!,
     ]);
+  });
+
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("claim: mixed-case bearer scheme (BeArEr) authenticates identically to canonical Bearer", async () => {
+    const { fetchImpl } = mockFetch({});
+    const deps = credDeps(fetchImpl, modulesOf(SURFACE_MANIFEST));
+    const direct = await mintDirectDelivered({ vault: "default", verb: "read", tags: ["boulder"] });
+
+    const claim = await handleConnections(
+      new Request(`http://127.0.0.1/admin/connections/${CLAIM_ID}/claim`, {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `BeArEr ${direct.token}` },
+        body: JSON.stringify(SURFACE_CLAIM),
+      }),
+      `/${CLAIM_ID}/claim`,
+      deps,
+    );
+    expect(claim.status).toBe(202);
+    const claimBody = (await claim.json()) as { ok: boolean; status: string };
+    expect(claimBody.ok).toBe(true);
+    expect(claimBody.status).toBe("pending");
   });
 
   test("the live docs shape: an UNTAGGED write credential is claimable verbatim (create's write-requires-tags guards NEW grants; the operator's approve sanctions the existing shape)", async () => {

--- a/src/__tests__/admin-surfaces.test.ts
+++ b/src/__tests__/admin-surfaces.test.ts
@@ -151,6 +151,27 @@ describe("routeAdminSurfaces — register + list", () => {
     }
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await mint(h, ["parachute:host:admin"]);
+      const res = await routeAdminSurfaces(
+        req(
+          "POST",
+          { authorization: `bearer ${token}`, "content-type": "application/json" },
+          { name: "brain", mount: "/surface/brain", mode: "prod" },
+        ),
+        deps(h),
+      );
+      expect(res?.status).toBe(200);
+      const body = (await res?.json()) as { ok: boolean };
+      expect(body.ok).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("POST with a missing name → 400", async () => {
     const h = await makeHarness();
     try {

--- a/src/__tests__/api-hub-upgrade.test.ts
+++ b/src/__tests__/api-hub-upgrade.test.ts
@@ -510,6 +510,17 @@ describe("GET /api/hub/upgrade/status", () => {
     const res = await handleHubUpgradeStatus(getStatusReq({}), deps);
     expect(res.status).toBe(401);
   });
+
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer (404, not 401)", async () => {
+    const bearer = await mintBearer(harness, ["parachute:host:admin"]);
+    const { deps } = baseDeps(harness);
+    const res = await handleHubUpgradeStatus(
+      getStatusReq({ authorization: `bearer ${bearer}` }),
+      deps,
+    );
+    expect(res.status).toBe(404);
+  });
 });
 
 describe("detectHubUpgradeMode — §5.3 heuristic", () => {

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -172,6 +172,31 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     }
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `bearer ${op.token}` },
+          ),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { scope: string };
+        expect(body.scope).toBe("scribe:transcribe");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   // hub#516 parity — the live "mint refused" after `parachute hub set-origin`.
   // An operator/agent credential minted under a PRIOR origin (still a member of
   // the hub's bound-origin set) must keep minting after the canonical issuer

--- a/src/__tests__/api-modules-ops.test.ts
+++ b/src/__tests__/api-modules-ops.test.ts
@@ -300,6 +300,29 @@ describe("POST /api/modules/:short/install", () => {
     expect(body.error_description).toContain("parachute:host:admin");
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const { supervisor } = makeIdleSupervisor();
+    const { run } = alwaysOkRun();
+    const bearer = await mintBearer(h, [API_MODULES_OPS_REQUIRED_SCOPE]);
+    const res = await handleInstall(
+      postReq("/api/modules/vault/install", { authorization: `bearer ${bearer}` }),
+      "vault",
+      {
+        db: h.db,
+        issuer: ISSUER,
+        manifestPath: h.manifestPath,
+        configDir: h.dir,
+        supervisor,
+        run,
+        isLinked: TEST_DEFAULT_NOT_LINKED,
+      },
+    );
+    expect(res.status).toBe(202);
+    const body = (await res.json()) as { operation_id: string };
+    expect(body.operation_id).toBeDefined();
+  });
+
   test("202 + operation_id, runs bun add + seeds services.json + spawns", async () => {
     const { supervisor, spawns } = makeIdleSupervisor();
     const { run, calls } = alwaysOkRun();

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -175,6 +175,18 @@ describe("GET /api/modules", () => {
     expect(body.error).toBe("insufficient_scope");
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_REQUIRED_SCOPE]);
+    const res = await handleApiModules(getReq({ authorization: `bearer ${bearer}` }), {
+      db: h.db,
+      issuer: ISSUER,
+      manifestPath: h.manifestPath,
+      fetchLatestVersion: async () => null,
+    });
+    expect(res.status).toBe(200);
+  });
+
   // hub#516: `parachute status` reads /api/modules on loopback presenting the
   // operator token, whose `iss` is the PUBLIC origin after `expose`. The
   // host-admin bearer's iss is validated against `knownIssuers` (loopback ∪
@@ -1464,6 +1476,18 @@ describe("PUT /api/modules/channel — hub#275 channel toggle", () => {
       issuer: ISSUER,
     });
     expect(res.status).toBe(401);
+  });
+
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const bearer = await mintBearer(h, [API_MODULES_CHANNEL_REQUIRED_SCOPE]);
+    const res = await handleApiModulesChannel(
+      putReq({ channel: "rc" }, { authorization: `bearer ${bearer}` }),
+      { db: h.db, issuer: ISSUER },
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { channel: string };
+    expect(body.channel).toBe("rc");
   });
 
   test("403 on bearer without parachute:host:admin", async () => {

--- a/src/__tests__/api-revoke-token.test.ts
+++ b/src/__tests__/api-revoke-token.test.ts
@@ -263,6 +263,29 @@ describe("POST /api/auth/revoke-token (closes hub#220)", () => {
     }
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const jti = await seedToken(db, userId);
+        const resp = await handleApiRevokeToken(
+          jsonRequest({ jti }, { authorization: `bearer ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { jti: string };
+        expect(body.jti).toBe(jti);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("idempotent: re-revoking returns 200 with the original revoked_at", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/api-settings-hub-origin.test.ts
+++ b/src/__tests__/api-settings-hub-origin.test.ts
@@ -258,6 +258,18 @@ describe("GET /api/settings/hub-origin", () => {
     expect(body.resolved_issuer).toBe("http://localhost"); // request origin from getReq()
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const bearer = await mintBearer(h, [API_SETTINGS_HUB_ORIGIN_REQUIRED_SCOPE]);
+    const res = await handleApiSettingsHubOrigin(
+      getReq({ authorization: `bearer ${bearer}` }),
+      deps(h),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { hub_origin: string | null };
+    expect(body.hub_origin).toBeNull();
+  });
+
   test("returns env source + env-resolved issuer when configuredIssuer is set", async () => {
     const bearer = await mintBearer(h, [API_SETTINGS_HUB_ORIGIN_REQUIRED_SCOPE]);
     const res = await handleApiSettingsHubOrigin(getReq({ authorization: `Bearer ${bearer}` }), {

--- a/src/__tests__/api-settings-root-redirect.test.ts
+++ b/src/__tests__/api-settings-root-redirect.test.ts
@@ -195,6 +195,18 @@ describe("GET /api/settings/root-redirect", () => {
     expect(body).toEqual({ root_redirect: null, resolved: "/admin", source: "default" });
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const bearer = await mintBearer(h, [API_SETTINGS_ROOT_REDIRECT_REQUIRED_SCOPE]);
+    const res = await handleApiSettingsRootRedirect(
+      getReq({ authorization: `bearer ${bearer}` }),
+      deps(h),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body).toEqual({ root_redirect: null, resolved: "/admin", source: "default" });
+  });
+
   test("reflects a stored value with source=db", async () => {
     setRootRedirect(h.db, "/surface/reading-room");
     const bearer = await mintBearer(h, [API_SETTINGS_ROOT_REDIRECT_REQUIRED_SCOPE]);

--- a/src/__tests__/api-tokens.test.ts
+++ b/src/__tests__/api-tokens.test.ts
@@ -139,6 +139,50 @@ describe("GET /api/auth/tokens (admin token list — Phase 2 backend)", () => {
     }
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("lowercase bearer scheme authenticates identically to canonical Bearer", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiTokens(
+          getRequest("", { authorization: `bearer ${op.token}` }),
+          {
+            db,
+            issuer: ISSUER,
+          },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { tokens: unknown[] };
+        expect(body.tokens).toHaveLength(1);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("mixed-case bearer scheme (BeArEr) authenticates identically to canonical Bearer", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiTokens(
+          getRequest("", { authorization: `BeArEr ${op.token}` }),
+          { db, issuer: ISSUER },
+        );
+        expect(resp.status).toBe(200);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("happy path: empty registry returns empty array", async () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/audience-gate.test.ts
+++ b/src/__tests__/audience-gate.test.ts
@@ -217,6 +217,30 @@ describe("audience gate matrix (H3)", () => {
     }
   });
 
+  // H1.1 — Bearer scheme is case-insensitive per RFC 7235 (V1.4/C1.3 parity).
+  test("audience: hub-users — lowercase/mixed-case bearer scheme authenticates identically to canonical Bearer", async () => {
+    const upstream = startEchoUpstream();
+    try {
+      writeServices(surfaceEntry(upstream.port, { audience: "hub-users" }));
+      const f = fetcher();
+      const bearer = await mintBearer(["vault:default:read", "vault:default:write"]);
+
+      const lower = await f(
+        req("/surface/notes/x", { headers: { authorization: `bearer ${bearer}` } }),
+        fakeServer("127.0.0.1"),
+      );
+      expect(lower?.status).toBe(200);
+
+      const mixed = await f(
+        req("/surface/notes/x", { headers: { authorization: `BeArEr ${bearer}` } }),
+        fakeServer("127.0.0.1"),
+      );
+      expect(mixed?.status).toBe(200);
+    } finally {
+      upstream.stop();
+    }
+  });
+
   test("audience: hub-users — Bearer with NON-satisfying scopes → 403; garbage Bearer → 401", async () => {
     const upstream = startEchoUpstream();
     try {

--- a/src/__tests__/bearer-scheme-casing.test.ts
+++ b/src/__tests__/bearer-scheme-casing.test.ts
@@ -1,0 +1,110 @@
+/**
+ * H1.1 (contracts-brief H1) — Bearer scheme-casing unification.
+ *
+ * RFC 7235 §2.1: the auth-scheme token ("Bearer") is case-insensitive; the
+ * credential (the token itself) is opaque and must be passed VERBATIM — never
+ * case-folded, never trimmed beyond surrounding whitespace. This mirrors
+ * parachute-vault's V1.4 (`BEARER_PREFIX`, case-insensitive) and
+ * parachute-cloud's C1.3 (`workers/vault/src/auth.ts:130-143`) — the other two
+ * door surfaces already converged on this shape; this file (plus the per-site
+ * tests below) closes the hub's half.
+ *
+ * Every converted call site (`src/api-hub-upgrade.ts`, `src/api-tokens.ts`,
+ * `src/api-revoke-token.ts`, `src/api-settings-root-redirect.ts`,
+ * `src/api-modules.ts` ×2, `src/api-modules-ops.ts`, `src/api-mint-token.ts`,
+ * `src/api-settings-hub-origin.ts`, `src/admin-surfaces.ts`,
+ * `src/admin-connections.ts` ×2, `src/audience-gate.ts`) uses the SAME
+ * two-step shape: a case-insensitive `/^Bearer\s+/i` scheme test, followed by
+ * the PRE-EXISTING `header.slice("Bearer ".length).trim()` extraction
+ * (unchanged — "Bearer ".length === "bearer ".length === 7, so the fixed-
+ * offset slice is casing-agnostic and the token substring is untouched).
+ * `src/admin-auth.ts`'s `extractBearerToken` (the documented shared helper,
+ * used by `requireScope` + several `/admin/*` and `/api/*` routes already)
+ * uses an equivalent `/^Bearer\s+(.+)$/i` regex. This file pins that shared
+ * pattern directly, independent of any one handler's DB/deps scaffolding.
+ *
+ * Live end-to-end coverage (a lowercase/mixed-case Authorization header
+ * reaching a real handler and authenticating) lives alongside each site's
+ * existing tests, NOT here:
+ *   - src/__tests__/api-hub-upgrade.test.ts
+ *   - src/__tests__/api-tokens.test.ts
+ *   - src/__tests__/api-revoke-token.test.ts
+ *   - src/__tests__/api-settings-root-redirect.test.ts
+ *   - src/__tests__/api-modules.test.ts (both handleApiModules + handleApiModulesChannel)
+ *   - src/__tests__/api-modules-ops.test.ts
+ *   - src/__tests__/api-mint-token.test.ts
+ *   - src/__tests__/api-settings-hub-origin.test.ts
+ *   - src/__tests__/admin-surfaces.test.ts
+ *   - src/__tests__/admin-connections-credentials.test.ts (renew + claim)
+ *   - src/__tests__/audience-gate.test.ts
+ */
+import { describe, expect, test } from "bun:test";
+import { extractBearerToken } from "../admin-auth.ts";
+
+/** The exact regex + slice shape used at all 12 converted call sites. */
+function siteShapeExtract(header: string | null): string | null {
+  if (!header || !/^Bearer\s+/i.test(header)) return null;
+  return header.slice("Bearer ".length).trim();
+}
+
+// A JWT-shaped token: base64url alphabet includes uppercase letters, so any
+// real access/operator token already exercises "verbatim, case preserved."
+// Use one explicitly so the pin doesn't depend on a real signer.
+const MIXED_CASE_TOKEN = "eyJhbGciOiJFZERTQSJ9.eyJzdWIiOiJBQkNkZWYxMjMifQ.SIGNATURE-Xyz";
+
+describe("H1.1 — site-shape extraction (regex test + fixed-offset slice)", () => {
+  test.each([
+    ["Bearer", `Bearer ${MIXED_CASE_TOKEN}`],
+    ["bearer", `bearer ${MIXED_CASE_TOKEN}`],
+    ["BEARER", `BEARER ${MIXED_CASE_TOKEN}`],
+    ["BeArEr", `BeArEr ${MIXED_CASE_TOKEN}`],
+    ["bEARER", `bEARER ${MIXED_CASE_TOKEN}`],
+  ])("scheme %s → token extracted verbatim, case preserved", (_label, header) => {
+    expect(siteShapeExtract(header)).toBe(MIXED_CASE_TOKEN);
+  });
+
+  test("wrong scheme keyword (not Bearer) → rejected regardless of case", () => {
+    expect(siteShapeExtract(`Basic ${MIXED_CASE_TOKEN}`)).toBeNull();
+    expect(siteShapeExtract(`Digest ${MIXED_CASE_TOKEN}`)).toBeNull();
+  });
+
+  test("missing header → rejected", () => {
+    expect(siteShapeExtract(null)).toBeNull();
+  });
+
+  test("scheme with no token → empty string (site's own 'empty bearer token' check catches this)", () => {
+    expect(siteShapeExtract("Bearer ")).toBe("");
+    expect(siteShapeExtract("bearer ")).toBe("");
+  });
+
+  test("extra internal whitespace after the scheme is tolerated (trim absorbs it), casing still ignored", () => {
+    expect(siteShapeExtract(`bearer   ${MIXED_CASE_TOKEN}`)).toBe(MIXED_CASE_TOKEN);
+    expect(siteShapeExtract(`Bearer\t${MIXED_CASE_TOKEN}`)).toBe(MIXED_CASE_TOKEN);
+  });
+});
+
+describe("H1.1 — admin-auth.ts extractBearerToken (the documented shared helper)", () => {
+  function reqWith(header: string | undefined): Request {
+    return new Request("http://127.0.0.1/admin/probe", {
+      headers: header !== undefined ? { authorization: header } : {},
+    });
+  }
+
+  test.each([
+    ["Bearer", `Bearer ${MIXED_CASE_TOKEN}`],
+    ["bearer", `bearer ${MIXED_CASE_TOKEN}`],
+    ["BeArEr", `BeArEr ${MIXED_CASE_TOKEN}`],
+  ])("scheme %s → extractBearerToken returns the token verbatim", (_label, header) => {
+    expect(extractBearerToken(reqWith(header))).toBe(MIXED_CASE_TOKEN);
+  });
+
+  test("missing Authorization header → AdminAuthError(401)", () => {
+    expect(() => extractBearerToken(reqWith(undefined))).toThrow(/missing Authorization header/);
+  });
+
+  test("non-Bearer scheme → AdminAuthError(401)", () => {
+    expect(() => extractBearerToken(reqWith(`Basic ${MIXED_CASE_TOKEN}`))).toThrow(
+      /Authorization header must be 'Bearer <token>'/,
+    );
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -3,6 +3,11 @@ import { createHash, randomBytes } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  checkAuthorizationServerMetadata,
+  checkProtectedResourceMetadata,
+  checkTokenResponseInvariants,
+} from "@openparachute/door-contract";
 import { handleAdminLoginPost, handleAdminLoginTotpPost } from "../admin-handlers.ts";
 import { approveClient, getClient, registerClient } from "../clients.ts";
 import { CSRF_COOKIE_NAME } from "../csrf.ts";
@@ -124,6 +129,10 @@ describe("authorizationServerMetadata", () => {
     expect(scopesSupported).not.toContain("scribe:admin");
     // Retired Agent scopes are no longer part of the first-party catalog.
     expect(scopesSupported).not.toContain("agent:send");
+    // H1.2 — door-contract conformance: the static RFC 8414 fields (endpoints,
+    // response/grant types, PKCE method, token-auth methods) match the shared
+    // contract exactly (V1.4/C1.4 twin coverage, hub half).
+    expect(checkAuthorizationServerMetadata(body, ISSUER, scopesSupported)).toEqual([]);
   });
 
   test("does NOT advertise non-requestable operator-only scopes", async () => {
@@ -261,6 +270,8 @@ describe("protectedResourceMetadata (RFC 9728, closes hub#393)", () => {
     expect(body.resource).toBe(ISSUER);
     expect(body.authorization_servers).toEqual([ISSUER]);
     expect(body.bearer_methods_supported).toEqual(["header"]);
+    // H1.2 — door-contract conformance (V1.4/C1.4 twin coverage, hub half).
+    expect(checkProtectedResourceMetadata(body, ISSUER)).toEqual([]);
     expect(Array.isArray(body.scopes_supported)).toBe(true);
     expect(body.resource_documentation).toMatch(/parachute\.computer/);
   });
@@ -2316,6 +2327,10 @@ describe("handleToken — full OAuth dance", () => {
       expect(tokenBody.token_type).toBe("Bearer");
       expect(tokenBody.scope).toBe("vault:default:read");
       expect(tokenBody.refresh_token.length).toBeGreaterThan(20);
+      // H1.2 — door-contract conformance: token_type/expires_in/scope/access_token
+      // invariants against a REAL `POST /oauth/token` success body (V1.4/C1.4 twin
+      // coverage, hub half).
+      expect(checkTokenResponseInvariants(tokenBody, "vault:default:read")).toEqual([]);
 
       // JWT must verify against the hub's signing keys, with the right sub +
       // aud (named `vault:default:read` → "vault.default" — RFC 8707-style

--- a/src/admin-connections.ts
+++ b/src/admin-connections.ts
@@ -1082,7 +1082,8 @@ async function renewCredentialConnection(
   }
 
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(
       401,
       "unauthenticated",
@@ -1257,7 +1258,8 @@ async function claimCredentialConnection(
   }
 
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(
       401,
       "unauthenticated",

--- a/src/admin-surfaces.ts
+++ b/src/admin-surfaces.ts
@@ -61,7 +61,8 @@ function jsonError(status: number, error: string, description: string): Response
 /** Validate the operator bearer + require the surfaces scope. Mirrors api-modules-ops. */
 async function authorize(req: Request, deps: AdminSurfacesDeps): Promise<Response | undefined> {
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-hub-upgrade.ts
+++ b/src/api-hub-upgrade.ts
@@ -158,7 +158,8 @@ interface ParsedBody {
 
 async function authorize(req: Request, deps: ApiHubUpgradeDeps): Promise<Response | undefined> {
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -132,7 +132,8 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
 
   // 1. Bearer presence + parsing.
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -308,7 +308,8 @@ export function parseModulesPath(pathname: string): PathMatch | undefined {
 
 async function authorize(req: Request, deps: ApiModulesOpsDeps): Promise<Response | undefined> {
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-modules.ts
+++ b/src/api-modules.ts
@@ -462,7 +462,8 @@ export async function handleApiModules(req: Request, deps: ApiModulesDeps): Prom
 
   // Bearer presence + parsing.
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();
@@ -780,7 +781,8 @@ export async function handleApiModulesChannel(
 
   // Bearer presence + parsing.
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-revoke-token.ts
+++ b/src/api-revoke-token.ts
@@ -100,7 +100,8 @@ export async function handleApiRevokeToken(
 
   // 1. Bearer presence + parsing.
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-settings-hub-origin.ts
+++ b/src/api-settings-hub-origin.ts
@@ -185,7 +185,8 @@ export async function handleApiSettingsHubOrigin(
   // Bearer presence + parsing — identical shape to api-modules
   // for consistency across hub-internal admin endpoints.
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-settings-root-redirect.ts
+++ b/src/api-settings-root-redirect.ts
@@ -119,7 +119,8 @@ export async function handleApiSettingsRootRedirect(
   // Bearer presence + parsing — identical shape to api-settings-hub-origin
   // for consistency across hub-internal admin endpoints.
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/api-tokens.ts
+++ b/src/api-tokens.ts
@@ -113,7 +113,8 @@ export async function handleApiTokens(req: Request, deps: ApiTokensDeps): Promis
 
   // 1. Bearer presence + parsing.
   const auth = req.headers.get("authorization");
-  if (!auth || !auth.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (!auth || !/^Bearer\s+/i.test(auth)) {
     return jsonError(401, "unauthenticated", "Authorization: Bearer <token> required");
   }
   const bearer = auth.slice("Bearer ".length).trim();

--- a/src/audience-gate.ts
+++ b/src/audience-gate.ts
@@ -235,7 +235,8 @@ export async function gateUiAudience(
   if (session) return null;
 
   const auth = req.headers.get("authorization");
-  if (auth?.startsWith("Bearer ")) {
+  // Bearer scheme is case-insensitive per RFC 7235; token passed verbatim (V1.4/C1.3 parity).
+  if (auth && /^Bearer\s+/i.test(auth)) {
     const token = auth.slice("Bearer ".length).trim();
     try {
       const validated = await validateHostAdminToken(db, token, [...deps.knownIssuers()]);

--- a/src/module-ops-client.ts
+++ b/src/module-ops-client.ts
@@ -376,7 +376,8 @@ export async function fetchModuleStates(deps: DriveModuleOpDeps): Promise<Module
   try {
     res = await doFetch(`${baseUrl}/api/modules`, {
       method: "GET",
-      // `/api/modules` parses the scheme-cased `Bearer ` prefix; match it exactly.
+      // `/api/modules` parses the Bearer scheme case-insensitively (RFC 7235,
+      // V1.4/C1.3 parity); we still emit the canonical `Bearer ` prefix.
       headers: { authorization: `Bearer ${bearer}` },
       // Bound the read so a wedged hub handler degrades `status` rather than
       // hanging it. AbortSignal.timeout fires `AbortError` once the ceiling


### PR DESCRIPTION
## Summary

This PR is **"contracts-brief H1"** — the hub wave of the cross-door contract-parity program. **Naming note:** hub PR #746 (merged) was also called "H1", but for a *different* campaign (#116). This PR is unrelated to that one.

Context: parachute-vault merged V1.4 (case-insensitive Bearer scheme) and parachute-cloud merged C1.3 (same, `workers/vault/src/auth.ts:130-143`); cloud's identity worker has been case-insensitive since PR #130. The hub was the last door surface with case-sensitive Bearer parsing, and internally split (2/14 sites already case-insensitive via `admin-auth.ts`'s `extractBearerToken`). Cloud identity also runs `@openparachute/door-contract` 0.4.0 conformance checkers against its live runtime; the hub only wired 2 of 7. This PR closes both gaps, plus pins the current `/account/*` error-shape contract.

### H1.1 — Bearer scheme-casing unification (RFC 7235)

RFC 7235 §2.1: the auth-scheme token is case-insensitive; the credential (token) is passed VERBATIM. Converted all 12 remaining case-sensitive `startsWith("Bearer ")` sites to an inline `/^Bearer\s+/i` regex test (with a one-line RFC 7235 / V1.4 / C1.3 comment), keeping each site's own downstream extraction (`slice("Bearer ".length).trim()`), error messages, and 401/403 flow byte-identical — only the scheme-detection step changed:

- `src/api-hub-upgrade.ts`, `src/api-tokens.ts`, `src/api-revoke-token.ts`, `src/api-settings-root-redirect.ts`, `src/api-modules.ts` (×2 — `handleApiModules` + `handleApiModulesChannel`), `src/api-modules-ops.ts`, `src/api-mint-token.ts`, `src/api-settings-hub-origin.ts`, `src/admin-surfaces.ts`, `src/admin-connections.ts` (×2 — renew + claim), `src/audience-gate.ts`

`grep -rn 'startsWith("Bearer' src/` now returns zero production hits (the one remaining hit, in `git-notify.test.ts`, asserts a *producer* still emits the canonical `Bearer ` prefix — correct, unchanged). `src/module-ops-client.ts`'s stale comment (claiming `/api/modules` parses the scheme-cased prefix) is corrected to note case-insensitivity.

**Tests**: every converted site has at least one live-handler test proving a lowercase `bearer <token>` header authenticates identically to canonical `Bearer <token>` (extended each handler's existing test file, reusing its existing bootstrap/token-minting helpers — no new scaffolding). A mixed-case (`BeArEr`) variant is covered in `api-tokens.test.ts` and `audience-gate.test.ts`. A new standalone `src/__tests__/bearer-scheme-casing.test.ts` pins the shared extraction pattern at the regex level (no DB/handler dependencies) and explicitly proves a token containing uppercase characters survives extraction byte-for-byte, for both the inline site-shape pattern and `admin-auth.ts`'s `extractBearerToken`.

### H1.2 — door-contract live-handler conformance (X1 hub half)

Wired the remaining 5 of 7 door-contract conformance checkers to REAL hub handlers, joining the 2 already wired (`account-api.test.ts`'s `checkAccountDescriptor` against live `handleAccountCapabilities`, `account-session.test.ts`'s `checkAccountSessionResponse` against live `handleAccountSession`):

| Checker | Wired against |
|---|---|
| `checkTokenResponseInvariants` | a REAL `POST /oauth/token` success body — bolted onto the existing "authorize → token → validate JWT" full-dance test in `oauth-handlers.test.ts` (no new OAuth dance built) |
| `checkAuthorizationServerMetadata` | the live `/.well-known/oauth-authorization-server` handler (`authorizationServerMetadata`) |
| `checkProtectedResourceMetadata` | the live `/.well-known/oauth-protected-resource` handler (`protectedResourceMetadata`) — the hub DOES serve RFC 9728 (closes hub#393), so this was **not** skipped |
| `checkAccountTokenMintResponse` | the live `POST /account/token` handler (`handleAccountToken`, `account-token.ts`) |
| `checkVaultTokenMintResponse` | the live `POST /account/vaults/<name>/token` handler (`handleAccountMintVaultToken`, `account-api.ts`) |

**All 7 checkers in the package are now wired on the hub side — none deferred.** Every addition bolted onto an existing passing test (same pattern as the 2 pre-existing wirings), no handler mocking/weakening.

### H1.3 — `/account/*` error-shape contract (pin, don't change)

Extended representative existing tests (not exhaustive) in `account-token.test.ts`, `account-session.test.ts`, and `account-api.test.ts` to assert the CURRENT wire shape without changing any response body:

- Auth-gate failures emit `{error, error_description}` (the shared `adminAuthErrorResponse` translator, and `account-token.ts`'s own local `jsonError`).
- Resource-level failures emit `{error, message}` (`account-api.ts`, `account-session.ts`).
- Emitted error codes are checked against door-contract's `ACCOUNT_ERROR_CODES` union where they're a member.

**Decisions-needed** (found, deliberately left unpinned/unfixed — listed per the task, not resolved):
1. `account-token.ts`'s 405 emits `{error, error_description}` while `account-session.ts`'s 405 emits `{error, message}` — the two `/account/*` handlers disagree on 405 shape.
2. `account-token.ts`'s `"not_admin"` error code (emitted on the friend-privesc-closure path) is **not** a member of door-contract's `ACCOUNT_ERROR_CODES` — a real gap in the shared vocabulary. Test comment flags it; no assertion of membership was added for it (documented, not silently pinned as passing).
3. `src/api-revocation-list.ts` (outside `/account/*` — `/.well-known/parachute-revocation.json`) emits `{error}` alone, a third shape. Named explicitly in the task brief; cataloged here since it's the same underlying "shape convention" concern, though technically off-surface.

## Gate results (both runs identical)

- `bun test ./src` — **4251 pass, 1 skip, 40 fail, 39457 expect() calls, 4292 tests across 162 files** (both runs). All 40 failures are in `src/__tests__/install.test.ts`, at `sizeOf` in `src/commands/migrate.ts` — a pre-existing environmental flake (the test walks the real live `~/.parachute` tree and races a `stat()` against files the operator's actual running hub/agent processes are mutating concurrently — `ENOENT` on a bun-cache path). **Confirmed pre-existing**: reproduces identically (44 pass / 40 fail) on a clean `main` checkout with none of this PR's changes applied (verified via `git stash` + re-run). None of this PR's files intersect `install.test.ts` or `migrate.ts`.
- `bun run typecheck` — clean, both runs (`tsc --noEmit`, no output).
- `bunx biome check .` — fixed one real formatting issue introduced in `api-tokens.test.ts` (`--write`, verified clean after). Final state: **16 errors, 4 warnings — identical to the `main` baseline** (verified via `git stash` diff of diagnostic locations); the only line-number drift is a pre-existing `api-modules.test.ts` suppression/any-lint pair that shifted because new tests were inserted earlier in the file (not a new finding).

Hub-only counts cited per CLAUDE.md (scope-guard/door-contract untouched by this PR — door-contract is *imported*, not modified).

## Version

`0.7.7-rc.11` → `0.7.7-rc.12`. CHANGELOG entry added at top.

## Do not merge

This PR awaits an independent reviewer dispatched by the orchestrator.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB
