### PR TITLE
release: hub 0.7.12-rc.1 — app at the root, and an rc channel that's usable again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.12-rc.1] - 2026-07-30
+
+**The app is served AT the root, not redirected to `/app` (#801).** hub#791 made
+`/` redirect to `/app`, which asked a bundle built for the origin root to live
+somewhere else. Four bugs followed from that one mismatch: an unstyled blank
+page, a PWA manifest that would have claimed the whole origin, CSS preloads
+404ing on some routes, and note URLs missing their `/app` prefix. `root-serve.ts`
+had stated the cause all along -- "the app expects to be served at the origin
+root". `serve-app` mode already existed; it is now the default when the app is
+installed. Default layer only: a stored row or env override still wins.
+
+Self-host now matches the hosted door exactly -- a note is `/n/<id>` on both, so
+links and docs are portable instead of needing two versions. `/app` remains a
+valid secondary mount, so existing bookmarks keep working.
+
+Ships with a collision guard: if the app ever adds a top-level route named like
+a hub prefix, hub dispatches first and that route becomes silently unreachable.
+The guard fails CI instead.
+
+**The mounted app is told where it lives (#800).** `@openparachute/app` resolves
+its router basename from `<meta name="parachute-mount">` -- its own documented
+contract -- and nothing injected one. Its pathname fallback knew
+`/surface/<slug>` and `/notes/` but not `/app`. Now injected when serving under
+a mount, which fixes routing for already-published bundles.
+
+**First rc since 0.7.11.** Cut as an rc rather than a stable per the governance
+rule: deploying is not a reason to promote. This also puts `@rc` ahead of
+`@latest` again, so a box can safely track the channel -- it had gone stale
+behind stable, and switching to it was a downgrade.
+
 ## [0.7.11] - 2026-07-30
 
 **Account scopes are OAuth-requestable, tiered by blast radius, and capped to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.11",
+  "version": "0.7.12-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Ships **#800 + #801**, which the new drift guard flagged as unpublished on `main`:

```
::warning::@openparachute/hub: 2 commit(s) on main are NOT in any published version:
  - 5ddc1bf feat(front-door): serve the app at the root by default… (#801)
  - 66a96f2 fix(bundle-serve): tell the mounted app where it lives… (#800)
```

That guard shipped in 0.7.11 and immediately did its job.

## An rc, not a stable

Per the rule added in workspace#19 today: **deploying is not a reason to promote.** Four stable releases went out in one evening for exactly that reason, and one put a broken front door on `@latest`.

## This also repairs the rc channel

`@rc` had gone stale at **0.7.9-rc.6** — *behind* `@latest` 0.7.11 — because everything shipped stable-direct. Pointing a box at `@rc` was a **downgrade** that reinstated already-fixed bugs; I did exactly that to Aaron's box earlier today and had to restore it.

`0.7.12-rc.1` puts `@rc` ahead of stable again, which is the precondition for any box tracking the channel. After this merges, moving a box to rc is safe:

```sh
parachute upgrade          # best-of resolution across rc/latest (hub#659)
```

## Contents

- **#801** — the app is served **at** the root rather than redirected to `/app`, plus the collision guard. Self-host note URLs now match cloud (`/n/<id>`); `/app` remains a valid secondary mount so existing bookmarks work.
- **#800** — the mounted app is told where it lives via `<meta name="parachute-mount">`, fixing routing for already-published bundles.

## Verification

- `bun test ./src` — **4465 pass**, 0 fail