### PR TITLE
fix(scope-guard): revocation fetch follows jwksOrigin; stop failing closed in silence

### DIFF
--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -4,6 +4,48 @@ All notable changes to `@openparachute/scope-guard` are documented here. The for
 
 The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
 
+## [0.5.1-rc.1]
+
+**`revocationOrigin` — the revocation fetch no longer hairpins through a
+public FQDN, and a fail-closed fetch no longer happens in silence.**
+
+### Why
+
+`jwksOrigin` landed in vault#464 because a co-located resource server must not
+fetch keys from the PUBLIC hub URL: that hairpins out through the tunnel and
+back to the same box — slow on a VPS, a hard failure under Docker NAT-loopback
+or a tailnet whose MagicDNS the box itself can't resolve.
+
+The revocation-list fetch has the identical topology and did **not** get the
+identical fix. It stayed pinned to the canonical `hubOrigin`. And because
+revocation **fails closed** on a cold cache, getting it wrong is far worse than
+the JWKS case: a box that can't reach its own public FQDN rejects *every*
+hub-issued JWT with `revocation_unavailable`. Observed live — a vault whose
+admin SPA rendered that 401 as "You're not signed in to the hub," so signing in
+again could never help, and the SPA's recovery poll spun forever because the
+token mint kept succeeding.
+
+The failure was also completely silent: the cache swallowed fetch errors on the
+grounds that "logging is the consumer's call." The only evidence anywhere was a
+terse 401 body.
+
+### Changed
+
+- **`revocationOrigin?: string | (() => string)`** — origin the revocation list
+  is fetched from. **Defaults to `jwksOrigin` when supplied, else `hubOrigin`.**
+  Chaining the default off `jwksOrigin` is the point: a consumer can no longer
+  fix one fetch and silently leave the other aimed at an unreachable origin.
+  Any consumer already opting into a loopback JWKS fetch (vault does) is fixed
+  with no code change on their side.
+- **`revocationOnFetchError`** — reports fetch failures, with `fatal: true` for
+  the fail-CLOSED case. Defaults to a throttled (1/min/origin) `console.warn`
+  naming the unreachable URL and pointing at `revocationOrigin`. Silent on
+  fail-open, which the security model explicitly allows. Pass `() => {}` to
+  silence entirely.
+
+Back-compat: a guard that supplies neither `jwksOrigin` nor `revocationOrigin`
+fetches from `hubOrigin` exactly as before.
+
 ## Unreleased
 
 JWKS force-reload-and-retry on rotation-class verification failures (hub#543). Closes the latent gap where `validateHubJwt` could hard-401 until `cacheMaxAge` expiry or a process restart after certain key rotations.

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.5.0",
+  "version": "0.5.1-rc.1",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",

--- a/packages/scope-guard/src/__tests__/validate.test.ts
+++ b/packages/scope-guard/src/__tests__/validate.test.ts
@@ -1467,3 +1467,108 @@ describe("createScopeGuard — jwksOrigin seam (vault#464)", () => {
     fixture.setKeys([kp]);
   });
 });
+
+// ---------------------------------------------------------------------------
+// revocationOrigin — the co-located-hairpin fix.
+//
+// `jwksOrigin` landed in vault#464 because a co-located resource server must
+// not fetch keys from the PUBLIC hub FQDN (hairpins out and back to the same
+// box; hard-fails under Docker NAT-loopback or a tailnet whose MagicDNS the
+// box can't resolve). The revocation fetch has the identical topology and did
+// NOT get the identical fix — and because revocation fails CLOSED on a cold
+// cache, getting it wrong bricks the resource server entirely: every
+// hub-issued JWT rejected with `revocation_unavailable`, surfacing to
+// operators as a 401 their UI renders as "you're not signed in."
+// ---------------------------------------------------------------------------
+describe("createScopeGuard — revocationOrigin", () => {
+  /** Capture which origin the revocation fetcher was handed. */
+  function captureOrigin() {
+    const seen: string[] = [];
+    const fetcher = async (origin: string) => {
+      seen.push(origin);
+      return { generated_at: new Date(0).toISOString(), jtis: [] };
+    };
+    return { seen, fetcher };
+  }
+
+  test("defaults to jwksOrigin when one is supplied — the fix", async () => {
+    const { seen, fetcher } = captureOrigin();
+    const guard = createScopeGuard({
+      hubOrigin: "https://public.example.ts.net",
+      allowedIssuers: () => ["https://public.example.ts.net"],
+      jwksOrigin: fixture.origin,
+      revocationFetcher: fetcher,
+    });
+    const token = await signJwt(kp, { iss: "https://public.example.ts.net" });
+    await guard.validateHubJwt(token);
+    // NOT the public FQDN — that's the origin the box may be unable to reach.
+    expect(seen).toEqual([fixture.origin]);
+    expect(seen).not.toContain("https://public.example.ts.net");
+  });
+
+  test("explicit revocationOrigin wins over jwksOrigin", async () => {
+    const { seen, fetcher } = captureOrigin();
+    const guard = createScopeGuard({
+      hubOrigin: "https://public.example.ts.net",
+      allowedIssuers: () => ["https://public.example.ts.net"],
+      // JWKS must actually resolve for the token to reach the revocation
+      // check at all; the point of the case is that revocation goes somewhere
+      // ELSE than jwksOrigin when told to.
+      jwksOrigin: fixture.origin,
+      revocationOrigin: "http://127.0.0.1:1939",
+      revocationFetcher: fetcher,
+    });
+    const token = await signJwt(kp, { iss: "https://public.example.ts.net" });
+    await guard.validateHubJwt(token);
+    expect(seen).toEqual(["http://127.0.0.1:1939"]);
+  });
+
+  test("falls back to hubOrigin when neither is supplied (back-compat)", async () => {
+    const { seen, fetcher } = captureOrigin();
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      revocationFetcher: fetcher,
+    });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    await guard.validateHubJwt(token);
+    expect(seen).toEqual([fixture.origin]);
+  });
+
+  test("resolver form is re-evaluated per call, like the other origins", async () => {
+    const { seen, fetcher } = captureOrigin();
+    let target = "http://127.0.0.1:1939";
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      revocationOrigin: () => target,
+      revocationFetcher: fetcher,
+      revocationTtlMs: 0, // always stale → always refetch
+    });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    await guard.validateHubJwt(token);
+    target = "http://127.0.0.1:2939";
+    await guard.validateHubJwt(token);
+    expect(seen).toEqual(["http://127.0.0.1:1939", "http://127.0.0.1:2939"]);
+  });
+
+  test("a fail-CLOSED fetch failure is reported, not swallowed", async () => {
+    const errors: { origin: string; fatal: boolean }[] = [];
+    const guard = createScopeGuard({
+      hubOrigin: fixture.origin,
+      revocationOrigin: "https://unreachable.invalid",
+      revocationFetcher: async () => {
+        throw new Error("getaddrinfo ENOTFOUND");
+      },
+      revocationOnFetchError: (info) => errors.push({ origin: info.origin, fatal: info.fatal }),
+    });
+    const token = await signJwt(kp, { iss: fixture.origin });
+    let caught: HubJwtError | undefined;
+    try {
+      await guard.validateHubJwt(token);
+    } catch (err) {
+      caught = err as HubJwtError;
+    }
+    expect(caught?.code).toBe("revocation_unavailable");
+    // The operator gets told WHY every token is being rejected, and where.
+    expect(errors).toEqual([{ origin: "https://unreachable.invalid", fatal: true }]);
+  });
+});

--- a/packages/scope-guard/src/revocation-cache.ts
+++ b/packages/scope-guard/src/revocation-cache.ts
@@ -121,6 +121,58 @@ export interface CreateRevocationCacheOptions {
   ttlMs?: number;
   /** Test seam for time. Defaults to `Date.now`. */
   now?: () => number;
+  /**
+   * Called when a fetch fails. `fatal` is true for the fail-CLOSED case (no
+   * last-good list, so every hub JWT is about to be rejected) and false for
+   * the fail-OPEN case (a stale list is still in hand).
+   *
+   * Defaults to a throttled `console.warn` on the fatal case only — see
+   * `warnFailClosed`. Pass a function to route it into a real logger, or
+   * `() => {}` to silence it.
+   */
+  onFetchError?: (info: { origin: string; fatal: boolean; error: unknown }) => void;
+}
+
+/**
+ * How often a single origin may emit the fail-closed warning. The check runs
+ * on every validation, so an unthrottled warn would print per rejected
+ * request — thousands of lines that bury the one that matters.
+ */
+const FAIL_CLOSED_WARN_INTERVAL_MS = 60_000;
+
+/** origin → last time we warned about it. */
+const lastFailClosedWarnAt = new Map<string, number>();
+
+/**
+ * Default `onFetchError`. Silent on fail-open (a stale list is a non-event
+ * the security model explicitly allows); LOUD on fail-closed.
+ *
+ * The fail-closed state means this resource server is rejecting **100% of
+ * hub-issued tokens** — every request, every client. That was previously
+ * swallowed entirely ("logging is the consumer's call"), so the only
+ * evidence was a terse `401 revocation list unavailable` on the wire, which
+ * downstream UIs cheerfully rendered as "you're not signed in." An operator
+ * had no way to reach the actual cause. It costs one line a minute to say it.
+ */
+function warnFailClosed(info: { origin: string; fatal: boolean; error: unknown }): void {
+  if (!info.fatal) return;
+  const now = Date.now();
+  const last = lastFailClosedWarnAt.get(info.origin);
+  if (last !== undefined && now - last < FAIL_CLOSED_WARN_INTERVAL_MS) return;
+  lastFailClosedWarnAt.set(info.origin, now);
+  const reason = info.error instanceof Error ? info.error.message : String(info.error);
+  console.warn(
+    `[scope-guard] REJECTING ALL hub-issued tokens: cannot fetch the revocation list from ` +
+      `${info.origin}/.well-known/parachute-revocation.json (${reason}). ` +
+      `This resource server fails closed until that URL is reachable. If this origin is the ` +
+      `PUBLIC hub URL, the box likely cannot resolve or hairpin its own FQDN — point ` +
+      `revocationOrigin at the local hub (e.g. http://127.0.0.1:1939) instead.`,
+  );
+}
+
+/** Test seam: forget which origins have been warned about. */
+export function _resetFailClosedWarnStateForTest(): void {
+  lastFailClosedWarnAt.clear();
 }
 
 export function createRevocationCache(opts: CreateRevocationCacheOptions): RevocationCache {
@@ -128,6 +180,7 @@ export function createRevocationCache(opts: CreateRevocationCacheOptions): Revoc
   const fetcher = opts.fetcher ?? defaultRevocationFetcher;
   const ttlMs = opts.ttlMs ?? REVOCATION_CACHE_TTL_MS;
   const now = opts.now ?? (() => Date.now());
+  const onFetchError = opts.onFetchError ?? warnFailClosed;
 
   let entry: CacheEntry | undefined;
   let inFlight: Promise<CacheEntry | undefined> | undefined;
@@ -154,12 +207,17 @@ export function createRevocationCache(opts: CreateRevocationCacheOptions): Revoc
         const next: CacheEntry = { jtis: new Set(body.jtis), fetchedAt: now() };
         entry = next;
         return next;
-      } catch {
-        // Swallow — caller decides fail-open vs fail-closed based on whether
-        // `entry` is set. Logging is the consumer's call (we don't know
-        // their logger). When last-good exists, bump its timestamp so we
-        // honour the TTL window before retrying — see comment above.
+      } catch (error) {
+        // Caller decides fail-open vs fail-closed based on whether `entry` is
+        // set. When last-good exists, bump its timestamp so we honour the TTL
+        // window before retrying — see comment above.
+        const fatal = entry === undefined;
         if (entry) entry = { jtis: entry.jtis, fetchedAt: now() };
+        try {
+          onFetchError({ origin, fatal, error });
+        } catch {
+          // A throwing logger must never turn a fetch failure into a crash.
+        }
         return undefined;
       } finally {
         inFlight = undefined;

--- a/packages/scope-guard/src/validate.ts
+++ b/packages/scope-guard/src/validate.ts
@@ -283,12 +283,54 @@ export interface CreateScopeGuardOptions {
   jwksGetter?: JwksGetter;
 
   /**
+   * Origin the revocation list is FETCHED from — the exact sibling of
+   * `jwksOrigin`, and for the exact same reason.
+   *
+   * **Defaults to `jwksOrigin` when that is supplied, else to `hubOrigin`.**
+   *
+   * Motivation (the bug this option exists to close): `jwksOrigin` landed in
+   * vault#464 because a co-located resource server must not fetch keys from
+   * the PUBLIC hub FQDN — that hairpins out and back to the same box, which
+   * is slow on a VPS and a hard failure under Docker NAT-loopback or a
+   * tailnet whose MagicDNS the box itself can't resolve. The revocation
+   * fetch has the identical topology and did NOT get the identical fix: it
+   * stayed pinned to the canonical `hubOrigin`.
+   *
+   * The consequence was worse than the JWKS case, because revocation
+   * **fails closed** on a cold cache. A box that couldn't reach its own
+   * public FQDN rejected *every* hub-issued JWT with
+   * `revocation_unavailable` — a fully bricked resource server, presenting
+   * to the operator as a 401 that downstream UIs render as "you're not
+   * signed in." Signing in again could never help.
+   *
+   * Defaulting to `jwksOrigin` means any consumer that already opted into
+   * the loopback JWKS fetch (vault does) is fixed without a code change on
+   * their side; the two fetches now travel the same path by construction,
+   * which is the property that was missing. Consumers with a genuinely
+   * split topology can still set this explicitly.
+   */
+  revocationOrigin?: string | (() => string);
+
+  /**
    * Inject a revocation-list fetcher. Tests use this to drive list contents
    * (revoked / clear / failure) deterministically without needing a real
    * `<origin>/.well-known/parachute-revocation.json` endpoint. Production
-   * uses the default fetcher (`globalThis.fetch` against the hub origin).
+   * uses the default fetcher (`globalThis.fetch` against the revocation
+   * origin).
    */
   revocationFetcher?: RevocationFetcher;
+
+  /**
+   * Called when a revocation-list fetch fails. See
+   * `CreateRevocationCacheOptions.onFetchError` — defaults to a throttled
+   * `console.warn` on the fail-CLOSED case (which means this resource server
+   * is rejecting 100% of hub tokens and an operator needs to know).
+   */
+  revocationOnFetchError?: (info: {
+    origin: string;
+    fatal: boolean;
+    error: unknown;
+  }) => void;
 
   /**
    * Override the revocation cache TTL (ms). Tests use small values to
@@ -360,6 +402,7 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
     hubOrigin,
     allowedIssuers,
     jwksOrigin,
+    revocationOrigin,
     jwks: jwksOpts,
     jwksGetter: injected,
     allowMissingJti = false,
@@ -372,6 +415,15 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
   // while accepting a public `iss` (vault#464). Both resolvers are re-evaluated
   // per request, so env changes propagate without a restart.
   const jwksOriginInput = jwksOrigin ?? hubOrigin;
+
+  // The origin the REVOCATION LIST is fetched from. Follows `jwksOrigin` by
+  // default, falling back to `hubOrigin` — see the `revocationOrigin` jsdoc.
+  // The short version: this fetch has the same co-located-hairpin problem
+  // vault#464 fixed for JWKS, but it fails CLOSED, so getting it wrong bricks
+  // the resource server rather than merely slowing it down. Chaining the
+  // default off `jwksOrigin` means a consumer can't fix one and silently
+  // leave the other pointed at an unreachable public FQDN.
+  const revocationOriginInput = revocationOrigin ?? jwksOriginInput;
 
   const reloadMinIntervalMs = opts.jwksReloadMinIntervalMs ?? DEFAULT_JWKS_RELOAD_MIN_INTERVAL_MS;
   const reloadNow = opts.jwksReloadNow ?? (() => Date.now());
@@ -400,6 +452,7 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
       fetcher: opts.revocationFetcher,
       ttlMs: opts.revocationTtlMs,
       now: opts.revocationNow,
+      onFetchError: opts.revocationOnFetchError,
     });
     revocation = { origin, cache };
     return cache;
@@ -644,7 +697,7 @@ export function createScopeGuard(opts: CreateScopeGuardOptions): ScopeGuard {
       // we may have undefined jti — those tokens skip the lookup entirely
       // since revocation can't be enforced without an index key.
       if (jti !== undefined) {
-        const cache = pickRevocationCache(origin);
+        const cache = pickRevocationCache(resolveOrigin(revocationOriginInput));
         const outcome = await cache.check(jti);
         if (outcome === "revoked") {
           // Surface the jti in the error message for operator audit visibility.


### PR DESCRIPTION
## The bug, found live

On a fresh self-hosted box, `https://<box>.ts.net/vault/<name>/admin` showed **"You're not signed in to the hub."** The operator was signed in. Signing in again changed nothing, forever.

The session was fine. The token mint was fine:

```
GET /admin/vault-admin-token/unforced   (session cookie)  → 200, valid JWT ✓
GET /vault/unforced                     (that Bearer)     → 401
  {"message":"token cannot be validated: revocation list unavailable"}
```

`jwksOrigin` landed in vault#464 because a co-located resource server must not fetch keys from the **public** hub URL — that hairpins out through the tunnel and back to the same box (slow on a VPS, a hard failure under Docker NAT-loopback). **The revocation-list fetch has the identical topology and never got the identical fix.** It stayed pinned to the canonical `hubOrigin`.

Because revocation **fails closed** on a cold cache, that's much worse than the JWKS case. This box's MagicDNS wasn't routing its own tailnet name — `host uni.taildf9ce2.ts.net` returned NXDOMAIN *on the box itself*, while `dig @100.100.100.100` resolved fine. So the revocation fetch failed, there was no last-good list, and the vault rejected **every** hub-issued JWT.

Two things then turned a network problem into an unfixable one:

1. **It was silent.** `revocation-cache.ts` swallowed fetch errors — "logging is the consumer's call (we don't know their logger)". The only evidence anywhere was that terse 401 body.
2. **Downstream read it as an auth problem.** The vault SPA maps 401 → sign-in banner, and its recovery poll calls `ensureToken`, which *succeeds* (minting was never broken) → `onRecovered()` → reload → 401 → banner. A 5-second infinite loop presenting as "you're not signed in."

## The fix

- **`revocationOrigin?: string | (() => string)`** — defaults to **`jwksOrigin` when supplied**, else `hubOrigin`. Chaining the default off `jwksOrigin` is the load-bearing part: a consumer can no longer fix one fetch and silently leave the other aimed at an origin the box can't reach. Vault already passes a loopback `jwksOrigin`, so **it's fixed with no change on its side** — it just needs the bump.
- **`revocationOnFetchError`** — reports failures with `fatal: true` for the fail-closed case. Defaults to a throttled (1/min/origin) `console.warn` naming the unreachable URL and pointing at `revocationOrigin`. Silent on fail-open, which the security model explicitly allows.

Back-compat: a guard supplying neither `jwksOrigin` nor `revocationOrigin` fetches from `hubOrigin` exactly as before.

## Verification

Reproduced against the real box, using a genuine JWT minted from the running hub — not a fixture:

```
BEFORE — revocation pinned to the canonical origin (0.5.0 behaviour):
  REJECTED — code=revocation_unavailable
AFTER  — revocation defaults to jwksOrigin (loopback):
  ACCEPTED — scopes=vault:unforced:admin
```

(The box's DNS has since been repaired, so the failure is reproduced by pointing the revocation origin at an unresolvable host — the same condition the box was in.)

scope-guard **135 pass / 0 fail** (5 new: jwksOrigin default, explicit override, hubOrigin fallback, per-call resolver re-evaluation, fail-closed reporting). Hub **4371 pass / 0 fail**. `tsc --noEmit` clean.

## Contracts touched

Purely additive to `@openparachute/scope-guard`'s options — no wire shapes, no OAuth behavior, no module protocol. The security posture is unchanged: fail-closed on a cold cache still fails closed; this only corrects *where* the list is read from and makes the failure audible. `0.5.0` → `0.5.1-rc.1`.

**Follow-up (not in this PR):** the vault admin SPA should stop rendering an infra 401 as "you're not signed in," and its recovery poll shouldn't spin when the mint succeeds but the API still 401s. That's a vault-side change; filing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPoTHLWtNvRVWYcs1K5i8b