### PR TITLE
feat(cli): add `parachute uninstall`, the command retirement already told people to run

### DIFF
--- a/src/__tests__/uninstall.test.ts
+++ b/src/__tests__/uninstall.test.ts
@@ -1,0 +1,222 @@
+/**
+ * `parachute uninstall` — the CLI surface for a removal operation that already
+ * existed but had no terminal entry point.
+ *
+ * The tests worth having here are about the two ways this command can be
+ * WRONG in a way that costs an operator something:
+ *
+ *   1. Removing something they didn't confirm (a prompt into a pipe reads EOF,
+ *      and a naive default turns that into "yes").
+ *   2. Refusing to remove a RETIRED module — which is the single most likely
+ *      thing anyone types this command for, since the retirement notes tell
+ *      them to.
+ *
+ * Everything else is a thin delegation to `driveModuleOp`, so it's asserted at
+ * the seam rather than re-tested through HTTP.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { uninstall } from "../commands/uninstall.ts";
+import type { DriveModuleOpDeps, ModuleOp, ModuleOpResult } from "../module-ops-client.ts";
+import {
+  ModuleOpHttpError,
+  NoOperatorTokenError,
+  OperatorTokenExpiredError,
+} from "../module-ops-client.ts";
+
+/** A no-op db handle — the command only passes it through and closes it. */
+function fakeDb() {
+  let closed = false;
+  const close = () => {
+    closed = true;
+  };
+  return {
+    handle: { close } as unknown as import("bun:sqlite").Database,
+    wasClosed: () => closed,
+  };
+}
+
+interface Recorded {
+  short: string;
+  op: ModuleOp;
+}
+
+function harness(
+  over: {
+    drive?: (short: string, op: ModuleOp, deps: DriveModuleOpDeps) => Promise<ModuleOpResult>;
+  } = {},
+) {
+  const calls: Recorded[] = [];
+  const lines: string[] = [];
+  const db = fakeDb();
+  const drive =
+    over.drive ??
+    (async (short: string, op: ModuleOp) => {
+      calls.push({ short, op });
+      return {
+        status: 200,
+        body: { short, log: [`${short} supervisor stopped`, "removed from services.json"] },
+      } as ModuleOpResult;
+    });
+  return {
+    calls,
+    lines,
+    db,
+    opts: {
+      driveModuleOp: drive,
+      openDb: () => db.handle,
+      configDir: "/tmp/does-not-matter",
+      log: (l: string) => lines.push(l),
+    },
+  };
+}
+
+describe("confirmation", () => {
+  test("a non-TTY run without --yes removes NOTHING", async () => {
+    // The failure this prevents: prompting into a pipe returns EOF instantly.
+    // Treating that as consent would silently uninstall inside any script.
+    const h = harness();
+    const code = await uninstall("vault", { ...h.opts, isTTY: false });
+    expect(code).toBe(1);
+    expect(h.calls).toEqual([]);
+  });
+
+  test("--yes in a non-TTY proceeds", async () => {
+    const h = harness();
+    const code = await uninstall("vault", { ...h.opts, isTTY: false, yes: true });
+    expect(code).toBe(0);
+    expect(h.calls).toEqual([{ short: "vault", op: "uninstall" }]);
+  });
+
+  test("answering no at the prompt removes NOTHING", async () => {
+    const h = harness();
+    const code = await uninstall("vault", {
+      ...h.opts,
+      isTTY: true,
+      confirm: async () => false,
+    });
+    expect(code).toBe(1);
+    expect(h.calls).toEqual([]);
+    expect(h.lines.join("\n")).toMatch(/Nothing changed/);
+  });
+
+  test("answering yes at the prompt proceeds", async () => {
+    const h = harness();
+    const code = await uninstall("vault", { ...h.opts, isTTY: true, confirm: async () => true });
+    expect(code).toBe(0);
+    expect(h.calls).toEqual([{ short: "vault", op: "uninstall" }]);
+  });
+
+  test("the prompt says vault DATA survives", async () => {
+    // Without this line the prompt reads like it might delete their notes,
+    // which is the one thing that would make someone abandon the command.
+    let asked = "";
+    const h = harness();
+    await uninstall("vault", {
+      ...h.opts,
+      isTTY: true,
+      confirm: async (q) => {
+        asked = q;
+        return false;
+      },
+    });
+    expect(asked).toMatch(/data is NOT touched/i);
+  });
+});
+
+describe("which services are valid targets", () => {
+  test("a RETIRED module can be uninstalled — the main reason to run this", async () => {
+    // `notes` is retired today and `scribe` is next; a retired module is not
+    // installable but is absolutely removable. The retirement notes tell
+    // operators to run exactly this, so rejecting it would make the advice a
+    // dead end for the second time. Validating against KNOWN rather than
+    // INSTALLABLE is what keeps that true as more modules retire.
+    for (const short of ["scribe", "notes"]) {
+      const h = harness();
+      const code = await uninstall(short, { ...h.opts, isTTY: false, yes: true });
+      expect(code).toBe(0);
+      expect(h.calls).toEqual([{ short, op: "uninstall" }]);
+    }
+  });
+
+  test("an unknown service is rejected without calling the hub", async () => {
+    const h = harness();
+    const code = await uninstall("nonsuch", { ...h.opts, isTTY: false, yes: true });
+    expect(code).toBe(1);
+    expect(h.calls).toEqual([]);
+  });
+
+  test("no service at all is rejected", async () => {
+    const h = harness();
+    expect(await uninstall(undefined, { ...h.opts, yes: true })).toBe(1);
+    expect(h.calls).toEqual([]);
+  });
+});
+
+describe("output + failure modes", () => {
+  test("prints the SERVER's per-step log, not a summary of our own", async () => {
+    // Those steps include the "already gone" ones that make the op idempotent;
+    // replacing them with "done!" hides what actually happened.
+    const h = harness({
+      drive: async () =>
+        ({
+          status: 200,
+          body: { log: ["scribe not supervised", "parachute-scribe not in services.json"] },
+        }) as ModuleOpResult,
+    });
+    await uninstall("scribe", { ...h.opts, isTTY: false, yes: true });
+    const out = h.lines.join("\n");
+    expect(out).toMatch(/not supervised/);
+    expect(out).toMatch(/not in services\.json/);
+  });
+
+  test("a missing operator token explains how to get one", async () => {
+    const h = harness({
+      drive: async () => {
+        throw new NoOperatorTokenError();
+      },
+    });
+    expect(await uninstall("vault", { ...h.opts, isTTY: false, yes: true })).toBe(1);
+  });
+
+  test("an expired operator token surfaces its own actionable message", async () => {
+    const h = harness({
+      drive: async () => {
+        throw new OperatorTokenExpiredError("operator token expired — run rotate-operator");
+      },
+    });
+    expect(await uninstall("vault", { ...h.opts, isTTY: false, yes: true })).toBe(1);
+  });
+
+  test("an HTTP error from the hub is reported, not swallowed as success", async () => {
+    const h = harness({
+      drive: async () => {
+        throw new ModuleOpHttpError(403, "forbidden", "operator scope required");
+      },
+    });
+    expect(await uninstall("vault", { ...h.opts, isTTY: false, yes: true })).toBe(1);
+  });
+
+  test("a hub that isn't running fails with a nonzero code", async () => {
+    // The most common real failure: uninstall needs the supervisor, so a down
+    // hub means the connection refuses.
+    const h = harness({
+      drive: async () => {
+        throw new Error("Unable to connect. Is the computer able to access the url?");
+      },
+    });
+    expect(await uninstall("vault", { ...h.opts, isTTY: false, yes: true })).toBe(1);
+  });
+
+  test("the db handle is closed on the failure path too", async () => {
+    // A leaked sqlite handle in a short-lived CLI is invisible; in a scripted
+    // loop it isn't.
+    const h = harness({
+      drive: async () => {
+        throw new Error("boom");
+      },
+    });
+    await uninstall("vault", { ...h.opts, isTTY: false, yes: true });
+    expect(h.db.wasClosed()).toBe(true);
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -36,6 +36,7 @@ import {
   statusHelp,
   stopHelp,
   topLevelHelp,
+  uninstallHelp,
   upgradeHelp,
 } from "./help.ts";
 import { HUB_SVC } from "./hub-control.ts";
@@ -484,6 +485,18 @@ async function main(argv: string[]): Promise<number> {
       const mod = await loadCommand("init", () => import("./commands/init.ts"));
       if (!mod) return 1;
       return await mod.init(initOpts);
+    }
+
+    case "uninstall": {
+      if (isHelpFlag(rest[0])) {
+        console.log(uninstallHelp());
+        return 0;
+      }
+      const yes = rest.includes("--yes") || rest.includes("-y");
+      const args = rest.filter((a) => a !== "--yes" && a !== "-y");
+      const mod = await loadCommand("uninstall", () => import("./commands/uninstall.ts"));
+      if (!mod) return 1;
+      return await mod.uninstall(args[0], { yes });
     }
 
     case "install": {

--- a/src/commands/uninstall.ts
+++ b/src/commands/uninstall.ts
@@ -1,0 +1,183 @@
+/**
+ * `parachute uninstall <service>` — remove a module from this box.
+ *
+ * ## Why this exists
+ *
+ * Retirement told operators to run a command that didn't exist. Both retired
+ * modules' notes end with "remove the row with `parachute uninstall <name>`",
+ * and the CLI answered `unknown command "uninstall"`. The operation itself was
+ * real the whole time — `POST /api/modules/:short/uninstall`, driven by the
+ * admin UI — it simply had no terminal surface, so anyone following the advice
+ * on a headless box hit a dead end with no second suggestion.
+ *
+ * That's the shape of the gap this closes: a retired module is precisely the
+ * one an operator wants gone, and retirement is precisely when the *web* UI is
+ * least likely to be the tool they reach for.
+ *
+ * ## A thin caller, deliberately
+ *
+ * This does NOT reimplement removal. It drives the same hub endpoint the admin
+ * UI does, via {@link driveModuleOp}, so stop-child → drop-row → `bun remove -g`
+ * → refresh-well-known stays one implementation with one set of idempotency
+ * guarantees. A CLI-local copy would drift, and the failure mode of drift here
+ * is a half-removed module: no row, but still supervised, or removed from disk
+ * while `/.well-known` still advertises it.
+ *
+ * The cost is that uninstall requires a RUNNING hub. That's a real constraint
+ * and it's surfaced explicitly rather than papered over with a filesystem
+ * fallback — a fallback would be a second implementation wearing a disguise,
+ * and it would run exactly when the supervisor can't be told to let go of the
+ * child it's still restarting.
+ */
+
+import type { Database } from "bun:sqlite";
+import { specFor } from "../api-modules-ops.ts";
+import { configDir as defaultConfigDir } from "../config.ts";
+import { readHubPort } from "../hub-control.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { HUB_UNIT_DEFAULT_PORT } from "../hub-unit.ts";
+import {
+  type DriveModuleOpDeps,
+  type ModuleOp,
+  ModuleOpHttpError,
+  type ModuleOpResult,
+  NoOperatorTokenError,
+  OperatorTokenExpiredError,
+  driveModuleOp as driveModuleOpImpl,
+} from "../module-ops-client.ts";
+import { isKnownModuleShort, knownServices } from "../service-spec.ts";
+
+export interface UninstallOpts {
+  /** Skip the confirmation prompt. Required when stdin isn't a TTY. */
+  yes?: boolean;
+  /** Seams (tests inject; production omits). */
+  driveModuleOp?: (short: string, op: ModuleOp, deps: DriveModuleOpDeps) => Promise<ModuleOpResult>;
+  openDb?: (configDir: string) => Database;
+  configDir?: string;
+  baseUrl?: string;
+  /** Confirmation seam — returns true to proceed. */
+  confirm?: (question: string) => Promise<boolean>;
+  log?: (line: string) => void;
+  isTTY?: boolean;
+}
+
+/**
+ * Ask before destroying. Uses readline over `Bun.stdin` rather than the global
+ * `confirm()`, which BLOCKS Bun's event loop — fine in a REPL, deadlock-prone
+ * in a command that also awaits HTTP.
+ */
+async function defaultConfirm(question: string): Promise<boolean> {
+  process.stdout.write(question);
+  for await (const line of console) {
+    return /^y(es)?$/i.test(line.trim());
+  }
+  return false;
+}
+
+/**
+ * Names to suggest. Deliberately KNOWN, not discoverable/installable: retired
+ * modules are valid uninstall targets, so omitting them here would tell an
+ * operator that `scribe` is unknown one line after the retirement note told
+ * them to uninstall it.
+ */
+function removableList(): string {
+  return knownServices().join(" | ");
+}
+
+/** The issuer the operator token validates against — mirrors status.ts. */
+function operatorTokenIssuer(configDir: string): string {
+  return `http://127.0.0.1:${readHubPort(configDir) ?? HUB_UNIT_DEFAULT_PORT}`;
+}
+
+export async function uninstall(
+  service: string | undefined,
+  opts: UninstallOpts = {},
+): Promise<number> {
+  const log = opts.log ?? ((l: string) => console.log(l));
+
+  if (!service) {
+    console.error("parachute uninstall: which service?\n");
+    console.error(`  parachute uninstall <${removableList()}>`);
+    return 1;
+  }
+
+  // Retired modules must stay uninstallable — that's the whole point. So this
+  // validates against KNOWN, not INSTALLABLE; `isInstallableShort` would reject
+  // exactly the modules an operator most needs to remove.
+  if (!isKnownModuleShort(service)) {
+    console.error(`parachute uninstall: unknown service "${service}".`);
+    console.error(`Known services: ${removableList()}`);
+    return 1;
+  }
+
+  const spec = specFor(service);
+  const configDir = opts.configDir ?? defaultConfigDir();
+  const isTTY = opts.isTTY ?? Boolean(process.stdin.isTTY);
+
+  if (!opts.yes) {
+    if (!isTTY) {
+      // Never prompt into a pipe: the read returns EOF immediately, which a
+      // naive default would read as a "yes" and silently uninstall in a script.
+      console.error(
+        `parachute uninstall: refusing to uninstall ${service} without a confirmation.
+stdin is not a terminal — pass --yes to confirm non-interactively.`,
+      );
+      return 1;
+    }
+    const ok = await (opts.confirm ?? defaultConfirm)(
+      `Uninstall ${service}? This stops it, removes its services.json row,\n` +
+        `and runs \`bun remove -g ${spec.package}\`. Vault data is NOT touched. [y/N] `,
+    );
+    if (!ok) {
+      log("Nothing changed.");
+      return 1;
+    }
+  }
+
+  const drive = opts.driveModuleOp ?? driveModuleOpImpl;
+  const openDb = opts.openDb ?? ((dir: string) => openHubDb(hubDbPath(dir)));
+  const db = openDb(configDir);
+  try {
+    const result = await drive(service, "uninstall", {
+      db,
+      issuer: operatorTokenIssuer(configDir),
+      configDir,
+      ...(opts.baseUrl !== undefined ? { baseUrl: opts.baseUrl } : {}),
+    });
+    // Print the server's own per-step log rather than a summary of our own —
+    // it's the record of what actually happened, including the "already gone"
+    // steps that make the op idempotent.
+    const steps = (result.body as { log?: unknown } | undefined)?.log;
+    if (Array.isArray(steps)) for (const s of steps) log(`  ${String(s)}`);
+    log(`✓ ${service} uninstalled.`);
+    return 0;
+  } catch (err) {
+    if (err instanceof NoOperatorTokenError) {
+      console.error(
+        "parachute uninstall: no operator token on this box.\n" +
+          "Run `parachute auth rotate-operator` (or `parachute auth set-password` first, on a fresh box).",
+      );
+      return 1;
+    }
+    if (err instanceof OperatorTokenExpiredError) {
+      console.error(`parachute uninstall: ${err.message}`);
+      return 1;
+    }
+    if (err instanceof ModuleOpHttpError) {
+      console.error(`parachute uninstall: hub returned ${err.status} — ${err.message}`);
+      return 1;
+    }
+    // The common one: hub isn't running, so the loopback POST connection-refuses.
+    // Say that plainly, because "fetch failed" reads as a network bug rather
+    // than "start the thing that owns this operation".
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(
+      `parachute uninstall: couldn't reach the hub — ${detail}
+Uninstall is driven by the running hub (it has to stop the supervised child first).
+Start it with \`parachute start\` and try again.`,
+    );
+    return 1;
+  } finally {
+    db.close();
+  }
+}

--- a/src/help.ts
+++ b/src/help.ts
@@ -1,8 +1,11 @@
 import pkg from "../package.json" with { type: "json" };
-import { knownServices } from "./service-spec.ts";
+import { isInstallableShort, knownServices } from "./service-spec.ts";
 
 export function topLevelHelp(): string {
-  const services = knownServices().join(" | ");
+  // INSTALLABLE, not known: `install` refuses retired modules, so listing them
+  // here advertises a command that errors. (`uninstall` deliberately still
+  // accepts them — a retired module is the one you most want to remove.)
+  const services = knownServices().filter(isInstallableShort).join(" | ");
   return `parachute ${pkg.version} — top-level CLI for the Parachute ecosystem
 
 Fresh install? Start here — works the same on a laptop or a remote server:
@@ -16,6 +19,8 @@ Usage:
   parachute setup                   interactive walk-through: install services + configure
   parachute install <service>       install and register a service
                                     services: ${services}
+  parachute uninstall <service>     stop it, drop its services.json row, remove
+                                    the package (vault DATA is never touched)
   parachute status                  show installed services, run state, health
   parachute doctor                  run health checks + tell you the one thing to fix
   parachute start   [service]       start a module via the supervisor (or ensure the hub is up)
@@ -43,6 +48,28 @@ Usage:
 Flags:
   --help, -h                        show this help (also per-subcommand: \`parachute <cmd> --help\`)
   --version, -v                     print version
+`;
+}
+
+export function uninstallHelp(): string {
+  return `parachute uninstall — remove a module from this box
+
+Usage:
+  parachute uninstall <service> [--yes]
+
+Stops the supervised child, removes the row from ~/.parachute/services.json,
+and runs \`bun remove -g <package>\`. Idempotent: any step that's already done
+is reported and skipped.
+
+  --yes, -y      skip the confirmation prompt (REQUIRED when stdin isn't a TTY,
+                 so a scripted run can never be confirmed by an EOF)
+
+Vault DATA is never touched — removing the vault module leaves every vault on
+disk. Retired modules (notes, scribe) can always be uninstalled even though
+they can no longer be installed.
+
+Needs a running hub: the hub owns the supervisor, so it has to be the one to
+stop the child. If it's down, \`parachute start\` first.
 `;
 }
 


### PR DESCRIPTION
## The bug

The notes retirement note (#788, mine) ends with:

> …remove the row with `parachute uninstall notes` once you've moved over.

That command doesn't exist:

```
$ parachute uninstall notes
parachute: unknown command "uninstall"
```

So the one documented way off a retired module was a dead end — and worst on headless boxes, which are exactly the ones least likely to reach for the admin UI. Found while checking (by reading, after one careless mutating command) whether retired modules were still installable.

The operation was real the whole time — `POST /api/modules/:short/uninstall`, driven by the admin UI. It just had no terminal surface.

## The fix

A thin caller of that endpoint via `driveModuleOp`, **not** a second implementation. Stop-child → drop-row → `bun remove -g` → refresh-well-known stays one code path with one set of idempotency guarantees.

The tradeoff: uninstall needs a **running hub**. That's stated plainly in the error rather than papered over with a filesystem fallback — a fallback would be a second implementation in disguise, and it would run precisely when the supervisor can't be told to let go of the child it keeps restarting.

Two load-bearing details:

- **Validates against KNOWN modules, not INSTALLABLE ones.** A retired module is the one you most want to remove; `isInstallableShort` would reject exactly those and reproduce the dead end.
- **Refuses without `--yes` when stdin isn't a TTY.** Prompting into a pipe returns EOF immediately; a default-yes there would silently uninstall inside any script.

## Third instance of the same bug family

`parachute --help` listed retired modules under `install`, advertising a command that refuses them:

```
services: notes | app | vault | scribe | surface      ← notes is retired
```

Now filtered to installable. `uninstall`'s own suggestions stay unfiltered, since retired modules are valid targets there — the two lists differ on purpose.

## What's deliberately NOT here

**Scribe's registry retirement.** I implemented it, ran the suite, and backed it out of this PR: it fails 23 tests, because ~15 install tests use `scribe` as their generic "installable module" fixture, and there's real scribe-install machinery (secret auto-wire, provider prompts, post-install footer) that becomes dead code.

That belongs in a diff where those deletions are the point and can be reviewed as such — not smuggled in behind a CLI addition. Its prerequisite already landed: vault#640 means a fresh box no longer defaults to `scribe-http`.

## Verification

- `bun test ./src` — **4418 pass**, 0 fail
- `bun run typecheck` — clean
- `bunx biome check` — clean

Exercised against the real CLI:

```
$ parachute uninstall vault < /dev/null   → refuses, exit 1
$ parachute uninstall nonsuch --yes       → unknown service, exit 1
$ parachute uninstall scribe < /dev/null  → accepted as a target, then refuses on TTY grounds
$ parachute --help                        → services: app | vault | scribe | surface
```

14 new tests cover the confirmation matrix, retired-modules-are-removable, the server-log passthrough, every error path, and that the sqlite handle closes on the failure path too.