### PR TITLE
chore(app-package): point the app front door at the renamed npm package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.8-rc.1] - 2026-07-25
+
+**chore(app-package): point the app front door at its renamed npm package — `@openparachute/parachute-app` → `@openparachute/app`.** The app package was renamed to drop the scope stutter (every other `@openparachute` package is a bare noun); this bump repoints every hub site that names it. Clean switch, no dual-name fallback (see below).
+
+- **The npm-name sites move, the identity sites don't.** Changed: `APP_PACKAGE` (`src/root-serve.ts`, the root-serve dist resolver), `APP_FALLBACK.package` + its `--package` startCmd arg (`src/service-spec.ts`), the `help` module-start-command line, and the resolver test's fixture package name — plus the comments that name the package. **Unchanged:** the `parachute-app` `manifestName` (hub's services.json discovery key, still matches the app's `dist/.parachute/info` name), the `app` short name, the port-1944 reservation, and every `parachute-app#N` / design-doc reference (those are the GitHub repo, which keeps its name).
+- **Clean switch, not dual-name.** Hub resolves only `@openparachute/app`. This is safe because (1) the merge order publishes `@openparachute/app` before this hub ships, so hub never names a package that doesn't exist; (2) the old `@openparachute/parachute-app` stays published (deprecated), so any un-upgraded hub keeps resolving it; (3) the npm-install base is ~zero — the app became installable-from-npm one day ago, and Aaron's dogfood box is bun-linked, not npm-installed. The one residual: an operator who npm-installed the app in that <1-day window and upgrades hub without re-running `parachute install app` re-resolves the now-absent old package until they do — a single command, and the resolver's uncached-failure recovery heals it with no restart.
+- **Depends on the app publish landing first** (`@openparachute/app` on npm) before this hub tags a release.
+
 ## [0.7.7-rc.17] - 2026-07-22
 
 Two real product/harness bugs that chronically hung the Tier-1 e2e (blocking the 0.7.7 stable push): the CLI setup-wizard busy-hangs on a closed stdin, and — once unhung — silently skips its vault step on an init'd box so `--vault-mode create --vault-name` is dropped.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.7",
+  "version": "0.7.8-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/notes-serve.test.ts
+++ b/src/__tests__/notes-serve.test.ts
@@ -190,8 +190,8 @@ describe("notesFetch /health (2026-07-11, hub-parity P5)", () => {
 });
 
 // hub-parity P5 (2026-07-11): the shim generalized beyond notes to serve
-// @openparachute/parachute-app (mount `/app`, port 1944) via the same
-// FIRST_PARTY_FALLBACKS startCmd shape (`--package @openparachute/parachute-app`).
+// @openparachute/app (mount `/app`, port 1944) via the same
+// FIRST_PARTY_FALLBACKS startCmd shape (`--package @openparachute/app`).
 // These tests re-run the load-bearing PWA regression (sw.js / manifest
 // content-type, SPA fallback, mount-strip) for a NON-notes package/mount to
 // prove the generalization didn't accidentally hardcode "notes" anywhere in
@@ -424,7 +424,7 @@ describe("resolveNotesDistFrom (hub#194)", () => {
  * is the caller's `pkg`, not a hardcoded "notes" string.
  */
 describe("resolveNotesDistFrom --package (hub-parity P5)", () => {
-  const APP_PKG = "@openparachute/parachute-app";
+  const APP_PKG = "@openparachute/app";
 
   function makeAppFixture(): { home: string; cleanup: () => void; dist: string } {
     const root = realpathSync(mkdtempSync(join(tmpdir(), "pcli-app-resolve-")));
@@ -505,7 +505,7 @@ describe("resolveNotesDistFrom --package (hub-parity P5)", () => {
         cwd: "/cwd-with-app",
         home: "/h",
         pkg: APP_PKG,
-        resolveSync: () => "/cwd-with-app/node_modules/@openparachute/parachute-app/package.json",
+        resolveSync: () => "/cwd-with-app/node_modules/@openparachute/app/package.json",
         existsSync: () => false,
       }),
     ).toThrow(new RegExp(`${APP_PKG.replace("/", "\\/")} resolved at .* has no dist/ directory`));

--- a/src/__tests__/services-manifest.test.ts
+++ b/src/__tests__/services-manifest.test.ts
@@ -1396,7 +1396,7 @@ describe("stale OLD-UI-host app row heal (hub-parity P5, B1)", () => {
       );
       const m = readManifest(path);
       // The stale row is gone — it never survives to spawn a crash-looping
-      // `--package @openparachute/parachute-app` unit the operator never
+      // `--package @openparachute/app` unit the operator never
       // installed.
       expect(m.services).toHaveLength(0);
       // Rewritten clean on disk too.

--- a/src/commands/setup.ts
+++ b/src/commands/setup.ts
@@ -176,7 +176,7 @@ const BLURBS: Record<string, string> = {
   vault: "knowledge graph (MCP) — your owner-authenticated note + tag store",
   surface: "Parachute UI host — auto-installs Notes on first boot (the recommended UI path)",
   // hub-parity P5 (2026-07-11): `app` is now the NEW super-surface front
-  // door (@openparachute/parachute-app) — a real FIRST_PARTY_FALLBACKS
+  // door (@openparachute/app) — a real FIRST_PARTY_FALLBACKS
   // entry, not a legacy survey row. It is UNRELATED to the pre-2026-05-27
   // `app` package that renamed to `surface` (that blurb lives under the
   // `surface` key above); the two just happen to share the short name

--- a/src/help.ts
+++ b/src/help.ts
@@ -552,7 +552,7 @@ Module start commands (run by the supervisor under \`serve\`):
   vault     parachute-vault serve
   scribe    parachute-scribe serve
   surface   parachute-surface serve
-  app       bun <cli>/notes-serve.ts --port <configured> --mount <paths[0]> --package @openparachute/parachute-app
+  app       bun <cli>/notes-serve.ts --port <configured> --mount <paths[0]> --package @openparachute/app
   notes     bun <cli>/notes-serve.ts --port <configured> --mount <paths[0]>   # back-compat: legacy notes-daemon
 `;
 }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -1439,7 +1439,7 @@ export interface HubFetchDeps {
    * Resolve the installed app's `dist/` directory for `root_mode = serve-app`.
    * Returns the dist dir, or `null` when the app isn't installed (→ serve-app
    * falls back to the redirect). Production defaults to a memoizing resolver
-   * over the real `@openparachute/parachute-app` package (`makeAppDistResolver`);
+   * over the real `@openparachute/app` package (`makeAppDistResolver`);
    * tests inject a fixture dir or a `() => null` to drive the not-installed
    * fallback without a real global install.
    */

--- a/src/notes-serve.ts
+++ b/src/notes-serve.ts
@@ -3,7 +3,7 @@
 /**
  * Tiny static-file server for a Parachute PWA bundle — originally written
  * for @openparachute/notes, generalized in hub-parity P5 (2026-07-11) to
- * also serve @openparachute/parachute-app (the super-surface front door,
+ * also serve @openparachute/app (the super-surface front door,
  * port 1944, mount `/app`) via the same shim. Any package matching this
  * shape (a prebuilt SPA `dist/` with no server of its own) can reuse it.
  *
@@ -27,7 +27,7 @@
  * `--package` (default `@openparachute/notes`, back-compat) names the npm
  * package whose `dist/` we resolve when `--dist` is omitted. Passed by
  * FIRST_PARTY_FALLBACKS entries whose startCmd composes this shim for a
- * package other than notes (e.g. `app`'s `--package @openparachute/parachute-app`).
+ * package other than notes (e.g. `app`'s `--package @openparachute/app`).
  *
  * If --dist is omitted, we resolve the package's dist directory via
  * Bun.resolveSync. If that fails (package not installed globally, or

--- a/src/root-serve.ts
+++ b/src/root-serve.ts
@@ -5,7 +5,7 @@
  *
  * When an operator flips the root mode to `serve-app` (or a fresh hub installs
  * the app during setup), the hub answers its own origin root with the installed
- * `@openparachute/parachute-app` bundle instead of 302-ing to `/admin`. This is
+ * `@openparachute/app` bundle instead of 302-ing to `/admin`. This is
  * the self-hosted mirror of the hosted door: hit your box's URL, land in the
  * app — no redirect hop.
  *
@@ -33,7 +33,7 @@ import { join } from "node:path";
 import { resolveNotesDistFrom } from "./notes-serve.ts";
 
 /** The npm package whose built `dist/` is the app front door. */
-export const APP_PACKAGE = "@openparachute/parachute-app";
+export const APP_PACKAGE = "@openparachute/app";
 
 /**
  * Namespaces that keep the hub's branded 404 even in serve-app mode. These are

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -74,7 +74,7 @@ export const PORT_RESERVATIONS: readonly PortReservation[] = [
   { port: 1942, name: "parachute-notes", status: "assigned" },
   { port: 1943, name: "parachute-scribe", status: "assigned" },
   // hub-parity P5 (2026-07-11): parachute-app's canonical slot — the NEW
-  // super-surface front door (@openparachute/parachute-app), landing as a
+  // super-surface front door (@openparachute/app), landing as a
   // FIRST_PARTY_FALLBACKS entry (short "app") with its own hub-side static-
   // serve shim (notes-serve.ts --package). This is a DIFFERENT, unrelated
   // module from the pre-2026-05-27 `app` package described in the 1946
@@ -296,10 +296,10 @@ export function composeServiceSpec(opts: {
 //     — its startCmd is composed from the services.json entry's port + mount,
 //     which is hub-side logic, not something notes itself runs. (The archive
 //     isn't done — notes-daemon Phase 3 retirement hasn't landed.)
-//   - app: the NEW super-surface front door (@openparachute/parachute-app,
+//   - app: the NEW super-surface front door (@openparachute/app,
 //     hub-parity P5, 2026-07-11) — same shape as notes: a frontend bundle
 //     with no server of its own, served by the SAME hub-side shim
-//     (`notes-serve.ts --package @openparachute/parachute-app`). Unrelated
+//     (`notes-serve.ts --package @openparachute/app`). Unrelated
 //     to the pre-2026-05-27 `app` package that renamed to `surface` (see
 //     the KNOWN_MODULES.surface tagline + the RETIRED_MODULES note below).
 //
@@ -341,7 +341,7 @@ const NOTES_FALLBACK: FirstPartyFallback = {
   },
 };
 
-// FALLBACK: Delete when @openparachute/parachute-app ships
+// FALLBACK: Delete when @openparachute/app ships
 // .parachute/module.json AND self-registers its services.json row at boot.
 // As of hub-parity P5 the app repo doesn't carry the real module.json yet —
 // only a stale `dist/.parachute/info` artifact (name: "parachute-notes")
@@ -354,7 +354,7 @@ const NOTES_FALLBACK: FirstPartyFallback = {
 // (port + mount), running through the SAME `notes-serve.ts` shim
 // generalized in hub-parity P5 via `--package`.
 const APP_FALLBACK: FirstPartyFallback = {
-  package: "@openparachute/parachute-app",
+  package: "@openparachute/app",
   manifest: {
     name: "app",
     manifestName: "parachute-app",
@@ -376,7 +376,7 @@ const APP_FALLBACK: FirstPartyFallback = {
         "--mount",
         mount,
         "--package",
-        "@openparachute/parachute-app",
+        "@openparachute/app",
       ];
     },
     postInstallFooter: () => [
@@ -594,7 +594,7 @@ export const RETIRED_MODULES: Record<string, { retiredAt: string; replacement?: 
   // this table carried `app` + `parachute-app` (retired 2026-05-27, the
   // app → surface rename, patterns#102) from hub#219 through hub-parity P4.
   // They are REMOVED as of this note: a NEW, unrelated module — the real
-  // `@openparachute/parachute-app` super-surface front door (see
+  // `@openparachute/app` super-surface front door (see
   // FIRST_PARTY_FALLBACKS.app + PORT_RESERVATIONS' port-1944 comment) —
   // claims the `parachute-app` manifestName (and the bare `app` short) for
   // real. Keeping these entries would make `dropRetiredModuleRows`

--- a/src/services-manifest.ts
+++ b/src/services-manifest.ts
@@ -774,7 +774,7 @@ function dropRetiredModuleRows(raw: unknown, where: string): { raw: unknown; cha
  * that would have GC'd their stale row. Without a heal, that stale row would:
  *   - crash-loop on boot — `reconcilePortToCanonical` rewrites its port to
  *     1944, then the supervisor spawns the app static-serve shim against a
- *     `@openparachute/parachute-app` that isn't installed → exit 1 → a
+ *     `@openparachute/app` that isn't installed → exit 1 → a
  *     forever-restarting "app" unit the operator never installed;
  *   - hijack `/surface/*` if a real `parachute-surface` row is also present
  *     (both claim `/surface`);


### PR DESCRIPTION
`@openparachute/parachute-app` → `@openparachute/app`.

The npm package was renamed; **the service was not**. `manifestName`, `serviceInfo.name`, the `app` service identity and the port-1944 reservation are all unchanged — this diff only rewrites the package string the front door resolves and launches.

**Unblocked as of today:** `@openparachute/app@0.22.5` is published and verified installable (clean install in a throwaway dir, 64 files, `dist/` present, tarball shasum matches `npm pack`). This branch was deliberately held until the package existed, because merging it earlier would have pointed the hub at a name npm would 404.

`@openparachute/parachute-app` remains published (deprecated, not unpublished) so existing hub 0.7.7 installs that pin it keep resolving.

Operator-visible: the `app` service `startCmd` changes to `--package @openparachute/app`.