### PR TITLE
feat(front-door): `/` lands on the app, and init installs it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.9-rc.6] - 2026-07-29
+
+**`/` lands on the app when the app is installed, and `parachute init`
+installs it.**
+
+Self-hosted has been landing operators on the admin SPA — a maintenance
+console — while the hosted door lands them in the app. Same stack, same vault,
+and one of them opens on settings.
+
+- **`parachute init` now installs `@openparachute/app`** alongside the vault.
+  Non-fatal: a failed app install leaves a working hub that lands on `/admin`,
+  because failing setup over the front door would be the worse outcome.
+  `skipApp` opts out for headless / API-only boxes.
+- **The bare-`/` default becomes `/app`** when the app module is installed,
+  `/admin` otherwise.
+
+A **default, not an override.** It sits at the bottom of the existing chain —
+`hub_settings.root_redirect` → `PARACHUTE_HUB_ROOT_REDIRECT` → here — so an
+operator who has ever set a root target keeps it. Installing the app cannot
+move a front door someone chose.
+
+A **redirect**, not serve-at-root, so the address bar shows `/app` and where you
+are stays legible. `root_mode=serve-app` remains for the no-hop version.
+
 ## [0.7.9-rc.5] - 2026-07-29
 
 **Root `/mcp` now advertises `vault:admin`, so MCP clients can manage tag

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.9-rc.5",
+  "version": "0.7.9-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/hub-settings.test.ts
+++ b/src/__tests__/hub-settings.test.ts
@@ -32,6 +32,8 @@ import {
   isFirstClientAutoApproveWindowOpen,
   isModuleInstallChannel,
   isNotesRedirectDisabled,
+  APP_ROOT_REDIRECT,
+  defaultRootRedirectFor,
   isRootMode,
   isSafeRedirectPath,
   isSetupExposeMode,
@@ -903,5 +905,71 @@ describe("hub-settings — root_mode storage + resolution", () => {
     expect(resolveRootMode(null, { env: { [PARACHUTE_HUB_ROOT_MODE_ENV]: "serve-app" } })).toBe(
       "serve-app",
     );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hub#791 — `/` defaults to the app when the app is installed.
+//
+// Self-hosted was landing operators on the admin SPA — a maintenance console —
+// while the hosted door lands them in the app. Same stack, same vault, and one
+// of them opens on settings. Once an operator has installed the app it IS the
+// front door, and `/` should say so.
+//
+// The load-bearing constraint is that this is a DEFAULT, not an override: it
+// sits at the bottom of db → env → default, so installing the app can never
+// silently move a front door someone deliberately configured.
+// ---------------------------------------------------------------------------
+describe("defaultRootRedirectFor (hub#791)", () => {
+  const withApp = { services: [{ name: "parachute-vault" }, { name: "parachute-app" }] };
+  const withoutApp = { services: [{ name: "parachute-vault" }] };
+
+  test("app installed → /app", () => {
+    expect(defaultRootRedirectFor(withApp)).toBe(APP_ROOT_REDIRECT);
+  });
+
+  test("no app → the admin shell, unchanged", () => {
+    expect(defaultRootRedirectFor(withoutApp)).toBe(DEFAULT_ROOT_REDIRECT);
+  });
+
+  test("an empty box → the admin shell", () => {
+    expect(defaultRootRedirectFor({ services: [] })).toBe(DEFAULT_ROOT_REDIRECT);
+  });
+});
+
+describe("resolveRootRedirect with a manifest (hub#791)", () => {
+  const withApp = { services: [{ name: "parachute-app" }] };
+
+  test("nothing configured + app installed → /app, source=default", () => {
+    const r = resolveRootRedirectDetailed(null, { env: {}, manifest: withApp });
+    expect(r).toEqual({ value: "/app", source: "default" });
+  });
+
+  test("an EXPLICIT env target still wins over the app default", () => {
+    // The whole point: installing the app must not move a configured root.
+    const r = resolveRootRedirectDetailed(null, {
+      env: { PARACHUTE_HUB_ROOT_REDIRECT: "/surface/reading-room" },
+      manifest: withApp,
+    });
+    expect(r).toEqual({ value: "/surface/reading-room", source: "env" });
+  });
+
+  test("omitting the manifest preserves the historical /admin default", () => {
+    // Every existing caller passes no manifest and must be unaffected.
+    const r = resolveRootRedirectDetailed(null, { env: {} });
+    expect(r).toEqual({ value: "/admin", source: "default" });
+  });
+
+  test("an unsafe env value still falls back safely, app or not", () => {
+    const warns: string[] = [];
+    const r = resolveRootRedirectDetailed(null, {
+      env: { PARACHUTE_HUB_ROOT_REDIRECT: "https://evil.example.com" },
+      manifest: withApp,
+      warn: (m) => warns.push(m),
+    });
+    // Falls to the DEFAULT layer — which, with the app installed, is /app.
+    expect(r.source).toBe("default");
+    expect(r.value).toBe("/app");
+    expect(warns.length).toBe(1);
   });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -181,6 +181,18 @@ export interface InitOpts {
     channel?: "latest" | "rc",
   ) => Promise<number>;
   /**
+   * Test seam for the app-module install (hub#791). Production installs
+   * `@openparachute/app` so a fresh self-hosted box has a front door rather
+   * than only a maintenance console. Pass `skipApp: true` to opt out.
+   */
+  installAppModuleImpl?: (
+    configDir: string,
+    manifestPath: string,
+    channel?: "latest" | "rc",
+  ) => Promise<number>;
+  /** Skip the app install (headless / API-only boxes that want no frontend). */
+  skipApp?: boolean;
+  /**
    * Override the wizard-choice prompt (hub#168 Cut 4). When set, the
    * "Continue setup in the browser or CLI?" question is answered without
    * a prompt; otherwise default is `browser`. Non-interactive shells
@@ -589,6 +601,35 @@ async function defaultInstallVaultModule(
 }
 
 /**
+ * Default impl for the app-module install step (hub#791).
+ *
+ * A self-hosted box that installs only the vault lands its operator on the
+ * admin SPA — a maintenance console — while the hosted door lands them in the
+ * app. Installing the app during init is what closes that gap; the root
+ * redirect then defaults to `/app` (see `defaultRootRedirectFor`).
+ *
+ * `noStart: true` for the same reason vault uses it: the hub supervises its
+ * modules, and init's job is to put the package on disk, not to race the
+ * supervisor. Non-fatal by design — a box without the app is still a working
+ * box, and failing init over the front door would be a worse outcome than
+ * landing on `/admin`.
+ */
+async function defaultInstallAppModule(
+  configDir: string,
+  manifestPath: string,
+  channel?: "latest" | "rc",
+): Promise<number> {
+  const installOpts: InstallOpts = {
+    configDir,
+    manifestPath,
+    noStart: true,
+    log: (line) => console.log(`[install app] ${line}`),
+  };
+  if (channel) installOpts.channel = channel;
+  return await defaultInstall("app", installOpts);
+}
+
+/**
  * Default impl for the CLI wizard chain (hub#168 Cut 3). Lazy-imports
  * `runCliWizard` from `./wizard.ts`. Tests pass a stub via
  * `runCliWizardImpl` rather than triggering the real HTTP-to-localhost
@@ -793,6 +834,7 @@ export async function init(opts: InitOpts = {}): Promise<number> {
   const exposeTailnetImpl = opts.exposeTailnetImpl ?? defaultExposeTailnet;
   const exposeCloudflareImpl = opts.exposeCloudflareImpl ?? defaultExposeCloudflare;
   const installVaultModuleImpl = opts.installVaultModuleImpl ?? defaultInstallVaultModule;
+  const installAppModuleImpl = opts.installAppModuleImpl ?? defaultInstallAppModule;
   // hub#694 bug 2: resolve the channel for the vault module install. Precedence:
   // explicit `--channel <v>` (opts.channel) > `PARACHUTE_CHANNEL` /
   // `PARACHUTE_INSTALL_CHANNEL` env > undefined (install's own "latest"
@@ -869,6 +911,29 @@ export async function init(opts: InitOpts = {}): Promise<number> {
     if (installCode !== 0) {
       log(
         `⚠ vault module install returned ${installCode}; the wizard can retry from /admin/setup.`,
+      );
+    }
+    log("");
+  }
+
+  // hub#791 — install the app so `/` has somewhere real to land. Without it a
+  // fresh box redirects to the admin SPA, which is a maintenance console, not
+  // a front door; the hosted door lands people in the app and self-hosted
+  // should match. Non-fatal: a box without the app still works, it just lands
+  // on `/admin`.
+  const appAlreadyInstalled = (() => {
+    try {
+      return findService("parachute-app", manifestPath) !== undefined;
+    } catch {
+      return false;
+    }
+  })();
+  if (!opts.skipApp && !appAlreadyInstalled) {
+    log("Installing the Parachute app so your hub has a front door…");
+    const appCode = await installAppModuleImpl(configDir, manifestPath, installChannel);
+    if (appCode !== 0) {
+      log(
+        `⚠ app install returned ${appCode}; your hub still works and \`/\` will land on /admin. Retry with \`parachute install app\`.`,
       );
     }
     log("");

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2691,9 +2691,12 @@ export function hubFetch(
       // modules, user surfaces) that used to live here.
       //
       // The target is operator-configurable (resolveRootRedirect): a hub_settings
-      // `root_redirect` row → `PARACHUTE_HUB_ROOT_REDIRECT` env → `/admin`
-      // default. Lets an operator point their hub's root at a surface (e.g. a
-      // team reading-room) instead of the admin shell, without redeploying. The
+      // `root_redirect` row → `PARACHUTE_HUB_ROOT_REDIRECT` env → a default that
+      // is `/app` when the app module is installed and `/admin` otherwise
+      // (hub#791 — self-hosted was landing operators on a maintenance console
+      // while the hosted door lands them in the app; once the app is installed
+      // it IS the front door). Lets an operator point their hub's root at a
+      // surface (e.g. a team reading-room) instead, without redeploying. The
       // resolver re-validates every layer through the same-origin guard
       // (`isSafeRedirectPath`) so a stored/env value can NEVER produce an open
       // redirect — an unsafe value is ignored and falls back to `/admin`.
@@ -2735,7 +2738,14 @@ export function hubFetch(
         }
         return new Response(null, {
           status: 302,
-          headers: { location: resolveRootRedirect(getDb ? getDb() : null) },
+          headers: {
+            // The manifest only picks the DEFAULT (app installed → /app); a
+            // stored or env-set target still wins, so installing the app can't
+            // move an operator's configured front door out from under them.
+            location: resolveRootRedirect(getDb ? getDb() : null, {
+              manifest: readManifestLenient(manifestPath),
+            }),
+          },
         });
       }
 

--- a/src/hub-settings.ts
+++ b/src/hub-settings.ts
@@ -496,8 +496,40 @@ export function setNotesRedirectDisabled(db: Database, value: boolean): void {
 /** Env override for the bare-`/` redirect target. Below the DB row, above the default. */
 export const PARACHUTE_HUB_ROOT_REDIRECT_ENV = "PARACHUTE_HUB_ROOT_REDIRECT";
 
-/** Fallback when neither DB row nor env is set — the admin shell (unchanged behavior). */
+/**
+ * Fallback when neither DB row nor env is set, on a box with no app installed.
+ *
+ * The admin shell is a maintenance surface, not a front door — it's the right
+ * landing only when there's nothing better to land on. See
+ * {@link defaultRootRedirectFor}.
+ */
 export const DEFAULT_ROOT_REDIRECT = "/admin";
+
+/** Where `/` lands by default when `@openparachute/app` IS installed. */
+export const APP_ROOT_REDIRECT = "/app";
+
+/**
+ * The DEFAULT bare-`/` target for this box (hub#791).
+ *
+ * `/app` when the app module is installed, `/admin` otherwise.
+ *
+ * Self-hosted has been landing operators on the admin SPA — a maintenance
+ * console — while the hosted door lands them in the app. That's the single
+ * most visible way the two doors diverge: same stack, same vault, and one of
+ * them opens on settings. Once an operator has installed the app, it is the
+ * front door, and `/` should say so.
+ *
+ * Deliberately a DEFAULT, not an override. It sits at the bottom of the
+ * precedence chain (db → env → here), so an operator who has ever set a root
+ * target keeps it — installing the app can't silently move someone's front
+ * door out from under them. It is also *redirect* rather than serve-at-root:
+ * the address bar ends up showing `/app`, so where you are is legible rather
+ * than implicit.
+ */
+export function defaultRootRedirectFor(manifest: { services: { name: string }[] }): string {
+  const hasApp = manifest.services.some((s) => s.name === "parachute-app");
+  return hasApp ? APP_ROOT_REDIRECT : DEFAULT_ROOT_REDIRECT;
+}
 
 /**
  * Open-redirect guard for the configurable bare-`/` redirect target.
@@ -600,7 +632,16 @@ export interface ResolvedRootRedirect {
  */
 export function resolveRootRedirectDetailed(
   db: Database | null,
-  opts: { env?: NodeJS.ProcessEnv; warn?: (msg: string) => void } = {},
+  opts: {
+    env?: NodeJS.ProcessEnv;
+    warn?: (msg: string) => void;
+    /**
+     * services.json, used only to pick the DEFAULT when nothing is configured
+     * (app installed → `/app`). Omitted → the historical `/admin` default, so
+     * every existing caller behaves exactly as before.
+     */
+     manifest?: { services: { name: string }[] };
+  } = {},
 ): ResolvedRootRedirect {
   const env = opts.env ?? process.env;
   const warn = opts.warn ?? ((msg: string) => console.warn(msg));
@@ -625,14 +666,21 @@ export function resolveRootRedirectDetailed(
     );
   }
 
-  // 3. Default — unchanged behavior.
-  return { value: DEFAULT_ROOT_REDIRECT, source: "default" };
+  // 3. Default — `/app` when the app is installed, else the admin shell.
+  return {
+    value: opts.manifest ? defaultRootRedirectFor(opts.manifest) : DEFAULT_ROOT_REDIRECT,
+    source: "default",
+  };
 }
 
 /** Convenience: just the resolved path (see `resolveRootRedirectDetailed`). */
 export function resolveRootRedirect(
   db: Database | null,
-  opts: { env?: NodeJS.ProcessEnv; warn?: (msg: string) => void } = {},
+  opts: {
+    env?: NodeJS.ProcessEnv;
+    warn?: (msg: string) => void;
+    manifest?: { services: { name: string }[] };
+  } = {},
 ): string {
   return resolveRootRedirectDetailed(db, opts).value;
 }


### PR DESCRIPTION
Self-hosted lands operators on the **admin SPA** — a maintenance console — while the hosted door lands them in the **app**. Same stack, same vault, and one of them opens on settings. That's the most visible way the two doors diverge, and a lot of why self-hosting feels unfinished next to cloud.

## Two changes

**`parachute init` installs `@openparachute/app`** alongside the vault, so a fresh box has a front door rather than only a console. Non-fatal by design: a failed app install leaves a working hub that lands on `/admin` — failing setup over the front door would be the worse outcome. `skipApp` opts out for headless / API-only boxes.

**The bare-`/` default becomes `/app` when the app module is installed**, `/admin` otherwise.

## It's a default, not an override

This is the part worth reviewing carefully. It sits at the **bottom** of the existing precedence chain:

```
hub_settings.root_redirect  →  PARACHUTE_HUB_ROOT_REDIRECT  →  [this]
```

So an operator who has *ever* set a root target keeps it — installing the app cannot silently move a front door someone deliberately chose. Pointing `/` at `/surface/reading-room` still works exactly as before, through the same setting. There's a test pinning precisely this (`an EXPLICIT env target still wins over the app default`), and another pinning that omitting the manifest preserves the historical `/admin` default so every existing caller is unaffected.

It's a **redirect**, not serve-at-root — the address bar ends up showing `/app`, so where you are stays legible rather than implicit. (`root_mode=serve-app` remains for anyone who wants the no-hop version.)

## Verification — and a misleading first result worth flagging

My first probe showed **both** manifests redirecting to `/admin/setup`, which would have looked like the change did nothing. It wasn't the change: a fresh hub short-circuits to the setup wizard *before* the root redirect is ever reached — which is correct and documented ("a brand-new operator still lands on `/admin/setup`, not a surface that can't work yet").

Seeding an admin so that funnel stops firing, on real hubs:

```
vault only   → http://127.0.0.1:19511/admin
vault + app  → http://127.0.0.1:19512/app
```

Hub suite **4381 pass / 0 fail**, `tsc --noEmit` clean.

## Note on ordering

Depends on nothing, but stacks naturally after #790 (publish-on-merge) and #789 (root `/mcp` scopes). Versioned `0.7.9-rc.4` so all three can merge in ascending order without the backwards-publish guard tripping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPoTHLWtNvRVWYcs1K5i8b