### PR TITLE
fix(release): dist-tag from the published version, not the git ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,11 +205,16 @@ jobs:
         run: |
           # Detect rc vs stable from tag name. Tag pattern in `on:` above
           # enforces the shape, so this is just disambiguation.
-          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
-            DIST_TAG=rc
-          else
-            DIST_TAG=latest
-          fi
+          # dist-tag comes from the VERSION BEING PUBLISHED, not from the ref.
+          # This used to read GITHUB_REF_NAME, which on a merge-triggered run is
+          # "main" — matching no rc pattern, so every publish-on-merge landed on
+          # `latest`. hub 0.7.9-rc.3 became @latest that way (hub#792). The
+          # package's own version is the only honest source here.
+          PKG_VERSION=$(bun -e "console.log(require('${{ github.workspace }}/package.json').version)")
+          case "$PKG_VERSION" in
+            *-rc.*) DIST_TAG=rc ;;
+            *)      DIST_TAG=latest ;;
+          esac
           echo "publishing with dist-tag=$DIST_TAG"
           npm publish --tag "$DIST_TAG" --access public --provenance
 
@@ -258,11 +263,16 @@ jobs:
           fi
       - name: publish
         run: |
-          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
-            DIST_TAG=rc
-          else
-            DIST_TAG=latest
-          fi
+          # dist-tag comes from the VERSION BEING PUBLISHED, not from the ref.
+          # This used to read GITHUB_REF_NAME, which on a merge-triggered run is
+          # "main" — matching no rc pattern, so every publish-on-merge landed on
+          # `latest`. hub 0.7.9-rc.3 became @latest that way (hub#792). The
+          # package's own version is the only honest source here.
+          PKG_VERSION=$(bun -e "console.log(require('${{ github.workspace }}/packages/scope-guard/package.json').version)")
+          case "$PKG_VERSION" in
+            *-rc.*) DIST_TAG=rc ;;
+            *)      DIST_TAG=latest ;;
+          esac
           echo "publishing @openparachute/scope-guard with dist-tag=$DIST_TAG"
           npm publish --tag "$DIST_TAG" --access public --provenance
 
@@ -311,11 +321,16 @@ jobs:
         # prepublishOnly runs `bun run build` (tsc → dist/) before the tarball
         # is assembled, so the published package ships compiled JS + d.ts.
         run: |
-          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
-            DIST_TAG=rc
-          else
-            DIST_TAG=latest
-          fi
+          # dist-tag comes from the VERSION BEING PUBLISHED, not from the ref.
+          # This used to read GITHUB_REF_NAME, which on a merge-triggered run is
+          # "main" — matching no rc pattern, so every publish-on-merge landed on
+          # `latest`. hub 0.7.9-rc.3 became @latest that way (hub#792). The
+          # package's own version is the only honest source here.
+          PKG_VERSION=$(bun -e "console.log(require('${{ github.workspace }}/packages/depcheck/package.json').version)")
+          case "$PKG_VERSION" in
+            *-rc.*) DIST_TAG=rc ;;
+            *)      DIST_TAG=latest ;;
+          esac
           echo "publishing @openparachute/depcheck with dist-tag=$DIST_TAG"
           npm publish --tag "$DIST_TAG" --access public --provenance
 
@@ -364,11 +379,16 @@ jobs:
         # prepublishOnly runs `bun run build` (tsc → dist/) before the tarball
         # is assembled, so the published package ships compiled JS + d.ts.
         run: |
-          if [[ "$GITHUB_REF_NAME" =~ -rc\. ]]; then
-            DIST_TAG=rc
-          else
-            DIST_TAG=latest
-          fi
+          # dist-tag comes from the VERSION BEING PUBLISHED, not from the ref.
+          # This used to read GITHUB_REF_NAME, which on a merge-triggered run is
+          # "main" — matching no rc pattern, so every publish-on-merge landed on
+          # `latest`. hub 0.7.9-rc.3 became @latest that way (hub#792). The
+          # package's own version is the only honest source here.
+          PKG_VERSION=$(bun -e "console.log(require('${{ github.workspace }}/packages/door-contract/package.json').version)")
+          case "$PKG_VERSION" in
+            *-rc.*) DIST_TAG=rc ;;
+            *)      DIST_TAG=latest ;;
+          esac
           echo "publishing @openparachute/door-contract with dist-tag=$DIST_TAG"
           npm publish --tag "$DIST_TAG" --access public --provenance
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.9-rc.3",
+  "version": "0.7.9-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
**I shipped this bug in #790 and it's live.** Merge this before the other open hub PRs.

## The live consequence

```
@openparachute/hub: { rc: '0.7.8-rc.5', latest: '0.7.9-rc.3' }
                                        ^^^^^^^^^^^^^^^^^^^^
```

`bun add -g @openparachute/hub` currently installs a **prerelease**.

## What I got wrong

The `plan` job derived `dist_tag` correctly. The four publish steps **ignored it** and re-derived their own from `GITHUB_REF_NAME` — which on a merge-triggered run is `"main"`, matching no rc pattern, so every publish-on-merge landed on `latest`.

The specific mistake: in #790 I gated the *"verify version matches tag"* steps to the tag path, because they parse `GITHUB_REF_NAME`. I did not notice that the **publish** steps two lines below made the *identical* assumption. I fixed one instance of a pattern and left four.

Vault's equivalent doesn't have the bug — there I rewrote the publish step from scratch rather than reusing an existing one, so `--tag "${{ needs.plan.outputs.dist_tag }}"` was correct from the start. Reusing four existing jobs and only auditing their `if:` conditions is what bit me.

## The fix

The dist-tag now comes from **the version being published**, read from that package's own `package.json` at publish time:

```sh
PKG_VERSION=$(bun -e "console.log(require('.../package.json').version)")
case "$PKG_VERSION" in
  *-rc.*) DIST_TAG=rc ;;
  *)      DIST_TAG=latest ;;
esac
```

That's the only honest source. It cannot drift from the artifact being published, and needs no cross-job plumbing that a future edit could silently break — which is exactly how the original failed.

Verified per package: hub `0.7.9-rc.4 → rc`, scope-guard `0.5.1 → latest`, depcheck `0.1.1 → latest`, door-contract `0.6.1 → latest`. YAML validates.

## ⚠️ Operator action needed regardless of this PR

Merging this stops the bleeding but **cannot repair the tag already moved**. Please run:

```sh
npm dist-tag add @openparachute/hub@0.7.8 latest
```

CI has no credential that can move a dist-tag backwards, and shouldn't.

## Also surfaced — pre-existing, not caused by publish-on-merge

`@openparachute/door-contract@0.6.1` fails with `404 … you do not have permission` — the signature of a **missing npm Trusted-Publisher rule**. `RELEASING.md` has listed this as an operator TODO since the package was added; auto-publish just made it visible by trying.

I left it **failing loudly on purpose.** A silent skip would hide a package that never ships — which is the same class of problem publish-on-merge was built to fix. It needs a Trusted Publisher rule (org `ParachuteComputer`, repo `parachute-hub`, workflow `release.yml`, env blank), then it'll publish on the next merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RPoTHLWtNvRVWYcs1K5i8b