### PR TITLE
fix(oauth): hub authors the root /mcp PRM, so vault:admin is advertised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,79 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.9-rc.5] - 2026-07-29
+
+**Root `/mcp` now advertises `vault:admin`, so MCP clients can manage tag
+schemas again.**
+
+The RFC 9728 document for root `/mcp` was being FORWARDED from the vault
+daemon. That was wrong in kind: root `/mcp` is a hub resource, so its metadata
+was authored by a service that doesn't know hub's scope registry. Vault's root
+PRM hard-codes `[vault:read, vault:write]`, on reasoning that predates the
+2026-05-29 single-consent change — per-vault `vault:<name>:admin` has been
+genuinely requestable through public consent since then, capped to the
+consenting user's own authority at the mint choke-point.
+
+So the issuer would grant admin happily; the advertisement was the only thing
+withholding it. A spec-following MCP client reads `scopes_supported` and
+requests exactly what it lists, so admin never got requested — and **updating
+tags needs admin**, which put a core workflow out of reach over MCP.
+
+Hub now authors the document, sharing `advertisedScopes` with the bare PRM so
+the two can't drift: one registry, one filter (requestable ∧
+module-installed), two documents. Non-requestable operator scopes are still
+excluded — advertising what the issuer always rejects would mislead clients.
+
+Forwarding also made hub-level scopes structurally impossible to surface here,
+since vault has no concept of them. That's now unblocked, though `account:self:*`
+remains in `NON_REQUESTABLE_SCOPES` and so is still (correctly) absent — see the
+PR discussion.
+
+## [0.7.9-rc.4] - 2026-07-29
+
+**Fix: publish-on-merge sent rc versions to `@latest`.**
+
+The `plan` job derived the dist-tag correctly, but the four publish steps
+re-derived their own from `GITHUB_REF_NAME` — which on a merge-triggered run is
+`"main"`, matching no rc pattern, so every publish-on-merge landed on `latest`.
+`0.7.9-rc.3` became `@latest` that way, meaning `bun add -g @openparachute/hub`
+installed a prerelease.
+
+The dist-tag now comes from the version being published, read from that
+package's own `package.json` at publish time — the only source that cannot drift
+from the artifact.
+
+Required a manual `npm dist-tag add @openparachute/hub@0.7.8 latest` to repair
+the tag already moved; CI has no credential that can move a dist-tag backwards.
+
+Also surfaced (pre-existing): `@openparachute/door-contract@0.6.1` fails to
+publish with `404 … you do not have permission` — a missing npm
+Trusted-Publisher rule, long listed in `RELEASING.md` as an operator TODO. Left
+failing loudly rather than skipped, since a silent skip hides a package that
+never ships.
+
+## [0.7.9-rc.3] - 2026-07-29
+
+**Publish on merge, and promote scope-guard 0.5.1 to stable.**
+
+Releasing required remembering `git tag && git push` after every merge, and the
+remembering was the weak link — several PRs merged in one session with no tags,
+so nothing published until someone asked why a box was stale. Governance rule 2
+already requires every code-touching PR to bump `version`, so package.json is
+the per-PR release intent; the tag was a second, manual copy of that decision.
+
+Tag-on-merge-and-let-the-tag-fire does not work: events triggered by
+`GITHUB_TOKEN` never start another workflow run. One workflow, no recursion.
+
+Decision logic lives in `scripts/release-plan.ts`, unit-tested, with three
+guards: idempotent (skip an already-published version), ambiguity refuses (a
+registry 5xx exits non-zero rather than guessing), and no backwards publishes
+(refuses to move a dist-tag to an older version — the parallel-merge hazard).
+
+`@openparachute/scope-guard` 0.5.1 went straight to stable, skipping `@rc`:
+vault depends on `^0.5.0` and semver excludes prereleases from a caret range, so
+an rc could never reach the consumer that needs the revocation-origin fix.
+
 ## [0.7.9-rc.1] - 2026-07-29
 
 **Notes is retired.** It stopped being maintained a long time ago, but it kept

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.9-rc.4",
+  "version": "0.7.9-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -6801,7 +6801,13 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
     }
   });
 
-  test("GET /.well-known/oauth-protected-resource/mcp forwards + carries wildcard CORS; OPTIONS answers locally", async () => {
+  // hub#789: this document is now HUB-authored, not forwarded. Root /mcp is a
+  // hub resource, so hub owns its metadata; forwarding meant vault — which
+  // hard-codes [read, write] and knows nothing of hub's scope registry — was
+  // describing a hub endpoint. The visible cost was `vault:admin` missing from
+  // the advertisement, so MCP clients never requested it and tag-schema
+  // management was unreachable over MCP.
+  test("GET /.well-known/oauth-protected-resource/mcp is answered LOCALLY (not forwarded), with wildcard CORS", async () => {
     const h = makeHarness();
     const upstream = startRecordingUpstream();
     try {
@@ -6810,19 +6816,23 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
 
       const getRes = await fetcher(req("/.well-known/oauth-protected-resource/mcp"));
       expect(getRes.status).toBe(200);
-      // The vault's Response.json carries no CORS of its own — hub folds it on.
       expect(getRes.headers.get("access-control-allow-origin")).toBe("*");
-      expect(upstream.requests().map((r) => r.pathname)).toEqual([
-        "/.well-known/oauth-protected-resource/mcp",
-      ]);
+
+      const body = (await getRes.json()) as Record<string, unknown>;
+      // Names the /mcp endpoint as the resource, and advertises hub's set —
+      // including admin, which the forwarded vault document omitted.
+      expect(String(body.resource)).toMatch(/\/mcp$/);
+      expect(body.scopes_supported as string[]).toContain("vault:admin");
+
+      // The decisive assertion: the vault daemon is never consulted.
+      expect(upstream.requests().length).toBe(0);
 
       const optRes = await fetcher(
         req("/.well-known/oauth-protected-resource/mcp", { method: "OPTIONS" }),
       );
       expect(optRes.status).toBe(204);
       expect(optRes.headers.get("access-control-allow-origin")).toBe("*");
-      // OPTIONS answered locally — the daemon only ever saw the earlier GET.
-      expect(upstream.requests().length).toBe(1);
+      expect(upstream.requests().length).toBe(0);
     } finally {
       upstream.stop();
       h.cleanup();

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -35,6 +35,7 @@ import {
   handleRevoke,
   handleToken,
   protectedResourceMetadata,
+  rootMcpProtectedResourceMetadata,
   vaultScopeForUser,
 } from "../oauth-handlers.ts";
 import { PENDING_LOGIN_COOKIE_NAME, _resetPendingLogins } from "../pending-login.ts";
@@ -296,6 +297,70 @@ describe("protectedResourceMetadata (RFC 9728, closes hub#393)", () => {
     expect(scopes).toContain("vault:read");
     expect(scopes).toContain("widget:read");
     expect(scopes).not.toContain("parachute:host:admin");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hub#789 — the root /mcp PRM is HUB-authored, not vault-forwarded.
+//
+// Root /mcp is a hub resource, so hub must author its metadata. It used to be
+// proxied straight from the vault daemon, which hard-codes
+// [vault:read, vault:write] — so `vault:admin` never appeared in the
+// advertisement, a spec-following MCP client never requested it, and
+// tag-schema management was unreachable over MCP even though the issuer
+// grants admin fine (per-vault admin became requestable in the 2026-05-29
+// single-consent change). Hub-level scopes could never appear at all, since
+// vault has no concept of them.
+// ---------------------------------------------------------------------------
+describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
+  const declared = new Set<string>([
+    "vault:read",
+    "vault:write",
+    "vault:admin",
+    "parachute:host:admin",
+  ]);
+  const call = () =>
+    rootMcpProtectedResourceMetadata({
+      issuer: ISSUER,
+      loadDeclaredScopes: () => declared,
+      loadServicesManifest: fixtureLoadServicesManifest,
+    });
+
+  test("advertises vault:admin — the regression that made tag editing unreachable over MCP", async () => {
+    const body = (await call().json()) as Record<string, unknown>;
+    expect(body.scopes_supported as string[]).toContain("vault:admin");
+  });
+
+  test("names the /mcp endpoint as the resource, not the bare origin", async () => {
+    // The client matches this against the endpoint that 401'd it; the bare
+    // origin is a different resource and wouldn't match.
+    const body = (await call().json()) as Record<string, unknown>;
+    expect(body.resource).toBe(`${ISSUER}/mcp`);
+    expect(body.authorization_servers).toEqual([ISSUER]);
+  });
+
+  test("still filters non-requestable scopes — advertising what we always reject misleads clients", async () => {
+    const body = (await call().json()) as Record<string, unknown>;
+    expect(body.scopes_supported as string[]).not.toContain("parachute:host:admin");
+  });
+
+  test("shares the bare PRM's scope set, so the two documents can't drift apart", async () => {
+    // The point of authoring locally: one registry, one filter, two documents.
+    const root = (await call().json()) as Record<string, unknown>;
+    const bare = (await protectedResourceMetadata({
+      issuer: ISSUER,
+      loadDeclaredScopes: () => declared,
+      loadServicesManifest: fixtureLoadServicesManifest,
+    }).json()) as Record<string, unknown>;
+    expect([...(root.scopes_supported as string[])].sort()).toEqual(
+      [...(bare.scopes_supported as string[])].sort(),
+    );
+  });
+
+  test("conforms to the door contract, same as its sibling", async () => {
+    const body = (await call().json()) as Record<string, unknown>;
+    expect(body.bearer_methods_supported).toEqual(["header"]);
+    expect(body.resource_documentation).toMatch(/parachute\.computer/);
   });
 });
 

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -339,6 +339,7 @@ import {
   handleRevoke,
   handleToken,
   protectedResourceMetadata,
+  rootMcpProtectedResourceMetadata,
 } from "./oauth-handlers.ts";
 import { renderNotFoundPage } from "./oauth-ui.ts";
 import { assertSameOriginForCookieMutation, buildHubBoundOrigins } from "./origin-check.ts";
@@ -2935,13 +2936,21 @@ export function hubFetch(
 
       // /.well-known/oauth-protected-resource/mcp — the PRM for root /mcp
       // (RFC 9728, path-suffixed per the MCP spec's per-resource discovery
-      // convention). UNLIKE the bare PRM above, this doc is FORWARDED from
-      // the vault daemon rather than built locally — the daemon names /mcp
-      // as the resource + its own scopes (vault:read / vault:write). Same
-      // wildcard CORS shape as its sibling; the vault's `Response.json`
-      // carries none of its own, so we fold it onto the proxied response —
-      // this well-known surface is deliberately CORS-open for browser-side
-      // MCP client discovery.
+      // convention).
+      //
+      // hub#789: this used to be FORWARDED from the vault daemon. That was
+      // wrong in kind — root /mcp is a HUB resource, so its metadata was being
+      // authored by a service that doesn't know hub's scope registry. The
+      // visible symptom was `vault:admin` missing from the advertisement (so a
+      // spec-following MCP client never requested it, and tag-schema
+      // management was unreachable over MCP even though the issuer grants
+      // admin happily since the 2026-05-29 single-consent change). It also
+      // made hub-level scopes structurally impossible to advertise here.
+      //
+      // Now built locally from the same `advertisedScopes` the bare PRM uses,
+      // so the two documents share one registry and one filter and can't drift.
+      // Same wildcard CORS shape as its sibling — this well-known surface is
+      // deliberately CORS-open for browser-side MCP client discovery.
       if (pathname === "/.well-known/oauth-protected-resource/mcp") {
         const corsHeaders = {
           "access-control-allow-origin": "*",
@@ -2950,11 +2959,10 @@ export function hubFetch(
         if (req.method === "OPTIONS") {
           return new Response(null, { status: 204, headers: corsHeaders });
         }
-        const proxied = await proxyToVaultDaemon(req, manifestPath, deps?.supervisor, peerAddr);
-        if (!proxied) return vaultModuleNotRunning();
-        const merged = new Headers(proxied.headers);
+        const res = rootMcpProtectedResourceMetadata(oauthDeps(req));
+        const merged = new Headers(res.headers);
         for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
-        return new Response(proxied.body, { status: proxied.status, headers: merged });
+        return new Response(res.body, { status: res.status, headers: merged });
       }
 
       // GET /.well-known/parachute-account — the account-door capabilities

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -451,6 +451,53 @@ function advertisedScopes(declared: ReadonlySet<string>, manifest: ServicesManif
     });
 }
 
+/**
+ * RFC 9728 PRM for the ROOT `/mcp` resource, authored HERE rather than
+ * forwarded from the vault daemon (hub#789).
+ *
+ * Root `/mcp` is a HUB resource — hub owns the endpoint, the issuer, and the
+ * scope registry. Until now hub proxied this document straight from the vault
+ * daemon, which meant the metadata describing a hub resource was written by a
+ * service that doesn't know hub's scope set. Two consequences, both observed
+ * live:
+ *
+ *   - **`vault:admin` was missing.** Vault's root PRM hard-codes
+ *     `[read, write]` on the reasoning that "admin is an operator concern, not
+ *     something the consent picker offers". That reasoning predates the
+ *     2026-05-29 single-consent change, which made per-vault
+ *     `vault:<name>:admin` genuinely requestable through public consent
+ *     (capped to the consenting user's own authority at the mint
+ *     choke-point). So the issuer would happily grant admin — the
+ *     advertisement was the only thing withholding it, and a spec-following
+ *     client reads the advertisement and requests exactly what it lists.
+ *     Admin is what MCP clients need to manage tag schemas, so the gap made a
+ *     core workflow unreachable over MCP.
+ *
+ *   - **Hub-level scopes could never appear at all.** Vault has no concept of
+ *     them, so no edit to vault could have surfaced them here.
+ *
+ * Sharing `advertisedScopes` with the bare PRM is the point: one scope
+ * registry, filtered by one rule (requestable ∧ module-installed), so the two
+ * documents cannot drift apart again.
+ */
+export function rootMcpProtectedResourceMetadata(deps: OAuthDeps): Response {
+  const iss = deps.issuer;
+  const declared = (deps.loadDeclaredScopes ?? loadDeclaredScopes)();
+  return jsonResponse({
+    // The resource is the root MCP endpoint, not the origin — that's what
+    // distinguishes this document from the bare PRM, and what the client
+    // matches against the endpoint it got the 401 from.
+    resource: `${iss}/mcp`,
+    authorization_servers: [iss],
+    scopes_supported: advertisedScopes(
+      declared,
+      (deps.loadServicesManifest ?? readServicesManifest)(),
+    ),
+    bearer_methods_supported: ["header"],
+    resource_documentation: "https://parachute.computer",
+  });
+}
+
 export function protectedResourceMetadata(deps: OAuthDeps): Response {
   const iss = deps.issuer;
   const declared = (deps.loadDeclaredScopes ?? loadDeclaredScopes)();


### PR DESCRIPTION
Found in direct testing: root `/mcp` advertised only `vault:read` and `vault:write`.

## Root cause

The RFC 9728 document for root `/mcp` was **forwarded from the vault daemon**. The old code said so outright:

> *"UNLIKE the bare PRM above, this doc is FORWARDED from the vault daemon rather than built locally — the daemon names /mcp as the resource + its own scopes (vault:read / vault:write)."*

That's wrong in kind. **Root `/mcp` is a hub resource** — hub owns the endpoint, the issuer, and the scope registry — so its metadata was being authored by a service that doesn't know hub's scope set.

## Why `vault:admin` was missing, and why that mattered

Vault's `handleRootProtectedResource` hard-codes `[read, write]`, reasoning that *"admin is an operator concern, not something the consent picker offers."*

**That reasoning predates the 2026-05-29 single-consent change.** Per-vault `vault:<name>:admin` has been genuinely requestable through public consent since then, capped to the consenting user's own authority at the mint choke-point (`capScopesToUserAuthority` inside `issueAuthCodeRedirect`).

So the issuer grants admin happily — **the advertisement was the only thing withholding it.** A spec-following MCP client reads `scopes_supported` and requests exactly what it lists, so admin never got requested. And **updating tags requires admin**, which put a core workflow out of reach over MCP entirely. That's the bug: not a policy the system was enforcing, just a stale advertisement contradicting the policy it actually has.

## The fix

Hub authors the document, sharing `advertisedScopes` with the bare PRM — one registry, one filter (requestable ∧ module-installed), two documents, so they can't drift apart again. Non-requestable operator scopes remain excluded; advertising what the issuer always rejects would mislead clients, which is the same reasoning the AS metadata already applies.

## Verified live

Real hubs, before and after:

```
BEFORE (0.7.8 running on the box):
  resource: http://127.0.0.1:1939/mcp
  scopes:   ['vault:read', 'vault:write']

AFTER (this branch):
  resource: http://127.0.0.1:19399/mcp
  scopes:   ['vault:admin', 'vault:read', 'vault:write']
```

Hub suite **4379 pass / 0 fail**, `tsc --noEmit` clean. The forwarding test is **rewritten, not deleted** — it now asserts the vault daemon is *never consulted*, which is the property that regressed.

## On `account:self:*` — deliberately NOT advertised here

Aaron asked for these too. Forwarding made them structurally impossible (vault has no concept of them), and that blocker is now gone — but they're still absent, because they sit in `NON_REQUESTABLE_SCOPES` by explicit design:

> *"cookie-minted only via `POST /account/token`, **NEVER OAuth-requestable**. A third-party app pointed at the hub AS must not be able to consent its way to account authority (create/delete vaults, mint per-vault tokens) — the account credential is exclusively the same-origin app's cookie→bearer exchange."*

Advertising them without making them requestable would mislead clients (the exact failure this PR fixes, in reverse). Making them requestable means an arbitrary MCP client could consent its way to creating and deleting vaults. That's a real security boundary someone drew on purpose, and unlike `vault:admin` — where the advertisement contradicted an existing grant policy — this one would *change* the policy.

**So it wants its own decision and its own PR.** Happy to do it; I didn't want to widen that boundary inside a bug fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPoTHLWtNvRVWYcs1K5i8b