### PR TITLE
release: publish @openparachute/door-contract to npm (hub npm-boot fix, step 1/3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,28 +1,32 @@
 # Release workflow — triggered by pushing a semver tag.
 #
-# This workflow publishes THREE packages on different tag namespaces:
+# This workflow publishes FOUR packages on different tag namespaces:
 #
-#   - @openparachute/hub          ← tag prefix `v...`            (e.g. v0.5.13-rc.33)
-#   - @openparachute/scope-guard  ← tag prefix `scope-guard-v...` (e.g. scope-guard-v0.4.0-rc.2)
-#   - @openparachute/depcheck     ← tag prefix `depcheck-v...`    (e.g. depcheck-v0.1.0-rc.1)
+#   - @openparachute/hub            ← tag prefix `v...`              (e.g. v0.5.13-rc.33)
+#   - @openparachute/scope-guard    ← tag prefix `scope-guard-v...`   (e.g. scope-guard-v0.4.0-rc.2)
+#   - @openparachute/depcheck       ← tag prefix `depcheck-v...`      (e.g. depcheck-v0.1.0-rc.1)
+#   - @openparachute/door-contract  ← tag prefix `door-contract-v...` (e.g. door-contract-v0.6.0)
 #
 # All packages have npm Trusted Publisher rules pointing at this workflow
 # file. The jobs below gate on the tag prefix so only one package publishes
 # per tag push. Independent release cadences; hub doesn't have to bump when
-# scope-guard / depcheck ship and vice versa.
+# scope-guard / depcheck / door-contract ship and vice versa.
 #
 # Tag conventions (matches governance rule 2, https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md):
 #   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.33)
 #                                    (scope-guard-v0.4.0-rc.2)
 #                                    (depcheck-v0.1.0-rc.1)
+#                                    (door-contract-v0.6.0-rc.1)
 #   - stable: v<X>.<Y>.<Z>          (e.g. v0.5.13)
 #                                    (scope-guard-v0.4.0)
 #                                    (depcheck-v0.1.0)
+#                                    (door-contract-v0.6.0)
 #
 # Release flow:
 #   1. When ready to ship: bump version in the relevant package.json on main
 #      (root for hub, packages/scope-guard/ for scope-guard,
-#      packages/depcheck/ for depcheck).
+#      packages/depcheck/ for depcheck, packages/door-contract/ for
+#      door-contract).
 #   2. Push a matching tag:
 #        # for hub
 #        git tag v$(bun -e "console.log(require('./package.json').version)") && git push --tags
@@ -30,13 +34,15 @@
 #        git tag scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)") && git push --tags
 #        # for depcheck
 #        git tag depcheck-v$(bun -e "console.log(require('./packages/depcheck/package.json').version)") && git push --tags
+#        # for door-contract
+#        git tag door-contract-v$(bun -e "console.log(require('./packages/door-contract/package.json').version)") && git push --tags
 #   3. CI runs tests once (workspace-wide), then publishes the package matching
 #      the tag prefix. Hub also publishes a container image to ghcr.io.
 #
 # Operator setup (one-time) — see RELEASING.md:
-#   - npm Trusted Publisher rules: one per package (hub, scope-guard, depcheck).
-#     All rules point at: org=ParachuteComputer, repo=parachute-hub,
-#     workflow=release.yml, env blank.
+#   - npm Trusted Publisher rules: one per package (hub, scope-guard, depcheck,
+#     door-contract). All rules point at: org=ParachuteComputer,
+#     repo=parachute-hub, workflow=release.yml, env blank.
 #   - ghcr.io needs no secret (uses the runner's GITHUB_TOKEN).
 
 name: Release
@@ -53,6 +59,9 @@ on:
       # depcheck release tags
       - 'depcheck-v[0-9]+.[0-9]+.[0-9]+'
       - 'depcheck-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+      # door-contract release tags
+      - 'door-contract-v[0-9]+.[0-9]+.[0-9]+'
+      - 'door-contract-v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
 
 concurrency:
   # Don't let two releases race on the same tag.
@@ -105,8 +114,8 @@ jobs:
   publish-hub-npm:
     name: publish hub to npm
     needs: test
-    # Hub-only: skip on scope-guard / depcheck tags (a `v*` tag is hub's).
-    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') }}
+    # Hub-only: skip on scope-guard / depcheck / door-contract tags (a `v*` tag is hub's).
+    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -257,11 +266,61 @@ jobs:
           echo "publishing @openparachute/depcheck with dist-tag=$DIST_TAG"
           npm publish --tag "$DIST_TAG" --access public --provenance
 
+  publish-door-contract-npm:
+    name: publish door-contract to npm
+    needs: test
+    # door-contract-only: skip on hub (`v*`) + scope-guard + depcheck tags.
+    if: ${{ startsWith(github.ref_name, 'door-contract-') }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    defaults:
+      run:
+        # All shell steps default to the door-contract package dir. Steps that
+        # need to run from the repo root explicitly override
+        # `working-directory: ${{ github.workspace }}`.
+        working-directory: packages/door-contract
+    steps:
+      - uses: actions/checkout@v6
+        # checkout has no working-directory option; runs from repo root.
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+      - name: install deps
+        # Install at workspace root so hoisted deps resolve.
+        working-directory: ${{ github.workspace }}
+        run: bun install --frozen-lockfile
+      - name: verify package.json version matches tag
+        run: |
+          PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
+          # Strip the `door-contract-v` prefix from the tag.
+          TAG_VERSION="${GITHUB_REF_NAME#door-contract-v}"
+          if [ "$PKG_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::packages/door-contract/package.json version ($PKG_VERSION) doesn't match tag ($TAG_VERSION)"
+            exit 1
+          fi
+      - name: publish
+        # prepublishOnly runs `bun run build` (tsc → dist/) before the tarball
+        # is assembled, so the published package ships compiled JS + d.ts.
+        run: |
+          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
+            DIST_TAG=rc
+          else
+            DIST_TAG=latest
+          fi
+          echo "publishing @openparachute/door-contract with dist-tag=$DIST_TAG"
+          npm publish --tag "$DIST_TAG" --access public --provenance
+
   publish-image:
     name: publish to ghcr.io
     needs: test
-    # Hub-only: scope-guard / depcheck don't ship a container image.
-    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') }}
+    # Hub-only: scope-guard / depcheck / door-contract don't ship a container image.
+    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,11 +1,13 @@
 # Releasing from `parachute-hub`
 
-This repo publishes TWO npm packages on independent release cadences via [`.github/workflows/release.yml`](./.github/workflows/release.yml):
+This repo publishes FOUR npm packages on independent release cadences via [`.github/workflows/release.yml`](./.github/workflows/release.yml):
 
 | Package | Tag prefix | Container image |
 |---|---|---|
 | `@openparachute/hub` | `v...` (e.g. `v0.5.13-rc.33`) | yes — `ghcr.io/parachutecomputer/parachute-hub` |
 | `@openparachute/scope-guard` | `scope-guard-v...` (e.g. `scope-guard-v0.4.0`) | no |
+| `@openparachute/depcheck` | `depcheck-v...` (e.g. `depcheck-v0.1.1`) | no |
+| `@openparachute/door-contract` | `door-contract-v...` (e.g. `door-contract-v0.6.0`) | no |
 
 Pushing a tag triggers CI which runs `bun run typecheck` + `bun test ./src`, then publishes the package matching the tag prefix.
 
@@ -19,6 +21,10 @@ Per [governance rule 2](https://github.com/ParachuteComputer/parachute-workspace
 | `vX.Y.Z` | `v0.5.13` | `latest` | `:v0.5.13`, `:stable` |
 | `scope-guard-vX.Y.Z-rc.N` | `scope-guard-v0.4.0-rc.2` | `rc` | — |
 | `scope-guard-vX.Y.Z` | `scope-guard-v0.4.0` | `latest` | — |
+| `depcheck-vX.Y.Z-rc.N` | `depcheck-v0.1.1-rc.1` | `rc` | — |
+| `depcheck-vX.Y.Z` | `depcheck-v0.1.1` | `latest` | — |
+| `door-contract-vX.Y.Z-rc.N` | `door-contract-v0.6.0-rc.1` | `rc` | — |
+| `door-contract-vX.Y.Z` | `door-contract-v0.6.0` | `latest` | — |
 
 The workflow auto-detects rc vs stable from the `-rc.` substring in the tag.
 
@@ -52,6 +58,36 @@ git push origin "$VERSION"
 
 The hub package is NOT republished. scope-guard runs on its own cadence.
 
+### Releasing depcheck
+
+```sh
+git fetch && git checkout main && git pull --ff-only
+# Bump the version in ./packages/depcheck/package.json, commit, push.
+VERSION="depcheck-v$(bun -e "console.log(require('./packages/depcheck/package.json').version)")"
+git tag "$VERSION"
+git push origin "$VERSION"
+```
+
+### Releasing door-contract
+
+`@openparachute/door-contract` is the shared OAuth-issuer + `/account/*` wire
+contract both doors implement. Hub currently consumes it as a `workspace:*`
+dep, which is fine for the bun-linked local install but unresolvable in the
+published hub tarball (`packages/` isn't shipped) — so door-contract must be a
+real npm dependency before hub can boot from npm. This section makes the
+publish path exist; the hub-dep flip is a follow-on PR.
+
+```sh
+git fetch && git checkout main && git pull --ff-only
+# Bump the version in ./packages/door-contract/package.json, commit, push.
+VERSION="door-contract-v$(bun -e "console.log(require('./packages/door-contract/package.json').version)")"
+git tag "$VERSION"
+git push origin "$VERSION"
+```
+
+The hub package is NOT republished. depcheck / door-contract run on their own
+cadence.
+
 ### Promoting an rc chain to stable
 
 Open a PR (or commit directly) that drops the `-rc.N` suffix from the relevant `package.json`, merge, then tag the bare version. CI publishes with `dist-tag=latest`.
@@ -64,11 +100,13 @@ Per governance, doc-only PRs DO NOT bump version. They merge straight to main; t
 
 Before the workflow can publish, this repo needs:
 
-1. **npm Trusted Publishers — one per published package**:
+1. **npm Trusted Publishers — one per published package** (OIDC is scoped per package, so each needs its OWN rule or the publish job 404s on provenance):
    - npmjs.com → `@openparachute/hub` → Settings → Trusted Publishers → add GitHub Actions: `ParachuteComputer` / `parachute-hub` / `release.yml` / env blank
    - npmjs.com → `@openparachute/scope-guard` → same Trusted Publisher (same org/repo/workflow/env)
+   - npmjs.com → `@openparachute/depcheck` → same Trusted Publisher (same org/repo/workflow/env)
+   - npmjs.com → `@openparachute/door-contract` → same Trusted Publisher (same org/repo/workflow/env). **Required before the first `door-contract-v*` tag can publish.**
 
-   Both rules point at the SAME workflow file. The jobs gate on tag prefix to decide which package to publish. No `NPM_TOKEN` secret needed — the workflow uses OIDC.
+   All rules point at the SAME workflow file. The jobs gate on tag prefix to decide which package to publish. No `NPM_TOKEN` secret needed — the workflow uses OIDC.
 
 2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`. First push of the image will create the package as **private by default**. After that first push, go to [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) → "Change visibility" → **Public**. Until you do this, any deploy target that pulls the image (Render, etc.) will 403 on `docker pull` unless you supply a `GHCR_PAT` read token. Doing it once at first-push time is the simplest path.
 
@@ -79,6 +117,8 @@ Before the workflow can publish, this repo needs:
 npm view @openparachute/hub@<version> dist.tarball
 npm view @openparachute/hub dist-tags
 npm view @openparachute/scope-guard dist-tags
+npm view @openparachute/depcheck dist-tags
+npm view @openparachute/door-contract dist-tags
 
 # ghcr (hub only)
 docker pull ghcr.io/parachutecomputer/parachute-hub:<tag>
@@ -101,9 +141,9 @@ There's no "unpublish" path for either npm (npm has a strict 72-hour unpublish p
 
 ## Troubleshooting
 
-- **Workflow doesn't trigger**: confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`).
+- **Workflow doesn't trigger**: confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`; depcheck: `depcheck-v[0-9]+...`; door-contract: `door-contract-v[0-9]+...`).
 - **`version mismatch` error in publish-npm**: the relevant `package.json` version differs from the tag. Re-tag the correct commit, or fix the version in `package.json`.
 - **`npm ERR! 403 You do not have permission to publish`**: Trusted Publisher rule on npm doesn't match this workflow. Verify org/repo/workflow filename are exactly `ParachuteComputer` / `parachute-hub` / `release.yml`. If the workflow file was renamed, the rule needs updating on npm.
 - **`npm ERR! 401 Unauthorized` with no OIDC token**: the workflow is missing `permissions: id-token: write` at the job level. Verify the YAML.
 - **ghcr push fails with 403**: confirm `permissions.packages: write` is in the publish-image job (it is).
-- **Two publish jobs running for the same tag**: the `if:` gates filter by `startsWith(github.ref_name, 'scope-guard-')` — verify the tag matches exactly one prefix.
+- **Two publish jobs running for the same tag**: the `if:` gates filter by tag prefix (`scope-guard-`, `depcheck-`, `door-contract-`; a bare `v*` is hub's) — verify the tag matches exactly one prefix.

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -33,6 +33,16 @@
  * ownership gate the cloud twin runs per-vault is trivially satisfied here.
  */
 import type { Database } from "bun:sqlite";
+// NOTE (npm-boot fix, step 3/3 follow-on): this is a VALUE import — hub can't
+// run without `@openparachute/door-contract` resolving at runtime. It's still a
+// `workspace:*` devDependency (package.json), which resolves only under the
+// bun-linked local install; the published hub tarball doesn't ship `packages/`,
+// so a `bun add -g @openparachute/hub@rc` install can't resolve it → boot
+// crash. Step 1 (this repo's release.yml) makes door-contract publishable to
+// npm; once Aaron adds its npm Trusted Publisher rule and it's tagged +
+// published, a follow-on PR flips this dep to a real `^0.6.0` (mirroring
+// `@openparachute/depcheck`) so the npm-installed hub boots. See RELEASING.md
+// → "Releasing door-contract".
 import {
   type AccountBootstrap,
   type ParachuteAccountDescriptor,


### PR DESCRIPTION
## The blocker (verified)

Hub `src/account-api.ts` **VALUE**-imports from `@openparachute/door-contract` (`validateVaultScopes`, and types `AccountBootstrap` / `ParachuteAccountDescriptor`; more consumers in tests). But door-contract is a `workspace:*` **devDependency** in hub's `package.json`, is **NOT published to npm** (E404), and is **excluded from hub's published `files`** (`["src","web/ui/dist",…]` — no `packages/`).

Net: `bun add -g @openparachute/hub@rc` installs a hub whose account-api import is unresolvable → boot crash-loop. The real-install `e2e.yml` workflow (`HUB_SOURCE=npm:rc`) is RED across rc.12–15. Dogfood / container-smoke pass only because they run **bun-linked** (the workspace resolves door-contract locally).

Fixing this fully is three steps. **This PR is step 1 of 3.**

## This PR — step 1: enable publishing door-contract

Mirrors the existing `scope-guard` / `depcheck` publish paths exactly.

- **`.github/workflows/release.yml`**
  - Add `door-contract-v*` tag triggers (rc + stable) to `on.push.tags`.
  - Add a `publish-door-contract-npm` job — a byte-for-byte mirror of `publish-depcheck-npm` (OIDC / `--provenance`, no `NPM_TOKEN`; version-vs-tag guard; rc/latest dist-tag from the `-rc.` substring; `prepublishOnly` builds `dist/`).
  - Extend the two hub-only jobs' `if:` gates to also skip `door-contract-` tags (so a door-contract tag doesn't republish hub or the container image).
  - Update the header docstring (THREE→FOUR packages).
- **`RELEASING.md`** — document door-contract **and** the previously-undocumented depcheck: packages table, tag-convention table, per-package release steps, the per-package Trusted Publisher requirement, verify + troubleshooting.
- **`src/account-api.ts`** — a comment above the import marking the `workspace:*` → `^0.6.0` dep flip as the step-3 follow-on. Comment only; no behavior change.

### door-contract's package.json was already publish-ready

No fixes were needed — it already mirrors depcheck: `name` `@openparachute/door-contract`, `version` `0.6.0`, `files: ["dist","README.md","CHANGELOG.md"]`, `prepublishOnly: bun run build`, `publishConfig.access: "public"`, `main`/`types`/`exports` all pointing at `dist`. `npm pack --dry-run` produces a clean 17-file tarball shipping `dist/*.js` + `*.d.ts` (the value exports hub needs are in `dist/index.js`). A real consumer can `bun add` it and import `validateVaultScopes` / `ACCOUNT_ERROR_CODES` / etc.

## ⚠️ Required out-of-band step — Aaron

Publishing will **404 on provenance** until an **npm Trusted Publisher rule for `@openparachute/door-contract`** exists (per-package OIDC — each `@openparachute/*` package needs its own rule; same as hub / scope-guard / depcheck):

> npmjs.com → `@openparachute/door-contract` → Settings → Trusted Publishers → add GitHub Actions: org `ParachuteComputer` / repo `parachute-hub` / workflow `release.yml` / env blank

## Remaining sequence (to unblock hub-from-npm)

1. **This PR merges** — publish path exists.
2. **Aaron**: add the door-contract npm Trusted Publisher rule (above).
3. Tag `door-contract-v0.6.0` → CI publishes `@openparachute/door-contract@0.6.0`.
4. **Follow-on PR (step 2/3)**: flip hub's dep `workspace:*` → `^0.6.0` (mirroring how `@openparachute/depcheck` is pinned to a real version).
5. Cut a fresh hub rc → the real-install **e2e.yml goes green**.
6. Then promote hub stable.

**No hub rc bump in this PR:** it's CI-config + docs + a comment; the hub tarball's runtime behavior is unchanged, and a hub rc now would ship the still-broken `workspace:*` dep. The rc bump belongs to the step-2 dep-flip PR. Consistent with RELEASING.md's doc-only/CI-config convention.

## Validation

- `actionlint .github/workflows/release.yml` — **PASS** (no issues); YAML parses, 6 jobs present, 8 tag patterns.
- `bun run typecheck` (`tsc --noEmit`) — **PASS**.
- `biome check src/account-api.ts` — **PASS**.
- `npm pack --dry-run` on door-contract — clean tarball, dist JS + types shipped.
- Did NOT run anything that launchctl-boots the live hub daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB