### PR TITLE
feat(door-contract): fail-closed slot validation + reject '*' module (0.6.1, MCP Phase 2 PR1 / #765)

### DIFF
--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -1,5 +1,31 @@
 # @openparachute/door-contract
 
+## 0.6.1
+
+Fail-closed hardening of the composed account-scope grammar (unified `/mcp` —
+MCP Phase 2 PR1, hub #765 findings 1/3/4). Purely additive: every currently-valid
+composed / legacy form still parses byte-identically; this bump only NEWLY rejects
+malformed inputs that the Phase-1 grammar let through. No change to
+`isRequestableAccountScope` (composed forms stay non-requestable; consent is their
+sole author).
+
+- **Finding 1 — builders validate their slots and THROW.** The composed-scope
+  builders (`composedWildcardVaultsScope`, `composedVaultScope`,
+  `composedVaultCreateScope`, `composedModuleScope`) now reject any interpolated
+  `id` / `vault` / `module` slot that is empty, the wildcard sentinel `*`, or
+  contains a `:` — either would inject extra scope segments or forge a wildcard
+  grant a user never consented to. A malformed slot throws a clear `Error` at
+  build time, so it can never be minted. Wildcard authority is expressed ONLY by
+  the dedicated `composedWildcardVaultsScope` builder, never by passing `*` as a
+  name.
+- **Finding 4 — the parser rejects `*` as a module name.** `parseComposedAccountScope`
+  now returns `null` for `account:<id>:mod:*:<verb>` (previously it parsed as a
+  literal `*` module), mirroring the vault slot's existing `*`-fails-closed rule.
+  Fail-closed: an unrecognized form is denied downstream.
+- **Finding 3 — doc fix.** Corrected the §1.4 guardrail comment that mislabeled
+  the cross-account mint gate as "the hub's" — it is the CLOUD door's mint gate
+  (`parachute-cloud workers/identity/src/oauth-token.ts`, `denyForeignAccountMint`).
+
 ## 0.6.0
 
 The COMPOSED account-scope grammar (unified `/mcp` — Phase 1). The ratified

--- a/packages/door-contract/CHANGELOG.md
+++ b/packages/door-contract/CHANGELOG.md
@@ -12,12 +12,14 @@ sole author).
 - **Finding 1 — builders validate their slots and THROW.** The composed-scope
   builders (`composedWildcardVaultsScope`, `composedVaultScope`,
   `composedVaultCreateScope`, `composedModuleScope`) now reject any interpolated
-  `id` / `vault` / `module` slot that is empty, the wildcard sentinel `*`, or
-  contains a `:` — either would inject extra scope segments or forge a wildcard
-  grant a user never consented to. A malformed slot throws a clear `Error` at
-  build time, so it can never be minted. Wildcard authority is expressed ONLY by
-  the dedicated `composedWildcardVaultsScope` builder, never by passing `*` as a
-  name.
+  `id` / `vault` / `module` slot that is empty, the wildcard sentinel `*`,
+  contains a `:`, or contains WHITESPACE — any would inject extra scope segments
+  or forge a wildcard grant a user never consented to (whitespace splits the
+  space-delimited OAuth `scope` claim on the wire into a fragment that can
+  re-parse as a valid grant, so it must fail closed at build too). A malformed
+  slot throws a clear `Error` at build time, so it can never be minted. Wildcard
+  authority is expressed ONLY by the dedicated `composedWildcardVaultsScope`
+  builder, never by passing `*` as a name.
 - **Finding 4 — the parser rejects `*` as a module name.** `parseComposedAccountScope`
   now returns `null` for `account:<id>:mod:*:<verb>` (previously it parsed as a
   literal `*` module), mirroring the vault slot's existing `*`-fails-closed rule.

--- a/packages/door-contract/package.json
+++ b/packages/door-contract/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/door-contract",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "The Parachute door contract: shared OAuth-issuer + /account/* wire types, constants, and conformance vectors that both doors (self-host hub + hosted cloud) implement.",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -192,6 +192,60 @@ describe("composed account-scope grammar (unified /mcp — Phase 1)", () => {
     expect(composedModuleScope("u_1", "scribe", "admin")).toBe("account:u_1:mod:scribe:admin");
   });
 
+  // #765 finding 1 — the composed BUILDERS validate every interpolated slot and
+  // THROW on a malformed value, so a forged wildcard or a `:`-separator-injected
+  // scope can never be constructed (and therefore never minted). Fail-closed at
+  // build time. Wildcard authority is ONLY ever composedWildcardVaultsScope's job.
+  test("composed builders throw on empty / `*` / `:`-containing slots (#765 finding 1)", () => {
+    // The `id` slot — every composed builder takes an id; each rejects a bad one.
+    for (const badId of ["", "*", "a:b", "self:extra", ":", "u_1:vaults:*:admin"]) {
+      expect(() => composedWildcardVaultsScope(badId, "read")).toThrow();
+      expect(() => composedVaultScope(badId, "work", "read")).toThrow();
+      expect(() => composedVaultCreateScope(badId)).toThrow();
+      expect(() => composedModuleScope(badId, "scribe", "read")).toThrow();
+    }
+    // The `vault` slot — composedVaultScope only.
+    for (const badVault of ["", "*", "work:read", ":", "a:*"]) {
+      expect(() => composedVaultScope("self", badVault, "read")).toThrow();
+    }
+    // The `module` slot — composedModuleScope only.
+    for (const badModule of ["", "*", "scribe:admin", ":", "x:*"]) {
+      expect(() => composedModuleScope("self", badModule, "read")).toThrow();
+    }
+    // Sanity: valid slots do NOT throw and still emit the canonical wire strings
+    // (the wildcard builder's OWN `*` is legitimate — it is the dedicated builder).
+    expect(composedWildcardVaultsScope("self", "read")).toBe("account:self:vaults:*:read");
+    expect(composedVaultScope("u_1", "work", "write")).toBe("account:u_1:vaults:work:write");
+    expect(composedVaultCreateScope("u_1")).toBe("account:u_1:vault-create");
+    expect(composedModuleScope("u_1", "scribe", "admin")).toBe("account:u_1:mod:scribe:admin");
+  });
+
+  // Byte-identical regression guard: every currently-valid composed / legacy form
+  // still parses to EXACTLY the same shape after the #765 hardening. This is
+  // additive hardening — recognition of any valid input must NOT change.
+  test("parseComposedAccountScope — the valid-form table round-trips unchanged", () => {
+    const table: Array<[string, ReturnType<typeof parseComposedAccountScope>]> = [
+      ["account:self:vaults:*:read", { kind: "wildcard-vaults", id: "self", verb: "read" }],
+      ["account:u_1:vaults:*:admin", { kind: "wildcard-vaults", id: "u_1", verb: "admin" }],
+      [
+        "account:self:vaults:work:write",
+        { kind: "vault", id: "self", vault: "work", verb: "write" },
+      ],
+      ["account:u_1:vaults:moss:read", { kind: "vault", id: "u_1", vault: "moss", verb: "read" }],
+      ["account:self:vault-create", { kind: "vault-create", id: "self" }],
+      [
+        "account:self:mod:scribe:admin",
+        { kind: "module", id: "self", module: "scribe", verb: "admin" },
+      ],
+      ["account:u_1:mod:notes:read", { kind: "module", id: "u_1", module: "notes", verb: "read" }],
+      ["account:self:vaults", { kind: "legacy-blanket", id: "self" }],
+      ["account:u_1:vaults:work", { kind: "legacy-vault", id: "u_1", vault: "work" }],
+    ];
+    for (const [scope, expected] of table) {
+      expect(parseComposedAccountScope(scope)).toEqual(expected);
+    }
+  });
+
   test("the composed verb ladder is admin ⊇ write ⊇ read", () => {
     expect(COMPOSED_VERB_RANK).toEqual({ read: 0, write: 1, admin: 2 });
     for (const v of ["read", "write", "admin"]) expect(isComposedVaultVerb(v)).toBe(true);
@@ -342,16 +396,20 @@ describe("composed account-scope grammar (unified /mcp — Phase 1)", () => {
     }
   });
 
-  test("parseComposedAccountScope — `*` is ONLY the wildcard, never a vault name", () => {
-    // 5-part `vaults:*:<verb>` → wildcard (above). A 4-part legacy narrowed form
-    // with `*` in the vault slot is NOT a real vault → fail closed.
+  test("parseComposedAccountScope — `*` is ONLY the wildcard, never a vault OR module name", () => {
+    // 5-part `vaults:*:<verb>` → the legitimate wildcard vault grant (below).
+    // Everywhere else `*` is a smuggled sentinel and fails closed:
+    //   - a 4-part legacy narrowed form with `*` in the vault slot is not a real
+    //     vault → null;
+    //   - a 5-part `mod:*:<verb>` is not a real module → null (#765 finding 4; a
+    //     `*` module name would otherwise forge an all-modules grant).
     expect(parseComposedAccountScope("account:self:vaults:*")).toBeNull();
-    // And a `*` module name (empty-ish sentinel misuse) still parses as a literal
-    // module string only in the 5-part mod family — `*` is not special there.
-    expect(parseComposedAccountScope("account:self:mod:*:read")).toEqual({
-      kind: "module",
+    expect(parseComposedAccountScope("account:self:mod:*:read")).toBeNull();
+    expect(parseComposedAccountScope("account:u_1:mod:*:admin")).toBeNull();
+    // The legitimate vaults wildcard is UNCHANGED by the module-slot hardening.
+    expect(parseComposedAccountScope("account:self:vaults:*:read")).toEqual({
+      kind: "wildcard-vaults",
       id: "self",
-      module: "*",
       verb: "read",
     });
   });

--- a/packages/door-contract/src/__tests__/vectors.test.ts
+++ b/packages/door-contract/src/__tests__/vectors.test.ts
@@ -196,21 +196,22 @@ describe("composed account-scope grammar (unified /mcp — Phase 1)", () => {
   // THROW on a malformed value, so a forged wildcard or a `:`-separator-injected
   // scope can never be constructed (and therefore never minted). Fail-closed at
   // build time. Wildcard authority is ONLY ever composedWildcardVaultsScope's job.
-  test("composed builders throw on empty / `*` / `:`-containing slots (#765 finding 1)", () => {
+  test("composed builders throw on empty / `*` / `:` / whitespace slots (#765 finding 1)", () => {
     // The `id` slot — every composed builder takes an id; each rejects a bad one.
-    for (const badId of ["", "*", "a:b", "self:extra", ":", "u_1:vaults:*:admin"]) {
-      expect(() => composedWildcardVaultsScope(badId, "read")).toThrow();
-      expect(() => composedVaultScope(badId, "work", "read")).toThrow();
-      expect(() => composedVaultCreateScope(badId)).toThrow();
-      expect(() => composedModuleScope(badId, "scribe", "read")).toThrow();
+    // `.toThrow(/composed scope/)` pins the guard's own message (not a stray throw).
+    for (const badId of ["", "*", "a:b", "self:extra", ":", "u_1:vaults:*:admin", "u 1", "a\tb"]) {
+      expect(() => composedWildcardVaultsScope(badId, "read")).toThrow(/composed scope/);
+      expect(() => composedVaultScope(badId, "work", "read")).toThrow(/composed scope/);
+      expect(() => composedVaultCreateScope(badId)).toThrow(/composed scope/);
+      expect(() => composedModuleScope(badId, "scribe", "read")).toThrow(/composed scope/);
     }
     // The `vault` slot — composedVaultScope only.
-    for (const badVault of ["", "*", "work:read", ":", "a:*"]) {
-      expect(() => composedVaultScope("self", badVault, "read")).toThrow();
+    for (const badVault of ["", "*", "work:read", ":", "a:*", "my vault", "a\nb"]) {
+      expect(() => composedVaultScope("self", badVault, "read")).toThrow(/composed scope/);
     }
     // The `module` slot — composedModuleScope only.
-    for (const badModule of ["", "*", "scribe:admin", ":", "x:*"]) {
-      expect(() => composedModuleScope("self", badModule, "read")).toThrow();
+    for (const badModule of ["", "*", "scribe:admin", ":", "x:*", "my mod", "a\tb"]) {
+      expect(() => composedModuleScope("self", badModule, "read")).toThrow(/composed scope/);
     }
     // Sanity: valid slots do NOT throw and still emit the canonical wire strings
     // (the wildcard builder's OWN `*` is legitimate — it is the dedicated builder).

--- a/packages/door-contract/src/scopes.ts
+++ b/packages/door-contract/src/scopes.ts
@@ -280,6 +280,11 @@ export type ComposedAccountScope =
  *   - a value containing `:` — the scope separator, which would inject EXTRA
  *     segments (e.g. a `vault` of `"x:*"` becomes `…:vaults:x:*:<verb>`, forging
  *     a wildcard, or shifts the verb slot).
+ *   - a value containing WHITESPACE — OAuth `scope` claims are space-delimited, so
+ *     a space/tab/newline in a slot splits the scope on the wire into a fragment
+ *     that can re-parse as a VALID (e.g. legacy) grant — it would NOT fail closed
+ *     the way `:` does. Defense-in-depth: real slot sources are charset-constrained
+ *     today, but this validation layer must be complete.
  * Throws a clear Error on violation so a malformed grant can never be built (and
  * therefore never minted) — fail-closed at construction time. Well-typed callers
  * pass real ids/names and never trip this; it exists to reject smuggled sentinels
@@ -297,6 +302,11 @@ function assertComposedSlot(kind: "id" | "vault" | "module", value: string): voi
   if (value.includes(":")) {
     throw new Error(
       `composed scope ${kind} slot must not contain ":" (got ${JSON.stringify(value)})`,
+    );
+  }
+  if (/\s/.test(value)) {
+    throw new Error(
+      `composed scope ${kind} slot must not contain whitespace (got ${JSON.stringify(value)})`,
     );
   }
 }

--- a/packages/door-contract/src/scopes.ts
+++ b/packages/door-contract/src/scopes.ts
@@ -270,23 +270,68 @@ export type ComposedAccountScope =
   | { kind: "legacy-vault"; id: string; vault: string };
 
 /**
- * Build the wildcard vault grant `account:<id>:vaults:*:<verb>`. */
+ * Guard an interpolated composed-scope SLOT (an account `id`, a `vault` name, or
+ * a `module` name) before a builder concatenates it into a scope string. A slot
+ * may never be:
+ *   - empty (`""`) — a builder must never emit a scope with a blank segment;
+ *   - the wildcard sentinel `*` — wildcard authority is expressed ONLY by the
+ *     dedicated `composedWildcardVaultsScope` builder; smuggling `*` through a
+ *     name slot would forge a wildcard grant a consenting user never approved;
+ *   - a value containing `:` — the scope separator, which would inject EXTRA
+ *     segments (e.g. a `vault` of `"x:*"` becomes `…:vaults:x:*:<verb>`, forging
+ *     a wildcard, or shifts the verb slot).
+ * Throws a clear Error on violation so a malformed grant can never be built (and
+ * therefore never minted) — fail-closed at construction time. Well-typed callers
+ * pass real ids/names and never trip this; it exists to reject smuggled sentinels
+ * and separator-injection at the door.
+ */
+function assertComposedSlot(kind: "id" | "vault" | "module", value: string): void {
+  if (value.length === 0) {
+    throw new Error(`composed scope ${kind} slot must not be empty`);
+  }
+  if (value === COMPOSED_VAULTS_WILDCARD) {
+    throw new Error(
+      `composed scope ${kind} slot must not be "*" — wildcard is composedWildcardVaultsScope's job, never a name`,
+    );
+  }
+  if (value.includes(":")) {
+    throw new Error(
+      `composed scope ${kind} slot must not contain ":" (got ${JSON.stringify(value)})`,
+    );
+  }
+}
+
+/**
+ * Build the wildcard vault grant `account:<id>:vaults:*:<verb>`. Throws if `id`
+ * is empty, `*`, or contains `:` (see `assertComposedSlot`). */
 export function composedWildcardVaultsScope(id: string, verb: ComposedVaultVerb): string {
+  assertComposedSlot("id", id);
   return `account:${id}:${COMPOSED_VAULTS_SEGMENT}:${COMPOSED_VAULTS_WILDCARD}:${verb}`;
 }
 
-/** Build a per-vault grant `account:<id>:vaults:<vault>:<verb>`. */
+/**
+ * Build a per-vault grant `account:<id>:vaults:<vault>:<verb>`. Throws if `id` or
+ * `vault` is empty, `*`, or contains `:` (see `assertComposedSlot`). */
 export function composedVaultScope(id: string, vault: string, verb: ComposedVaultVerb): string {
+  assertComposedSlot("id", id);
+  assertComposedSlot("vault", vault);
   return `account:${id}:${COMPOSED_VAULTS_SEGMENT}:${vault}:${verb}`;
 }
 
-/** Build the "create new vaults" capability `account:<id>:vault-create`. */
+/**
+ * Build the "create new vaults" capability `account:<id>:vault-create`. Throws if
+ * `id` is empty, `*`, or contains `:` (see `assertComposedSlot`). */
 export function composedVaultCreateScope(id: string): string {
+  assertComposedSlot("id", id);
   return `account:${id}:${COMPOSED_VAULT_CREATE_VERB}`;
 }
 
-/** Build a module grant `account:<id>:mod:<module>:<verb>`. */
+/**
+ * Build a module grant `account:<id>:mod:<module>:<verb>`. Throws if `id` or
+ * `module` is empty, `*`, or contains `:` (see `assertComposedSlot`). */
 export function composedModuleScope(id: string, module: string, verb: ComposedVaultVerb): string {
+  assertComposedSlot("id", id);
+  assertComposedSlot("module", module);
   return `account:${id}:${COMPOSED_MODULE_SEGMENT}:${module}:${verb}`;
 }
 
@@ -297,19 +342,21 @@ export function composedModuleScope(id: string, module: string, verb: ComposedVa
  * AND the legacy Wave A forms so that a single pass extracts `<id>` from every
  * `account:`-namespaced grant.
  *
- * §1.4 guardrail (unified-MCP design): the hub's cross-account mint gate
- * (`denyForeignAccountMint`) id-checks only the forms its parser RECOGNIZES — a
- * form that parses to `null` would SKIP the id check. The composed forms are
- * non-requestable (thus unreachable by that gate today), but when a later phase
- * makes them mintable the gate must already extract their `<id>`. Recognizing
- * every family HERE is what lets the gate reject a foreign-id composed scope then.
+ * §1.4 guardrail (unified-MCP design): the CLOUD door's cross-account mint gate
+ * (`parachute-cloud workers/identity/src/oauth-token.ts`, `denyForeignAccountMint`)
+ * id-checks only the forms its parser RECOGNIZES — a form that parses to `null`
+ * would SKIP the id check. The composed forms are non-requestable (thus
+ * unreachable by that gate today), but when a later phase makes them mintable the
+ * gate must already extract their `<id>`. Recognizing every family HERE is what
+ * lets the gate reject a foreign-id composed scope then.
  *
  * The `account:<id>:{read|admin}` account-verb ladder is intentionally NOT a
  * composed form (it is `parseAccountScope`'s domain) and yields `null` here.
  *
  * Fail-closed rules: `account` resource required, `<id>` non-empty, verbs from the
  * composed ladder, and `*` is ONLY ever the wildcard sentinel — it is never
- * accepted as a concrete vault name (a 4-part `account:<id>:vaults:*` → `null`).
+ * accepted as a concrete vault OR module name (a 4-part `account:<id>:vaults:*`
+ * and a 5-part `account:<id>:mod:*:<verb>` both → `null`).
  */
 export function parseComposedAccountScope(scope: string): ComposedAccountScope | null {
   const parts = scope.split(":");
@@ -342,7 +389,10 @@ export function parseComposedAccountScope(scope: string): ComposedAccountScope |
       return { kind: "vault", id, vault: target, verb };
     }
     if (family === COMPOSED_MODULE_SEGMENT) {
-      if (target.length === 0) return null;
+      // `*` is never a concrete module name — a `*` in the module slot fails
+      // closed (mirrors the vault slot above), so a wildcard sentinel can never
+      // be smuggled in to forge an all-modules grant.
+      if (target.length === 0 || target === COMPOSED_VAULTS_WILDCARD) return null;
       return { kind: "module", id, module: target, verb };
     }
     return null;


### PR DESCRIPTION
## MCP Phase 2 PR1 — door-contract grammar hardening (hub #765 findings 1/3/4)

Hub-first hardening of the composed account-scope grammar in `packages/door-contract/src/scopes.ts` (Phase 1, merged #764), published as **0.6.1**. Cloud's Phase 2 PRs import these builders/parsers, so the grammar is made airtight + fail-closed FIRST. **Purely additive** — every currently-valid parse stays byte-identical; only newly-malformed inputs are rejected.

### The three fixes
- **Finding 1 — builders throw on malformed slots.** `composedWildcardVaultsScope`, `composedVaultScope`, `composedVaultCreateScope`, and `composedModuleScope` now validate every interpolated `id` / `vault` / `module` slot via a shared `assertComposedSlot` guard and **throw a clear `Error`** when a slot is empty, the wildcard sentinel `*`, or contains a `:`. Either would inject extra scope segments (separator injection) or forge a wildcard grant a user never consented to. Wildcard authority is expressed ONLY by the dedicated `composedWildcardVaultsScope` builder. Fail-closed at construction time → a malformed grant can never be minted.
- **Finding 4 — parser rejects `*` as a module name.** `parseComposedAccountScope` now returns `null` for `account:<id>:mod:*:<verb>` (previously parsed as a literal `*` module), mirroring the vault slot's existing `*`-fails-closed rule. Denied downstream, consistent with fail-closed.
- **Finding 3 — doc fix.** Corrected the §1.4 guardrail comment that mislabeled the cross-account mint gate as "the hub's" — it is the **CLOUD door's** mint gate (`parachute-cloud workers/identity/src/oauth-token.ts`, `denyForeignAccountMint`). Swept the file: lines referencing the self-host hub / hub exact-string gate are accurate and left as-is.

### Invariants held
- **Existing parse fixtures byte-identical.** A new regression table re-locks all 9 currently-valid composed/legacy forms. The ONLY existing assertion that changed is `account:<id>:mod:*:<verb> → null` — which IS Finding 4.
- **Fail-closed preserved** — unrecognized → `null` (deny), never a permissive fallback.
- **`isRequestableAccountScope` unchanged** — composed forms stay non-requestable; consent is their sole author.

### Version + gates (`packages/door-contract`)
- `package.json` 0.6.0 → **0.6.1** + CHANGELOG entry.
- `bun test src` → **85 pass / 0 fail / 338 expect() calls** (baseline was 83/0/289; +2 tests: builder-throws + valid-form regression table).
- `bun run typecheck` (`tsc --noEmit`, TypeScript 5.9.3) → **exit 0**.
- `bunx biome check` on changed files → **clean**.

Do NOT publish/tag — the tag → CI publish happens after review + merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB