### PR TITLE
fix(uninstall): un-wire scribe from vault's .env, the mirror of what install wrote

### DIFF
--- a/src/__tests__/unwire-scribe.test.ts
+++ b/src/__tests__/unwire-scribe.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Un-wiring scribe from vault's `.env` on uninstall.
+ *
+ * Found on a live box: `parachute install scribe` writes `SCRIBE_URL` +
+ * `SCRIBE_AUTH_TOKEN` into vault's env for the operator, and uninstall left
+ * them there. The result was a vault whose transcription worker announced
+ * `worker started → http://127.0.0.1:1943` on a machine where nothing had
+ * listened on 1943 since the uninstall. Nothing errors; audio simply stops
+ * being transcribed.
+ *
+ * The second-order damage is worse: vault#640 falls back to the local provider
+ * only when no scribe is CONFIGURED, and a stale `SCRIBE_URL` looks exactly
+ * like configuration. So the box that most needs the local default is the one
+ * guaranteed not to get it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { unwireScribeAuth } from "../auto-wire.ts";
+
+function boxWithVaultEnv(contents: string): string {
+  const configDir = mkdtempSync(join(tmpdir(), "unwire-"));
+  mkdirSync(join(configDir, "vault"), { recursive: true });
+  writeFileSync(join(configDir, "vault", ".env"), contents);
+  return configDir;
+}
+
+const readEnv = (configDir: string) => readFileSync(join(configDir, "vault", ".env"), "utf8");
+
+describe("unwireScribeAuth", () => {
+  test("removes exactly the two keys install wrote", () => {
+    const dir = boxWithVaultEnv(
+      "SCRIBE_AUTH_TOKEN=2cb68667b193\nSCRIBE_URL=http://127.0.0.1:1943\n",
+    );
+    const res = unwireScribeAuth({ configDir: dir });
+    expect(res.changed).toBe(true);
+    expect(res.removed.sort()).toEqual(["SCRIBE_AUTH_TOKEN", "SCRIBE_URL"]);
+    expect(readEnv(dir)).not.toMatch(/SCRIBE_URL/);
+    expect(readEnv(dir)).not.toMatch(/SCRIBE_AUTH_TOKEN/);
+  });
+
+  test("leaves every unrelated key untouched", () => {
+    // The whole file is the operator's; only the machine-written keys are ours
+    // to remove. Truncating it would destroy real configuration.
+    const dir = boxWithVaultEnv(
+      [
+        "# my vault config",
+        "PARACHUTE_GITHUB_CLIENT_ID=Iv1.abc",
+        "SCRIBE_URL=http://127.0.0.1:1943",
+        "EMBEDDINGS_ENABLED=true",
+        "SCRIBE_AUTH_TOKEN=deadbeef",
+        "TRANSCRIPTION_MODEL=whisper-base.en",
+        "",
+      ].join("\n"),
+    );
+    unwireScribeAuth({ configDir: dir });
+    const after = readEnv(dir);
+    expect(after).toMatch(/# my vault config/);
+    expect(after).toMatch(/PARACHUTE_GITHUB_CLIENT_ID=Iv1\.abc/);
+    expect(after).toMatch(/EMBEDDINGS_ENABLED=true/);
+    expect(after).toMatch(/TRANSCRIPTION_MODEL=whisper-base\.en/);
+    expect(after).not.toMatch(/SCRIBE/);
+  });
+
+  test("is a no-op when the keys aren't there (uninstall must stay idempotent)", () => {
+    const dir = boxWithVaultEnv("EMBEDDINGS_ENABLED=true\n");
+    const res = unwireScribeAuth({ configDir: dir });
+    expect(res.changed).toBe(false);
+    expect(res.removed).toEqual([]);
+    expect(readEnv(dir)).toBe("EMBEDDINGS_ENABLED=true\n");
+  });
+
+  test("running it twice is safe", () => {
+    const dir = boxWithVaultEnv("SCRIBE_URL=http://127.0.0.1:1943\n");
+    expect(unwireScribeAuth({ configDir: dir }).changed).toBe(true);
+    expect(unwireScribeAuth({ configDir: dir }).changed).toBe(false);
+  });
+
+  test("no vault installed at all → no-op, no crash", () => {
+    // Uninstalling scribe on a scribe-only box must not fail because vault
+    // isn't there to unwire.
+    const dir = mkdtempSync(join(tmpdir(), "unwire-novault-"));
+    const res = unwireScribeAuth({ configDir: dir });
+    expect(res.changed).toBe(false);
+    expect(existsSync(join(dir, "vault", ".env"))).toBe(false);
+  });
+
+  test("removes only one key when only one was written", () => {
+    const dir = boxWithVaultEnv("SCRIBE_URL=http://127.0.0.1:1943\nOTHER=1\n");
+    const res = unwireScribeAuth({ configDir: dir });
+    expect(res.removed).toEqual(["SCRIBE_URL"]);
+    expect(readEnv(dir)).toMatch(/OTHER=1/);
+  });
+
+  test("the log names the consequence and the next step", () => {
+    // "removed SCRIBE_URL" alone doesn't tell an operator that transcription
+    // just changed hands, or what to run.
+    const dir = boxWithVaultEnv("SCRIBE_URL=http://127.0.0.1:1943\n");
+    const lines: string[] = [];
+    unwireScribeAuth({ configDir: dir, log: (l) => lines.push(l) });
+    const out = lines.join("\n");
+    expect(out).toMatch(/transcription install/);
+  });
+
+  test("the live-box shape: stale URL, no scribe, no token", () => {
+    // Exactly what was found in the wild after `parachute uninstall scribe`:
+    // the URL survived, pointing at a dead port, which reads to vault#640 as
+    // "a scribe is configured" and suppresses the local-provider fallback.
+    const dir = boxWithVaultEnv(
+      "SCRIBE_AUTH_TOKEN=2cb68667b19385ecfc2b6e14563a0a0127656ffa1c6224b11c0c9978a1f86f3a\nSCRIBE_URL=http://127.0.0.1:1943\n",
+    );
+    unwireScribeAuth({ configDir: dir });
+    expect(readEnv(dir).trim()).toBe("");
+  });
+});

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -37,6 +37,7 @@ import { randomUUID } from "node:crypto";
 import { dirname } from "node:path";
 import { MissingDependencyError, type MissingDependencyWire } from "@openparachute/depcheck";
 import type { CuratedModuleShort } from "./api-modules.ts";
+import { unwireScribeAuth } from "./auto-wire.ts";
 import { isLinked as defaultIsLinked } from "./bun-link.ts";
 import { PARACHUTE_INSTALL_CHANNEL_ENV } from "./commands/install.ts";
 import { buildModuleSpawnRequest, reconcilePortToCanonical } from "./commands/serve-boot.ts";
@@ -1293,6 +1294,20 @@ export async function handleUninstall(
   const run = deps.run ?? defaultRun;
   const code = await run(["bun", "remove", "-g", spec.package]);
   log.push(`bun remove -g ${spec.package} exited ${code}`);
+
+  // 3b. Un-wire what INSTALL wired. Installing scribe writes SCRIBE_URL +
+  // SCRIBE_AUTH_TOKEN into vault's .env on the operator's behalf; leaving them
+  // behind points vault's transcription worker at a dead port and — because a
+  // stale SCRIBE_URL reads as "a scribe is configured" — suppresses vault's own
+  // fallback to the local provider (vault#640). Machine-written config gets
+  // machine-removed.
+  if (short === "scribe") {
+    const unwired = unwireScribeAuth({
+      configDir: deps.configDir,
+      log: (line) => log.push(line),
+    });
+    if (!unwired.changed) log.push("no scribe keys in vault .env — nothing to unwire");
+  }
 
   // 4. Refresh the on-disk well-known so the uninstalled module no
   // longer appears in the inspection artifact. The HTTP path rebuilds

--- a/src/auto-wire.ts
+++ b/src/auto-wire.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto";
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { restart as lifecycleRestart } from "./commands/lifecycle.ts";
-import { parseEnvFile, upsertEnvLine, writeEnvFile } from "./env-file.ts";
+import { parseEnvFile, removeEnvLine, upsertEnvLine, writeEnvFile } from "./env-file.ts";
 import { type AliveFn, defaultAlive, processState } from "./process-state.ts";
 import { PORT_RESERVATIONS } from "./service-spec.ts";
 
@@ -124,6 +124,69 @@ function readScribeAuthToken(path: string): string | undefined {
  * pin SCRIBE_URL on vault's side. Caller has already confirmed both services
  * are installed. Restarts vault if it's running so the worker re-reads .env.
  */
+/** What {@link unwireScribeAuth} actually changed. */
+export interface UnwireResult {
+  /** Keys removed from vault's .env (empty when there was nothing to remove). */
+  readonly removed: string[];
+  /** Whether the .env file was rewritten. */
+  readonly changed: boolean;
+}
+
+/**
+ * The counterpart to {@link autoWireScribeAuth}: drop the auto-wired scribe
+ * keys from vault's `.env` when scribe is uninstalled.
+ *
+ * ## Why this has to exist
+ *
+ * Install wires `SCRIBE_URL` + `SCRIBE_AUTH_TOKEN` into vault's env *for* the
+ * operator. Uninstall didn't unwire them, so removing scribe left vault
+ * pointing its transcription worker at a port with nothing behind it —
+ * `[transcribe] worker started → http://127.0.0.1:1943` on a box where 1943 is
+ * dead. Nothing errors at boot; audio just stops being transcribed.
+ *
+ * It also defeats vault's own recovery. Vault#640 made `whisper-cpp` the
+ * default provider unless a scribe is configured — and a stale `SCRIBE_URL`
+ * reads as "configured", so the box that most needs the local default is
+ * exactly the one that doesn't get it. Machine-written config has to be
+ * machine-removed; leaving it is asymmetry that reads as an operator's
+ * deliberate choice.
+ *
+ * Removes ONLY the two keys install writes, never the whole file, and is a
+ * no-op when they're absent (uninstall must stay idempotent).
+ */
+export function unwireScribeAuth(opts: {
+  configDir: string;
+  log?: (line: string) => void;
+}): UnwireResult {
+  const log = opts.log ?? (() => {});
+  const vaultEnvPath = join(opts.configDir, "vault", ".env");
+
+  // Vault may not be installed at all — nothing to unwire, not an error.
+  if (!existsSync(vaultEnvPath)) return { removed: [], changed: false };
+
+  const parsed = parseEnvFile(vaultEnvPath);
+  let lines = parsed.lines;
+  const removed: string[] = [];
+
+  for (const key of [SCRIBE_URL_ENV_KEY, SCRIBE_AUTH_ENV_KEY]) {
+    const existing = parsed.values[key];
+    if (existing !== undefined) {
+      lines = removeEnvLine(lines, key);
+      removed.push(key);
+    }
+  }
+
+  if (removed.length === 0) return { removed: [], changed: false };
+
+  writeEnvFile(vaultEnvPath, lines);
+  log(
+    `removed ${removed.join(" + ")} from vault .env — vault falls back to its ` +
+      `default transcription provider (run \`parachute-vault transcription install\` ` +
+      `to set up local transcription).`,
+  );
+  return { removed, changed: true };
+}
+
 export async function autoWireScribeAuth(opts: AutoWireOpts): Promise<AutoWireResult> {
   const random = opts.randomToken ?? defaultRandomToken;
   const log = opts.log ?? (() => {});


### PR DESCRIPTION
Found on a live box, immediately after using the `parachute uninstall` from #793.

## The bug

`parachute install scribe` writes `SCRIBE_URL` + `SCRIBE_AUTH_TOKEN` into vault's `.env` **for** the operator. Uninstall left them there. So with scribe gone, vault still announced:

```
[transcribe] worker started → http://127.0.0.1:1943
```

…on a machine where nothing had listened on 1943 since the uninstall. Nothing errors at boot. Audio just quietly stops being transcribed — the same silent-no-op class as vault#643, arriving by a different road.

Real `.env` from the box:

```
SCRIBE_AUTH_TOKEN=2cb68667b193…
SCRIBE_URL=http://127.0.0.1:1943      ← nothing listening
```

## Why it's worse than a stale line

vault#640 made `whisper-cpp` the default **unless a scribe is configured**. A stale `SCRIBE_URL` reads exactly like configuration — so the box that most needs the local-provider fallback is precisely the one that can't get it. Uninstalling scribe actively disabled the recovery path intended for it.

Worth naming plainly: vault#640's probe answers *"is a scribe URL configured"* while its docs claim *"is a scribe reachable"*. Those differ exactly here. Un-wiring removes the case where the difference bites; correcting the naming is a separate vault-side fix I'll open.

## The fix

`unwireScribeAuth` — the counterpart to `autoWireScribeAuth`, called from `handleUninstall` when `short === "scribe"`. Machine-written config gets machine-removed.

Constrained deliberately:

- removes **only** the two keys install writes — never the file, never anything the operator put there
- **no-ops** when they're absent, so uninstall stays idempotent (and repeat runs are safe)
- **no-ops** when vault isn't installed at all, so uninstalling scribe on a scribe-only box doesn't fail
- the log names the *consequence* and the next command, not just the key names

## Tests

8 new, including the exact live-box shape (stale URL + token, nothing listening) and the one that matters most — **a mixed `.env` where every unrelated key survives**, since truncating an operator's config would be a far worse bug than the one being fixed.

- `bun test ./src` — **4411 pass**, 0 fail
- `bun run typecheck` — clean
- `bunx biome check` — clean

One unrelated flake appeared in a full run (`handleAccountHomeGet > renders the per-vault usage stat`, a 5s timeout under load); it passes 3/3 in isolation and 0-fail on re-run, and touches nothing here.