### PR TITLE
release: hub 0.7.8 — root /mcp, install-cache rollback fix, date-fuse defused; promote to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,40 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.8] - 2026-07-28
+
+**Stable promotion of the 0.7.8 line (7 commits over 0.7.7).** Promotes rc.1–rc.5
+to `@latest`. The theme is the unified `/mcp` root and two silent-failure fixes.
+
+- **Canonical root `/mcp` forwarded to the vault daemon (#774)**, and the OAuth
+  client now recognizes the remote root-form MCP URL when deriving scope (#778).
+  Self-host reaches parity with the hosted door: one `/mcp` at the root, rather
+  than only per-module endpoints.
+- **The install cache can no longer silently roll back a bun-linked bundle
+  (#780 / #782).** Supervised services launch with `cwd = /`, and resolution
+  tried `cwd` first — from `/`, Bun's resolver prefers its own install cache over
+  the global link. A linked checkout was therefore ignored in favour of whatever
+  npm version happened to be cached. Observed in the wild: a hub served a
+  months-old published bundle for nine hours while `parachute status` reported the
+  linked checkout, because that line described *resolution*, not what was served.
+  `/` is dropped from the candidate list, and `status` now reports the version at
+  the path it actually serves from, printing `! SERVED-DRIFT:` when resolution
+  lands anywhere other than the link.
+- **A test whose fuse had already burned (#784).** `operator-token.test.ts` minted
+  a token at a pinned 2026-04-26 and validated it against the real clock; with the
+  90-day operator TTL it began failing permanently on 2026-07-25. It went unseen
+  because hub PRs gate on container-smoke only — the full suite runs at tag time,
+  and the previous tag predated the fuse. Fixed, plus a sweep confirming it was
+  the only armed instance.
+- **App front door repointed** to the renamed `@openparachute/app` package (#772),
+  and door-contract fail-closed slot validation (#770, published separately as
+  `@openparachute/door-contract` 0.6.1).
+
+Also: CLAUDE.md slimmed to gotchas-only (#771, docs-only).
+
+Operator note: this is the first 0.7.8 artifact published to `@latest`; the line
+was gated green end-to-end (unit suite, e2e, publish, container) at `v0.7.8-rc.5`.
+
 ## [0.7.8-rc.5] - 2026-07-28
 
 **fix(test): defuse an operator-token test whose fuse had already burned — a self-expiring assertion, invisible because the gate that runs it only fires at tag time.** `operator-token.test.ts`'s "returns a JWT with operator audience, broad scopes, …" minted the operator token at a **pinned past clock** (`now: () => 2026-04-26`) and then validated it with `validateAccessToken`, which enforces `exp` against **jose's real clock** (no override). With the 90-day operator TTL, the minted `exp` landed at **2026-07-25** — so from that date on the test failed on every run with `JWTExpired`, permanently, not as a flake. It went unseen because a hub PR runs container-smoke only; the full unit suite runs at tag time, and the hub hadn't tagged since `v0.7.7` (2026-07-22, green) — three days before the fuse.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.8-rc.5",
+  "version": "0.7.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Promotes the 0.7.8 rc line (rc.1–rc.5) to `@latest`. Version-and-CHANGELOG only; no code change.

**What ships:**
- **#774 / #778 — canonical root `/mcp`** forwarded to the vault daemon, with the OAuth client recognizing the remote root-form URL for scope derivation. Self-host reaches parity with the hosted door.
- **#780 / #782 — the install cache can no longer silently roll back a bun-linked bundle.** Supervised services launch with `cwd = /`, and resolution tried `cwd` first; from `/`, Bun prefers its own install cache over the global link. Observed in the wild: a hub served a months-old published bundle for nine hours while `parachute status` reported the linked checkout — true of *resolution*, false of what was served. `/` is dropped from the candidates, and `status` now reports the version at the path it actually serves from, with a `! SERVED-DRIFT:` warning on divergence.
- **#784 — a test whose fuse had already burned.** `operator-token.test.ts` minted at a pinned 2026-04-26 and validated against the real clock; with the 90-day TTL it failed permanently from 2026-07-25. Unseen because hub PRs gate on container-smoke only and the full suite runs at tag time. Fixed, with a sweep confirming it was the only armed instance.
- #772 app front door repointed to `@openparachute/app`; #770 door-contract fail-closed slot validation; #771 docs.

**Release readiness:**
- **The line was gated green end-to-end at `v0.7.8-rc.5`** — full unit suite, e2e, npm publish, and container image. This matters: the audit's one caveat was *don't let stable be a line's first gate run*, and the first run did catch a real failure (the date fuse above). rc.5 is the green one.
- Published manifest carries no `workspace:`/`file:`/`link:` runtime deps; `bin` and `git-credential-parachute` both 100755
- `bun add @openparachute/hub@0.7.8-rc.5` verified installable in a clean dir, and the `#780` fix confirmed present by executing `notesDistCandidates("/", …)` out of the published package

**Known, not blocking:** `@openparachute/door-contract@0.6.1` is tagged but unpublished (its release 404'd — see #781). Hub floors at `^0.6.0` and only imports `validateVaultScopes`, which 0.6.1 did not touch, so hub is behaviorally identical against either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XLZtmuSs1RirWGMGyCB1QB