### PR TITLE
fix(bundle-serve): tell the mounted app where it lives, via its own meta contract

### DIFF
--- a/src/__tests__/bundle-serve-mount-urls.test.ts
+++ b/src/__tests__/bundle-serve-mount-urls.test.ts
@@ -16,7 +16,7 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { rewriteManifestScope, rewriteRootAbsoluteUrls } from "../bundle-serve.ts";
+import { injectMountMeta, rewriteManifestScope, rewriteRootAbsoluteUrls } from "../bundle-serve.ts";
 
 const REAL_SHELL = `<!doctype html>
 <html lang="en">
@@ -129,5 +129,37 @@ describe("rewriteManifestScope", () => {
       rewriteManifestScope(JSON.stringify({ start_url: "https://x.example/" }), "/app"),
     );
     expect(out.start_url).toBe("https://x.example/");
+  });
+});
+
+describe("injectMountMeta", () => {
+  test("tells the bundle where it's mounted, in <head>, before the module script", () => {
+    // `@openparachute/app` resolves its router basename from
+    // `<meta name="parachute-mount">` — its own documented, highest-priority
+    // contract — and nothing was injecting one. Its pathname fallback knows
+    // `/surface/<slug>` and `/notes/` but NOT `/app`, so a bundle served at
+    // `/app` fell through to ROOT_FALLBACK ("") and believed it lived at the
+    // origin root: opening a note produced `/n/<id>` instead of `/app/n/<id>`.
+    const out = injectMountMeta("<html><head><script src=x></script></head></html>", "/app");
+    expect(out).toContain('<meta name="parachute-mount" content="/app">');
+    expect(out.indexOf("parachute-mount")).toBeLessThan(out.indexOf("<script"));
+  });
+
+  test("does NOT override a tag the host already injected", () => {
+    // A surface host injects its own; the host's contract must win, or we'd
+    // silently remount someone else's embed.
+    const html = '<html><head><meta name="parachute-mount" content="/surface/notes"></head></html>';
+    expect(injectMountMeta(html, "/app")).toBe(html);
+  });
+
+  test("empty mount is a no-op — the origin-root case is already correct", () => {
+    const html = "<html><head></head></html>";
+    expect(injectMountMeta(html, "")).toBe(html);
+  });
+
+  test("works for a nested mount", () => {
+    expect(injectMountMeta("<html><head></head></html>", "/surface/notes")).toContain(
+      'content="/surface/notes"',
+    );
   });
 });

--- a/src/bundle-serve.ts
+++ b/src/bundle-serve.ts
@@ -223,6 +223,38 @@ function mimeFor(path: string): string | undefined {
  * alone, and nothing outside those two attributes is touched, so inline styles
  * and scripts are untouched. A no-op when `mount` is empty.
  */
+/**
+ * Tell the bundle where it's mounted, via the contract the bundle already has.
+ *
+ * `@openparachute/app` resolves its React Router basename at runtime through
+ * `detectMountBase()`, whose HIGHEST-priority source is
+ * `<meta name="parachute-mount" content="...">` — documented as "the canonical
+ * contract: … once the host injects one". Nothing injected one.
+ *
+ * Its fallback is a list of recognised mount shapes: `/surface/<slug>` and the
+ * legacy `/notes/`. `/app` is not among them — it became the front door in
+ * hub#791, long after that list was written — so a bundle served at `/app` fell
+ * through to `ROOT_FALLBACK` (`""`) and believed it lived at the origin root.
+ * Every route it generated came out origin-rooted: opening a note produced
+ * `https://host/n/<id>` instead of `https://host/app/n/<id>`, which hub doesn't
+ * route to the app at all.
+ *
+ * Injecting the meta tag fixes it for ALREADY-PUBLISHED bundles, and does so
+ * through the app's own documented contract rather than by teaching hub to
+ * rewrite router internals. The host knows the mount; this is how it says so.
+ *
+ * Idempotent: a bundle that already carries the tag (a surface host that
+ * injects its own) is left alone, so the host's contract still wins.
+ */
+export function injectMountMeta(html: string, mount: string): string {
+  if (!mount) return html;
+  if (/<meta\s+name=["']parachute-mount["']/i.test(html)) return html;
+  const tag = `<meta name="parachute-mount" content="${mount}">`;
+  // Must land inside <head>, before the module script that reads it.
+  if (/<head[^>]*>/i.test(html)) return html.replace(/(<head[^>]*>)/i, `$1\n    ${tag}`);
+  return `${tag}\n${html}`;
+}
+
 export function rewriteRootAbsoluteUrls(html: string, mount: string): string {
   if (!mount) return html;
   return html.replace(
@@ -272,7 +304,10 @@ export function notesFetch(dist: string, mount: string): (req: Request) => Respo
   const spaShell = () => {
     if (shellHtml === undefined) {
       try {
-        shellHtml = rewriteRootAbsoluteUrls(readFileSync(indexHtml, "utf8"), mount);
+        shellHtml = injectMountMeta(
+          rewriteRootAbsoluteUrls(readFileSync(indexHtml, "utf8"), mount),
+          mount,
+        );
       } catch {
         // Missing/unreadable index.html — fall back to streaming the file so
         // the existing 404/500 behaviour is unchanged rather than throwing here.


### PR DESCRIPTION
Reported live on `/app`: opening a note produced `https://host/n/<id>` — **no `/app` prefix** — and some pages failed with `Unable to preload CSS for /assets/index-*.css`.

Aaron's instinct ("should that have `/app` before it?") was exactly right, and both symptoms are one cause: **the published app bundle believes it lives at the origin root.**

## Why the URL had no prefix

`@openparachute/app` resolves its React Router basename through `detectMountBase()`. Its highest-priority source is `<meta name="parachute-mount">`, described in its own source as:

> the canonical contract: … once the host injects one

**Nothing injected one.** Its pathname fallback recognises exactly two shapes — `/surface/<slug>` and legacy `/notes/`:

```ts
const MOUNT_PATTERNS = [
  /^(\/surface\/[a-z0-9][a-z0-9_-]*)(?=\/|$)/,
  /^(\/notes)(?=\/)/,
] as const;
const ROOT_FALLBACK = "" as const;
```

`/app` isn't there — it became the front door in hub#791, long after that list was written. So a bundle at `/app` fell through to `ROOT_FALLBACK` (`""`), believed it was at the origin root, and generated routes hub never routes to the app.

This injects the tag, fixing **already-published bundles** through the app's own contract rather than teaching hub to rewrite router internals. Idempotent — a surface host that injects its own still wins.

## What this does NOT fix, and why

**The CSS preload.** Vite's base is *compiled into* the bundle — the built helper resolves deps as `"/"+dep`, confirmed by grepping the shipped JS. So a route whose lazy chunk carries a CSS dependency requests `/assets/...` no matter what the runtime basename says.

That's exactly why it's **"some pages, not all"**: chunk-to-chunk imports are relative (`"./NoteRenderer-*.js"`) and resolve fine under `/app/assets/`; only CSS-bearing chunks hit the absolute path.

## The real resolution is architectural — and hub already has it

`root_mode = serve-app` serves the app's dist **at the origin root**, which is precisely what `root-serve.ts`'s own docstring says the bundle expects:

> the app expects to be served at the origin root (absolute `/assets/*`, PWA scope `/`, OAuth redirect URIs at the origin root)

The default `redirect` mode plus a `/app` mount asks the bundle to live somewhere it was never built for. Every symptom here follows from that mismatch.

**This PR makes the mounted path materially better. It does not make it right.** Two coherent end states, and we should pick one deliberately:

1. **`serve-app` at the origin root** — matches the hosted door, needs no app change, and is what the bundle is built for. hub#791's redirect-to-`/app` is then the thing to reconsider.
2. **Keep the `/app` mount** — then the app must ship a relative Vite base for the npm/multi-mount build, which its own `vite.config.ts` comment already prescribes for exactly this case ("no VITE_BASE_PATH → base='' → relative URLs") while the code does `?? "/"`.

## Verification

- `bun test ./src` — **4462 pass**, 0 fail · typecheck + biome clean
- Exercised against the real installed 0.22.9 bundle over HTTP: the tag lands inside `<head>`, ahead of the module script that reads it