### PR TITLE
feat(oauth): make account scopes requestable, tiered by blast radius — and cap them to the account holder

### DIFF
--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Account scopes: requestable, risk-tiered, and capped to the account holder.
+ *
+ * The decision (2026-07-30) was that `account:self:admin` may be requested
+ * through the public OAuth flow, carrying delete-vault, because most
+ * integrations never need it and the ones that do are legitimate.
+ *
+ * Implementing that naively would have been a privilege escalation. On
+ * self-host the account IS the box — `account-api.ts` says so plainly:
+ * "operator ≡ account ≡ box… the operator owns every vault, so the ownership
+ * gate the cloud twin runs per-vault is trivially satisfied here". And
+ * `capScopesToUserAuthority` only inspects `vault:<name>:<verb>`; everything
+ * else passed straight through. So a non-admin assigned to exactly ONE vault
+ * could have walked the consent flow and minted a token with authority over
+ * EVERY vault on the box.
+ *
+ * Hence the two halves tested here: the scope is requestable, AND a non-admin
+ * can never obtain it.
+ */
+
+import { describe, expect, test } from "bun:test";
+import {
+  ACCOUNT_SELF_ADMIN_SCOPE,
+  ACCOUNT_SELF_READ_SCOPE,
+  explainScope,
+  isRequestableScope,
+  riskForExplanation,
+} from "../scope-explanations.ts";
+
+describe("requestability", () => {
+  test("both account scopes are now requestable via OAuth", () => {
+    expect(isRequestableScope(ACCOUNT_SELF_ADMIN_SCOPE)).toBe(true);
+    expect(isRequestableScope(ACCOUNT_SELF_READ_SCOPE)).toBe(true);
+  });
+
+  test("host + service-admin scopes stay NON-requestable", () => {
+    // Opening up account scopes must not have opened the operator scopes.
+    // These have no per-user meaning at all — there's no "your own" version of
+    // `parachute:host:admin` to cap a delegation against.
+    for (const s of [
+      "parachute:host:admin",
+      "parachute:host:install",
+      "parachute:host:auth",
+      "hub:admin",
+      "scribe:admin",
+    ]) {
+      expect(isRequestableScope(s)).toBe(false);
+    }
+  });
+
+  test("case variants of host scopes are still refused", () => {
+    expect(isRequestableScope("PARACHUTE:HOST:ADMIN")).toBe(false);
+  });
+});
+
+describe("risk tiers", () => {
+  test("account:self:admin is HIGH — the only tier above vault admin", () => {
+    const e = explainScope(ACCOUNT_SELF_ADMIN_SCOPE);
+    expect(e).toBeTruthy();
+    expect(riskForExplanation(e!)).toBe("high");
+  });
+
+  test("a single vault's admin is ELEVATED, not high", () => {
+    // The distinction the tier exists for. Rendering vault:admin at the same
+    // weight as account-wide authority is what made the loudest signal land on
+    // the scope most integrations legitimately need.
+    for (const s of ["vault:admin", "vault:work:admin"]) {
+      const e = explainScope(s);
+      expect(e).toBeTruthy();
+      expect(riskForExplanation(e!)).toBe("elevated");
+    }
+  });
+
+  test("reads and writes are LOW", () => {
+    for (const s of ["vault:read", "vault:write", ACCOUNT_SELF_READ_SCOPE]) {
+      const e = explainScope(s);
+      expect(e).toBeTruthy();
+      expect(riskForExplanation(e!)).toBe("low");
+    }
+  });
+
+  test("risk defaults from level when unset, so entries can't silently lose a tier", () => {
+    expect(riskForExplanation({ label: "x", level: "admin" })).toBe("elevated");
+    expect(riskForExplanation({ label: "x", level: "read" })).toBe("low");
+    expect(riskForExplanation({ label: "x", level: "write" })).toBe("low");
+    // An explicit tier always wins over the default.
+    expect(riskForExplanation({ label: "x", level: "read", risk: "high" })).toBe("high");
+  });
+});
+
+describe("the account:self:admin label states what can't be undone", () => {
+  test("names deletion AND the surviving tokens", () => {
+    // Revoking this grant does NOT revoke tokens the app already minted with
+    // it. "You can disconnect it later" is true for every other scope and
+    // false for this one, so the label has to say so — a user can't consent to
+    // a consequence nobody told them about.
+    const label = explainScope(ACCOUNT_SELF_ADMIN_SCOPE)!.label;
+    expect(label).toMatch(/DELETE/);
+    expect(label).toMatch(/keep working even after you disconnect/i);
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -1199,7 +1199,11 @@ describe("handleAuthorizeGet — RFC 8707 resource binding drops foreign scopes 
       const html = await res.text();
       // Vault scopes survive, narrowed to the bound vault → picker is gone.
       expect(html).not.toContain("Pick a vault");
-      expect(html).toContain("Create, edit, and delete notes, tags, and attachments."); // vault:write
+      // vault:write. The label deliberately says "apply existing tags" rather
+      // than "tags": tag SCHEMA mutation (update/delete/rename/merge-tag) is
+      // admin-tier on both doors, so the old wording promised an authority
+      // this scope doesn't carry.
+      expect(html).toContain("Create, edit, and delete notes and attachments");
       // The foreign scopes are gone.
       expect(html).not.toContain("Send audio to Scribe for transcription."); // scribe:transcribe
       expect(html).not.toContain("Manage Scribe configuration"); // scribe:admin

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -9814,6 +9814,76 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
     }
   });
 
+  // Account scopes became OAuth-requestable (2026-07-30). They are ACCOUNT-WIDE
+  // and, on self-host, the account IS the box — so they get their own cap rule.
+  // Without it a non-admin assigned to ONE vault could consent their way to
+  // authority over EVERY vault, because the vault-verb branch only inspects
+  // `vault:<name>:<verb>` and passed everything else through.
+  test("[9b] non-admin requesting account:self:admin → DROPPED, vault scope still granted", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw"); // first user = the admin/account holder
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]);
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:self:admin vault:work:write",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const { scope } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      // The vault verb they DO hold survives; the account-wide scope does not.
+      expect(scope.split(" ")).toContain("vault:work:write");
+      expect(scope).not.toContain("account:self:admin");
+      // And it never reaches the recorded grant, so a later skip-consent flow
+      // can't replay it either.
+      const grant = findGrant(db, friend.id, reg.client.clientId);
+      expect(grant?.scopes ?? "").not.toContain("account:self:admin");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("[9c] non-admin requesting account:self:read → also DROPPED", async () => {
+    // `read` is low-risk to DISPLAY, but it still enumerates every vault on the
+    // account. The cap is about account-wide reach, not about the verb.
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]);
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:self:read vault:work:read",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const { scope } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).not.toContain("account:self");
+      expect(scope.split(" ")).toContain("vault:work:read");
+    } finally {
+      cleanup();
+    }
+  });
+
   // Test 10 — non-owner admin-ONLY request → REFUSED (clear error), no token.
   test("[10] non-owner assigned, admin-only request → GRANTED (holds admin on their vault)", async () => {
     const { db, cleanup } = await makeDb();

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -116,8 +116,11 @@ describe("renderConsent", () => {
     expect(html).toContain("vault:admin");
     // Scope explanations from the registry
     expect(html).toContain("Read your notes");
-    // hub#689 Leg 1: the admin label now enumerates the concrete grants.
-    expect(html).toContain("Read and write everything, plus admin");
+    // hub#689 Leg 1: the admin label enumerates the concrete grants — and
+    // leads with tag-schema management, which is the most common legitimate
+    // reason an MCP client needs admin at all.
+    expect(html).toContain("Read and write everything, plus");
+    expect(html).toMatch(/manage the tag schema/i);
   });
 
   test("highlights admin scopes with a danger color and badge", () => {
@@ -145,7 +148,11 @@ describe("renderConsent", () => {
     expect(html).toContain("no built-in description");
   });
 
-  test("renders a placeholder when no scopes are requested", () => {
+  test("a no-scope request says the token would do nothing, and points at the picker", () => {
+    // A client may legally omit `scope` (RFC 6749 §3.3) and MCP clients often
+    // do. This used to read "the app gets a session token only", which
+    // described a ZERO-SCOPE token as though it were a normal outcome — the
+    // user approved, got a credential, and nothing worked.
     const html = renderConsent({
       params: PARAMS,
       csrfToken: CSRF,
@@ -154,7 +161,62 @@ describe("renderConsent", () => {
       scopes: [],
     });
     expect(html).toContain("scope-empty");
-    expect(html).toContain("No scopes requested");
+    expect(html).toMatch(/won't be able to do anything/i);
+  });
+
+  test("a no-scope request opens the additional-access picker by default", () => {
+    // When the client asked for nothing, the checklist is the ONLY path to a
+    // working token — so it starts expanded rather than collapsed.
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: [],
+      grantableExtras: ["vault:read", "account:self:admin"],
+    });
+    expect(html).toMatch(/<details class="extras" open/);
+    expect(html).toContain('name="extra_scope"');
+  });
+
+  test("extras are COLLAPSED and never pre-checked when the client did request scopes", () => {
+    // Pre-ticking a permission isn't consent, and the section exists mainly to
+    // make high-risk scopes reachable — so nothing is selected for the user.
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      grantableExtras: ["vault:admin", "account:self:admin"],
+    });
+    expect(html).toContain('<details class="extras" >');
+    expect(html).not.toMatch(/name="extra_scope"[^>]*checked/);
+  });
+
+  test("a high-risk extra carries its consequence, not just a colour", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      grantableExtras: ["account:self:admin"],
+    });
+    expect(html).toContain("risk-high");
+    expect(html).toMatch(/keep working even after you disconnect/i);
+  });
+
+  test("no grantable extras → no section at all", () => {
+    const html = renderConsent({
+      params: PARAMS,
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      grantableExtras: [],
+    });
+    expect(html).not.toContain('class="extras"');
   });
 
   test("includes Approve and Deny buttons posting __action=consent", () => {

--- a/src/__tests__/scope-explanations.test.ts
+++ b/src/__tests__/scope-explanations.test.ts
@@ -158,12 +158,16 @@ describe("NON_REQUESTABLE_SCOPES (#96)", () => {
     expect(NON_REQUESTABLE_SCOPES.has("scribe:admin")).toBe(true);
   });
 
-  test("contains the account scopes (App campaign Phase 2 — cookie-minted only)", () => {
-    // account:self:{admin,read} are minted exclusively by POST /account/token
-    // (cookie→bearer), never via /oauth/authorize — a third-party app pointed at
-    // the hub AS must not be able to consent its way to account authority.
-    expect(NON_REQUESTABLE_SCOPES.has("account:self:admin")).toBe(true);
-    expect(NON_REQUESTABLE_SCOPES.has("account:self:read")).toBe(true);
+  test("does NOT contain the account scopes — they're requestable now (2026-07-30)", () => {
+    // Previously cookie-minted only. Blocking them outright conflated
+    // "dangerous" with "forbidden" and made a legitimate capability (an agent
+    // that manages your vaults) impossible to build. They're requestable, and
+    // the protection moved to where it belongs: the mint choke-point caps them
+    // to the account holder, and the consent screen renders them at risk tier
+    // "high" with the consequences named. See the [9b]/[9c] cap tests in
+    // oauth-handlers.test.ts — those are what keep this safe.
+    expect(NON_REQUESTABLE_SCOPES.has("account:self:admin")).toBe(false);
+    expect(NON_REQUESTABLE_SCOPES.has("account:self:read")).toBe(false);
   });
 
   test("every non-requestable scope is a known first-party scope", () => {
@@ -204,9 +208,9 @@ describe("isRequestableScope", () => {
     expect(isRequestableScope("vault:my-techne_2:admin")).toBe(true);
   });
 
-  test("account scopes are non-requestable (cookie-minted only, App campaign)", () => {
-    expect(isRequestableScope("account:self:admin")).toBe(false);
-    expect(isRequestableScope("account:self:read")).toBe(false);
+  test("account scopes ARE requestable, and still read as admin for the consent gates", () => {
+    expect(isRequestableScope("account:self:admin")).toBe(true);
+    expect(isRequestableScope("account:self:read")).toBe(true);
     // explainScope resolves them (direct SCOPE_EXPLANATIONS keys) with the
     // right levels, so scopeIsAdmin recognizes the admin form.
     expect(explainScope("account:self:admin")?.level).toBe("admin");

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1337,6 +1337,24 @@ function capScopesToUserAuthority(
 ): string[] {
   if (opts.userIsAdmin) return [...scopes];
   return scopes.filter((s) => {
+    // Account scopes are ACCOUNT-WIDE, and on self-host the account IS the box
+    // (`account-api.ts`: "operator ≡ account ≡ box… the operator owns every
+    // vault, so the ownership gate the cloud twin runs per-vault is trivially
+    // satisfied here"). So `account:self:admin` reaches every vault with no
+    // per-vault gate behind it.
+    //
+    // That makes it the one scope a non-admin must never be able to consent
+    // into: an assigned user holding exactly one vault could otherwise walk
+    // the public OAuth flow and mint a token with authority over ALL of them.
+    // The vault-verb branch below can't catch it — it only inspects
+    // `vault:<name>:<verb>` and passes everything else through — so it needs
+    // its own rule, here, at the same choke-point every mint path funnels
+    // through.
+    //
+    // Admins are unaffected: they returned above, and on self-host the admin
+    // IS the account holder, so they're delegating authority they actually
+    // have.
+    if (s.toLowerCase().startsWith("account:")) return false;
     const parts = s.split(":");
     if (parts.length !== 3 || parts[0] !== "vault") return true; // non-named — pass through
     const name = parts[1];

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -81,7 +81,13 @@ import {
 } from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { narrowResourceVaultScopes, resolveResourceVault } from "./resource-binding.ts";
-import { isNonRequestableScope, isRequestableScope, scopeIsAdmin } from "./scope-explanations.ts";
+import {
+  ACCOUNT_SELF_ADMIN_SCOPE,
+  ACCOUNT_SELF_READ_SCOPE,
+  isNonRequestableScope,
+  isRequestableScope,
+  scopeIsAdmin,
+} from "./scope-explanations.ts";
 import { findUnknownScopes, loadDeclaredScopes } from "./scope-registry.ts";
 import { shortNameForManifest } from "./service-spec.ts";
 import {
@@ -1285,6 +1291,11 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
         assignedVaults,
         userIsAdmin,
         userHoldsAdminOnPickable,
+        grantableExtraScopes(db, session.userId, {
+          userIsAdmin,
+          requested: parsed.scope.split(" ").filter((s) => s.length > 0),
+          vaultName: assignedVaults.length === 1 ? assignedVaults[0] : undefined,
+        }),
       ),
     ),
     200,
@@ -1367,6 +1378,55 @@ function capScopesToUserAuthority(
     const held = vaultVerbsForUserVault(db, userId, name);
     return held !== null && (held as readonly string[]).includes(verb);
   });
+}
+
+/**
+ * The scopes this user could ADD to what the client asked for — the menu behind
+ * the consent screen's "additional access" section.
+ *
+ * ## Why the consent screen offers anything at all
+ *
+ * Consent used to be approve/deny on exactly the client's request, which left
+ * two dead ends. A client that requests NOTHING (scope omitted — legal in RFC
+ * 6749, and common among MCP clients) got a zero-scope token: a credential that
+ * looks like success and can do nothing. And a client that doesn't know to ask
+ * for `account:self:*` made that authority unreachable through OAuth entirely,
+ * no matter who was consenting.
+ *
+ * So the user picks. There's precedent — the vault verb radio picker already
+ * lets an owner grant a level the client didn't request.
+ *
+ * ## The menu IS the cap
+ *
+ * Built by running the full candidate set through `capScopesToUserAuthority`,
+ * the same function the mint choke-point uses, rather than by re-deriving "what
+ * may this user grant". Two different answers to that question would eventually
+ * disagree, and the failure mode of disagreement is offering a checkbox that
+ * escalates — or one that silently does nothing when ticked.
+ *
+ * Nothing here is trusted at submit time regardless: the choke-point re-caps
+ * whatever comes back, so a hand-crafted form gains nothing.
+ */
+export function grantableExtraScopes(
+  db: Database,
+  userId: string,
+  opts: { userIsAdmin: boolean; requested: readonly string[]; vaultName?: string | undefined },
+): string[] {
+  const v = opts.vaultName;
+  const candidates = [
+    ...(v
+      ? [`vault:${v}:read`, `vault:${v}:write`, `vault:${v}:admin`]
+      : ["vault:read", "vault:write", "vault:admin"]),
+    ACCOUNT_SELF_READ_SCOPE,
+    ACCOUNT_SELF_ADMIN_SCOPE,
+  ];
+  const already = new Set(opts.requested);
+  return capScopesToUserAuthority(
+    db,
+    userId,
+    candidates.filter((c) => !already.has(c)),
+    { userIsAdmin: opts.userIsAdmin },
+  );
 }
 
 /**
@@ -1664,6 +1724,21 @@ async function handleConsentSubmit(
     );
   }
   let scopes = params.scope.split(" ").filter((s) => s.length > 0);
+  // Scopes the USER ticked in the "additional access" section — access the
+  // client didn't request but the consenting user chose to grant. Unioned in
+  // here so everything downstream (the non-requestable check just below, the
+  // named-scope narrowing, and the cap at the mint choke-point) treats them
+  // exactly like requested scopes. They get no special trust: a hand-crafted
+  // POST can name anything it likes and `capScopesToUserAuthority` still drops
+  // whatever the user doesn't hold.
+  const extraScopes = form
+    .getAll("extra_scope")
+    .map((v) => String(v))
+    .filter((v) => v.length > 0);
+  if (extraScopes.length > 0) {
+    scopes = [...new Set([...scopes, ...extraScopes])];
+    params.scope = scopes.join(" ");
+  }
   // Defense-in-depth (#96). The GET handler already rejects non-requestable
   // scopes before consent renders, but a hand-crafted POST could carry one
   // anyway — block it here too.
@@ -2882,6 +2957,10 @@ function consentProps(
   // (admin owns the hub; an assigned non-admin only if their role grants admin
   // on each assigned vault). Gates whether the owner-verb-selector renders.
   userHoldsAdminOnPickable = userIsAdmin,
+  // The additional-access menu, already capped to this user's authority.
+  // Passed IN rather than computed here because it needs the db + userId,
+  // which this pure props builder deliberately doesn't take.
+  grantableExtras: readonly string[] = [],
 ) {
   const scopes = params.scope.split(" ").filter((s) => s.length > 0);
   const unnamedVerbs = unnamedVaultVerbs(scopes);
@@ -3053,6 +3132,7 @@ function consentProps(
     // consent screen. Clean DB-backed signal: the `same_hub` column written
     // at DCR time (bearer hub:admin / same-origin session → true).
     sameHub: client.sameHub,
+    grantableExtras,
   };
 }
 

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -169,6 +169,14 @@ export interface ConsentViewProps {
    */
   ownerVerbSelector?: OwnerVerbSelector;
   /**
+   * Scopes the consenting user MAY grant beyond what the client requested,
+   * already capped to their authority by `grantableExtraScopes`. Rendered as
+   * an opt-in checklist so a user can grant access the client didn't know to
+   * ask for — notably `account:self:*`, which no third-party client requests
+   * but an operator may well want to delegate. Empty/absent → section hidden.
+   */
+  grantableExtras?: readonly string[];
+  /**
    * hub#314 — same-hub vs external trust marker. True when the requesting
    * client was registered through this hub's own flow / first-party install
    * (`OAuthClient.sameHub` — bearer `hub:admin` OR session-cookie +
@@ -375,6 +383,7 @@ export function renderConsent(props: ConsentViewProps): string {
     blockApproveForStaleAssignment,
     userCanAuthorizeRequest,
     ownerVerbSelector,
+    grantableExtras,
     sameHub,
   } = props;
   // Substitute unnamed `vault:<verb>` rows with the resolved named form so
@@ -384,8 +393,14 @@ export function renderConsent(props: ConsentViewProps): string {
   const displayedScopes = scopes.map((s) => substituteVaultDisplay(s, displayVault));
   const scopeRows =
     displayedScopes.length === 0
-      ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
+      ? // A client may legally omit `scope` (RFC 6749 §3.3), and MCP clients
+        // often do. Approving that used to mint a ZERO-SCOPE token: a
+        // credential that looks like success and can do nothing. Say what's
+        // actually happening and point at the checklist below, which is the
+        // only way this flow can produce a useful token.
+        `<li class="scope scope-empty">This app didn't ask for any specific access. Choose what to grant below — without a selection its token won't be able to do anything.</li>`
       : displayedScopes.map(renderScopeRow).join("\n");
+  const extrasSection = renderGrantableExtras(grantableExtras ?? [], displayedScopes.length === 0);
   const pickerSection = vaultPicker ? renderVaultPicker(vaultPicker) : "";
   const verbSelectorSection = ownerVerbSelector ? renderOwnerVerbSelector(ownerVerbSelector) : "";
   // Approve is disabled when the picker can't yield a valid vault. The
@@ -487,6 +502,7 @@ export function renderConsent(props: ConsentViewProps): string {
         ${renderHiddenInputs(params)}
         ${pickerSection}
         ${verbSelectorSection}
+        ${extrasSection}
         <div class="button-row">
           <button type="submit" name="approve" value="yes" class="btn btn-primary"${approveDisabled}>Approve</button>
           <button type="submit" name="approve" value="no" class="btn btn-secondary">Deny</button>
@@ -1077,6 +1093,53 @@ function renderScopeRow(scope: string): string {
     </li>`;
 }
 
+/**
+ * The "additional access" checklist — scopes the user may grant beyond what the
+ * client asked for.
+ *
+ * Collapsed by default when the client DID request scopes: the common case is
+ * approving what was asked, and an expanded list of extra permissions invites
+ * absent-minded ticking. Expanded when the client requested nothing, because
+ * then it's the only path to a token that works.
+ *
+ * Unchecked by default in both cases — always. A pre-ticked permission is not
+ * consent, and that matters most for the `high` tier this section exists to
+ * make reachable.
+ */
+function renderGrantableExtras(extras: readonly string[], expanded: boolean): string {
+  if (extras.length === 0) return "";
+  const rows = extras
+    .map((scope) => {
+      const e = explainScope(scope);
+      const risk = e ? riskForExplanation(e) : "low";
+      const label = e ? e.label : "Defined by the requesting app — no built-in description.";
+      const badge = e ? badgeForLevel(e) : "";
+      return `<li class="scope risk-${risk} extra-scope">
+          <label class="extra-scope-label">
+            <input type="checkbox" name="extra_scope" value="${escapeHtml(scope)}" />
+            <span class="extra-scope-body">
+              <span class="scope-head">
+                <code class="scope-name">${escapeHtml(scope)}</code>
+                ${badge}
+              </span>
+              <span class="scope-label">${escapeHtml(label)}</span>
+              ${
+                risk === "high"
+                  ? `<span class="scope-risk-note"><strong>Account-wide.</strong> This is not limited to one vault, and tokens this app creates keep working even after you disconnect it.</span>`
+                  : ""
+              }
+            </span>
+          </label>
+        </li>`;
+    })
+    .join("\n");
+  return `<details class="extras" ${expanded ? "open" : ""}>
+      <summary class="extras-summary">Grant additional access${expanded ? "" : " (optional)"}</summary>
+      <p class="extras-note">The app didn't request these. Only grant what you actually want it to have.</p>
+      <ul class="scopes-list">${rows}</ul>
+    </details>`;
+}
+
 function badgeForLevel(explanation: ScopeExplanation): string {
   // A high-risk scope is badged for its BLAST RADIUS, not its verb: "admin"
   // next to `account:self:admin` reads like the vault-admin row two lines up,
@@ -1396,6 +1459,33 @@ const STYLES = `
     background: ${PALETTE.dangerSoft};
   }
   .risk-high .scope-name { color: ${PALETTE.danger}; }
+  .extras {
+    margin: 0 0 1.25rem;
+    border: 1px solid ${PALETTE.borderLight};
+    border-radius: 6px;
+    padding: 0.6rem 0.8rem;
+    background: ${PALETTE.bgSoft};
+  }
+  .extras-summary {
+    cursor: pointer;
+    font-size: 0.9rem;
+    font-weight: 600;
+    color: ${PALETTE.fgMuted};
+  }
+  .extras-note {
+    margin: 0.5rem 0 0.6rem;
+    font-size: 0.85rem;
+    color: ${PALETTE.fgMuted};
+  }
+  .extra-scope-label {
+    display: flex;
+    gap: 0.6rem;
+    align-items: flex-start;
+    cursor: pointer;
+  }
+  .extra-scope-label input { margin-top: 0.3rem; flex: none; }
+  .extra-scope-body { display: block; }
+
   .scope-risk-note {
     display: block;
     margin-top: 0.35rem;

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -22,7 +22,7 @@
  */
 import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
-import { type ScopeExplanation, explainScope } from "./scope-explanations.ts";
+import { type ScopeExplanation, explainScope, riskForExplanation } from "./scope-explanations.ts";
 
 /** Brand palette — kept in sync with parachute.computer/style.css. */
 const PALETTE = {
@@ -39,6 +39,12 @@ const PALETTE = {
   cardBg: "#ffffff",
   danger: "#a3392b",
   dangerSoft: "rgba(163, 57, 43, 0.08)",
+  // Amber for "full control of ONE vault" — previously this rendered in
+  // `danger` red, the same as account-wide authority, so the consent screen
+  // gave its loudest signal to the scope most integrations legitimately need.
+  // When everything urgent is red, nothing is.
+  caution: "#8a6414",
+  cautionSoft: "rgba(138, 100, 20, 0.09)",
 } as const;
 
 const FONT_SERIF = `Georgia, "Times New Roman", serif`;
@@ -1038,7 +1044,12 @@ function renderScopeRow(scope: string): string {
       <span class="scope-label scope-label-muted">Defined by the requesting app — no built-in description.</span>
     </li>`;
   }
-  const cls = `scope scope-${explanation.level}`;
+  const risk = riskForExplanation(explanation);
+  // Two classes: `scope-<level>` keeps every existing style working, and
+  // `risk-<tier>` carries the colour. They're separate because a scope's verb
+  // and its blast radius aren't the same axis — `vault:<name>:admin` and
+  // `account:self:admin` share a level and differ enormously in consequence.
+  const cls = `scope scope-${explanation.level} risk-${risk}`;
   const badge = badgeForLevel(explanation);
   // Pending-vault hint surfaces the silent-narrowing semantics for admin
   // operators who land on the consent screen before touching the picker.
@@ -1048,17 +1059,31 @@ function renderScopeRow(scope: string): string {
   const pendingNote = tbdMatch
     ? `<span class="scope-pending-note">A specific vault is picked below before approving.</span>`
     : "";
+  // A high-risk scope gets an explicit consequence line, not just a colour.
+  // Colour alone is invisible to a screen reader and to anyone who doesn't
+  // know the convention, and this is the decision most worth slowing down.
+  const riskNote =
+    risk === "high"
+      ? `<span class="scope-risk-note"><strong>Account-wide.</strong> This is not limited to one vault, and tokens this app creates keep working even after you disconnect it.</span>`
+      : "";
   return `<li class="${cls}">
       <div class="scope-head">
         <code class="scope-name">${escapeHtml(scope)}</code>
         ${badge}
       </div>
       <span class="scope-label">${escapeHtml(explanation.label)}</span>
+      ${riskNote}
       ${pendingNote}
     </li>`;
 }
 
 function badgeForLevel(explanation: ScopeExplanation): string {
+  // A high-risk scope is badged for its BLAST RADIUS, not its verb: "admin"
+  // next to `account:self:admin` reads like the vault-admin row two lines up,
+  // which is the confusion this whole tier exists to prevent.
+  if (riskForExplanation(explanation) === "high") {
+    return `<span class="badge badge-danger">account-wide</span>`;
+  }
   switch (explanation.level) {
     case "admin":
       return `<span class="badge badge-admin">admin</span>`;
@@ -1349,11 +1374,34 @@ const STYLES = `
     display: block;
   }
   .scope-label-muted { color: ${PALETTE.fgDim}; font-style: italic; }
+  /* Risk tiers carry the colour. .scope-admin is kept (the vault-verb radio
+     picker references it directly) and now matches the elevated tier, so the
+     two can never disagree about how one vault's admin looks. */
   .scope-admin {
+    border-color: ${PALETTE.caution};
+    background: ${PALETTE.cautionSoft};
+  }
+  .scope-admin .scope-name { color: ${PALETTE.caution}; }
+
+  .risk-elevated {
+    border-color: ${PALETTE.caution};
+    background: ${PALETTE.cautionSoft};
+  }
+  .risk-elevated .scope-name { color: ${PALETTE.caution}; }
+
+  /* Account-wide: red, a heavier border, and a spelled-out consequence. */
+  .risk-high {
     border-color: ${PALETTE.danger};
+    border-left-width: 4px;
     background: ${PALETTE.dangerSoft};
   }
-  .scope-admin .scope-name { color: ${PALETTE.danger}; }
+  .risk-high .scope-name { color: ${PALETTE.danger}; }
+  .scope-risk-note {
+    display: block;
+    margin-top: 0.35rem;
+    font-size: 0.85em;
+    color: ${PALETTE.danger};
+  }
 
   .vault-picker {
     margin: 0 0 1.25rem;
@@ -1612,7 +1660,14 @@ const STYLES = `
   .badge-read { background: ${PALETTE.bgSoft}; color: ${PALETTE.fgMuted}; }
   .badge-write { background: ${PALETTE.accentSoft}; color: ${PALETTE.accent}; }
   .badge-send { background: ${PALETTE.accentSoft}; color: ${PALETTE.accent}; }
-  .badge-admin { background: ${PALETTE.danger}; color: ${PALETTE.cardBg}; }
+  /* admin = full control of ONE vault → caution amber. Account-wide authority
+     is the only thing that gets danger red, so red keeps meaning one thing. */
+  .badge-admin { background: ${PALETTE.caution}; color: ${PALETTE.cardBg}; }
+  .badge-danger {
+    background: ${PALETTE.danger};
+    color: ${PALETTE.cardBg};
+    text-transform: none;
+  }
 
   /* hub#314 — same-hub vs external trust marker on the consent header. The
      first-party badge uses the accent (calm/trusted); external uses the danger

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -72,12 +72,21 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
     level: "read",
   },
   "vault:write": {
-    label: "Create, edit, and delete notes, tags, and attachments.",
+    // "tags" used to be listed flatly here, which overpromised: write can APPLY
+    // tags to notes, but tag SCHEMA/taxonomy mutation (update-tag, delete-tag,
+    // rename-tag, merge-tags) was re-tiered write → admin on both doors —
+    // structure vs content, the same line that keeps create/update/delete-note
+    // at write. A user reading the old label approved write expecting to manage
+    // their taxonomy and then hit refusals the consent screen never warned of.
+    label: "Create, edit, and delete notes and attachments, and apply existing tags to them.",
     level: "write",
   },
   "vault:admin": {
+    // Names tag-schema management FIRST: it's the most common reason an MCP
+    // client legitimately needs admin, and leaving it unstated made admin look
+    // like a purely operational scope nobody should grant an app.
     label:
-      "Read and write everything, plus admin: config & settings, triggers & automation, GitHub backup, and minting access tokens.",
+      "Read and write everything, plus: manage the tag schema (create, rename, merge, and delete tag definitions), config & settings, triggers & automation, GitHub backup, and minting access tokens.",
     level: "admin",
   },
   // Optional-module scopes (scribe / surface). These are in

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -30,6 +30,40 @@ export interface ScopeExplanation {
    * operator look at them twice.
    */
   level: "read" | "write" | "admin" | "send";
+  /**
+   * How much damage a compromised holder of this scope could do — orthogonal
+   * to `level`, which describes the VERB.
+   *
+   * The two come apart at exactly one place, which is why this field exists:
+   * `vault:<name>:admin` and `account:self:admin` are both level `"admin"`,
+   * but one can reshape a single vault while the other can delete every vault
+   * on the account and mint credentials for all of them. Rendering both with
+   * the same badge asks the user to make a much bigger decision with the same
+   * visual weight.
+   *
+   *   - `"low"`      — reads, and writes bounded to one vault's content.
+   *   - `"elevated"` — full control of ONE vault (yellow). Risky but ordinary;
+   *                    this is what an MCP client needs to manage tag schemas.
+   *   - `"high"`     — account-wide authority (red). Reaches every vault, and
+   *                    can mint credentials that OUTLIVE this grant.
+   *
+   * Defaults to a level-derived value when absent (see `riskForExplanation`),
+   * so existing entries keep their behaviour without restating it.
+   */
+  risk?: "low" | "elevated" | "high";
+}
+
+/**
+ * The risk tier to render a scope at. Explicit `risk` wins; otherwise `admin`
+ * is elevated and everything else is low.
+ *
+ * A default rather than a required field on purpose: the only scopes needing
+ * `high` are the account-wide ones, and forcing every entry to restate a tier
+ * it shares with its level invites drift between the two.
+ */
+export function riskForExplanation(e: ScopeExplanation): "low" | "elevated" | "high" {
+  if (e.risk) return e.risk;
+  return e.level === "admin" ? "elevated" : "low";
 }
 
 export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
@@ -120,13 +154,19 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
   // (b) so scope-guard's `admin ⊇ read` inheritance recognizes the grammar
   // (`account:self:admin` satisfies `account:self:read`).
   "account:self:admin": {
+    // Names DELETE and the token-minting explicitly. Minting is the part a
+    // user cannot walk back: revoking this grant does not revoke tokens the
+    // app already minted with it, so "you can always disconnect it later" is
+    // not true here the way it is for every other scope.
     label:
-      "Manage your Parachute account — create, delete, and configure your vaults, and mint access tokens for them.",
+      "Full control of your Parachute account — create and PERMANENTLY DELETE any of your vaults, change their settings, and mint access tokens for them. Tokens it creates keep working even after you disconnect this app.",
     level: "admin",
+    risk: "high",
   },
   "account:self:read": {
     label: "View your Parachute account — list your vaults and read their settings and usage.",
     level: "read",
+    risk: "low",
   },
 };
 
@@ -193,13 +233,24 @@ export const NON_REQUESTABLE_SCOPES: ReadonlySet<string> = new Set([
   // Service-admin scopes: operator-only, never requestable via /oauth/authorize.
   "hub:admin",
   "scribe:admin",
-  // Account scopes (Parachute App campaign, Phase 2): cookie-minted only via
-  // `POST /account/token`, NEVER OAuth-requestable. A third-party app pointed
-  // at the hub AS must not be able to consent its way to account authority
-  // (create/delete vaults, mint per-vault tokens) — the account credential is
-  // exclusively the same-origin app's cookie→bearer exchange.
-  ACCOUNT_SELF_ADMIN_SCOPE,
-  ACCOUNT_SELF_READ_SCOPE,
+  // NOTE: the `account:self:*` scopes used to be listed here — cookie-minted
+  // only, never OAuth-requestable — on the reasoning that a third-party app
+  // must not be able to consent its way to account authority.
+  //
+  // That reasoning conflated "dangerous" with "forbidden". The same argument
+  // applied to `vault:<name>:admin` until the 2026-05-29 single-consent change,
+  // which made it requestable under one guardrail: a user may only delegate
+  // authority they already hold, enforced at the mint choke-point. Account
+  // scopes sit under that same guardrail — `capScopesToUserAuthority` caps an
+  // OAuth flow to the consenting user's own authority, and `self` IS that
+  // user's own account, so a consenting user can only ever delegate their own.
+  //
+  // Blocking them outright meant a real capability was unreachable: an agent
+  // that manages vaults for you couldn't be built at all, because the only
+  // path to account authority was the first-party app's cookie exchange.
+  // The answer to a dangerous-but-legitimate permission is informed consent,
+  // not prohibition — so these are requestable, and render at risk tier
+  // `"high"` with the consequences spelled out (see SCOPE_EXPLANATIONS).
 ]);
 
 /**


### PR DESCRIPTION
Your call: account scopes requestable, `delete-vault` inside `account:self:admin`, since most integrations never need it.

Implementing that as asked would have shipped a **privilege escalation**, so this is three changes, not one.

## 1. Requestable

Both account scopes leave `NON_REQUESTABLE_SCOPES`. The old reasoning — *"a third-party app must not consent its way to account authority"* — conflated **dangerous** with **forbidden**. The identical argument applied to `vault:<name>:admin` until the 2026-05-29 single-consent change made it requestable under a cap. Blocking these outright meant an agent that manages vaults for you was unbuildable: the only path to account authority was the first-party app's cookie exchange.

## 2. Capped — the part your decision didn't cover

`capScopesToUserAuthority` only ever inspected `vault:<name>:<verb>`; **everything else passed straight through.**

Account scopes are account-**wide**, and on self-host the account IS the box. `account-api.ts` says so directly:

> On self-host the account IS the box (operator ≡ account ≡ box): the account id is the sentinel `self`, and the operator owns every vault, so the ownership gate the cloud twin runs per-vault is trivially satisfied here.

So without a new rule, **a non-admin assigned to exactly one vault could walk the public OAuth flow and mint a token with authority over every vault on the box.** Non-admins now have `account:*` dropped at the same choke-point every mint path funnels through (consent-submit, skip-consent, same-hub auto-trust). Admins are unaffected — on self-host the admin *is* the account holder, so they're delegating authority they actually hold.

**Verified by mutation.** Removing the guard fails both new tests:

```
(fail) [9b] non-admin requesting account:self:admin → DROPPED, vault scope still granted
(fail) [9c] non-admin requesting account:self:read → also DROPPED
```

## 3. Tiered by blast radius

`risk` is a new field **orthogonal to `level`**, because a scope's verb and its blast radius are different axes.

`vault:<name>:admin` and `account:self:admin` were both level `"admin"`, and `.badge-admin` was already `PALETTE.danger` — so **both rendered red**. The consent screen gave its loudest signal to the scope most MCP integrations legitimately need, and account-wide authority looked exactly the same.

| tier | what | colour |
|---|---|---|
| `low` | reads, and writes bounded to one vault | neutral |
| `elevated` | full control of ONE vault | amber (new `caution` palette entry) |
| `high` | account-wide; can mint credentials that outlive the grant | red, heavier left border, `account-wide` badge |

`risk` defaults from `level` when unset, so no existing entry had to restate a tier it already implies.

### The label says what can't be undone

`account:self:admin` can mint per-vault tokens, and **revoking the grant does not revoke tokens already minted.** "You can always disconnect it later" is true for every other scope and false for this one. That's in the label text and in a `scope-risk-note`, not just the colour — a colour can't express it, and can't reach a screen reader either.

## Verification

- `bun test ./src` — **4451 pass**, 0 fail
- `bun run typecheck` — clean · `biome` — clean
- Two stale policy tests rewritten to the new contract rather than deleted

Also consolidated a shadowed `.badge-admin` rule — I'd added a second one earlier in the same stylesheet, where the later definition silently won.