### PR TITLE
feat(front-door): serve the app at the root by default, instead of redirecting to /app

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -113,9 +113,16 @@ describe("hubFetch routing", () => {
     }
   });
 
-  test("/ redirects (302) to /app once the app IS installed", async () => {
-    // The other half of the contract (hub#791). Asserting only the /admin case
-    // meant the default that actually ships to new boxes was untested.
+  test("/ SERVES the app (not a redirect) once the app IS installed", async () => {
+    // Changed deliberately. hub#791 made this a 302 to `/app`, which asked a
+    // bundle built for the origin root to live at `/app` — every symptom that
+    // followed (blank page, PWA scope, CSS preload 404s, `/n/<id>` URLs missing
+    // their prefix) traces to that one mismatch. `root-serve.ts` says it plainly:
+    // "the app expects to be served at the origin root". So the default is now
+    // serve-app, and `/` is the app.
+    //
+    // An operator's stored row or env override still wins — only the DEFAULT
+    // layer changed — which is asserted separately in hub-settings tests.
     const h = makeHarness();
     try {
       writeFileSync(join(h.dir, "hub.html"), "<html><body>hi</body></html>");
@@ -123,13 +130,21 @@ describe("hubFetch routing", () => {
         h.manifestPath,
         JSON.stringify({
           services: [
-            { name: "parachute-app", port: 1944, paths: ["/app"], health: "/app/health", version: "0.22.9" },
+            {
+              name: "parachute-app",
+              port: 1944,
+              paths: ["/app"],
+              health: "/app/health",
+              version: "0.22.9",
+            },
           ],
         }),
       );
       const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(req("/"));
-      expect(res.status).toBe(302);
-      expect(res.headers.get("location")).toBe("/app");
+      // Not a 302. Either the app dist answers (200) or it's unresolvable in
+      // this harness and we fall back — what must NOT happen is redirecting to
+      // a mount the bundle can't live at.
+      expect(res.status).not.toBe(302);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/root-serve-collisions.test.ts
+++ b/src/__tests__/root-serve-collisions.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Root-namespace collisions between hub and the app.
+ *
+ * In `serve-app` mode the app owns the origin root and hub claims a set of
+ * prefixes ahead of it — the same shape GitHub uses (`/<user>/<repo>` from the
+ * root, `/settings` and `/notifications` reserved). Dispatch order is what
+ * enforces it: hub routes match first, and only an unclaimed GET reaches the
+ * app tail.
+ *
+ * The risk that shape carries is one-directional and quiet: if the app ever
+ * adds a top-level route named like a hub prefix, hub wins and that app route
+ * becomes unreachable. It wouldn't error — the operator would get hub's page
+ * where they expected the app's, or a 404 — so it can ship unnoticed.
+ *
+ * This test makes that collision loud at CI time instead.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { ROOT_SERVE_RESERVED_PREFIXES } from "../root-serve.ts";
+
+/**
+ * Top-level path segments hub claims before the serve-app tail ever runs.
+ * Sourced from the route table in `hub-server.ts`'s header docstring, which is
+ * the canonical dispatch-order record.
+ *
+ * Deliberately a hand-maintained list rather than something derived: deriving
+ * it from the router would make the test agree with whatever the code does,
+ * which is exactly the property a guard must NOT have. A human adding a hub
+ * route should have to state that it's a root-namespace claim.
+ */
+const HUB_CLAIMED_SEGMENTS: readonly string[] = [
+  "admin",
+  "api",
+  "app",
+  "hub.html",
+  "mcp",
+  "oauth",
+  "surface",
+  "vault",
+  "vaults",
+  ".well-known",
+];
+
+/**
+ * Top-level route segments `@openparachute/app` serves from its own router.
+ * Update when the app adds a top-level route — the point of the exercise is
+ * that adding one which collides makes this fail.
+ */
+const APP_TOP_LEVEL_SEGMENTS: readonly string[] = [
+  "n",
+  "notes",
+  "tags",
+  "settings",
+  "account",
+  "vaults-list",
+  "welcome",
+  "activity",
+  "calendar",
+  "import",
+  "export",
+  "graph",
+];
+
+describe("hub / app root-namespace split", () => {
+  test("no app route is shadowed by a hub-claimed prefix", () => {
+    // A collision here means the app route is UNREACHABLE in serve-app mode:
+    // hub dispatches first and the app never sees the request. The failure
+    // would look like a wrong page, not an error, so catching it here is the
+    // whole point.
+    const collisions = APP_TOP_LEVEL_SEGMENTS.filter((seg) => HUB_CLAIMED_SEGMENTS.includes(seg));
+    expect(collisions).toEqual([]);
+  });
+
+  test("every reserved prefix is a hub-claimed segment", () => {
+    // `ROOT_SERVE_RESERVED_PREFIXES` keeps hub's branded 404 for protocol
+    // surfaces even in serve-app mode. If one drifted out of the claimed set,
+    // it would be reserving a namespace nothing else defends.
+    for (const prefix of ROOT_SERVE_RESERVED_PREFIXES) {
+      const seg = prefix.replace(/^\//, "").replace(/\/$/, "");
+      expect(HUB_CLAIMED_SEGMENTS).toContain(seg);
+    }
+  });
+
+  test("the protocol surfaces that must never be SPA-shelled are reserved", () => {
+    // SPA-shelling one of these turns a genuine API/OAuth/discovery 404 into a
+    // 200 of HTML, which breaks clients in a way that's hard to diagnose from
+    // the other end — they get a page where they expected JSON.
+    for (const required of ["/api/", "/oauth/", "/.well-known/", "/mcp/"]) {
+      expect(ROOT_SERVE_RESERVED_PREFIXES).toContain(required);
+    }
+  });
+});

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2724,7 +2724,12 @@ export function hubFetch(
         // wizard funnel + pre-admin 503 above (a not-yet-set-up hub still lands
         // on setup, never a half-working app shell). Falls back to the redirect
         // when the app isn't installed (dist unresolvable), with a one-time log.
-        if (req.method === "GET" && resolveRootMode(getDb ? getDb() : null) === "serve-app") {
+        if (
+          req.method === "GET" &&
+          resolveRootMode(getDb ? getDb() : null, {
+            manifest: readManifestLenient(manifestPath),
+          }) === "serve-app"
+        ) {
           const dist = resolveAppDist();
           if (dist) {
             const served = serveAppAtRoot(dist, req, "/");
@@ -4383,7 +4388,11 @@ export function hubFetch(
       // non-HTML unclaimed request, or a reserved /api|/oauth|/.well-known
       // prefix. NO chrome injection — the app owns its whole page. In redirect
       // mode this branch is inert and the tail stays byte-identical to before.
-      if (req.method === "GET" && resolveRootMode(getDb ? getDb() : null) === "serve-app") {
+      if (
+        req.method === "GET" &&
+        resolveRootMode(getDb ? getDb() : null, { manifest: readManifestLenient(manifestPath) }) ===
+          "serve-app"
+      ) {
         const dist = resolveAppDist();
         if (dist) {
           const served = serveAppAtRoot(dist, req, pathname);

--- a/src/hub-settings.ts
+++ b/src/hub-settings.ts
@@ -640,7 +640,7 @@ export function resolveRootRedirectDetailed(
      * (app installed → `/app`). Omitted → the historical `/admin` default, so
      * every existing caller behaves exactly as before.
      */
-     manifest?: { services: { name: string }[] };
+    manifest?: { services: { name: string }[] };
   } = {},
 ): ResolvedRootRedirect {
   const env = opts.env ?? process.env;
@@ -764,9 +764,48 @@ export interface ResolvedRootMode {
  * skipped and resolution starts from env. The `env` / `warn` knobs are test
  * seams (production uses `process.env` + `console.warn`).
  */
+/**
+ * The default root mode for a box, given what's installed.
+ *
+ * `serve-app` when the app is present, `redirect` otherwise.
+ *
+ * hub#791 (mine) made `/` REDIRECT to `/app` when the app was installed. That
+ * was the wrong half of a choice hub already offered, and it produced a steady
+ * stream of bugs — every one traceable to the same mismatch:
+ *
+ *   - `/app` served HTML asking for `/assets/…` → unstyled blank page (#796)
+ *   - a PWA manifest scoped `/` while mounted at `/app` → the installed app
+ *     would have claimed the whole origin (#796)
+ *   - CSS preloads for lazy chunks 404ing on *some* routes, because Vite's
+ *     base is compiled in as `/`
+ *   - note URLs coming out `/n/<id>` instead of `/app/n/<id>`, because the
+ *     bundle's mount detection never learned about `/app` (#800)
+ *
+ * None of those are independent bugs. `root-serve.ts` states the cause
+ * directly: "the app expects to be served at the origin root (absolute
+ * `/assets/*`, PWA scope `/`, OAuth redirect URIs at the origin root)". The
+ * redirect asked a bundle built for `/` to live at `/app`, and every symptom
+ * followed.
+ *
+ * Serving at the root also makes self-host match the hosted door exactly — a
+ * note is `/n/<id>` on both, so links, docs, and screenshots are portable
+ * between them instead of needing two versions.
+ *
+ * DEFAULT layer only: an operator's stored row or env override still wins, so
+ * anyone who deliberately chose `redirect` keeps it.
+ */
+export function defaultRootModeFor(manifest: { services: { name: string }[] }): RootMode {
+  return manifest.services.some((s) => s.name === "parachute-app") ? "serve-app" : "redirect";
+}
+
 export function resolveRootModeDetailed(
   db: Database | null,
-  opts: { env?: NodeJS.ProcessEnv; warn?: (msg: string) => void } = {},
+  opts: {
+    env?: NodeJS.ProcessEnv;
+    warn?: (msg: string) => void;
+    /** Installed services — only consulted for the DEFAULT layer. */
+    manifest?: { services: { name: string }[] };
+  } = {},
 ): ResolvedRootMode {
   const env = opts.env ?? process.env;
   const warn = opts.warn ?? ((msg: string) => console.warn(msg));
@@ -791,14 +830,20 @@ export function resolveRootModeDetailed(
     );
   }
 
-  // 3. Default — historical redirect behavior.
-  return { value: DEFAULT_ROOT_MODE, source: "default" };
+  // 3. Default — serve-app when the app is installed (see defaultRootModeFor),
+  // otherwise the historical redirect.
+  const fallback = opts.manifest ? defaultRootModeFor(opts.manifest) : DEFAULT_ROOT_MODE;
+  return { value: fallback, source: "default" };
 }
 
 /** Convenience: just the resolved mode (see `resolveRootModeDetailed`). */
 export function resolveRootMode(
   db: Database | null,
-  opts: { env?: NodeJS.ProcessEnv; warn?: (msg: string) => void } = {},
+  opts: {
+    env?: NodeJS.ProcessEnv;
+    warn?: (msg: string) => void;
+    manifest?: { services: { name: string }[] };
+  } = {},
 ): RootMode {
   return resolveRootModeDetailed(db, opts).value;
 }


### PR DESCRIPTION
Reverts the *choice* in hub#791 (mine), not the feature. The app is still the front door — it's now served **at the root** rather than redirected to `/app`.

## One root cause, four bugs

hub#791 made `/` redirect to `/app`. Everything since traces to that:

| symptom | PR |
|---|---|
| `/app` served HTML asking for `/assets/…` → unstyled blank page | #796 |
| PWA manifest scoped `/` while mounted at `/app` → installed app would claim the whole origin | #796 |
| CSS preloads for lazy chunks 404ing on **some** routes (Vite's base is compiled in as `/`) | — |
| note URLs `/n/<id>` instead of `/app/n/<id>` — the bundle's mount detection never learned `/app` | #800 |

These aren't independent bugs. `root-serve.ts` says the cause outright:

> the app expects to be served at the origin root (absolute `/assets/*`, PWA scope `/`, OAuth redirect URIs at the origin root)

The redirect asked a bundle built for `/` to live at `/app`. Each fix patched a symptom; this removes the mismatch.

**`serve-app` mode already existed and does the right thing.** This makes it the default when the app is installed — **DEFAULT layer only**, so a stored row or `PARACHUTE_HUB_ROOT_MODE` still wins and anyone who deliberately chose `redirect` keeps it.

## It also makes self-host match cloud

A note is `/n/<id>` on both doors. Links, docs, and screenshots are portable instead of needing two versions — which was the point of the whole exercise.

## Verified on a live box

| | |
|---|---|
| `/` | 200, app served at root |
| `/assets/index-rEtUY3V3.css` | **200** (was 404) |
| `/n/<id>` with a browser `Accept` | 200, SPA shell |
| `/admin`, `/vault/*`, `/.well-known/*`, `/mcp` | still claimed by hub |
| `/api/nonsuch` | still an honest 404, not SPA-shelled |

## The collision guard

Aaron asked whether root-serving is awkward alongside `/admin` and `/surface/*`. It isn't — dispatch order enforces the split, the same shape GitHub uses (`/<user>/<repo>` from the root, `/settings` reserved).

But the shape carries one quiet risk: **if the app ever adds a top-level route named like a hub prefix, hub dispatches first and that app route becomes unreachable** — a wrong page, not an error, so it ships unnoticed.

`root-serve-collisions.test.ts` makes that loud at CI time. The two lists are **hand-maintained on purpose**: deriving them from the router would make the test agree with whatever the code does, which is exactly the property a guard must not have. Adding a hub root route should require stating that it's a namespace claim.

## Verification

- `bun test ./src` — **4465 pass**, 0 fail · typecheck + biome clean
- The hub#796 test asserting `302 → /app` is rewritten to the new contract rather than deleted

## Note on #800

#800 (inject `<meta name="parachute-mount">`) is still worth merging — it fixes the `/app` mount, which stays reachable as a secondary path. It just stops being the front door.