### PR TITLE
release: hub 0.7.10 — publish the mounted-asset fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.10] - 2026-07-30
+
+**The app renders when it's mounted (#796).** 0.7.9 made `/` land on the app and
+shipped that front door broken: `@openparachute/app` is built with an absolute
+Vite base, so its HTML asks for `/assets/index-*.js` while the bundle is served
+at `/app/assets/...`. Every mounted install got an unstyled blank page with two
+404s. The mount was always correct -- the HTML simply never pointed at it.
+
+Hub now re-roots root-absolute `src`/`href` URLs onto the mount at serve time,
+which is the only place the mount is known: one published package is served at
+`/app`, `/notes`, `/surface/<name>`, and the origin root, so no single
+build-time base is right for all of them. The origin-root case is untouched.
+
+Also re-roots the PWA manifest's `start_url` + `scope`. A manifest declaring
+`scope: "/"` while the app is served at `/app` claims the whole origin for the
+installed PWA -- it would capture `/admin` and every vault URL alongside its own.
+
+This is a same-day follow-up to 0.7.9 because that release is what put the app
+in front of people: without it, `/` redirects to a blank page.
+
 ## [0.7.9] - 2026-07-30
 
 **Stable promotion of the 0.7.9 line (7 commits over 0.7.8).** Promotes rc.1-rc.6

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
**Ordering problem, worth fixing today.** #795 (the 0.7.9 promotion) merged *before* #796 (the asset fix), so:

```
npm latest:                    0.7.9
#796 on main:                  yes
#796 in the published 0.7.9:   NO
```

That's the worst possible split: **0.7.9 is the release that puts the app in front of people, and it's the one that can't render it.** Anyone who installs hub 0.7.9 and runs `parachute install app` gets `/` redirecting to an unstyled blank page with two 404s — exactly the report that prompted #796.

This bumps `0.7.9` → `0.7.10` so publish-on-merge ships the fix. **Nothing else changed since 0.7.9** — #794 made it in under the wire (merged before the release), so this is #796 alone.

## Verification

- `bun test ./src` — **4441 pass**, 0 fail
- `bun run typecheck` — clean

## After merge

```sh
bun add -g @openparachute/hub    # or: parachute upgrade
parachute restart
```

`/` then lands on an app that actually renders. No re-install of `app` needed — the fix is entirely in how hub serves the existing bundle, so the already-installed 0.22.9 works as-is.

## Worth noting for next time

Two release PRs in a row have had a fix land just after promotion. The version bump is a snapshot of `main` at merge time, and PR merge order isn't something the release PR can see. Cheapest guard: when a release PR is open, merge it **last** in a batch — or check `git log <published-tag>..main` before promoting. Not proposing tooling for it yet; flagging the pattern.