### PR TITLE
feat(mcp): forward canonical root /mcp to the vault module's daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.8-rc.2] - 2026-07-27
+
+**feat(mcp): forward canonical root `/mcp` to the vault module's daemon.** Vault has shipped root `/mcp` — a vault-agnostic MCP surface where the TOKEN's audience (not the URL) names the target vault — since 0.7.3, but the hub had no route to it: `POST /mcp` 404'd even with a vault module installed and running. This closes that missing leg.
+
+- **`/mcp` + `/mcp/*` proxy to the vault module's daemon**, same resolution (`findServiceByShort(services, "vault")`) and `publicExposure: "loopback"` cloak as the existing `/vault/admin` daemon-level mount — dispatched before the per-vault proxy and generic service mounts so no installed module can claim the namespace via `services.json` paths. The response is returned raw (no chrome injection — it's a JSON-RPC protocol surface, not a page). No running vault module → a legible JSON 404 (`{"error":"vault_module_not_running", ...}`) naming the fix, not a bare branded 404.
+- **`/.well-known/oauth-protected-resource/mcp` (RFC 9728) forwards too**, folding the same wildcard CORS headers the hub's own well-known docs carry onto the vault's proxied response (its `Response.json` carries none of its own) — browser-side MCP clients can discover root `/mcp`'s scopes cross-origin.
+- **`proxyToVaultAdmin`'s body extracted into `proxyToVaultDaemon`**, shared by both `/vault/admin` and `/mcp`; `proxyToVaultAdmin` is now a thin caller. Same documented old-install degradation as before: a legacy per-instance `parachute-vault-<name>` row doesn't resolve via `findServiceByShort`, so on such an install both surfaces 404 until vault's boot `selfRegister` rewrites the canonical row.
+- **`root-serve.ts` reserves `/mcp` from the serve-app SPA shell** (belt-and-suspenders — the hub-owned `/mcp` dispatch above already always returns before reaching the serve-app tail, but this closes the gap explicitly rather than incidentally, matching the existing `/api`, `/oauth`, `/.well-known` reservations).
+
+### Known follow-ups (deliberately out of scope — tracked as issues)
+
+- `deriveVaultScopeFromMcpUrl` (`oauth-client.ts`) doesn't recognize a remote root-form `…/mcp`, so an outbound grant falls back to broad `vault:read vault:write` instead of least-privilege.
+- Path-inserted per-vault PRM forms (`/.well-known/oauth-protected-resource/vault/<name>[/mcp]`) 404 at the hub while the vault daemon implements them.
+- Operator-facing copy (setup wizard, docs, `hub.html`) should advertise `https://<host>/mcp` as the MCP URL now that both doors accept it.
+
 ## [0.7.8-rc.1] - 2026-07-25
 
 **chore(app-package): point the app front door at its renamed npm package — `@openparachute/parachute-app` → `@openparachute/app`.** The app package was renamed to drop the scope stutter (every other `@openparachute` package is a bare noun); this bump repoints every hub site that names it. Clean switch, no dual-name fallback (see below).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.8-rc.1",
+  "version": "0.7.8-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -6702,3 +6702,209 @@ describe("hubFetch — root_mode serve-app", () => {
     }
   });
 });
+
+describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () => {
+  // The vault daemon ships canonical root /mcp (vault-agnostic — the
+  // TOKEN's audience names the target vault) since 0.7.3. This suite pins
+  // the hub-side leg: forwarding root /mcp + its PRM well-known to the
+  // vault module's daemon via `proxyToVaultDaemon`, the same resolution +
+  // loopback-cloak `/vault/admin` already uses.
+
+  /** Upstream that RECORDS every request it sees (method/path/body/forwarded
+   * host) so tests can assert both what reached the daemon and — for the
+   * cloak test — that nothing did. */
+  function startRecordingUpstream(): {
+    port: number;
+    stop: () => void;
+    requests: () => Array<{
+      method: string;
+      pathname: string;
+      body: string;
+      forwardedHost: string | null;
+    }>;
+  } {
+    const seen: Array<{
+      method: string;
+      pathname: string;
+      body: string;
+      forwardedHost: string | null;
+    }> = [];
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: async (r) => {
+        const u = new URL(r.url);
+        const body = r.body ? await r.text() : "";
+        seen.push({
+          method: r.method,
+          pathname: u.pathname,
+          body,
+          forwardedHost: r.headers.get("x-forwarded-host"),
+        });
+        return new Response(JSON.stringify({ tag: "vault-daemon", pathname: u.pathname }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+    return { port: server.port as number, stop: () => server.stop(true), requests: () => seen };
+  }
+
+  // The CANONICAL self-registered row — findServiceByShort resolves
+  // "parachute-vault" → short "vault". Deliberately NOT the vaultEntry()
+  // helper used elsewhere in this file: that emits legacy
+  // `parachute-vault-<name>` rows, which findServiceByShort intentionally
+  // does not resolve — using it here would fail these tests for the wrong
+  // reason (the same trap the /vault/admin suite above calls out).
+  function canonicalVaultRow(port: number, extra?: Partial<ServiceEntry>): ServiceEntry {
+    return {
+      name: "parachute-vault",
+      port,
+      paths: ["/vault/default"],
+      health: "/vault/default/health",
+      version: "0.7.3",
+      ...extra,
+    };
+  }
+
+  const fakeServer = (address: string) => ({ requestIP: () => ({ address }) });
+
+  test("POST/GET/DELETE /mcp reach the daemon with the JSON-RPC body + forwarded host intact", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const rpcBody = JSON.stringify({ jsonrpc: "2.0", method: "initialize", id: 1 });
+      for (const method of ["POST", "GET", "DELETE"]) {
+        const init: RequestInit = { method, headers: { host: "hub.example.com" } };
+        if (method === "POST") {
+          init.headers = { ...init.headers, "content-type": "application/json" };
+          init.body = rpcBody;
+        }
+        const res = await fetcher(new Request("http://hub.example.com/mcp", init));
+        expect(res.status).toBe(200);
+      }
+      const seen = upstream.requests();
+      expect(seen.map((r) => r.method)).toEqual(["POST", "GET", "DELETE"]);
+      for (const r of seen) {
+        expect(r.pathname).toBe("/mcp");
+        // Forwarded so the vault daemon's getBaseUrl names the public origin
+        // in the challenge + PRM (hub#358), not its internal loopback URL.
+        expect(r.forwardedHost).toBe("hub.example.com");
+      }
+      const postSeen = seen.find((r) => r.method === "POST");
+      expect(postSeen?.body).toBe(rpcBody);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("GET /.well-known/oauth-protected-resource/mcp forwards + carries wildcard CORS; OPTIONS answers locally", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+
+      const getRes = await fetcher(req("/.well-known/oauth-protected-resource/mcp"));
+      expect(getRes.status).toBe(200);
+      // The vault's Response.json carries no CORS of its own — hub folds it on.
+      expect(getRes.headers.get("access-control-allow-origin")).toBe("*");
+      expect(upstream.requests().map((r) => r.pathname)).toEqual([
+        "/.well-known/oauth-protected-resource/mcp",
+      ]);
+
+      const optRes = await fetcher(
+        req("/.well-known/oauth-protected-resource/mcp", { method: "OPTIONS" }),
+      );
+      expect(optRes.status).toBe(204);
+      expect(optRes.headers.get("access-control-allow-origin")).toBe("*");
+      // OPTIONS answered locally — the daemon only ever saw the earlier GET.
+      expect(upstream.requests().length).toBe(1);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test('loopback cloak: publicExposure:"loopback" + non-loopback peer → 404, daemon never reached (#526 posture)', async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    try {
+      writeManifest(
+        { services: [canonicalVaultRow(upstream.port, { publicExposure: "loopback" })] },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      // Header-absent NON-loopback peer (0.0.0.0 bind) — #526 posture.
+      const res = await fetcher(req("/mcp", { method: "POST" }), fakeServer("198.51.100.4"));
+      expect(res.status).toBe(404);
+      // The 404 alone passes on unfixed (unrouted) code too — the load-bearing
+      // assertion is that the cloak fired BEFORE the daemon was ever hit.
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("no vault module installed → legible JSON 404 (vault_module_not_running)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest(
+        {
+          services: [
+            // Some other module installed — must not satisfy findServiceByShort("vault").
+            {
+              name: "parachute-scribe",
+              port: 1942,
+              paths: ["/scribe"],
+              health: "/scribe/health",
+              version: "0.1.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(req("/mcp", { method: "POST" }));
+      expect(res.status).toBe(404);
+      const body = (await res.json()) as { error?: string; message?: string };
+      expect(body.error).toBe("vault_module_not_running");
+      expect(body.message).toContain("/mcp");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("serve-app mode does NOT SPA-shell /mcp when no vault module is installed (masking pin)", async () => {
+    const h = makeHarness();
+    // A legacy-named instance row (parachute-vault-default) satisfies
+    // hasVaultInstalled (bypasses the fresh-hub wizard funnel) WITHOUT
+    // resolving via findServiceByShort — the realistic "old-install
+    // degradation" shape the proxyToVaultDaemon docstring calls out, not a
+    // contrived empty manifest.
+    writeManifest({ services: [vaultEntry("default")] }, h.manifestPath);
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      await createUser(db, "owner", "pw");
+      setRootMode(db, "serve-app");
+      const dist = join(h.dir, "app-dist");
+      mkdirSync(dist, { recursive: true });
+      writeFileSync(join(dist, "index.html"), "<!doctype html><title>PARACHUTE-APP-SHELL</title>");
+      const res = await hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        resolveAppDist: () => dist,
+      })(req("/mcp", { headers: { accept: "text/html" } }));
+      expect(res.status).toBe(404);
+      const body = await res.text();
+      expect(body).not.toContain("PARACHUTE-APP-SHELL");
+    } finally {
+      db.close();
+      h.cleanup();
+    }
+  });
+});

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -52,6 +52,10 @@
  *   /.well-known/jwks.json                     → JWKS from hub.db
  *   /.well-known/parachute-account             → account-door capabilities descriptor (public, H2)
  *   /.well-known/oauth-authorization-server    → RFC 8414 metadata (issuer, endpoints)
+ *   /.well-known/oauth-protected-resource/mcp  → RFC 9728 PRM for root /mcp,
+ *                                                FORWARDED from the vault daemon
+ *                                                (not built locally like the
+ *                                                hub-issued PRM)
  *
  *   # OAuth issuer.
  *   /oauth/authorize  (GET + POST)             → login → consent → auth code
@@ -167,6 +171,13 @@
  *   # hub-module-boundary). Runs BEFORE the per-vault proxy; "admin" is a
  *   # reserved vault name so no instance can claim the mount.
  *   /vault/admin, /vault/admin/*               → proxy to the vault module's daemon
+ *
+ *   # Root MCP surface (hub-owned protocol namespace, dispatched BEFORE the
+ *   # per-vault proxy and generic service mounts so no module can claim it
+ *   # via services.json paths). Vault-agnostic — the TOKEN's audience names
+ *   # the target vault, re-validated by the daemon; no "which vault" in the
+ *   # URL. Same daemon resolution + loopback-cloak as /vault/admin above.
+ *   /mcp, /mcp/*                                → proxy to the vault module's daemon
  *
  *   # Per-vault content proxy (user-facing vault data: Notes PWA, MCP, etc.).
  *   /vault/<name>/*                            → proxy to the vault backend
@@ -1124,34 +1135,39 @@ async function proxyToVault(
 }
 
 /**
- * Reverse-proxy `/vault/admin` + `/vault/admin/*` to the vault MODULE's
- * daemon — the daemon-level multi-vault admin surface (B-route, 2026-06-09
- * hub-module-boundary migration), NOT a per-instance path.
+ * Reverse-proxy a request onto the vault MODULE's daemon — the shared
+ * plumbing behind two hub-owned protocol mounts: `/vault/admin` (the
+ * daemon-level multi-vault admin surface, B-route, 2026-06-09
+ * hub-module-boundary migration) and root `/mcp` (the canonical
+ * vault-agnostic MCP surface the vault daemon has shipped since 0.7.3 — the
+ * TOKEN's audience, not the URL, names the target vault, so there's no
+ * "which vault" question at this layer).
  *
  * Resolution is via `findServiceByShort(services, "vault")` (the canonical
  * self-registered `parachute-vault` row — same shape as the agentEntry
  * lookup in the Connections deps), deliberately NOT `findVaultUpstream`:
- * vault must NOT self-register `/vault/admin` in `paths[]`, because every
+ * vault must NOT self-register either mount in `paths[]`, because every
  * consumer that derives instance names from paths (`vaultInstanceNameFor`,
  * the well-known vaults[] fan-out, `findExistingVault`, the mint
  * allowlists, the users vault-picker) would fabricate a phantom vault named
- * "admin". The mount is hub-owned and gated on the B2h `admin` name
- * reservation, so no real instance can ever claim it.
+ * "admin" or "mcp". Both mounts are hub-owned (the B2h `admin` name
+ * reservation covers the first; `/mcp` lives outside `/vault/*` entirely),
+ * so no real instance can ever claim them.
  *
  * Applies the SAME `publicExposure: "loopback"` 404-cloak as `proxyToVault`
  * (the per-vault proxy's only layer-gate; "allowed"/"auth-required" pass
  * through and the daemon self-gates). Vault's row declares no `stripPrefix`
- * — the FULL path forwards, so the daemon's own `/vault/admin` routing
- * branch (vault wave, B3) serves it.
+ * — the FULL path forwards, so the daemon's own routing (the `/vault/admin`
+ * branch, vault wave B3, and root `/mcp`, vault 0.7.3) serves it.
  *
  * Returns `undefined` when no vault module is installed (caller 404s).
  * NOTE: legacy per-instance rows named `parachute-vault-<name>` don't
  * resolve through `findServiceByShort` (it only knows the canonical
- * manifest name) — on such an install this surface 404s until vault's boot
+ * manifest name) — on such an install both surfaces 404 until vault's boot
  * selfRegister rewrites the canonical row, which is the documented
  * old-install degradation, not a routing hole.
  */
-async function proxyToVaultAdmin(
+async function proxyToVaultDaemon(
   req: Request,
   manifestPath: string,
   supervisor: Supervisor | undefined,
@@ -1165,6 +1181,21 @@ async function proxyToVaultAdmin(
     return new Response("not found", { status: 404 });
   }
   return proxyRequest(req, entry.port, "vault", "vault", supervisor, peerAddr);
+}
+
+/**
+ * `/vault/admin` + `/vault/admin/*` specifically — thin caller over
+ * `proxyToVaultDaemon` (see its docstring for the full resolution + cloak +
+ * old-install-degradation detail), kept as its own named entry point since
+ * its call site reads clearer naming the mount it serves.
+ */
+async function proxyToVaultAdmin(
+  req: Request,
+  manifestPath: string,
+  supervisor: Supervisor | undefined,
+  peerAddr: string | null,
+): Promise<Response | undefined> {
+  return proxyToVaultDaemon(req, manifestPath, supervisor, peerAddr);
 }
 
 /**
@@ -1712,6 +1743,22 @@ function dbNotConfigured(): Response {
   return Response.json(
     { error: "service_unavailable", error_description: "hub db not configured" },
     { status: 503 },
+  );
+}
+
+// Canonical 404 body for root `/mcp` + its PRM well-known when
+// `proxyToVaultDaemon` resolves no vault module row — a legible JSON error
+// (vs the branded-text 404 the rest of dispatch falls back to) naming the
+// fix, since `/mcp` is a protocol surface API clients parse, not a page a
+// human reads.
+function vaultModuleNotRunning(): Response {
+  return Response.json(
+    {
+      error: "vault_module_not_running",
+      message:
+        "This hub has no running vault module, so /mcp cannot answer. Install and start the vault module, then use https://<host>/mcp as your MCP URL.",
+    },
+    { status: 404 },
   );
 }
 
@@ -2884,6 +2931,30 @@ export function hubFetch(
         const merged = new Headers(res.headers);
         for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
         return new Response(res.body, { status: res.status, headers: merged });
+      }
+
+      // /.well-known/oauth-protected-resource/mcp — the PRM for root /mcp
+      // (RFC 9728, path-suffixed per the MCP spec's per-resource discovery
+      // convention). UNLIKE the bare PRM above, this doc is FORWARDED from
+      // the vault daemon rather than built locally — the daemon names /mcp
+      // as the resource + its own scopes (vault:read / vault:write). Same
+      // wildcard CORS shape as its sibling; the vault's `Response.json`
+      // carries none of its own, so we fold it onto the proxied response —
+      // this well-known surface is deliberately CORS-open for browser-side
+      // MCP client discovery.
+      if (pathname === "/.well-known/oauth-protected-resource/mcp") {
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        const proxied = await proxyToVaultDaemon(req, manifestPath, deps?.supervisor, peerAddr);
+        if (!proxied) return vaultModuleNotRunning();
+        const merged = new Headers(proxied.headers);
+        for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+        return new Response(proxied.body, { status: proxied.status, headers: merged });
       }
 
       // GET /.well-known/parachute-account — the account-door capabilities
@@ -4076,6 +4147,30 @@ export function hubFetch(
         const proxied = await proxyToVaultAdmin(req, manifestPath, deps?.supervisor, peerAddr);
         if (proxied) return decorateWithChrome(proxied, req, pathname, getDb);
         return new Response("not found", { status: 404 });
+      }
+
+      // /mcp + /mcp/* — the canonical, vault-agnostic root MCP surface the
+      // vault daemon has served since 0.7.3. Hub-owned protocol namespace,
+      // dispatched here (BEFORE the /vault/ per-vault proxy and the generic
+      // service mounts) so no service can claim it via services.json paths.
+      // There's no "which vault" question at this layer — the TOKEN's
+      // audience names the target vault, re-validated by the daemon itself
+      // — so we forward via `proxyToVaultDaemon` unconditionally, the same
+      // resolution + loopback-cloak as `/vault/admin`. The response is
+      // returned RAW (no `decorateWithChrome`): this is a JSON-RPC protocol
+      // surface, not an HTML page, so chrome injection would be wrong even
+      // when it no-ops on non-HTML bodies.
+      if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
+        // Same per-request force-change-password gate as the twins above —
+        // a pre-rotation signed-in user can't reach vault data through here
+        // either.
+        if (getDb) {
+          const gate = forceChangePasswordGate(getDb(), req);
+          if (gate) return gate;
+        }
+        const proxied = await proxyToVaultDaemon(req, manifestPath, deps?.supervisor, peerAddr);
+        if (proxied) return proxied;
+        return vaultModuleNotRunning();
       }
 
       // /vault/<name>/* — per-vault content proxy. Stays as user-facing

--- a/src/root-serve.ts
+++ b/src/root-serve.ts
@@ -38,14 +38,18 @@ export const APP_PACKAGE = "@openparachute/app";
 /**
  * Namespaces that keep the hub's branded 404 even in serve-app mode. These are
  * hub / protocol surfaces, never app client-side routes, so an SPA shell there
- * would be wrong — and would mask a genuine 404 for an API/OAuth/well-known
+ * would be wrong — and would mask a genuine 404 for an API/OAuth/well-known/MCP
  * typo. (Real dist files never live under these prefixes anyway; this makes the
- * "don't shell it" decision explicit rather than incidental.)
+ * "don't shell it" decision explicit rather than incidental.) In practice
+ * `hub-server.ts` dispatches `/mcp` itself before ever reaching this tail —
+ * this entry is belt-and-suspenders so a future reordering can't regress into
+ * SPA-shelling a protocol 404.
  */
 export const ROOT_SERVE_RESERVED_PREFIXES: readonly string[] = [
   "/api/",
   "/oauth/",
   "/.well-known/",
+  "/mcp/",
 ];
 
 /**
@@ -108,6 +112,9 @@ export function serveAppAtRoot(dist: string, req: Request, pathname: string): Re
   if (req.method !== "GET") return null;
 
   // Hub/protocol namespaces are never the app's — leave their 404 branded.
+  // The bare `/mcp` (no trailing slash) needs its own check since the
+  // prefixes below are all trailing-slash-based.
+  if (pathname === "/mcp") return null;
   for (const prefix of ROOT_SERVE_RESERVED_PREFIXES) {
     if (pathname.startsWith(prefix)) return null;
   }


### PR DESCRIPTION
## Summary

The vault daemon **already implements** canonical root `/mcp` (shipped in vault 0.7.3) — a vault-agnostic MCP surface where the TOKEN's audience, not the URL, names the target vault. The hub side was the missing leg: `POST 127.0.0.1:1940/mcp` (vault) correctly 401'd with a `WWW-Authenticate` challenge naming its PRM, while `POST 127.0.0.1:1939/mcp` (hub) 404'd even with a vault module installed and running. This PR closes that gap.

- **`/mcp` + `/mcp/*` proxy to the vault module's daemon**, dispatched before the per-vault proxy and generic service mounts (a hub-owned protocol namespace, same posture as `/vault/admin`). Resolution/cloak reuse `proxyToVaultDaemon`, extracted from `proxyToVaultAdmin`'s body (`proxyToVaultAdmin` is now a thin caller over it). Returned raw — no chrome injection, since it's a JSON-RPC surface, not a page. No running vault module → a legible JSON 404 (`vault_module_not_running`) instead of a bare branded 404.
- **`/.well-known/oauth-protected-resource/mcp` (RFC 9728) forwards too**, with the hub's usual wildcard-CORS folded onto the proxied response (the vault's `Response.json` carries none of its own) so browser-side MCP clients can discover it cross-origin.
- **`root-serve.ts` reserves `/mcp`** from the serve-app SPA shell — belt-and-suspenders, since the `/mcp` dispatch block above already always returns before the serve-app tail is reached, but matches the existing `/api`, `/oauth`, `/.well-known` reservations and closes the gap explicitly.
- Header route-table docstring updated (dispatch order is load-bearing there).
- Version bump `0.7.8-rc.1` → `0.7.8-rc.2` + CHANGELOG entry. No migration file (additive routes only).

## Test plan

- [x] `bun run typecheck` — clean
- [x] `bun test src/__tests__/hub-server.test.ts` (only this file — the suite's launchd-hardcoded lifecycle tests can bootout a real running hub; this file imports nothing lifecycle-related) — **260 pass, 0 fail, 739 expect() calls** (255 pre-existing + 5 new)
- [x] Each of the 5 new tests watched RED first against the reverted implementation (stashed `hub-server.ts` + `root-serve.ts`, kept the new test file), confirmed failing for the stated reason, then the implementation was restored — per the workspace's "watch it fail" discipline
- [x] `bunx biome check` clean on touched files
- [x] No orphaned Bun test/workerd processes left running

New coverage: POST/GET/DELETE `/mcp` reach the daemon with the JSON-RPC body + forwarded host intact; the PRM well-known forwards + carries CORS (OPTIONS answers locally, never touching upstream); the `publicExposure: "loopback"` cloak 404s a non-loopback peer *and* the daemon is never hit; no vault module installed → the JSON 404; and a serve-app-mode masking pin (no vault row, `GET /mcp` with `Accept: text/html` does NOT get SPA-shelled).

## Deliberately out of scope (filed as follow-up issues)

1. `deriveVaultScopeFromMcpUrl` (`oauth-client.ts`) doesn't recognize a remote root-form `…/mcp`, so an outbound grant falls back to broad `vault:read vault:write` instead of #671's least-privilege posture.
2. Path-inserted per-vault PRM forms (`/.well-known/oauth-protected-resource/vault/<name>[/mcp]`) 404 at the hub while the daemon implements them (`parachute-vault/src/routing.ts:295–318`).
3. Operator-facing copy (setup wizard, docs, `hub.html`) should advertise `https://<host>/mcp` as **the** MCP URL now that both doors accept it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB