### PR TITLE
feat(door-contract): account:<id>:vaults scope grammar (Wave A PR1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.13",
+  "version": "0.7.7-rc.14",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -1,5 +1,45 @@
 # @openparachute/door-contract
 
+## 0.5.0
+
+The `account:<id>:vaults` scope grammar (Wave A PR1) — the foundation the cloud
+Wave A PRs consume as a pinned dependency (a cloud pin-bump follows). Wave A is
+an account-level MCP connection (list-vaults + create-vault + query-across-vaults)
+opened by a NEW narrow requestable scope, the SINGLE deliberate exception to the
+account wall. Purely additive: new exports + one optional descriptor field, zero
+change to any existing signature or behavior.
+
+New in `scopes.ts` (re-exported from the package root):
+
+- `isRequestableAccountScope(scope)` — the account wall stays closed except for
+  the account-vaults connection scope. `account:vaults` (un-narrowed, the
+  PRM-advertised request form) and `account:<id>:vaults` (consent-bound blanket)
+  are requestable; `account:<id>:{admin,read}`, `account:admin`, `account:read`,
+  and the 4-part `account:<id>:vaults:<vault>` (consent-narrowed — consent
+  narrows, a client can't pre-narrow itself) are NOT. Exact-lowercase; casing
+  variants fail closed.
+- `ACCOUNT_VAULTS_VERB` (`"vaults"`), `ACCOUNT_VAULTS_UNNARROWED`
+  (`"account:vaults"`), and `accountVaultsScope(id)` → `account:<id>:vaults`.
+- `parseAccountVaultsScope(scope)` — 3-part → `{ id, vault: null }` (blanket),
+  4-part → `{ id, vault }` (narrowed), else `null` (fail-closed on empty id/vault
+  or extra parts).
+- `accountVaultsGrant(grantedScopes, accountId)` — the coverage-set deriver:
+  `{ blanket: true }` when a bare 3-part scope for this id is present (blanket
+  always wins), else `{ vaults: [...] }` (the de-duped set of narrowed vault
+  names for this id), else `null`. Foreign-id scopes are ignored.
+
+The narrowing rides the SCOPE STRING (a set of 4-part scopes), NOT a side
+`vault_scope` claim — a vault_scope wouldn't survive token refresh, whereas the
+scope string does. The existing `account:<id>:<verb>` grammar
+(`parseAccountScope` / `hasAccountScope` / `NON_REQUESTABLE_SCOPES`) and the REST
+read/admin ladder are untouched.
+
+`ParachuteAccountDescriptor` gains an optional `account_mcp_endpoint?: string` —
+the account-MCP endpoint a client opens against the `account:<id>:vaults` scope.
+Unset today (no door advertises it yet; `checkAccountDescriptor` does not require
+it). This bump does NOT flip the `auth` field required — that flip stays gated on
+both doors serving it (its own later PR), out of scope for this additive change.
+
 ## 0.4.0
 
 The auth block + the session/token wire canon (hub-parity P0). `signup_path` and

--- a/packages/door-contract/package.json
+++ b/packages/door-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/door-contract",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "The Parachute door contract: shared OAuth-issuer + /account/* wire types, constants, and conformance vectors that both doors (self-host hub + hosted cloud) implement.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -5,10 +5,14 @@ import {
   ACCOUNT_ROUTES,
   ACCOUNT_SELF_ADMIN_SCOPE,
   ACCOUNT_SELF_READ_SCOPE,
+  ACCOUNT_VAULTS_UNNARROWED,
+  ACCOUNT_VAULTS_VERB,
   REFRESH_GRACE_MS,
   REFRESH_TOKEN_TTL_MS,
   TOKEN_TYPE,
   accountScope,
+  accountVaultsGrant,
+  accountVaultsScope,
   checkAccountDescriptor,
   checkAccountSessionResponse,
   checkAccountTokenMintResponse,
@@ -19,7 +23,9 @@ import {
   expectedAuthorizationServerMetadata,
   expectedProtectedResourceMetadata,
   hasAccountScope,
+  isRequestableAccountScope,
   parseAccountScope,
+  parseAccountVaultsScope,
   validateVaultScopes,
 } from "../index.js";
 
@@ -66,6 +72,98 @@ describe("account scope grammar", () => {
     expect(hasAccountScope(["account:self:read"], "self", "admin")).toBe(false);
     expect(hasAccountScope(["account:u_1:admin"], "u_2", "read")).toBe(false);
     expect(hasAccountScope(["vault:x:admin"], "self", "read")).toBe(false);
+  });
+});
+
+describe("account-vaults scope grammar (Wave A)", () => {
+  test("constants + builder", () => {
+    expect(ACCOUNT_VAULTS_VERB).toBe("vaults");
+    expect(ACCOUNT_VAULTS_UNNARROWED).toBe("account:vaults");
+    expect(accountVaultsScope("self")).toBe("account:self:vaults");
+    expect(accountVaultsScope("u_123")).toBe("account:u_123:vaults");
+  });
+
+  // The account wall stays closed to everything except the account-vaults
+  // connection scope — the single deliberate exception (Wave A). This table is
+  // the requestable/refused contract the door's consent gate enforces.
+  test("isRequestableAccountScope — the requestable/refused vector table", () => {
+    // Requestable: the un-narrowed PRM form + the consent-bound blanket form.
+    for (const scope of ["account:vaults", "account:self:vaults", "account:u_123:vaults"]) {
+      expect(isRequestableAccountScope(scope)).toBe(true);
+    }
+    // Refused: the account wall (admin/read, 2- and 3-part), the 4-part
+    // consent-NARROWED form (consent narrows; a client can't pre-narrow itself),
+    // casing variants (exact-lowercase, fail closed), and non-account scopes.
+    for (const scope of [
+      "account:self:admin",
+      "account:self:read",
+      "account:u_123:admin",
+      "account:u_123:read",
+      "account:admin",
+      "account:read",
+      "account:self:vaults:work", // 4-part narrowed — NOT requestable
+      "account:self:vaults:work:extra", // over-long
+      "account::vaults", // empty id
+      "Account:self:vaults", // casing
+      "account:self:Vaults", // casing
+      "account:vaults:extra", // 3-part but not <id>:vaults
+      "vault:work:read", // non-account
+      "account", // bare
+      "",
+    ]) {
+      expect(isRequestableAccountScope(scope)).toBe(false);
+    }
+  });
+
+  test("parseAccountVaultsScope — blanket / narrowed / foreign / malformed", () => {
+    // 3-part blanket.
+    expect(parseAccountVaultsScope("account:self:vaults")).toEqual({ id: "self", vault: null });
+    expect(parseAccountVaultsScope("account:u_1:vaults")).toEqual({ id: "u_1", vault: null });
+    // 4-part narrowed.
+    expect(parseAccountVaultsScope("account:self:vaults:work")).toEqual({
+      id: "self",
+      vault: "work",
+    });
+    expect(parseAccountVaultsScope("account:u_1:vaults:moss")).toEqual({
+      id: "u_1",
+      vault: "moss",
+    });
+    // Malformed / non-member → null.
+    expect(parseAccountVaultsScope("account:self:admin")).toBeNull(); // wrong verb
+    expect(parseAccountVaultsScope("account:self:read")).toBeNull(); // wrong verb
+    expect(parseAccountVaultsScope("vault:work:read")).toBeNull(); // wrong resource
+    expect(parseAccountVaultsScope("account::vaults")).toBeNull(); // empty id (3-part)
+    expect(parseAccountVaultsScope("account::vaults:work")).toBeNull(); // empty id (4-part)
+    expect(parseAccountVaultsScope("account:self:vaults:")).toBeNull(); // empty vault
+    expect(parseAccountVaultsScope("account:vaults")).toBeNull(); // 2-part un-narrowed has no id
+    expect(parseAccountVaultsScope("account:self:vaults:a:b")).toBeNull(); // over-long
+  });
+
+  test("accountVaultsGrant — blanket wins, narrowed set, foreign-id ignored, empty→null", () => {
+    // Blanket present → { blanket: true } (covers every vault the account owns).
+    expect(accountVaultsGrant(["account:self:vaults"], "self")).toEqual({ blanket: true });
+    // Blanket wins even alongside narrowed scopes and regardless of order.
+    expect(accountVaultsGrant(["account:self:vaults:work", "account:self:vaults"], "self")).toEqual(
+      { blanket: true },
+    );
+    // Narrowed only → the de-duped set of vault names.
+    expect(accountVaultsGrant(["account:self:vaults:work"], "self")).toEqual({ vaults: ["work"] });
+    expect(
+      accountVaultsGrant(
+        ["account:self:vaults:work", "account:self:vaults:moss", "account:self:vaults:work"],
+        "self",
+      ),
+    ).toEqual({ vaults: ["work", "moss"] });
+    // Foreign-id scopes are ignored — a grant for account A never covers B.
+    expect(accountVaultsGrant(["account:u_2:vaults"], "u_1")).toBeNull();
+    expect(accountVaultsGrant(["account:u_2:vaults:work"], "u_1")).toBeNull();
+    // A foreign blanket alongside this id's narrowed → only this id's set.
+    expect(accountVaultsGrant(["account:u_2:vaults", "account:u_1:vaults:work"], "u_1")).toEqual({
+      vaults: ["work"],
+    });
+    // No account-vaults scope at all → null.
+    expect(accountVaultsGrant([], "self")).toBeNull();
+    expect(accountVaultsGrant(["account:self:admin", "vault:work:read"], "self")).toBeNull();
   });
 });
 

--- a/packages/door-contract/src/account-contract.ts
+++ b/packages/door-contract/src/account-contract.ts
@@ -138,6 +138,14 @@ export interface ParachuteAccountDescriptor {
   /** The `/account/*` API base — always `${issuer}/account`. */
   account_endpoint: string;
   /**
+   * The account-level MCP endpoint (Wave A) — the connection a client opens
+   * against the `account:<id>:vaults` scope for list-vaults + create-vault +
+   * query-across-vaults. Optional and unset today: no door advertises it yet
+   * (`checkAccountDescriptor` does not require it). Present only once a door
+   * mounts its account-MCP surface.
+   */
+  account_mcp_endpoint?: string;
+  /**
    * How a person signs IN at this door. Optional in 0.4.0 so cloud@main keeps
    * typechecking while it lands its own twin (P3); P7 flips this required once
    * both doors serve it.

--- a/packages/door-contract/src/index.ts
+++ b/packages/door-contract/src/index.ts
@@ -41,6 +41,12 @@ export {
   accountScope,
   parseAccountScope,
   hasAccountScope,
+  ACCOUNT_VAULTS_VERB,
+  ACCOUNT_VAULTS_UNNARROWED,
+  accountVaultsScope,
+  isRequestableAccountScope,
+  parseAccountVaultsScope,
+  accountVaultsGrant,
 } from "./scopes.js";
 
 export {

--- a/packages/door-contract/src/scopes.ts
+++ b/packages/door-contract/src/scopes.ts
@@ -69,3 +69,110 @@ export function hasAccountScope(
   }
   return false;
 }
+
+/**
+ * The account-vaults scope family (Wave A) — the SINGLE deliberate exception to
+ * the account wall. `account:<id>:{admin,read}` stay non-requestable (an OAuth
+ * client can never ask for the whole account); the ONE requestable account scope
+ * is the account-MCP connection scope `account:<id>:vaults`, which opens exactly
+ * the narrow account-MCP surface (list-vaults + create-vault + query-across).
+ *
+ * Two forms carry the grant:
+ *   - `account:vaults` — the un-narrowed, PRM-advertised request form (no id yet;
+ *     the door binds the id at consent).
+ *   - `account:<id>:vaults` — the consent-bound BLANKET grant: every vault the
+ *     account owns.
+ *   - `account:<id>:vaults:<vault>` — the consent-NARROWED grant: only the named
+ *     vault(s). The narrowing rides the SCOPE STRING (not a side `vault_scope`
+ *     claim, which doesn't survive token refresh), so a set of 4-part scopes is
+ *     how "these specific vaults" is expressed on the wire.
+ *
+ * The 4-part narrowed form is deliberately NOT requestable — a client asks for
+ * the blanket/un-narrowed form and the CONSENT step narrows it; a client cannot
+ * pre-narrow itself into a specific-vault grant.
+ */
+
+/** The verb rung that opens the account-MCP surface. */
+export const ACCOUNT_VAULTS_VERB = "vaults";
+
+/** The un-narrowed, PRM-advertised request form (`account:vaults`, id bound at consent). */
+export const ACCOUNT_VAULTS_UNNARROWED = "account:vaults";
+
+/** Build the consent-bound blanket account-vaults scope (`account:<id>:vaults`). */
+export function accountVaultsScope(id: string): string {
+  return `account:${id}:${ACCOUNT_VAULTS_VERB}`;
+}
+
+/**
+ * Is `scope` a REQUESTABLE account scope? The account wall stays closed to
+ * everything except the account-vaults connection scope:
+ *   - `account:vaults` (un-narrowed, PRM form) → requestable.
+ *   - `account:<id>:vaults` (consent-bound blanket) → requestable.
+ *   - `account:<id>:{admin,read}`, `account:admin`, `account:read` → NOT.
+ *   - `account:<id>:vaults:<vault>` (4-part, consent-narrowed) → NOT (consent
+ *     narrows; a client can't pre-narrow itself).
+ *
+ * Exact-lowercase: casing variants (`Account:...`, `...:Vaults`) fail closed.
+ */
+export function isRequestableAccountScope(scope: string): boolean {
+  const parts = scope.split(":");
+  if (parts[0] !== "account") return false;
+  if (parts.length === 2) return parts[1] === "vaults";
+  if (parts.length === 3) {
+    const [, id, verb] = parts as [string, string, string];
+    return verb === ACCOUNT_VAULTS_VERB && id.length > 0;
+  }
+  return false;
+}
+
+/**
+ * Parse an `account:<id>:vaults[:<vault>]` scope into its id + (optional) vault.
+ *   - 3-part `account:<id>:vaults` → `{ id, vault: null }` (blanket).
+ *   - 4-part `account:<id>:vaults:<vault>` → `{ id, vault }` (narrowed).
+ *   - anything else (wrong resource, wrong verb, empty id/vault, extra parts) →
+ *     `null`.
+ * Fail-closed: an empty id or empty vault name yields `null`.
+ */
+export function parseAccountVaultsScope(
+  scope: string,
+): { id: string; vault: string | null } | null {
+  const parts = scope.split(":");
+  if (parts[0] !== "account") return null;
+  if (parts.length === 3) {
+    const [, id, verb] = parts as [string, string, string];
+    if (verb !== ACCOUNT_VAULTS_VERB || id.length === 0) return null;
+    return { id, vault: null };
+  }
+  if (parts.length === 4) {
+    const [, id, verb, vault] = parts as [string, string, string, string];
+    if (verb !== ACCOUNT_VAULTS_VERB || id.length === 0 || vault.length === 0) return null;
+    return { id, vault };
+  }
+  return null;
+}
+
+/**
+ * Derive what an account-vaults grant COVERS for `accountId` from a granted
+ * scope set:
+ *   - `{ blanket: true }` — a bare 3-part `account:<accountId>:vaults` is present
+ *     (blanket always wins; it covers every vault the account owns).
+ *   - `{ vaults: [...] }` — no blanket, but one or more 4-part
+ *     `account:<accountId>:vaults:<vault>` are present (the de-duped set of the
+ *     specifically-granted vault names).
+ *   - `null` — no account-vaults scope for THIS id at all.
+ * Scopes for a different `<id>` are ignored (a grant for account A never covers
+ * account B).
+ */
+export function accountVaultsGrant(
+  grantedScopes: readonly string[],
+  accountId: string,
+): { blanket: true } | { vaults: string[] } | null {
+  const vaults: string[] = [];
+  for (const s of grantedScopes) {
+    const parsed = parseAccountVaultsScope(s);
+    if (!parsed || parsed.id !== accountId) continue;
+    if (parsed.vault === null) return { blanket: true };
+    if (!vaults.includes(parsed.vault)) vaults.push(parsed.vault);
+  }
+  return vaults.length > 0 ? { vaults } : null;
+}


### PR DESCRIPTION
## What

PR1 of the Wave A account-MCP train: the `account:<id>:vaults` scope grammar in the shared `@openparachute/door-contract` package. Wave A opens an account-level MCP connection (list-vaults + create-vault + query-notes-across-vaults) via a NEW narrow requestable scope — the single deliberate exception to the account wall.

## Why

cloud consumes door-contract as a **pinned file dependency**, so this hub PR lands first; the cloud Wave A PRs then bump their pin to `0.5.0` and build on these exports. This PR is purely the foundation — **additive, zero behavior change**.

## The additive exports (`packages/door-contract/src/scopes.ts`, re-exported from the root)

- `isRequestableAccountScope(scope)` — the account wall stays closed except for the account-vaults connection scope. Requestable: `account:vaults` (un-narrowed, PRM-advertised form) and `account:<id>:vaults` (consent-bound blanket). **NOT** requestable: `account:<id>:{admin,read}`, `account:admin`, `account:read`, and the 4-part `account:<id>:vaults:<vault>` (consent narrows a grant; a client can't pre-narrow itself). Exact-lowercase — casing variants fail closed.
- `ACCOUNT_VAULTS_VERB` (`"vaults"`), `ACCOUNT_VAULTS_UNNARROWED` (`"account:vaults"`), `accountVaultsScope(id)` → `account:<id>:vaults`.
- `parseAccountVaultsScope(scope)` — 3-part → `{ id, vault: null }` (blanket), 4-part → `{ id, vault }` (narrowed), else `null` (fail-closed on empty id/vault or extra parts).
- `accountVaultsGrant(granted, accountId)` — coverage-set deriver: `{ blanket: true }` (a bare 3-part for this id, blanket always wins) | `{ vaults: [...] }` (de-duped narrowed set for this id) | `null`. Foreign-id scopes ignored.

The narrowed-to-specific-vaults grant rides the **scope string** (a set of 4-part scopes), NOT a side `vault_scope` claim — a vault_scope wouldn't survive token refresh, the scope string does.

`ParachuteAccountDescriptor` gains an optional `account_mcp_endpoint?: string` (the account-MCP endpoint a client opens against the scope) — unset today, nobody advertises it yet, `checkAccountDescriptor` does not require it.

## Untouched (deliberately)

The existing `account:<id>:<verb>` grammar — `parseAccountScope` / `hasAccountScope` / `NON_REQUESTABLE_SCOPES` — and the REST read/admin ladder do not shift. The version bump does NOT flip the `auth` field required (that stays gated on both doors serving it, its own later PR). Hub's own account-MCP is Wave C, not this PR.

## Tests

New `account-vaults scope grammar (Wave A)` block in `vectors.test.ts`: the requestable/refused vector table (positives + every negative above, incl. casing + 4-part), `parseAccountVaultsScope` round-trips (blanket / narrowed / foreign / malformed), and `accountVaultsGrant` derivation (blanket-wins / narrowed set / foreign-id-ignored / empty→null). Existing corpus assertions unchanged (exports are purely additive).

## Gates (verdict lines, not tailed)

- `bun test packages/door-contract/src` → **63 pass / 0 fail** (183 expect)
- door-contract `tsc --noEmit` → clean
- hub `bun run typecheck` → clean (exit 0)
- door-contract-consuming hub tests (oauth-handlers, account-token, account-api, account-session, door-contract-parity — the acceptance parity suite) → **312 pass / 0 fail** (1110 expect)
- `bunx biome check packages/door-contract/src` → clean

## Versions

door-contract `0.4.0 → 0.5.0` (+ CHANGELOG); hub root `0.7.7-rc.13 → 0.7.7-rc.14`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB