### PR TITLE
release: hub 0.7.9 — the self-hosted front door, promote to stable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.9] - 2026-07-30
+
+**Stable promotion of the 0.7.9 line (7 commits over 0.7.8).** Promotes rc.1-rc.6
+plus #793 to `@latest`. The theme is the self-hosted front door: what a new box
+shows you, what it advertises to an AI client, and what it stops offering.
+
+- **`/` lands on the app (#791).** A fresh self-hosted box put its operator on a
+  directory page; the hosted door puts them in the product. `parachute init` now
+  installs `@openparachute/app`, and `/` redirects to it -- a redirect, not a
+  mount, so the target stays operator-selectable (`/admin`, a surface, anything)
+  rather than being frozen by whatever we picked.
+- **The root `/mcp` advertises `vault:admin` (#789).** The protected-resource
+  metadata offered only `vault:read` / `vault:write`, so an AI client walking
+  OAuth could never request the scope that edits tags -- the thing much of the
+  product is for. Hub now authors that document itself instead of proxying
+  vault's, which is why it could omit scopes hub knows about.
+- **Notes is retired (#788).** Invisible to anyone new -- not offered, not
+  installable, not discoverable -- and completely intact on boxes already
+  serving it. `@openparachute/app` is the front door now.
+- **`parachute uninstall` exists (#793).** The retirement note told operators to
+  run it; the CLI answered `unknown command`. It drives the same endpoint the
+  admin UI does, so removal is one implementation, and it accepts retired
+  modules -- which are exactly the ones people need to remove.
+- **Publish-on-merge (#790, #792).** A merged version bump ships itself. #792
+  fixes a bug shipped in #790: the publish steps re-derived the dist-tag from
+  `GITHUB_REF_NAME`, which is `main` on a merge, so `0.7.9-rc.3` went out as
+  `@latest`. The tag now comes from the published version itself.
+- **scope-guard follows `jwksOrigin` and stops failing closed in silence
+  (#787).** A hub reached at a different origin than its canonical one couldn't
+  fetch its revocation list, so it rejected every token it had just issued --
+  and swallowed the reason. Found live: an operator was told they weren't
+  signed in while holding a valid session.
+
 ## [0.7.9-rc.6] - 2026-07-29
 
 **`/` lands on the app when the app is installed, and `parachute init`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.9-rc.6",
+  "version": "0.7.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Promotes **rc.1–rc.6 plus #793** to `@latest`. Version `0.7.9-rc.6` → `0.7.9`.

## Why now

Prompted by a live box: **app isn't installed, and can't become the front door.** Checked rather than assumed —

```
running hub:  0.7.8
npm latest:   0.7.8
front-door redirect logic in the installed 0.7.8:  absent
```

`app` *is* installable on 0.7.8 (you'd reach it at `/app`), but the redirect that makes `/` land there is 0.7.9-only. So a box installed today:

- puts a new operator on a **directory page** instead of the product
- advertises a root `/mcp` **without `vault:admin`**, so an AI client walking OAuth can't request the scope that edits tags
- still offers the **retired notes** module
- carries the **scope-guard** bug that tells a signed-in operator they're signed out

All four are fixed in this line and stranded on `@rc`.

## What's in the line

| PR | What it does |
|---|---|
| #787 | scope-guard follows `jwksOrigin`; stops failing closed in silence |
| #788 | Notes retired — invisible to anyone new, intact where it runs |
| #789 | Hub authors the root `/mcp` PRM, so `vault:admin` is advertised |
| #790, #792 | Publish-on-merge (and the dist-tag bug #790 shipped) |
| #791 | `/` lands on the app; `init` installs it |
| #793 | `parachute uninstall` — the command retirement told people to run |

The changelog entry names #792 as fixing a bug **#790 shipped** rather than quietly folding it in — the publish steps re-derived the dist-tag from `GITHUB_REF_NAME` (`main` on a merge), so `0.7.9-rc.3` went out as `@latest` and needed a manual `npm dist-tag` to undo. That belongs in the record.

## Verification

- `bun test ./src` — **4418 pass**, 0 fail
- `bun run typecheck` — clean

## After merge

Publish-on-merge ships `0.7.9` to `@latest` itself. Then on the box:

```sh
bun add -g @openparachute/hub    # or: parachute upgrade
parachute install app
parachute restart
```

`/` then lands on the app, and the target stays operator-selectable — it's a redirect, not a mount, so `/admin` or a surface can be chosen instead.