### PR TITLE
release: hub door-contract dep workspace:* → ^0.6.0 (npm-boot fix, step 2/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.7-rc.16] - 2026-07-22
+
+The npm-boot fix, step 2/3: hub now resolves `@openparachute/door-contract` from the registry, so the published hub boots from a clean `bun add -g @openparachute/hub@rc` install instead of crash-looping.
+
+### Fixed
+
+- **`@openparachute/door-contract` moved from a `workspace:*` devDependency to a real `^0.6.0` runtime `dependency`** (mirroring `@openparachute/depcheck`). `src/account-api.ts` does a VALUE import of the contract (`validateVaultScopes`, account/descriptor types), so it must resolve at runtime — but the published hub tarball ships only `src` (not `packages/`), so a `workspace:*` spec could never resolve outside the bun-linked dev checkout. An npm-installed hub therefore crashed at boot with `Cannot find module '@openparachute/door-contract'`. Now that door-contract@0.6.0 is published to npm (step 1/3, #766), the npm-installed hub resolves it from the registry. Proven locally with a `npm pack` + clean-install-outside-the-workspace smoke (the exact crash is gone); CI's `e2e.yml` `HUB_SOURCE=npm:rc` run against this rc is the authoritative gate. Step 3/3 = promote (drop `-rc` → `0.7.7`) once e2e is green. Stale "dep-flip pending" comment removed from `src/account-api.ts`.
+
 ## [0.7.7-rc.13] - 2026-07-20
 
 Serve the Parachute app at the origin root — the self-hosted mirror of the hosted door. Hitting a self-host URL now lands in the app directly (no redirect hop), configurable, with every existing funnel preserved.

--- a/bun.lock
+++ b/bun.lock
@@ -7,13 +7,13 @@
       "dependencies": {
         "@node-rs/argon2": "^2.0.2",
         "@openparachute/depcheck": "0.1.1",
+        "@openparachute/door-contract": "^0.6.0",
         "jose": "^6.2.2",
         "otpauth": "^9.5.0",
         "qrcode": "^1.5.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
-        "@openparachute/door-contract": "workspace:*",
         "@types/bun": "latest",
         "@types/qrcode": "^1.5.6",
       },
@@ -30,7 +30,7 @@
     },
     "packages/door-contract": {
       "name": "@openparachute/door-contract",
-      "version": "0.1.0",
+      "version": "0.6.0",
       "peerDependencies": {
         "typescript": "^5",
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.15",
+  "version": "0.7.7-rc.16",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -34,7 +34,6 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
-    "@openparachute/door-contract": "workspace:*",
     "@types/bun": "latest",
     "@types/qrcode": "^1.5.6"
   },
@@ -44,6 +43,7 @@
   "dependencies": {
     "@node-rs/argon2": "^2.0.2",
     "@openparachute/depcheck": "0.1.1",
+    "@openparachute/door-contract": "^0.6.0",
     "jose": "^6.2.2",
     "otpauth": "^9.5.0",
     "qrcode": "^1.5.4"

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -33,16 +33,12 @@
  * ownership gate the cloud twin runs per-vault is trivially satisfied here.
  */
 import type { Database } from "bun:sqlite";
-// NOTE (npm-boot fix, step 3/3 follow-on): this is a VALUE import — hub can't
-// run without `@openparachute/door-contract` resolving at runtime. It's still a
-// `workspace:*` devDependency (package.json), which resolves only under the
-// bun-linked local install; the published hub tarball doesn't ship `packages/`,
-// so a `bun add -g @openparachute/hub@rc` install can't resolve it → boot
-// crash. Step 1 (this repo's release.yml) makes door-contract publishable to
-// npm; once Aaron adds its npm Trusted Publisher rule and it's tagged +
-// published, a follow-on PR flips this dep to a real `^0.6.0` (mirroring
-// `@openparachute/depcheck`) so the npm-installed hub boots. See RELEASING.md
-// → "Releasing door-contract".
+// NOTE: this is a VALUE import — hub can't run without
+// `@openparachute/door-contract` resolving at runtime, so it's a real
+// `^0.6.0` runtime `dependency` (package.json, mirroring `@openparachute/depcheck`)
+// and NOT a `workspace:*` devDependency. The published hub tarball doesn't ship
+// `packages/`, so the npm-installed hub resolves door-contract from the registry.
+// See RELEASING.md → "Releasing door-contract".
 import {
   type AccountBootstrap,
   type ParachuteAccountDescriptor,


### PR DESCRIPTION
## What & why (step 2/3 of the hub-can't-boot-from-npm fix)

`src/account-api.ts` does a **VALUE import** of `@openparachute/door-contract` (`validateVaultScopes`, `AccountBootstrap`/`ParachuteAccountDescriptor` types), so the module must resolve **at runtime**. It was declared `@openparachute/door-contract: "workspace:*"` in **devDependencies** — resolvable only inside the bun-linked dev checkout. The published hub tarball ships only `src` (its `files` array excludes `packages/`), so a real `bun add -g @openparachute/hub@rc` install crash-looped at boot with:

```
Cannot find module '@openparachute/door-contract'
```

`@openparachute/door-contract@0.6.0` is **now published to npm** (step 1/3, #766). This PR is the actual blocker fix: it **moves the dep from `devDependencies` (`workspace:*`) to `dependencies` (`^0.6.0`)**, mirroring how `@openparachute/depcheck` is declared, so the npm-installed hub resolves door-contract from the registry.

## The dep move
- `package.json`: `@openparachute/door-contract` removed from `devDependencies` (`workspace:*`), added to `dependencies` as `^0.6.0`.
- `bun.lock` refreshed (also picks up the stale `packages/door-contract` version `0.1.0 → 0.6.0` in the package listing).
- `src/account-api.ts`: stale "dep-flip pending (step 3/3 follow-on)" comment that #766 added replaced with an accurate note (this PR does the flip).

> Note: in the **workspace** (dev) tree, bun links door-contract to the local `packages/door-contract` path — identical to how `@openparachute/depcheck` (also a real `dependencies` entry) resolves. That is correct bun workspace behavior; the meaningful proof is the packed-tarball install below, where `packages/` is absent.

## Pack + clean-install SMOKE (the crash-gone proof)
`npm pack` the hub, then `bun add <tgz>` in a fresh temp project **outside the workspace** with a clean cache:
- Tarball ships **no `packages/`** and carries the flipped dep (`"@openparachute/door-contract": "^0.6.0"`). ✅
- Fresh install pulls `@openparachute/door-contract@0.6.0` **from npm** — a **real directory** (not a workspace symlink), with `dist/`, exporting `validateVaultScopes` (function) + `ACCOUNT_ERROR_CODES` (19 codes). ✅
- Importing `@openparachute/door-contract` from **inside the installed hub** resolves to `.../node_modules/@openparachute/door-contract/dist/index.js` — **the exact `Cannot find module` crash is GONE.** ✅

CI's `e2e.yml` `HUB_SOURCE=npm:rc` run against this fresh **rc.16** is the **authoritative gate** — it exercises a real npm install of the tagged rc end-to-end.

## Versioning / gates
- Bumps `0.7.7-rc.15 → 0.7.7-rc.16` (a fresh rc whose e2e can verify the fix) + CHANGELOG entry.
- `bun test ./src` (hub-only): **4301 pass / 1 skip / 40 fail**. All 40 failures are the **pre-existing, environmental** `install.test.ts` ENOENT — `migrate.ts` `sizeOf()` races the live `~/.parachute` agent-sessions dir (a bun cache file vanishing mid-scan). **Identical 40 failures reproduce on clean `origin/main`** (`c15b1fd`), so they are not introduced here. door-contract consumer + oauth/session suites in isolation: **357 pass / 0 fail**.
- `bun run typecheck` clean · `biome check` clean on changed files.

## Step 3/3
Promote: drop `-rc` → `0.7.7` + tag, once **rc.16's `e2e` (npm:rc) is green** — that is the final gate before hub stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB