### PR TITLE
release: hub 0.7.7 (@latest)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7-rc.17",
+  "version": "0.7.7",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Promote the 0.7.7-rc chain to stable **@latest** — version-only bump (`0.7.7-rc.17` → `0.7.7`), no code change (this commit is byte-identical to rc.17 except the version).

**Why now:** the two blockers are cleared —
- **rc.16** flipped `@openparachute/door-contract` to a real npm dependency, so the published hub boots from a clean `bun add -g @openparachute/hub@rc` install instead of crash-looping (`Cannot find module`).
- **rc.17** fixed the two chronic setup-wizard bugs (headless stdin busy-hang + silent vault-step skip on an init'd box) that had hung the Tier-1 e2e for months — real product bugs affecting headless/cloud-init operators too.

**Gate:** the CI `e2e.yml` `HUB_SOURCE=npm:rc` run against **0.7.7-rc.17** is GREEN — first genuine pass of this tier in months (stages 1/2/4: install → init → wizard creates vault → MCP round-trip → idempotent re-init → wipe-recovery; stage 3 self-skips without a CF cert). Plus a local `HUB_SOURCE=local` Docker green on the same commit, full unit suite, and two review rounds on #768.

On merge → tag `v0.7.7` → CI publishes to `@latest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)