### PR TITLE
feat(door-contract): composed-MCP scope grammar (unified /mcp Phase 1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.14",
+  "version": "0.7.7-rc.15",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -1,5 +1,67 @@
 # @openparachute/door-contract
 
+## 0.6.0
+
+The COMPOSED account-scope grammar (unified `/mcp` — Phase 1). The ratified
+unified-MCP design collapses the per-resource MCP endpoints into ONE `/mcp`
+gateway whose OAuth consent composes a single grant across the account, its
+vaults, the "create vaults" capability, and future modules; the whole composed
+grant rides one `aud="account"` token that the gateway decomposes per-call into
+60s single-audience mints. Because the gateway owns decomposition, ALL composed
+vault/module authority is encoded INSIDE the `account:` namespace (never a raw
+`vault:<name>:<verb>`, which `inferAudience` would stamp as a vault audience and
+route around the gateway).
+
+This bump only DEFINES + PARSES the grammar — nothing emits or mints these forms
+yet; consent, minting, and the gateway are LATER phases that consume this
+vocabulary. Purely additive: new exports only, zero change to any existing
+signature or behavior, and every new form is NON-REQUESTABLE (consent is the sole
+author — `isRequestableAccountScope` is unchanged and refuses all of them).
+
+New granted forms (all consent-authored, none requestable):
+
+- `account:<id>:vaults:*:<verb>` — WILDCARD vault grant (every owned vault at
+  `<verb>`; `*` can never collide with a vault name — the vault-name charset
+  excludes `*`).
+- `account:<id>:vaults:<vault>:<verb>` — per-vault 5-part grant at a verb.
+- `account:<id>:vault-create` — the "create new vaults" capability (a distinct
+  3-part verb-slot, NOT a member of the `vaults` family).
+- `account:<id>:mod:<module>:<verb>` — module grant (future modules).
+
+`<verb>` is the three-rung vault/module ladder `read|write|admin` (distinct from
+the two-rung account ladder `read|admin`). The LEGACY Wave A forms keep their
+exact frozen meaning — `account:<id>:vaults` (blanket) and
+`account:<id>:vaults:<vault>` (4-part narrowed) parse identically; existing
+tokens + refresh families are untouched.
+
+New in `scopes.ts` (re-exported from the package root):
+
+- `ComposedVaultVerb` + `COMPOSED_VERB_RANK` (`admin ⊇ write ⊇ read`) +
+  `isComposedVaultVerb` + `composedVerbSatisfies(granted, required)` — the verb
+  ladder + the "requiredVerb ≤ grantedVerb" helper the later mint phase uses.
+- Segment/sentinel constants (`COMPOSED_VAULTS_WILDCARD`,
+  `COMPOSED_VAULTS_SEGMENT`, `COMPOSED_VAULT_CREATE_VERB`,
+  `COMPOSED_MODULE_SEGMENT`) + builders (`composedWildcardVaultsScope`,
+  `composedVaultScope`, `composedVaultCreateScope`, `composedModuleScope`).
+- `ComposedAccountScope` + `parseComposedAccountScope(scope)` — a fail-closed,
+  discriminated-union recognizer that is deliberately a SUPERSET (covers the new
+  composed families AND the legacy Wave A forms) so ONE pass extracts `<id>` from
+  every `account:`-namespaced grant. §1.4 rationale: the hub's cross-account mint
+  gate id-checks only the forms its parser recognizes — a form parsing to `null`
+  would SKIP the id check; recognizing every family here means that when a later
+  phase makes them mintable, the gate already extracts (and can reject) a
+  foreign-id composed scope. `*` is ONLY ever the wildcard sentinel — never a
+  concrete vault name.
+- `ComposedAccountCoverage` + `composedAccountGrant(grantedScopes, accountId)` —
+  the coverage deriver over the verb-carrying composed forms: `wildcard` (highest
+  wildcard verb, or null), `vaults` (Map name→highest verb), `create` (boolean),
+  `modules` (Map module→highest verb). Foreign-id scopes ignored; the verb-less
+  legacy forms are NOT folded in (they remain `accountVaultsGrant`'s domain — Wave
+  A semantics untouched).
+
+The existing Wave A surface (`isRequestableAccountScope`, `parseAccountVaultsScope`,
+`accountVaultsGrant`) and the account read/admin ladder are unchanged.
+
 ## 0.5.0
 
 The `account:<id>:vaults` scope grammar (Wave A PR1) — the foundation the cloud

--- a/packages/door-contract/package.json
+++ b/packages/door-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/door-contract",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "The Parachute door contract: shared OAuth-issuer + /account/* wire types, constants, and conformance vectors that both doors (self-host hub + hosted cloud) implement.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -7,6 +7,11 @@ import {
   ACCOUNT_SELF_READ_SCOPE,
   ACCOUNT_VAULTS_UNNARROWED,
   ACCOUNT_VAULTS_VERB,
+  COMPOSED_MODULE_SEGMENT,
+  COMPOSED_VAULTS_SEGMENT,
+  COMPOSED_VAULTS_WILDCARD,
+  COMPOSED_VAULT_CREATE_VERB,
+  COMPOSED_VERB_RANK,
   REFRESH_GRACE_MS,
   REFRESH_TOKEN_TTL_MS,
   TOKEN_TYPE,
@@ -20,12 +25,20 @@ import {
   checkProtectedResourceMetadata,
   checkTokenResponseInvariants,
   checkVaultTokenMintResponse,
+  composedAccountGrant,
+  composedModuleScope,
+  composedVaultCreateScope,
+  composedVaultScope,
+  composedVerbSatisfies,
+  composedWildcardVaultsScope,
   expectedAuthorizationServerMetadata,
   expectedProtectedResourceMetadata,
   hasAccountScope,
+  isComposedVaultVerb,
   isRequestableAccountScope,
   parseAccountScope,
   parseAccountVaultsScope,
+  parseComposedAccountScope,
   validateVaultScopes,
 } from "../index.js";
 
@@ -164,6 +177,319 @@ describe("account-vaults scope grammar (Wave A)", () => {
     // No account-vaults scope at all → null.
     expect(accountVaultsGrant([], "self")).toBeNull();
     expect(accountVaultsGrant(["account:self:admin", "vault:work:read"], "self")).toBeNull();
+  });
+});
+
+describe("composed account-scope grammar (unified /mcp — Phase 1)", () => {
+  test("constants + builders round-trip to the wire strings", () => {
+    expect(COMPOSED_VAULTS_WILDCARD).toBe("*");
+    expect(COMPOSED_VAULTS_SEGMENT).toBe("vaults");
+    expect(COMPOSED_VAULT_CREATE_VERB).toBe("vault-create");
+    expect(COMPOSED_MODULE_SEGMENT).toBe("mod");
+    expect(composedWildcardVaultsScope("self", "read")).toBe("account:self:vaults:*:read");
+    expect(composedVaultScope("u_1", "work", "write")).toBe("account:u_1:vaults:work:write");
+    expect(composedVaultCreateScope("u_1")).toBe("account:u_1:vault-create");
+    expect(composedModuleScope("u_1", "scribe", "admin")).toBe("account:u_1:mod:scribe:admin");
+  });
+
+  test("the composed verb ladder is admin ⊇ write ⊇ read", () => {
+    expect(COMPOSED_VERB_RANK).toEqual({ read: 0, write: 1, admin: 2 });
+    for (const v of ["read", "write", "admin"]) expect(isComposedVaultVerb(v)).toBe(true);
+    for (const v of ["", "READ", "vaults", "delete", "*"])
+      expect(isComposedVaultVerb(v)).toBe(false);
+    // admin satisfies everything; write satisfies write+read; read only read.
+    expect(composedVerbSatisfies("admin", "read")).toBe(true);
+    expect(composedVerbSatisfies("admin", "write")).toBe(true);
+    expect(composedVerbSatisfies("admin", "admin")).toBe(true);
+    expect(composedVerbSatisfies("write", "read")).toBe(true);
+    expect(composedVerbSatisfies("write", "write")).toBe(true);
+    expect(composedVerbSatisfies("write", "admin")).toBe(false);
+    expect(composedVerbSatisfies("read", "read")).toBe(true);
+    expect(composedVerbSatisfies("read", "write")).toBe(false);
+    expect(composedVerbSatisfies("read", "admin")).toBe(false);
+  });
+
+  // The composed grammar is carried on the aud="account" token; NONE of its new
+  // forms may ever be requested — consent is the sole author. The legacy Wave A
+  // blanket stays requestable (unchanged); every new form is refused.
+  test("isRequestableAccountScope refuses every NEW composed form (consent-only)", () => {
+    for (const scope of [
+      "account:self:vaults:*:read", // wildcard
+      "account:self:vaults:*:write",
+      "account:self:vaults:*:admin",
+      "account:self:vaults:work:read", // per-vault 5-part
+      "account:u_1:vaults:work:write",
+      "account:self:vault-create", // create capability
+      "account:self:mod:scribe:read", // module
+      "account:u_1:mod:notes:admin",
+    ]) {
+      expect(isRequestableAccountScope(scope)).toBe(false);
+    }
+    // The one legacy requestable form is untouched.
+    expect(isRequestableAccountScope("account:vaults")).toBe(true);
+    expect(isRequestableAccountScope("account:self:vaults")).toBe(true);
+  });
+
+  test("parseComposedAccountScope — wildcard vault grant", () => {
+    expect(parseComposedAccountScope("account:self:vaults:*:read")).toEqual({
+      kind: "wildcard-vaults",
+      id: "self",
+      verb: "read",
+    });
+    expect(parseComposedAccountScope("account:u_1:vaults:*:admin")).toEqual({
+      kind: "wildcard-vaults",
+      id: "u_1",
+      verb: "admin",
+    });
+  });
+
+  test("parseComposedAccountScope — per-vault (5-part) grant", () => {
+    expect(parseComposedAccountScope("account:self:vaults:work:write")).toEqual({
+      kind: "vault",
+      id: "self",
+      vault: "work",
+      verb: "write",
+    });
+    expect(parseComposedAccountScope("account:u_1:vaults:moss:read")).toEqual({
+      kind: "vault",
+      id: "u_1",
+      vault: "moss",
+      verb: "read",
+    });
+  });
+
+  test("parseComposedAccountScope — vault-create capability", () => {
+    expect(parseComposedAccountScope("account:self:vault-create")).toEqual({
+      kind: "vault-create",
+      id: "self",
+    });
+    expect(parseComposedAccountScope("account:u_1:vault-create")).toEqual({
+      kind: "vault-create",
+      id: "u_1",
+    });
+  });
+
+  test("parseComposedAccountScope — module grant", () => {
+    expect(parseComposedAccountScope("account:self:mod:scribe:admin")).toEqual({
+      kind: "module",
+      id: "self",
+      module: "scribe",
+      verb: "admin",
+    });
+    expect(parseComposedAccountScope("account:u_1:mod:notes:read")).toEqual({
+      kind: "module",
+      id: "u_1",
+      module: "notes",
+      verb: "read",
+    });
+  });
+
+  test("parseComposedAccountScope — legacy Wave A forms parse identically", () => {
+    // The recognizer is a SUPERSET so a single pass extracts <id> from legacy
+    // grants too (existing tokens/refresh families must keep parsing).
+    expect(parseComposedAccountScope("account:self:vaults")).toEqual({
+      kind: "legacy-blanket",
+      id: "self",
+    });
+    expect(parseComposedAccountScope("account:u_1:vaults:work")).toEqual({
+      kind: "legacy-vault",
+      id: "u_1",
+      vault: "work",
+    });
+  });
+
+  test("parseComposedAccountScope — builders round-trip through the parser", () => {
+    expect(parseComposedAccountScope(composedWildcardVaultsScope("self", "admin"))).toEqual({
+      kind: "wildcard-vaults",
+      id: "self",
+      verb: "admin",
+    });
+    expect(parseComposedAccountScope(composedVaultScope("u_9", "moss", "read"))).toEqual({
+      kind: "vault",
+      id: "u_9",
+      vault: "moss",
+      verb: "read",
+    });
+    expect(parseComposedAccountScope(composedVaultCreateScope("u_9"))).toEqual({
+      kind: "vault-create",
+      id: "u_9",
+    });
+    expect(parseComposedAccountScope(composedModuleScope("u_9", "scribe", "write"))).toEqual({
+      kind: "module",
+      id: "u_9",
+      module: "scribe",
+      verb: "write",
+    });
+  });
+
+  // §1.4 guardrail: the mint gate id-checks only what the parser recognizes; a
+  // form parsing to null would SKIP the cross-account check. Every new family
+  // (and a FOREIGN-id instance of each) must yield an extractable `id` so the
+  // later mint gate can reject a foreign-id composed scope.
+  test("§1.4 — every new family exposes an extractable id (mint-gate coverage)", () => {
+    const foreign = [
+      "account:attacker:vaults:*:admin",
+      "account:attacker:vaults:secret:write",
+      "account:attacker:vault-create",
+      "account:attacker:mod:scribe:admin",
+      "account:attacker:vaults", // legacy blanket
+      "account:attacker:vaults:secret", // legacy narrowed
+    ];
+    for (const scope of foreign) {
+      const parsed = parseComposedAccountScope(scope);
+      expect(parsed).not.toBeNull();
+      expect(parsed?.id).toBe("attacker"); // extractable → gate can reject foreign id
+    }
+  });
+
+  test("parseComposedAccountScope — `*` is ONLY the wildcard, never a vault name", () => {
+    // 5-part `vaults:*:<verb>` → wildcard (above). A 4-part legacy narrowed form
+    // with `*` in the vault slot is NOT a real vault → fail closed.
+    expect(parseComposedAccountScope("account:self:vaults:*")).toBeNull();
+    // And a `*` module name (empty-ish sentinel misuse) still parses as a literal
+    // module string only in the 5-part mod family — `*` is not special there.
+    expect(parseComposedAccountScope("account:self:mod:*:read")).toEqual({
+      kind: "module",
+      id: "self",
+      module: "*",
+      verb: "read",
+    });
+  });
+
+  test("parseComposedAccountScope — the account-verb ladder is NOT a composed form", () => {
+    // `account:<id>:{read,admin}` belong to parseAccountScope, not here.
+    expect(parseComposedAccountScope("account:self:admin")).toBeNull();
+    expect(parseComposedAccountScope("account:self:read")).toBeNull();
+    // `write` is not even an account verb — still null.
+    expect(parseComposedAccountScope("account:self:write")).toBeNull();
+  });
+
+  test("parseComposedAccountScope — garbage / casing / whitespace fail closed → null", () => {
+    for (const scope of [
+      "", // empty
+      "account", // bare
+      "account:", // trailing empty id
+      "account::vaults:*:read", // empty id
+      "account:self", // 2-part
+      "vault:work:read", // non-account resource
+      "Account:self:vaults:*:read", // resource casing
+      "account:self:Vaults:*:read", // family casing
+      "account:self:vaults:*:READ", // verb casing
+      "account:self:vaults:*:delete", // unknown verb
+      "account:self:vaults::read", // empty vault (5-part)
+      "account:self:mod::read", // empty module
+      "account:self:MOD:scribe:read", // module-family casing
+      "account:self:widgets:x:read", // unknown 5-part family
+      "account:self:vaults:*:read:extra", // over-long (6-part)
+      "account:self:mod:scribe:read:extra", // over-long
+      " account:self:vault-create", // leading whitespace
+      "account:self:vault-create ", // trailing whitespace on the verb-slot
+      "account:self:Vault-Create", // create casing
+    ]) {
+      expect(parseComposedAccountScope(scope)).toBeNull();
+    }
+  });
+
+  test("composedAccountGrant — wildcard coverage keeps the highest verb", () => {
+    expect(composedAccountGrant(["account:self:vaults:*:read"], "self")).toEqual({
+      wildcard: "read",
+      vaults: new Map(),
+      create: false,
+      modules: new Map(),
+    });
+    // read + admin wildcards → admin wins (highest rung), order-independent.
+    expect(
+      composedAccountGrant(["account:self:vaults:*:read", "account:self:vaults:*:admin"], "self")
+        .wildcard,
+    ).toBe("admin");
+    expect(
+      composedAccountGrant(["account:self:vaults:*:admin", "account:self:vaults:*:read"], "self")
+        .wildcard,
+    ).toBe("admin");
+  });
+
+  test("composedAccountGrant — explicit per-vault map (highest verb per name)", () => {
+    const cov = composedAccountGrant(
+      [
+        "account:self:vaults:work:read",
+        "account:self:vaults:work:admin", // raises work → admin
+        "account:self:vaults:moss:write",
+      ],
+      "self",
+    );
+    expect(cov.wildcard).toBeNull();
+    expect(cov.vaults).toEqual(
+      new Map([
+        ["work", "admin"],
+        ["moss", "write"],
+      ]),
+    );
+    expect(cov.create).toBe(false);
+    expect(cov.modules.size).toBe(0);
+  });
+
+  test("composedAccountGrant — the create flag", () => {
+    expect(composedAccountGrant(["account:self:vault-create"], "self").create).toBe(true);
+    expect(composedAccountGrant(["account:self:vaults:work:read"], "self").create).toBe(false);
+  });
+
+  test("composedAccountGrant — module map (highest verb per module)", () => {
+    const cov = composedAccountGrant(
+      [
+        "account:self:mod:scribe:read",
+        "account:self:mod:scribe:write", // raises scribe → write
+        "account:self:mod:notes:admin",
+      ],
+      "self",
+    );
+    expect(cov.modules).toEqual(
+      new Map([
+        ["scribe", "write"],
+        ["notes", "admin"],
+      ]),
+    );
+  });
+
+  test("composedAccountGrant — a mixed composed set derives all four axes", () => {
+    const cov = composedAccountGrant(
+      [
+        "account:self:vaults:*:read",
+        "account:self:vaults:work:admin",
+        "account:self:vault-create",
+        "account:self:mod:scribe:write",
+        // legacy verb-less forms are NOT folded into composed coverage.
+        "account:self:vaults",
+        "account:self:vaults:archive",
+      ],
+      "self",
+    );
+    expect(cov.wildcard).toBe("read");
+    expect(cov.vaults).toEqual(new Map([["work", "admin"]])); // NOT "archive" (legacy)
+    expect(cov.create).toBe(true);
+    expect(cov.modules).toEqual(new Map([["scribe", "write"]]));
+  });
+
+  test("composedAccountGrant — foreign-id scopes are ignored (grant for A never covers B)", () => {
+    const cov = composedAccountGrant(
+      [
+        "account:u_2:vaults:*:admin", // foreign wildcard
+        "account:u_2:vaults:work:admin", // foreign vault
+        "account:u_2:vault-create", // foreign create
+        "account:u_2:mod:scribe:admin", // foreign module
+        "account:u_1:vaults:mine:read", // this id
+      ],
+      "u_1",
+    );
+    expect(cov.wildcard).toBeNull();
+    expect(cov.vaults).toEqual(new Map([["mine", "read"]]));
+    expect(cov.create).toBe(false);
+    expect(cov.modules.size).toBe(0);
+  });
+
+  test("composedAccountGrant — an empty / non-composed set yields empty coverage", () => {
+    const empty = { wildcard: null, vaults: new Map(), create: false, modules: new Map() };
+    expect(composedAccountGrant([], "self")).toEqual(empty);
+    expect(composedAccountGrant(["account:self:admin", "vault:work:read"], "self")).toEqual(empty);
   });
 });
 

--- a/packages/door-contract/src/index.ts
+++ b/packages/door-contract/src/index.ts
@@ -47,6 +47,22 @@ export {
   isRequestableAccountScope,
   parseAccountVaultsScope,
   accountVaultsGrant,
+  type ComposedVaultVerb,
+  COMPOSED_VERB_RANK,
+  isComposedVaultVerb,
+  composedVerbSatisfies,
+  COMPOSED_VAULTS_WILDCARD,
+  COMPOSED_VAULTS_SEGMENT,
+  COMPOSED_VAULT_CREATE_VERB,
+  COMPOSED_MODULE_SEGMENT,
+  type ComposedAccountScope,
+  composedWildcardVaultsScope,
+  composedVaultScope,
+  composedVaultCreateScope,
+  composedModuleScope,
+  parseComposedAccountScope,
+  type ComposedAccountCoverage,
+  composedAccountGrant,
 } from "./scopes.js";
 
 export {

--- a/packages/door-contract/src/scopes.ts
+++ b/packages/door-contract/src/scopes.ts
@@ -176,3 +176,251 @@ export function accountVaultsGrant(
   }
   return vaults.length > 0 ? { vaults } : null;
 }
+
+/**
+ * ─────────────────────────────────────────────────────────────────────────────
+ * The COMPOSED account-scope grammar (unified `/mcp` — Phase 1).
+ * ─────────────────────────────────────────────────────────────────────────────
+ *
+ * The ratified unified-MCP design collapses the many per-resource MCP endpoints
+ * into ONE `/mcp` gateway. Its OAuth consent composes a single grant spanning the
+ * account, its vaults (a wildcard over every owned vault, a set of named vaults,
+ * or one vault — each at a verb), the "create new vaults" capability, and future
+ * modules. The whole composed grant rides on ONE `aud="account"` token; the
+ * gateway decomposes it per-call into 60s single-audience mints.
+ *
+ * Because the composed grant is decomposed by the gateway (never handed to a
+ * resource server directly), ALL composed vault/module authority is encoded
+ * INSIDE the `account:` namespace — deliberately NOT as a raw `vault:<name>:<verb>`
+ * scope, which `inferAudience` would stamp as a vault audience and route around
+ * the gateway. The `account:<id>:…` prefix keeps every composed grant on the
+ * account token where the gateway owns decomposition.
+ *
+ * This Phase-1 PR only DEFINES + PARSES the grammar. Nothing emits or mints these
+ * forms yet; consent, minting, and the gateway are later phases that consume this
+ * vocabulary. Every new form below is NON-REQUESTABLE — a client can never
+ * pre-narrow or pre-widen itself into one; the consent step is the sole author.
+ *
+ * The composed granted forms (all built by consent, never requested):
+ *   - `account:<id>:vaults:*:<verb>`      — WILDCARD vault grant: every vault the
+ *                                            account owns, at `<verb>`. `*` can
+ *                                            never collide with a vault name (the
+ *                                            vault-name charset excludes `*`).
+ *   - `account:<id>:vaults:<vault>:<verb>` — a PER-VAULT grant at `<verb>` (5-part).
+ *   - `account:<id>:vault-create`          — the "create new vaults" capability
+ *                                            (3-part; a distinct `vault-create`
+ *                                            verb-slot, NOT a member of the
+ *                                            `vaults` family).
+ *   - `account:<id>:mod:<module>:<verb>`   — a MODULE grant (future modules).
+ *
+ * `<verb>` here is the three-rung vault/module ladder `read|write|admin` (NOT the
+ * two-rung account ladder `read|admin` — a composed vault grant can be `write`).
+ *
+ * The LEGACY Wave A forms keep their exact meaning, frozen — existing tokens and
+ * refresh families must parse identically:
+ *   - `account:<id>:vaults`          — the blanket account-vaults connection grant.
+ *   - `account:<id>:vaults:<vault>`  — the consent-narrowed 4-part grant.
+ * Neither carries a verb; they remain `accountVaultsGrant`'s domain and are NOT
+ * folded into the composed coverage below (which is verb-carrying).
+ */
+
+/** The three-rung composed vault/module verb ladder (`admin ⊇ write ⊇ read`). */
+export type ComposedVaultVerb = "read" | "write" | "admin";
+
+/** `admin ⊇ write ⊇ read` — the rank used for "requiredVerb ≤ grantedVerb" checks. */
+export const COMPOSED_VERB_RANK: Record<ComposedVaultVerb, number> = {
+  read: 0,
+  write: 1,
+  admin: 2,
+};
+
+/** Narrow an arbitrary string to a composed vault/module verb. */
+export function isComposedVaultVerb(s: string): s is ComposedVaultVerb {
+  return s === "read" || s === "write" || s === "admin";
+}
+
+/**
+ * Does a `granted` verb satisfy a `required` verb on the composed ladder? `admin`
+ * satisfies `write` and `read`; `write` satisfies `read`. The later gateway/mint
+ * phases use this for "the call needs `read`, the grant carries `write` → allow".
+ */
+export function composedVerbSatisfies(
+  granted: ComposedVaultVerb,
+  required: ComposedVaultVerb,
+): boolean {
+  return COMPOSED_VERB_RANK[granted] >= COMPOSED_VERB_RANK[required];
+}
+
+/** The wildcard vault-slot sentinel (`account:<id>:vaults:*:<verb>`). */
+export const COMPOSED_VAULTS_WILDCARD = "*";
+/** The `vaults` family segment (composed vault grants + legacy Wave A forms). */
+export const COMPOSED_VAULTS_SEGMENT = "vaults";
+/** The 3-part "create new vaults" capability verb-slot. */
+export const COMPOSED_VAULT_CREATE_VERB = "vault-create";
+/** The `mod` family segment (`account:<id>:mod:<module>:<verb>`). */
+export const COMPOSED_MODULE_SEGMENT = "mod";
+
+/** A parsed composed account scope — the discriminated union over every family. */
+export type ComposedAccountScope =
+  | { kind: "wildcard-vaults"; id: string; verb: ComposedVaultVerb }
+  | { kind: "vault"; id: string; vault: string; verb: ComposedVaultVerb }
+  | { kind: "vault-create"; id: string }
+  | { kind: "module"; id: string; module: string; verb: ComposedVaultVerb }
+  | { kind: "legacy-blanket"; id: string }
+  | { kind: "legacy-vault"; id: string; vault: string };
+
+/**
+ * Build the wildcard vault grant `account:<id>:vaults:*:<verb>`. */
+export function composedWildcardVaultsScope(id: string, verb: ComposedVaultVerb): string {
+  return `account:${id}:${COMPOSED_VAULTS_SEGMENT}:${COMPOSED_VAULTS_WILDCARD}:${verb}`;
+}
+
+/** Build a per-vault grant `account:<id>:vaults:<vault>:<verb>`. */
+export function composedVaultScope(id: string, vault: string, verb: ComposedVaultVerb): string {
+  return `account:${id}:${COMPOSED_VAULTS_SEGMENT}:${vault}:${verb}`;
+}
+
+/** Build the "create new vaults" capability `account:<id>:vault-create`. */
+export function composedVaultCreateScope(id: string): string {
+  return `account:${id}:${COMPOSED_VAULT_CREATE_VERB}`;
+}
+
+/** Build a module grant `account:<id>:mod:<module>:<verb>`. */
+export function composedModuleScope(id: string, module: string, verb: ComposedVaultVerb): string {
+  return `account:${id}:${COMPOSED_MODULE_SEGMENT}:${module}:${verb}`;
+}
+
+/**
+ * Parse ANY composed account scope into its discriminated shape, or `null` for
+ * anything unrecognized (fail-closed — mirrors `parseAccountVaultsScope`). This
+ * recognizer is deliberately a SUPERSET: it covers both the new composed families
+ * AND the legacy Wave A forms so that a single pass extracts `<id>` from every
+ * `account:`-namespaced grant.
+ *
+ * §1.4 guardrail (unified-MCP design): the hub's cross-account mint gate
+ * (`denyForeignAccountMint`) id-checks only the forms its parser RECOGNIZES — a
+ * form that parses to `null` would SKIP the id check. The composed forms are
+ * non-requestable (thus unreachable by that gate today), but when a later phase
+ * makes them mintable the gate must already extract their `<id>`. Recognizing
+ * every family HERE is what lets the gate reject a foreign-id composed scope then.
+ *
+ * The `account:<id>:{read|admin}` account-verb ladder is intentionally NOT a
+ * composed form (it is `parseAccountScope`'s domain) and yields `null` here.
+ *
+ * Fail-closed rules: `account` resource required, `<id>` non-empty, verbs from the
+ * composed ladder, and `*` is ONLY ever the wildcard sentinel — it is never
+ * accepted as a concrete vault name (a 4-part `account:<id>:vaults:*` → `null`).
+ */
+export function parseComposedAccountScope(scope: string): ComposedAccountScope | null {
+  const parts = scope.split(":");
+  if (parts[0] !== "account") return null;
+  const id = parts[1];
+  if (!id || id.length === 0) return null;
+
+  if (parts.length === 3) {
+    const slot = parts[2] as string;
+    if (slot === COMPOSED_VAULTS_SEGMENT) return { kind: "legacy-blanket", id };
+    if (slot === COMPOSED_VAULT_CREATE_VERB) return { kind: "vault-create", id };
+    return null;
+  }
+
+  if (parts.length === 4) {
+    // Legacy Wave A consent-narrowed form `account:<id>:vaults:<vault>`. `*` is
+    // never a concrete vault name, so a `*` in the vault slot fails closed.
+    const [, , family, vault] = parts as [string, string, string, string];
+    if (family !== COMPOSED_VAULTS_SEGMENT) return null;
+    if (vault.length === 0 || vault === COMPOSED_VAULTS_WILDCARD) return null;
+    return { kind: "legacy-vault", id, vault };
+  }
+
+  if (parts.length === 5) {
+    const [, , family, target, verb] = parts as [string, string, string, string, string];
+    if (!isComposedVaultVerb(verb)) return null;
+    if (family === COMPOSED_VAULTS_SEGMENT) {
+      if (target === COMPOSED_VAULTS_WILDCARD) return { kind: "wildcard-vaults", id, verb };
+      if (target.length === 0) return null;
+      return { kind: "vault", id, vault: target, verb };
+    }
+    if (family === COMPOSED_MODULE_SEGMENT) {
+      if (target.length === 0) return null;
+      return { kind: "module", id, module: target, verb };
+    }
+    return null;
+  }
+
+  return null;
+}
+
+/**
+ * The coverage a COMPOSED grant confers for one account id — derived from the
+ * verb-carrying composed forms plus the create capability and modules:
+ *   - `wildcard` — the highest wildcard verb granted (`account:<id>:vaults:*:<verb>`),
+ *     or `null` if no wildcard vault grant is present. A wildcard covers every
+ *     owned vault at that verb.
+ *   - `vaults`   — a Map of vault-name → highest explicitly-granted verb
+ *     (`account:<id>:vaults:<vault>:<verb>`).
+ *   - `create`   — whether `account:<id>:vault-create` is present.
+ *   - `modules`  — a Map of module-name → highest granted verb
+ *     (`account:<id>:mod:<module>:<verb>`).
+ * Duplicate/overlapping grants collapse to the highest verb per key. Foreign-id
+ * scopes are ignored. The LEGACY (verb-less) `account:<id>:vaults[:<vault>]` forms
+ * are NOT folded in here — they carry no verb and remain `accountVaultsGrant`'s
+ * domain; this keeps legacy Wave A semantics untouched.
+ */
+export interface ComposedAccountCoverage {
+  wildcard: ComposedVaultVerb | null;
+  vaults: Map<string, ComposedVaultVerb>;
+  create: boolean;
+  modules: Map<string, ComposedVaultVerb>;
+}
+
+/** Fold `<verb>` into `map[key]`, keeping the higher rung. */
+function raiseVerb(
+  map: Map<string, ComposedVaultVerb>,
+  key: string,
+  verb: ComposedVaultVerb,
+): void {
+  const cur = map.get(key);
+  if (!cur || COMPOSED_VERB_RANK[verb] > COMPOSED_VERB_RANK[cur]) map.set(key, verb);
+}
+
+export function composedAccountGrant(
+  grantedScopes: readonly string[],
+  accountId: string,
+): ComposedAccountCoverage {
+  const coverage: ComposedAccountCoverage = {
+    wildcard: null,
+    vaults: new Map(),
+    create: false,
+    modules: new Map(),
+  };
+  for (const s of grantedScopes) {
+    const parsed = parseComposedAccountScope(s);
+    if (!parsed || parsed.id !== accountId) continue;
+    switch (parsed.kind) {
+      case "wildcard-vaults":
+        if (
+          !coverage.wildcard ||
+          COMPOSED_VERB_RANK[parsed.verb] > COMPOSED_VERB_RANK[coverage.wildcard]
+        ) {
+          coverage.wildcard = parsed.verb;
+        }
+        break;
+      case "vault":
+        raiseVerb(coverage.vaults, parsed.vault, parsed.verb);
+        break;
+      case "vault-create":
+        coverage.create = true;
+        break;
+      case "module":
+        raiseVerb(coverage.modules, parsed.module, parsed.verb);
+        break;
+      // Legacy verb-less forms are not part of the composed (verb-carrying)
+      // coverage — they stay in `accountVaultsGrant`.
+      case "legacy-blanket":
+      case "legacy-vault":
+        break;
+    }
+  }
+  return coverage;
+}


### PR DESCRIPTION
## What

Phase 1 of the unified-MCP migration: **define + parse the composed account-scope grammar** the one `/mcp` gateway will consume. This is the foundation the later consent / mint / gateway phases build on — it must land before anything can mint the new forms.

**ADDITIVE + low-risk.** New vocabulary + parsers only. Nothing emits or mints these forms yet, and **every new form is NON-REQUESTABLE** (consent is the sole author). No existing signature or behavior changes; legacy Wave A parsing is untouched.

## The new granted forms (all consent-authored, none requestable)

| Form | Meaning |
|---|---|
| `account:<id>:vaults:*:<verb>` | **wildcard** vault grant — every owned vault at `<verb>` |
| `account:<id>:vaults:<vault>:<verb>` | per-vault 5-part grant at a verb |
| `account:<id>:vault-create` | the "create new vaults" capability (distinct 3-part verb-slot, not a `vaults` member) |
| `account:<id>:mod:<module>:<verb>` | module grant (future modules) |

`<verb>` is the three-rung vault/module ladder `read|write|admin` (distinct from the two-rung account ladder `read|admin`). The **legacy Wave A** forms keep their exact frozen meaning: `account:<id>:vaults` (blanket) and `account:<id>:vaults:<vault>` (4-part narrowed) parse identically — existing tokens + refresh families are untouched.

All composed vault/module authority is encoded **inside the `account:` namespace** — never a raw `vault:<name>:<verb>`, which `inferAudience` would stamp as a vault audience and route around the gateway. The whole composed grant rides one `aud="account"` token that the gateway decomposes per-call into 60s single-audience mints.

## Nothing mints these yet

Consent, token minting, and the gateway are **later phases**. This PR only DEFINES + PARSES the grammar. `isRequestableAccountScope` is unchanged and refuses every new form (verified by the vector table).

## §1.4 — parser covers the id-check

The hub's cross-account mint gate (`denyForeignAccountMint`) id-checks only the forms its parser recognizes; a form parsing to `null` would **skip** the cross-account id check. These forms are unreachable by that gate today (non-requestable), but `parseComposedAccountScope` is deliberately a **superset recognizer** (new families + legacy) so that when a later phase makes them mintable, the gate already extracts `<id>` from every family and can reject a foreign-id composed scope. Tests assert `id` is extractable for each family and for a foreign-id instance of each.

## API added (in `scopes.ts`, re-exported from the root)

- `ComposedVaultVerb` + `COMPOSED_VERB_RANK` (`admin ⊇ write ⊇ read`) + `isComposedVaultVerb` + `composedVerbSatisfies(granted, required)` — the ladder + the `requiredVerb ≤ grantedVerb` helper the later mint phase uses.
- Segment/sentinel constants + builders (`composedWildcardVaultsScope`, `composedVaultScope`, `composedVaultCreateScope`, `composedModuleScope`).
- `ComposedAccountScope` + `parseComposedAccountScope(scope)` — fail-closed discriminated-union recognizer; `*` is only ever the wildcard sentinel, never a concrete vault name.
- `ComposedAccountCoverage` + `composedAccountGrant(scopes, accountId)` — coverage deriver: `wildcard` (highest wildcard verb or null), `vaults` (Map name→highest verb), `create` (boolean), `modules` (Map module→highest verb). Foreign-id ignored; verb-less legacy forms not folded in (they remain `accountVaultsGrant`'s domain).

## Not in scope

No consent, token-minting, gateway, or cloud changes. No new form made requestable. No change to legacy Wave A semantics.

## Versioning

door-contract `0.5.0 → 0.6.0` (+ CHANGELOG); hub root `0.7.7-rc.14 → rc.15` per governance.

## Gates (verdict lines, not tailed)

- `bun test packages/door-contract/src` → **83 pass / 0 fail / 289 expect() calls**
- hub `bun run typecheck` (`tsc --noEmit`) → **exit 0**
- hub door-contract parity suite → **3 pass / 0 fail**
- `biome check packages/door-contract/src` → **clean, no fixes**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB