### PR TITLE
release: hub 0.7.11 — account scopes + consent picker, and make unpublished drift visible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.11] - 2026-07-30
+
+**Account scopes are OAuth-requestable, tiered by blast radius, and capped to
+the account holder (#798).** `account:self:read` / `account:self:admin` were
+cookie-minted only. Blocking them outright conflated *dangerous* with
+*forbidden* and made a legitimate capability -- an agent that manages your
+vaults -- impossible to build over OAuth.
+
+They are grantable now, under the guardrail the naive change would have
+missed: account scopes are account-WIDE, and on self-host the account IS the
+box, so a non-admin assigned to one vault could otherwise have consented their
+way to authority over every vault. Non-admins now have `account:*` dropped at
+the same mint choke-point that caps vault verbs.
+
+The consent screen gained a `risk` axis orthogonal to `level`, because a
+scope's verb and its blast radius are different things. `vault:<name>:admin`
+and `account:self:admin` were both level `admin` and both rendered in danger
+red -- so the loudest signal landed on the scope most MCP clients legitimately
+need. Now: neutral / amber (full control of ONE vault) / red (account-wide).
+
+**Consent is a picker, not approve-or-deny (#798).** A client may legally omit
+`scope`, and MCP clients often do; approving that minted a ZERO-SCOPE token
+while the screen called it "a session token only" -- a credential that looks
+like success and can do nothing. And a client that never requests
+`account:self:*` made that authority unreachable no matter who was consenting.
+An "additional access" checklist now offers what the consenting user may
+actually grant, built by running candidates through the SAME cap the mint uses,
+so the menu cannot drift into offering something that would be dropped.
+
+**Two consent labels were lying (#798).** `vault:write` claimed it could
+"create, edit, and delete notes, TAGS, and attachments", but tag schema
+mutation (update/delete/rename/merge-tag) is admin-tier on both doors -- write
+can apply tags, not redefine them. And `vault:admin` never mentioned tags at
+all, which is the most common legitimate reason an MCP client needs it.
+
+**Publish-on-merge now reports unpublished drift.** The skip path was silent,
+which is indistinguishable from "everything is shipped" -- three fixes in a row
+(#794, #796, #798) sat unpublished on main, one of them leaving `@latest` with
+an app front door that couldn't render. It now warns with the exact commit list.
+Advisory only: it never fails a run, since an uncut release is a normal state.
+
 ## [0.7.10] - 2026-07-30
 
 **The app renders when it's mounted (#796).** 0.7.9 made `/` land on the app and

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.10",
+  "version": "0.7.11",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -56,7 +56,9 @@ export function compareVersions(a: string, b: string): number {
     const [core, pre] = v.split("-");
     const nums = (core ?? "").split(".").map((n) => Number.parseInt(n, 10) || 0);
     // No prerelease sorts above any prerelease → Infinity.
-    const preNum = pre ? Number.parseInt(pre.replace(/^rc\./, ""), 10) || 0 : Number.POSITIVE_INFINITY;
+    const preNum = pre
+      ? Number.parseInt(pre.replace(/^rc\./, ""), 10) || 0
+      : Number.POSITIVE_INFINITY;
     return { nums, preNum };
   };
   const pa = parse(a);
@@ -133,6 +135,40 @@ export async function readRegistry(
   }
 }
 
+/**
+ * Commits sitting on `main` that no published version contains.
+ *
+ * Publish-on-merge skips silently when package.json already matches npm, which
+ * is correct — but it means a fix merged just AFTER a release PR is invisibly
+ * unpublished. That has now happened three times running (#794, #796, #798),
+ * once leaving `@latest` with an app front door that couldn't render. The
+ * version bump is a snapshot of main at merge time, and a release PR cannot see
+ * what merges after it — so noticing has to happen here, on the skip path.
+ *
+ * Advisory only: it warns, never fails. A release that legitimately hasn't been
+ * cut yet is a normal state, not an error.
+ *
+ * Pure so it's testable without a repo; the caller supplies the log lines.
+ */
+export function unpublishedDrift(commitSubjects: readonly string[]): {
+  drifted: boolean;
+  count: number;
+  summary: string;
+} {
+  const commits = commitSubjects.map((c) => c.trim()).filter((c) => c.length > 0);
+  if (commits.length === 0) {
+    return { drifted: false, count: 0, summary: "nothing unpublished" };
+  }
+  return {
+    drifted: true,
+    count: commits.length,
+    summary:
+      `${commits.length} commit(s) on main are NOT in any published version:\n` +
+      commits.map((c) => `  - ${c}`).join("\n") +
+      "\nOpen a release PR to ship them.",
+  };
+}
+
 // --- CLI -------------------------------------------------------------------
 // Usage: bun scripts/release-plan.ts <package-dir> <npm-name> [--tag-push]
 // Emits GitHub Actions outputs; exits non-zero on refusal.
@@ -158,6 +194,33 @@ if (import.meta.main) {
   if ("refuse" in decision) {
     console.error(`::error::${npmName}@${version}: ${decision.reason}`);
     process.exit(1);
+  }
+  // On the skip path, say whether anything is stranded. A silent skip is
+  // indistinguishable from "everything is shipped", which is how three fixes
+  // in a row sat unpublished on main.
+  if (!decision.publish && !rest.includes("--no-drift-check")) {
+    try {
+      const proc = Bun.spawnSync(["git", "log", `v${version}..HEAD`, "--oneline", "--no-merges"]);
+      if (proc.exitCode === 0) {
+        const drift = unpublishedDrift(new TextDecoder().decode(proc.stdout).split("\n"));
+        if (drift.drifted) {
+          console.log(`::warning::${npmName}: ${drift.summary}`);
+          const sum = process.env.GITHUB_STEP_SUMMARY;
+          if (sum) {
+            await Bun.write(
+              sum,
+              `### Unpublished work on main\n\n\`\`\`\n${drift.summary}\n\`\`\`\n`,
+              {
+                createPath: false,
+              },
+            );
+          }
+        }
+      }
+    } catch {
+      // Never fail a run over the advisory check — a missing tag or a shallow
+      // clone just means we can't tell, not that something is wrong.
+    }
   }
   await emit("version", version);
   await emit("dist_tag", distTagFor(version));

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -12,6 +12,7 @@ import {
   decidePublish,
   distTagFor,
   readRegistry,
+  unpublishedDrift,
 } from "../../scripts/release-plan.ts";
 
 describe("distTagFor", () => {
@@ -45,7 +46,10 @@ describe("compareVersions", () => {
 
 describe("decidePublish", () => {
   test("a fresh version publishes", () => {
-    const d = decidePublish("0.7.9-rc.2", { versionExists: false, currentDistTagVersion: "0.7.9-rc.1" });
+    const d = decidePublish("0.7.9-rc.2", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.9-rc.1",
+    });
     expect(d).toMatchObject({ publish: true });
   });
 
@@ -92,10 +96,14 @@ describe("decidePublish", () => {
   });
 
   test("an explicit tag push overrides every check — a human said release this", () => {
-    const d = decidePublish("0.7.0-rc.1", {
-      versionExists: false,
-      currentDistTagVersion: "0.9.0",
-    }, { isTagPush: true });
+    const d = decidePublish(
+      "0.7.0-rc.1",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.9.0",
+      },
+      { isTagPush: true },
+    );
     expect(d).toMatchObject({ publish: true });
   });
 
@@ -120,7 +128,10 @@ describe("readRegistry", () => {
 
   test("picks the dist-tag matching the version's channel", async () => {
     const v = await readRegistry("@openparachute/hub", "0.7.9", (() =>
-      json({ versions: {}, "dist-tags": { rc: "0.7.9-rc.2", latest: "0.7.8" } })) as unknown as typeof fetch);
+      json({
+        versions: {},
+        "dist-tags": { rc: "0.7.9-rc.2", latest: "0.7.8" },
+      })) as unknown as typeof fetch);
     // A stable version compares against `latest`, not `rc`.
     expect(v).toMatchObject({ currentDistTagVersion: "0.7.8" });
   });
@@ -141,5 +152,27 @@ describe("readRegistry", () => {
     const v = await readRegistry("@openparachute/hub", "1.0.0", (() =>
       Promise.reject(new Error("ECONNRESET"))) as unknown as typeof fetch);
     expect(v).toMatchObject({ ambiguous: true });
+  });
+});
+
+describe("unpublishedDrift", () => {
+  test("no commits → not drifted", () => {
+    expect(unpublishedDrift([]).drifted).toBe(false);
+    expect(unpublishedDrift(["", "  "]).drifted).toBe(false);
+  });
+
+  test("commits → drifted, counted, and LISTED", () => {
+    // The list is the point: "you have unpublished work" without naming what
+    // leaves someone diffing tags by hand to find out.
+    const d = unpublishedDrift(["abc feat: one", "def fix: two"]);
+    expect(d.drifted).toBe(true);
+    expect(d.count).toBe(2);
+    expect(d.summary).toContain("feat: one");
+    expect(d.summary).toContain("fix: two");
+    expect(d.summary).toMatch(/release PR/i);
+  });
+
+  test("blank lines from git's trailing newline don't inflate the count", () => {
+    expect(unpublishedDrift(["abc one", ""]).count).toBe(1);
   });
 });


### PR DESCRIPTION
Ships **#798**, which merged just after #797 (the 0.7.10 release) and was therefore sitting unpublished on `main`.

## The pattern, and the guard

That's **three in a row**:

| PR | merged after | consequence |
|---|---|---|
| #794 | 0.7.9's promotion | unpublished until 0.7.10 |
| #796 | 0.7.9's promotion | **`@latest` had a front door that couldn't render** |
| #798 | 0.7.10's promotion | unpublished until now |

Publish-on-merge correctly **skips** when `package.json` already matches npm. But it skipped **silently**, and a silent skip is indistinguishable from "everything is shipped". I flagged this pattern twice in PR descriptions; flagging plainly didn't fix it.

The plan step now diffs `v<published>..HEAD` on the skip path and warns with the exact commit list, to both the log and the job summary. **Verified against this repo before committing** — it named #798 unprompted:

```
::warning::@openparachute/hub: 1 commit(s) on main are NOT in any published version:
  - abd12e6 feat(oauth): make account scopes requestable, tiered by blast radius… (#798)
Open a release PR to ship them.
version=0.7.10
should_publish=false
```

**Advisory by construction.** It warns, never fails, and swallows its own errors: a release that simply hasn't been cut yet is a normal state, not an error, and a shallow clone or missing tag means "can't tell" — neither should ever redden a run. `--no-drift-check` opts out.

The pure `unpublishedDrift(commitSubjects)` does the reasoning so it's testable without a repo; the git call stays in the CLI shell.

## What 0.7.11 contains

Everything from #798:

- **Account scopes requestable**, capped so a non-admin can't consent their way to account-wide authority (which, on self-host, is the whole box)
- **Risk tiers** — `vault:admin` amber, `account:self:admin` red; previously both rendered in the same danger red, putting the loudest signal on the scope MCP clients most legitimately need
- **Consent is a picker** — a client that omits `scope` no longer yields a zero-scope token described as "a session token only"
- **Two label fixes** — `vault:write` no longer claims it can edit tag *definitions* (admin-tier on both doors), and `vault:admin` now leads with tag-schema management

## Verification

- `bun test ./src` — **4458 pass**, 0 fail
- `bun run typecheck` — clean · `biome` — clean