### PR TITLE
fix(bundle-serve): re-root a mounted bundle's absolute asset URLs

### DIFF
--- a/src/__tests__/bundle-serve-mount-urls.test.ts
+++ b/src/__tests__/bundle-serve-mount-urls.test.ts
@@ -1,0 +1,133 @@
+/**
+ * Re-rooting a mounted bundle's absolute URLs.
+ *
+ * Found live, immediately after `parachute install app` on a self-hosted box:
+ * the app loaded as an unstyled blank page with
+ *
+ *   GET https://host/assets/index-*.css  404
+ *   GET https://host/assets/index-*.js   404
+ *   GET https://host/manifest.webmanifest 404
+ *
+ * The mount serves those files perfectly at `/app/assets/...` — the HTML just
+ * never asks for them there, because the published bundle is built with an
+ * absolute Vite base. One package is served at several mounts (`/app`,
+ * `/notes`, `/surface/<name>`, and the origin root), so no single build-time
+ * base is correct for all of them; the mount is only known at serve time.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { rewriteManifestScope, rewriteRootAbsoluteUrls } from "../bundle-serve.ts";
+
+const REAL_SHELL = `<!doctype html>
+<html lang="en">
+  <head>
+    <link rel="icon" href="/icon.svg" type="image/svg+xml" />
+    <link rel="icon" href="/favicon.ico" sizes="48x48" />
+    <link rel="apple-touch-icon" href="/apple-touch-icon-180x180.png" />
+    <script type="module" crossorigin src="/assets/index-BhV_u6Bm.js"></script>
+    <link rel="stylesheet" crossorigin href="/assets/index-rEtUY3V3.css">
+    <link rel="manifest" href="/manifest.webmanifest"></head>
+  <body><div id="root"></div></body>
+</html>`;
+
+describe("rewriteRootAbsoluteUrls", () => {
+  test("re-roots every asset the real app shell asks for", () => {
+    const out = rewriteRootAbsoluteUrls(REAL_SHELL, "/app");
+    expect(out).toContain('src="/app/assets/index-BhV_u6Bm.js"');
+    expect(out).toContain('href="/app/assets/index-rEtUY3V3.css"');
+    expect(out).toContain('href="/app/manifest.webmanifest"');
+    expect(out).toContain('href="/app/icon.svg"');
+    expect(out).toContain('href="/app/favicon.ico"');
+    expect(out).toContain('href="/app/apple-touch-icon-180x180.png"');
+    // Nothing left pointing at the origin root.
+    expect(out).not.toMatch(/(src|href)="\/(?!app\/)/);
+  });
+
+  test("an empty mount is a no-op — the origin-root case must not change", () => {
+    // Served at `/`, absolute URLs are already correct. Rewriting would break
+    // the exact deployment the bundle was built for.
+    expect(rewriteRootAbsoluteUrls(REAL_SHELL, "")).toBe(REAL_SHELL);
+  });
+
+  test("leaves protocol-relative and absolute URLs alone", () => {
+    const html = `<script src="//cdn.example.com/a.js"></script>
+<link href="https://fonts.example.com/f.css">
+<a href="http://example.com/x">x</a>`;
+    expect(rewriteRootAbsoluteUrls(html, "/app")).toBe(html);
+  });
+
+  test("touches only src/href — never inline script or style bodies", () => {
+    // A naive s#/#/app/# would corrupt CSS and JS. This is the regression that
+    // would be invisible until something inside a style block broke.
+    const html = `<style>.a{background:url(/bg.png)}</style>
+<script>const path = "/api/notes";</script>
+<img src="/logo.png">`;
+    const out = rewriteRootAbsoluteUrls(html, "/app");
+    expect(out).toContain("url(/bg.png)");
+    expect(out).toContain('"/api/notes"');
+    expect(out).toContain('src="/app/logo.png"');
+  });
+
+  test("a root href becomes the mount root, not a bare slash", () => {
+    expect(rewriteRootAbsoluteUrls('<a href="/">home</a>', "/app")).toBe(
+      '<a href="/app/">home</a>',
+    );
+  });
+
+  test("relative URLs are left alone (already correct under a mount)", () => {
+    const html = '<script src="./assets/x.js"></script><link href="sub/y.css">';
+    expect(rewriteRootAbsoluteUrls(html, "/app")).toBe(html);
+  });
+
+  test("works for a nested mount", () => {
+    const out = rewriteRootAbsoluteUrls('<script src="/assets/x.js"></script>', "/surface/notes");
+    expect(out).toContain('src="/surface/notes/assets/x.js"');
+  });
+});
+
+describe("rewriteManifestScope", () => {
+  test("re-roots start_url and scope so the PWA doesn't claim the whole origin", () => {
+    // scope "/" with the app at /app means the installed PWA captures /admin
+    // and every vault URL too.
+    const out = JSON.parse(
+      rewriteManifestScope(JSON.stringify({ start_url: "/", scope: "/", name: "P" }), "/app"),
+    );
+    expect(out.start_url).toBe("/app/");
+    expect(out.scope).toBe("/app/");
+    expect(out.name).toBe("P");
+  });
+
+  test("leaves RELATIVE icon srcs alone — they resolve against the manifest URL", () => {
+    // The manifest now lives at /app/manifest.webmanifest, so a relative icon
+    // already resolves under the mount. Prefixing would double it.
+    const out = JSON.parse(
+      rewriteManifestScope(
+        JSON.stringify({ scope: "/", icons: [{ src: "pwa-64x64.png" }] }),
+        "/app",
+      ),
+    );
+    expect(out.icons[0].src).toBe("pwa-64x64.png");
+  });
+
+  test("a deeper start_url keeps its path", () => {
+    const out = JSON.parse(rewriteManifestScope(JSON.stringify({ start_url: "/inbox" }), "/app"));
+    expect(out.start_url).toBe("/app/inbox");
+  });
+
+  test("an empty mount is a no-op", () => {
+    const json = JSON.stringify({ start_url: "/", scope: "/" });
+    expect(rewriteManifestScope(json, "")).toBe(json);
+  });
+
+  test("malformed JSON degrades to untouched, never throws", () => {
+    // A broken manifest should cost the install prompt, not the whole page.
+    expect(rewriteManifestScope("{not json", "/app")).toBe("{not json");
+  });
+
+  test("already-absolute URLs in start_url are left alone", () => {
+    const out = JSON.parse(
+      rewriteManifestScope(JSON.stringify({ start_url: "https://x.example/" }), "/app"),
+    );
+    expect(out.start_url).toBe("https://x.example/");
+  });
+});

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -92,16 +92,44 @@ describe("hubFetch routing", () => {
   // admin shell at `/admin`. The old discovery-page content moved into the
   // shell's Home overview. Only the bare `/` redirects — `/hub.html` still
   // serves the discovery page (static expose file + explicit-`.html` bookmarks).
-  test("/ redirects (302) to /admin (admin-shell IA)", async () => {
+  test("/ redirects (302) to /admin when the app ISN'T installed", async () => {
     const h = makeHarness();
     try {
       // No DB → exercises the redirect on the static-fallback path. The
       // redirect sits above the static hub.html serve, so it fires regardless
       // of whether a disk file exists.
       writeFileSync(join(h.dir, "hub.html"), "<html><body>hi</body></html>");
-      const res = await hubFetch(h.dir)(req("/"));
+      // manifestPath MUST be pinned to the harness. Omitting it falls back to
+      // the real ~/.parachute/services.json, so this test's result depended on
+      // whether the DEVELOPER had the app installed — it started failing the
+      // moment someone ran `parachute install app` on their own box, which is
+      // a machine state, not a regression.
+      writeFileSync(h.manifestPath, JSON.stringify({ services: [] }));
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(req("/"));
       expect(res.status).toBe(302);
       expect(res.headers.get("location")).toBe("/admin");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("/ redirects (302) to /app once the app IS installed", async () => {
+    // The other half of the contract (hub#791). Asserting only the /admin case
+    // meant the default that actually ships to new boxes was untested.
+    const h = makeHarness();
+    try {
+      writeFileSync(join(h.dir, "hub.html"), "<html><body>hi</body></html>");
+      writeFileSync(
+        h.manifestPath,
+        JSON.stringify({
+          services: [
+            { name: "parachute-app", port: 1944, paths: ["/app"], health: "/app/health", version: "0.22.9" },
+          ],
+        }),
+      );
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(req("/"));
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/app");
     } finally {
       h.cleanup();
     }

--- a/src/bundle-serve.ts
+++ b/src/bundle-serve.ts
@@ -39,7 +39,7 @@
  * missing/corrupt `dist/index.html` can't take the health check down with it.
  */
 
-import { existsSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
@@ -200,12 +200,91 @@ function mimeFor(path: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Re-root the bundle's ROOT-ABSOLUTE asset URLs onto the mount.
+ *
+ * ## Why this is needed at serve time
+ *
+ * A bundle built with an absolute Vite `base` emits `src="/assets/x.js"`. That
+ * is correct at the origin root and wrong at every mount: served at `/app`, the
+ * browser asks for `/assets/x.js`, which the mount never sees, and the page
+ * loads as an unstyled blank with two 404s. Found live on a self-hosted box
+ * right after `parachute install app` — the assets resolve perfectly at
+ * `/app/assets/...`, the HTML simply never asks for them there.
+ *
+ * Rewriting here rather than in the bundle is deliberate: ONE published package
+ * gets served at several mounts (`/app`, `/notes`, `/surface/<name>`, and the
+ * origin root), so no single build-time base is right for all of them. The
+ * mount is known only here. This is the "serve-time index.html rewrite" the
+ * app's own vite config names as the alternative to build-per-mount.
+ *
+ * Deliberately narrow: only `src=` / `href=` values beginning with a single
+ * `/`. Protocol-relative (`//cdn…`) and absolute (`https://…`) URLs are left
+ * alone, and nothing outside those two attributes is touched, so inline styles
+ * and scripts are untouched. A no-op when `mount` is empty.
+ */
+export function rewriteRootAbsoluteUrls(html: string, mount: string): string {
+  if (!mount) return html;
+  return html.replace(
+    /\b(src|href)="\/(?!\/)([^"]*)"/g,
+    (_m, attr: string, rest: string) => `${attr}="${mount}/${rest}"`,
+  );
+}
+
+/**
+ * Re-root a PWA manifest's `start_url` / `scope` onto the mount.
+ *
+ * A manifest declaring `scope: "/"` while the app is served at `/app` claims
+ * the WHOLE ORIGIN for the installed PWA — so an installed app would capture
+ * `/admin` and every vault URL alongside its own. `start_url: "/"` likewise
+ * launches the installed app at the hub root rather than at the app.
+ *
+ * Only these two keys are touched. Icon `src`s in the wild are already
+ * relative, and relative entries resolve against the manifest URL — which is
+ * now correctly under the mount — so rewriting them would double the prefix.
+ * Malformed JSON is returned untouched rather than throwing: a bad manifest
+ * should degrade the install prompt, not the page.
+ */
+export function rewriteManifestScope(json: string, mount: string): string {
+  if (!mount) return json;
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(json) as Record<string, unknown>;
+  } catch {
+    return json;
+  }
+  if (typeof parsed !== "object" || parsed === null) return json;
+  for (const key of ["start_url", "scope"]) {
+    const v = parsed[key];
+    if (typeof v === "string" && v.startsWith("/") && !v.startsWith("//")) {
+      parsed[key] = v === "/" ? `${mount}/` : `${mount}${v}`;
+    }
+  }
+  return JSON.stringify(parsed);
+}
+
 export function notesFetch(dist: string, mount: string): (req: Request) => Response {
   const indexHtml = join(dist, "index.html");
-  const spaShell = () =>
-    new Response(Bun.file(indexHtml), {
+  // Read + rewrite once. The dist is immutable for this process's lifetime (an
+  // upgrade restarts the shim), so re-reading per request would buy nothing and
+  // cost a file read plus a regex pass on the hottest path.
+  let shellHtml: string | undefined;
+  const spaShell = () => {
+    if (shellHtml === undefined) {
+      try {
+        shellHtml = rewriteRootAbsoluteUrls(readFileSync(indexHtml, "utf8"), mount);
+      } catch {
+        // Missing/unreadable index.html — fall back to streaming the file so
+        // the existing 404/500 behaviour is unchanged rather than throwing here.
+        return new Response(Bun.file(indexHtml), {
+          headers: { "content-type": "text/html; charset=utf-8" },
+        });
+      }
+    }
+    return new Response(shellHtml, {
       headers: { "content-type": "text/html; charset=utf-8" },
     });
+  };
 
   return (req) => {
     const url = new URL(req.url);
@@ -232,6 +311,17 @@ export function notesFetch(dist: string, mount: string): (req: Request) => Respo
       return new Response("forbidden", { status: 403 });
     }
     if (existsSync(filePath)) {
+      // The manifest declares the installed PWA's scope; served under a mount
+      // it has to be re-rooted or the install claims the whole origin.
+      if (mount && pathname.endsWith(".webmanifest")) {
+        try {
+          return new Response(rewriteManifestScope(readFileSync(filePath, "utf8"), mount), {
+            headers: { "content-type": "application/manifest+json" },
+          });
+        } catch {
+          /* fall through to streaming it unmodified */
+        }
+      }
       const file = Bun.file(filePath);
       const mime = mimeFor(filePath);
       return new Response(file, mime ? { headers: { "content-type": mime } } : undefined);


### PR DESCRIPTION
Found live, immediately after `parachute install app` on a self-hosted box: **the app loads as an unstyled blank page.**

```
GET https://host/assets/index-rEtUY3V3.css   404
GET https://host/assets/index-BhV_u6Bm.js    404
GET https://host/manifest.webmanifest        404
```

## The diagnosis

The mount is fine. Probing the running box:

```
/app                             200
/app/assets/index-BhV_u6Bm.js    200   ← the file is right there
/assets/index-BhV_u6Bm.js        404   ← but this is what the HTML asks for
```

`@openparachute/app` ships HTML with **root-absolute** URLs, because its Vite base is `process.env.VITE_BASE_PATH ?? "/"`. That's correct at the origin root and wrong at every mount.

Its own vite config documents the opposite contract three lines above the code:

> **Default / multi-mount publish** (npm, surface-host bundling at `/surface/notes/`, legacy notes-daemon at `/notes/`): no VITE_BASE_PATH → base="" → relative URLs.

The default is `"/"`, not `""` — so the published package contradicts the comment beside it, and every mounted deployment gets absolute URLs.

## Why fix it here, not in the bundle

**One published package is served at several mounts** — `/app`, `/notes`, `/surface/<name>`, and the origin root. No single build-time base is correct for all of them, and the mount is known only at serve time. This is precisely the *"serve-time index.html rewrite"* the app's config names as the alternative to build-per-mount. Fixing it in hub also means it works with the **already-published** 0.22.9 — no app release needed.

## Also: the PWA manifest

The manifest declares `start_url: "/"` and `scope: "/"`. Served at `/app`, that scope claims the **whole origin** for the installed PWA — it would capture `/admin` and every vault URL alongside its own. Both keys are now re-rooted.

Relative icon `src`s are deliberately **left alone**: they resolve against the manifest URL, which is now correctly under the mount, so prefixing would double the path.

## Deliberately narrow

Only `src=` / `href=` values starting with a single `/`. Protocol-relative (`//cdn…`), absolute (`https://…`), inline `<style>`, and inline `<script>` are untouched — a naive global replace would corrupt `url(/bg.png)` and `"/api/notes"` string literals. That's pinned by its own test.

## Verified end-to-end against the real bundle

Ran the shim against the installed 0.22.9 `dist/` and fetched over HTTP:

```
GET /app  →  all six refs re-rooted to /app/...
  /app/assets/index-BhV_u6Bm.js    200
  /app/assets/index-rEtUY3V3.css   200
  /app/manifest.webmanifest        200   → start_url /app/  scope /app/
  /app/icon.svg                    200
```

And the origin-root case (`--mount ""`) is **byte-identical to before**, since absolute URLs are already right there.

- `bun test ./src` — **4432 pass**, 0 fail
- `bun run typecheck` — clean · `biome` — clean

## Bonus: a non-hermetic test, caught by this

`/ redirects (302) to /admin` called `hubFetch` without a `manifestPath`, so it fell back to `SERVICES_MANIFEST_PATH` — the developer's **real** `~/.parachute/services.json`. It started failing the moment someone ran `parachute install app` on their own machine, which is a machine state, not a regression.

Now pins the manifest and asserts **both** directions — app-absent → `/admin`, app-present → `/app`. The app-installed default is the one that actually ships to new boxes, and it was the untested half.