### PR TITLE
ci(release): publish on merge; promote scope-guard 0.5.1 to stable

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,11 @@ name: Release
 
 on:
   push:
+    # hub#790: publish-on-merge. See the `plan` job for why the tag was
+    # replaced as the release SIGNAL (it's still honoured, and still cut as a
+    # record).
+    branches:
+      - main
     tags:
       # Hub release tags
       - 'v[0-9]+.[0-9]+.[0-9]+'
@@ -69,6 +74,45 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  # ---------------------------------------------------------------------------
+  # What, if anything, needs publishing.
+  #
+  # hub#790: releasing used to require remembering `git tag && git push` after
+  # every merge. The remembering is the weak link — several PRs merged in one
+  # session with no tags, so nothing published and nobody noticed until an
+  # operator asked why their box was stale.
+  #
+  # Governance rule 2 already requires every code-touching PR to bump `version`,
+  # so package.json IS the per-PR release intent; the tag was a second, manual
+  # copy of a decision the PR already made. The decision logic lives in
+  # `scripts/release-plan.ts` (unit-tested — release logic that can
+  # double-publish or drop a release shouldn't be untested shell in a `run:`).
+  #
+  # Note the tag-push path is unchanged: an explicit tag still publishes, and
+  # still overrides every check, because a tag is a human saying "release this".
+  # ---------------------------------------------------------------------------
+  plan:
+    name: plan
+    runs-on: ubuntu-latest
+    outputs:
+      hub: ${{ steps.hub.outputs.should_publish }}
+      scope_guard: ${{ steps.scope_guard.outputs.should_publish }}
+      depcheck: ${{ steps.depcheck.outputs.should_publish }}
+      door_contract: ${{ steps.door_contract.outputs.should_publish }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - id: hub
+        run: bun scripts/release-plan.ts . @openparachute/hub
+      - id: scope_guard
+        run: bun scripts/release-plan.ts packages/scope-guard @openparachute/scope-guard
+      - id: depcheck
+        run: bun scripts/release-plan.ts packages/depcheck @openparachute/depcheck
+      - id: door_contract
+        run: bun scripts/release-plan.ts packages/door-contract @openparachute/door-contract
+
   test:
     name: test
     runs-on: ubuntu-latest
@@ -113,9 +157,9 @@ jobs:
 
   publish-hub-npm:
     name: publish hub to npm
-    needs: test
+    needs: [plan, test]
     # Hub-only: skip on scope-guard / depcheck / door-contract tags (a `v*` tag is hub's).
-    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-') }}
+    if: ${{ (github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -136,6 +180,9 @@ jobs:
       - name: install deps
         run: bun install --frozen-lockfile
       - name: verify package.json version matches tag
+        # Tag path only — on a branch push the version comes FROM
+        # package.json, so there is nothing to drift against.
+        if: github.ref_type == 'tag'
         # Defense against tag-vs-package.json drift. If they don't match,
         # we'd publish under the wrong version.
         run: |
@@ -168,9 +215,9 @@ jobs:
 
   publish-scope-guard-npm:
     name: publish scope-guard to npm
-    needs: test
+    needs: [plan, test]
     # scope-guard-only: skip on hub (`v*`) tags.
-    if: ${{ startsWith(github.ref_name, 'scope-guard-') }}
+    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'scope-guard-'))) || (github.ref_type != 'tag' && needs.plan.outputs.scope_guard == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -198,6 +245,9 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bun install --frozen-lockfile
       - name: verify package.json version matches tag
+        # Tag path only — on a branch push the version comes FROM
+        # package.json, so there is nothing to drift against.
+        if: github.ref_type == 'tag'
         run: |
           PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
           # Strip the `scope-guard-v` prefix from the tag.
@@ -218,9 +268,9 @@ jobs:
 
   publish-depcheck-npm:
     name: publish depcheck to npm
-    needs: test
+    needs: [plan, test]
     # depcheck-only: skip on hub (`v*`) + scope-guard tags.
-    if: ${{ startsWith(github.ref_name, 'depcheck-') }}
+    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'depcheck-'))) || (github.ref_type != 'tag' && needs.plan.outputs.depcheck == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -246,6 +296,9 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bun install --frozen-lockfile
       - name: verify package.json version matches tag
+        # Tag path only — on a branch push the version comes FROM
+        # package.json, so there is nothing to drift against.
+        if: github.ref_type == 'tag'
         run: |
           PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
           # Strip the `depcheck-v` prefix from the tag.
@@ -268,9 +321,9 @@ jobs:
 
   publish-door-contract-npm:
     name: publish door-contract to npm
-    needs: test
+    needs: [plan, test]
     # door-contract-only: skip on hub (`v*`) + scope-guard + depcheck tags.
-    if: ${{ startsWith(github.ref_name, 'door-contract-') }}
+    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.door_contract == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -296,6 +349,9 @@ jobs:
         working-directory: ${{ github.workspace }}
         run: bun install --frozen-lockfile
       - name: verify package.json version matches tag
+        # Tag path only — on a branch push the version comes FROM
+        # package.json, so there is nothing to drift against.
+        if: github.ref_type == 'tag'
         run: |
           PKG_VERSION=$(bun -e "console.log(require('./package.json').version)")
           # Strip the `door-contract-v` prefix from the tag.
@@ -318,9 +374,9 @@ jobs:
 
   publish-image:
     name: publish to ghcr.io
-    needs: test
+    needs: [plan, test]
     # Hub-only: scope-guard / depcheck / door-contract don't ship a container image.
-    if: ${{ !startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-') }}
+    if: ${{ (github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true') }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -360,3 +416,43 @@ jobs:
           # fast (typically ~30s warm vs ~3min cold).
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+  # ---------------------------------------------------------------------------
+  # Record what shipped as git tags.
+  #
+  # A RECORD, not a trigger — nothing fires off these, which is exactly why
+  # GITHUB_TOKEN pushing them is fine (a token-pushed tag can't start a
+  # workflow, and here it doesn't need to). `always()` with per-package result
+  # checks so one package's publish failure doesn't suppress the others' tags.
+  # ---------------------------------------------------------------------------
+  tag-record:
+    name: tag what shipped
+    needs: [plan, publish-hub-npm, publish-scope-guard-npm, publish-depcheck-npm, publish-door-contract-npm]
+    if: ${{ always() && github.ref_type != 'tag' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: tag published packages
+        continue-on-error: true
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          tag_if() {  # <prefix> <dir> <published?>
+            [ "$3" = "success" ] || return 0
+            V=$(bun -e "console.log(require('./$2/package.json').version)")
+            T="$1$V"
+            if git rev-parse "$T" >/dev/null 2>&1; then
+              echo "$T already exists"
+            else
+              git tag "$T" && git push origin "$T" && echo "tagged $T"
+            fi
+          }
+          tag_if "v"              "."                      "${{ needs.publish-hub-npm.result }}"
+          tag_if "scope-guard-v"  "packages/scope-guard"   "${{ needs.publish-scope-guard-npm.result }}"
+          tag_if "depcheck-v"     "packages/depcheck"      "${{ needs.publish-depcheck-npm.result }}"
+          tag_if "door-contract-v" "packages/door-contract" "${{ needs.publish-door-contract-npm.result }}"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.9-rc.1",
+  "version": "0.7.9-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/packages/scope-guard/CHANGELOG.md
+++ b/packages/scope-guard/CHANGELOG.md
@@ -4,10 +4,16 @@ All notable changes to `@openparachute/scope-guard` are documented here. The for
 
 The library's RC cadence is independent of `@openparachute/hub`'s — they ship from the same repo but aren't coupled in version.
 
-## [0.5.1-rc.1]
+## [0.5.1]
 
 **`revocationOrigin` — the revocation fetch no longer hairpins through a
 public FQDN, and a fail-closed fetch no longer happens in silence.**
+
+> Shipped straight to STABLE rather than sitting on `@rc`. Vault depends on
+> `^0.5.0`, and semver excludes prereleases from a caret range — `^0.5.0` does
+> not match `0.5.1-rc.1`. So an rc could never reach the consumer that needs
+> the fix; a box would keep resolving 0.5.0 and keep rejecting every token.
+> The change is additive to the options surface and covered by 135 tests.
 
 ### Why
 

--- a/packages/scope-guard/package.json
+++ b/packages/scope-guard/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/scope-guard",
-  "version": "0.5.1-rc.1",
+  "version": "0.5.1",
   "description": "Hub-issued JWT validation for Parachute resource servers (vault, scribe, parachute-agent, third-party modules).",
   "license": "AGPL-3.0",
   "type": "module",

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -1,0 +1,166 @@
+/**
+ * Decide whether a package should publish, for the publish-on-merge workflow.
+ *
+ * Lives here rather than inline in release.yml for two reasons: release logic
+ * that can double-publish or silently skip deserves unit tests, and hub has
+ * four packages that would otherwise repeat the same twenty lines of shell.
+ *
+ * ## What it guards against
+ *
+ * **Double-publishing.** Skip when the exact version already exists on npm, so
+ * a re-run, a revert, or a merge that didn't bump is a no-op.
+ *
+ * **Silently skipping a real release.** An ambiguous registry response (5xx,
+ * network failure) REFUSES rather than guessing. A false "not published"
+ * double-publishes; a false "published" drops a release on the floor. Neither
+ * is acceptable, so we don't pick one.
+ *
+ * **Publishing backwards.** This is the one the vault version of this workflow
+ * doesn't have yet, and it matters as soon as PRs land in parallel: several
+ * open PRs each pin their own `rc.N`, and they don't necessarily merge in
+ * version order. Merging rc.6 and then rc.5 would leave the `rc` dist-tag
+ * pointing at rc.5 — older than what consumers already had — so an operator
+ * installing `@rc` would silently DOWNGRADE. We refuse to move a dist-tag
+ * backwards. (Re-publishing an older version deliberately is still possible
+ * via an explicit tag push, which takes the tag branch below.)
+ */
+
+/** Where a version stands relative to what's already published. */
+export type PublishDecision =
+  | { publish: true; reason: string }
+  | { publish: false; reason: string }
+  | { refuse: true; reason: string };
+
+export interface RegistryView {
+  /** True when this exact version is already on npm. */
+  versionExists: boolean;
+  /** Current version behind the dist-tag we'd move (`rc` or `latest`). */
+  currentDistTagVersion?: string;
+}
+
+/** `rc` for a prerelease, `latest` otherwise. */
+export function distTagFor(version: string): "rc" | "latest" {
+  return /-rc\./.test(version) ? "rc" : "latest";
+}
+
+/**
+ * Compare two semver-ish versions. Returns <0, 0, >0.
+ *
+ * Deliberately small rather than pulling a dependency into CI: handles
+ * `X.Y.Z` and `X.Y.Z-rc.N`, which is the entire shape governance allows. A
+ * release version always sorts ABOVE its own prereleases (0.7.5 > 0.7.5-rc.9),
+ * matching semver.
+ */
+export function compareVersions(a: string, b: string): number {
+  const parse = (v: string) => {
+    const [core, pre] = v.split("-");
+    const nums = (core ?? "").split(".").map((n) => Number.parseInt(n, 10) || 0);
+    // No prerelease sorts above any prerelease → Infinity.
+    const preNum = pre ? Number.parseInt(pre.replace(/^rc\./, ""), 10) || 0 : Number.POSITIVE_INFINITY;
+    return { nums, preNum };
+  };
+  const pa = parse(a);
+  const pb = parse(b);
+  for (let i = 0; i < 3; i++) {
+    const d = (pa.nums[i] ?? 0) - (pb.nums[i] ?? 0);
+    if (d !== 0) return d < 0 ? -1 : 1;
+  }
+  if (pa.preNum === pb.preNum) return 0;
+  return pa.preNum < pb.preNum ? -1 : 1;
+}
+
+/**
+ * The decision. `isTagPush` short-circuits every check but the shape one — an
+ * explicit tag is a human saying "release this", including a deliberate
+ * re-release of something older.
+ */
+export function decidePublish(
+  version: string,
+  registry: RegistryView | { ambiguous: true },
+  opts: { isTagPush?: boolean } = {},
+): PublishDecision {
+  if (opts.isTagPush) {
+    return { publish: true, reason: `explicit tag push for ${version}` };
+  }
+  if ("ambiguous" in registry) {
+    return {
+      refuse: true,
+      reason:
+        "couldn't determine what's published (registry error) — refusing to guess, " +
+        "since a wrong answer either double-publishes or drops a release",
+    };
+  }
+  if (registry.versionExists) {
+    return { publish: false, reason: `${version} is already on npm` };
+  }
+  const current = registry.currentDistTagVersion;
+  if (current && compareVersions(version, current) < 0) {
+    return {
+      refuse: true,
+      reason:
+        `${version} is OLDER than the current ${distTagFor(version)} (${current}) — ` +
+        "publishing would move the dist-tag backwards and downgrade anyone installing it. " +
+        "This usually means parallel PRs merged out of version order; bump and re-merge.",
+    };
+  }
+  return { publish: true, reason: `${version} is not on npm` };
+}
+
+/** Query npm for a package's state. Ambiguity is reported, never guessed. */
+export async function readRegistry(
+  npmName: string,
+  version: string,
+  fetchImpl: typeof fetch = fetch,
+): Promise<RegistryView | { ambiguous: true }> {
+  const encoded = npmName.replace("/", "%2f");
+  try {
+    const res = await fetchImpl(`https://registry.npmjs.org/${encoded}`);
+    if (res.status === 404) {
+      // Package has never been published at all — first release.
+      return { versionExists: false };
+    }
+    if (!res.ok) return { ambiguous: true };
+    const body = (await res.json()) as {
+      versions?: Record<string, unknown>;
+      "dist-tags"?: Record<string, string>;
+    };
+    return {
+      versionExists: Boolean(body.versions?.[version]),
+      currentDistTagVersion: body["dist-tags"]?.[distTagFor(version)],
+    };
+  } catch {
+    return { ambiguous: true };
+  }
+}
+
+// --- CLI -------------------------------------------------------------------
+// Usage: bun scripts/release-plan.ts <package-dir> <npm-name> [--tag-push]
+// Emits GitHub Actions outputs; exits non-zero on refusal.
+if (import.meta.main) {
+  const [dir, npmName, ...rest] = process.argv.slice(2);
+  if (!dir || !npmName) {
+    console.error("usage: release-plan.ts <package-dir> <npm-name> [--tag-push]");
+    process.exit(2);
+  }
+  const pkg = await Bun.file(`${dir}/package.json`).json();
+  const version: string = pkg.version;
+  const registry = await readRegistry(npmName, version);
+  const decision = decidePublish(version, registry, {
+    isTagPush: rest.includes("--tag-push"),
+  });
+
+  const out = process.env.GITHUB_OUTPUT;
+  const emit = async (k: string, v: string) => {
+    if (out) await Bun.write(out, `${k}=${v}\n`, { createPath: false });
+    console.log(`${k}=${v}`);
+  };
+
+  if ("refuse" in decision) {
+    console.error(`::error::${npmName}@${version}: ${decision.reason}`);
+    process.exit(1);
+  }
+  await emit("version", version);
+  await emit("dist_tag", distTagFor(version));
+  await emit("should_publish", String(decision.publish));
+  console.log(`${npmName}@${version}: ${decision.reason}`);
+}

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -1,0 +1,145 @@
+/**
+ * The publish-on-merge decision.
+ *
+ * Release logic that can double-publish or silently drop a release is exactly
+ * the kind that should not live untested in a YAML `run:` block. Every case
+ * here is one where a wrong answer costs something real.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  compareVersions,
+  decidePublish,
+  distTagFor,
+  readRegistry,
+} from "../../scripts/release-plan.ts";
+
+describe("distTagFor", () => {
+  test("prerelease → rc, release → latest", () => {
+    expect(distTagFor("0.7.9-rc.2")).toBe("rc");
+    expect(distTagFor("0.7.9")).toBe("latest");
+  });
+});
+
+describe("compareVersions", () => {
+  test("orders patch versions", () => {
+    expect(compareVersions("0.7.5", "0.7.4")).toBeGreaterThan(0);
+    expect(compareVersions("0.7.4", "0.7.5")).toBeLessThan(0);
+    expect(compareVersions("0.7.5", "0.7.5")).toBe(0);
+  });
+
+  test("orders rc chains numerically, not lexically", () => {
+    // The lexical trap: "rc.10" < "rc.9" as strings.
+    expect(compareVersions("0.7.5-rc.10", "0.7.5-rc.9")).toBeGreaterThan(0);
+    expect(compareVersions("0.7.5-rc.5", "0.7.5-rc.6")).toBeLessThan(0);
+  });
+
+  test("a release sorts above its own prereleases", () => {
+    expect(compareVersions("0.7.5", "0.7.5-rc.99")).toBeGreaterThan(0);
+  });
+
+  test("major/minor dominate the prerelease suffix", () => {
+    expect(compareVersions("0.8.0-rc.1", "0.7.9")).toBeGreaterThan(0);
+  });
+});
+
+describe("decidePublish", () => {
+  test("a fresh version publishes", () => {
+    const d = decidePublish("0.7.9-rc.2", { versionExists: false, currentDistTagVersion: "0.7.9-rc.1" });
+    expect(d).toMatchObject({ publish: true });
+  });
+
+  test("an already-published version is skipped — the idempotency guarantee", () => {
+    // Re-runs, reverts, and merges that didn't bump must all be no-ops.
+    const d = decidePublish("0.7.9-rc.1", { versionExists: true });
+    expect(d).toMatchObject({ publish: false });
+  });
+
+  test("first-ever release of a package publishes", () => {
+    const d = decidePublish("0.1.0", { versionExists: false });
+    expect(d).toMatchObject({ publish: true });
+  });
+
+  test("REFUSES to move a dist-tag backwards — the parallel-merge hazard", () => {
+    // Several open PRs each pin their own rc.N and don't necessarily merge in
+    // order. Publishing rc.5 after rc.6 would leave `@rc` pointing at the
+    // older one, silently downgrading anyone who installs it.
+    const d = decidePublish("0.7.5-rc.5", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.5-rc.6",
+    });
+    expect(d).toMatchObject({ refuse: true });
+    expect("refuse" in d && d.reason).toMatch(/OLDER than the current rc/);
+    expect("refuse" in d && d.reason).toMatch(/merged out of version order/);
+  });
+
+  test("rc and latest are tracked independently", () => {
+    // Publishing 0.8.0-rc.1 compares against the `rc` tag, not `latest`, so a
+    // newer stable doesn't block the next prerelease line.
+    const d = decidePublish("0.8.0-rc.1", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.9-rc.5",
+    });
+    expect(d).toMatchObject({ publish: true });
+  });
+
+  test("an ambiguous registry REFUSES rather than guessing", () => {
+    // A false "not published" double-publishes; a false "published" drops a
+    // release. Guessing is worse than failing loudly.
+    const d = decidePublish("0.7.9", { ambiguous: true });
+    expect(d).toMatchObject({ refuse: true });
+    expect("refuse" in d && d.reason).toMatch(/refusing to guess/);
+  });
+
+  test("an explicit tag push overrides every check — a human said release this", () => {
+    const d = decidePublish("0.7.0-rc.1", {
+      versionExists: false,
+      currentDistTagVersion: "0.9.0",
+    }, { isTagPush: true });
+    expect(d).toMatchObject({ publish: true });
+  });
+
+  test("a tag push even overrides ambiguity", () => {
+    const d = decidePublish("0.7.9", { ambiguous: true }, { isTagPush: true });
+    expect(d).toMatchObject({ publish: true });
+  });
+});
+
+describe("readRegistry", () => {
+  const json = (body: unknown, status = 200) =>
+    Promise.resolve(new Response(JSON.stringify(body), { status }));
+
+  test("reads existence + the relevant dist-tag", async () => {
+    const v = await readRegistry("@openparachute/hub", "0.7.9-rc.2", (() =>
+      json({
+        versions: { "0.7.9-rc.1": {}, "0.7.9-rc.2": {} },
+        "dist-tags": { rc: "0.7.9-rc.2", latest: "0.7.8" },
+      })) as unknown as typeof fetch);
+    expect(v).toMatchObject({ versionExists: true, currentDistTagVersion: "0.7.9-rc.2" });
+  });
+
+  test("picks the dist-tag matching the version's channel", async () => {
+    const v = await readRegistry("@openparachute/hub", "0.7.9", (() =>
+      json({ versions: {}, "dist-tags": { rc: "0.7.9-rc.2", latest: "0.7.8" } })) as unknown as typeof fetch);
+    // A stable version compares against `latest`, not `rc`.
+    expect(v).toMatchObject({ currentDistTagVersion: "0.7.8" });
+  });
+
+  test("a never-published package is not ambiguous — it's a first release", async () => {
+    const v = await readRegistry("@openparachute/new", "0.1.0", (() =>
+      json({}, 404)) as unknown as typeof fetch);
+    expect(v).toMatchObject({ versionExists: false });
+  });
+
+  test("a 5xx is ambiguous", async () => {
+    const v = await readRegistry("@openparachute/hub", "1.0.0", (() =>
+      json({}, 503)) as unknown as typeof fetch);
+    expect(v).toMatchObject({ ambiguous: true });
+  });
+
+  test("a network throw is ambiguous, not a crash", async () => {
+    const v = await readRegistry("@openparachute/hub", "1.0.0", (() =>
+      Promise.reject(new Error("ECONNRESET"))) as unknown as typeof fetch);
+    expect(v).toMatchObject({ ambiguous: true });
+  });
+});


### PR DESCRIPTION
Hub's version of ParachuteComputer/parachute-vault#637, plus the scope-guard promotion that actually gets the auth fix onto a box.

## Publish on merge

Same rationale as vault's: releasing required remembering `git tag && git push`, and the remembering was the weak link. Governance rule 2 already makes every code-touching PR bump `version`, so **package.json is the per-PR release intent** — the tag was a second, manual copy of a decision the PR had already made.

Tag-on-merge-and-let-the-tag-fire **does not work**: events triggered by `GITHUB_TOKEN` never start another workflow run. One workflow, no recursion.

## What's different from vault's version

**The logic is a tested script, not shell in a `run:` block.** `scripts/release-plan.ts`, 18 unit tests. Hub has four packages, so the shell would have been repeated four times — and release logic that can double-publish or drop a release shouldn't be untested either way.

**A third guard vault doesn't have yet: no backwards publishes.**

Several PRs are open right now, each pinning its own `rc.N`, and they don't merge in version order. Merging rc.6 then rc.5 would leave `@rc` pointing at **rc.5 — older than what consumers already had** — silently downgrading anyone who installs it. The plan refuses:

> `0.7.5-rc.5 is OLDER than the current rc (0.7.5-rc.6) — publishing would move the dist-tag backwards and downgrade anyone installing it. This usually means parallel PRs merged out of version order; bump and re-merge.`

**This is a live gap in vault#637 as merged.** I'd like to backport it — say the word.

The other two guards match vault: idempotent (skip an already-published version) and ambiguity-refuses (a registry 5xx exits non-zero rather than guessing, because a false "not published" double-publishes and a false "published" drops a release).

## A latent bug this surfaced

The per-job **"verify package.json version matches tag"** steps parse `GITHUB_REF_NAME` as a tag. On a branch push there is no tag, so they'd compare against `"main"` and **fail every merge-triggered run**. Now gated to the tag path — on the branch path the version comes *from* package.json, so there's nothing to drift against.

## scope-guard 0.5.1 → stable, deliberately skipping `@rc`

Vault depends on `"@openparachute/scope-guard": "^0.5.0"`, and semver excludes prereleases from a caret range:

```
^0.5.0 satisfied by 0.5.1      → true
^0.5.0 satisfied by 0.5.1-rc.1 → false
```

So an rc **could never reach the consumer that needs it** — a box would keep resolving 0.5.0 and keep rejecting every hub-issued token with `revocation_unavailable`. The change is additive to the options surface and covered by 135 tests, so stable is the proportionate call. scope-guard's cadence is explicitly independent of hub's.

## Verified

Decision logic run against the **live registry**, and this is what merging does:

```
@openparachute/hub             0.7.9-rc.3 → PUBLISH
@openparachute/scope-guard     0.5.1      → PUBLISH   ← the auth fix, finally reachable
@openparachute/depcheck        0.1.1      → skip      (already published)
@openparachute/door-contract   0.6.1      → PUBLISH
```

Note **door-contract 0.6.1 has also been sitting unpublished on `main`** — nobody noticed. More evidence for the change than I'd have chosen to have.

Hub suite **4392 pass / 0 fail**, `tsc --noEmit` clean, workflow YAML validates, job graph checked (`plan → test → publish-* → tag-record`).

## ⚠️ Merging publishes immediately

Three packages, including a **stable** scope-guard. Conscious click, please.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPoTHLWtNvRVWYcs1K5i8b