### PR TITLE
fix(oauth): stop ADVERTISING account scopes — requestable is not the same as advertised

### DIFF
--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -99,3 +99,39 @@ describe("the account:self:admin label states what can't be undone", () => {
     expect(label).toMatch(/keep working even after you disconnect/i);
   });
 });
+
+describe("requestable is NOT the same as advertised", () => {
+  test("account scopes stay requestable", () => {
+    // A client that genuinely manages vaults must still be able to ask.
+    expect(isRequestableScope(ACCOUNT_SELF_ADMIN_SCOPE)).toBe(true);
+    expect(isRequestableScope(ACCOUNT_SELF_READ_SCOPE)).toBe(true);
+  });
+
+  test("but they are NOT in the advertised catalog", async () => {
+    // Advertising a scope tells every discovery client "ask for this", and
+    // clients routinely request the whole catalog. With account scopes listed,
+    // a plain note-taking integration asked for PERMANENT DELETE across every
+    // vault — observed live on a self-hosted box, where the consent screen led
+    // with account-wide admin for a client that only wanted notes.
+    const { rootMcpProtectedResourceMetadata } = await import("../oauth-handlers.ts");
+    const res = rootMcpProtectedResourceMetadata({
+      issuer: "https://hub.example",
+      loadDeclaredScopes: () =>
+        new Set([
+          "vault:read",
+          "vault:write",
+          "vault:admin",
+          ACCOUNT_SELF_READ_SCOPE,
+          ACCOUNT_SELF_ADMIN_SCOPE,
+        ]),
+      loadServicesManifest: () => ({ services: [{ name: "parachute-vault", port: 1940 }] }),
+    } as never);
+    const body = (await res.json()) as { scopes_supported: string[] };
+    // The ordinary surface is advertised…
+    expect(body.scopes_supported).toContain("vault:read");
+    expect(body.scopes_supported).toContain("vault:admin");
+    // …account-wide authority is not.
+    expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_ADMIN_SCOPE);
+    expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_READ_SCOPE);
+  });
+});

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -447,14 +447,31 @@ function advertisedScopes(declared: ReadonlySet<string>, manifest: ServicesManif
   const installedShorts = new Set(
     manifest.services.map((s) => shortNameForManifest(s.name) ?? s.name),
   );
-  return Array.from(declared)
-    .filter(isRequestableScope)
-    .filter((scope) => {
-      for (const [prefix, short] of OPTIONAL_MODULE_SCOPES) {
-        if (scope.startsWith(prefix) && !installedShorts.has(short)) return false;
-      }
-      return true;
-    });
+  return (
+    Array.from(declared)
+      .filter(isRequestableScope)
+      // REQUESTABLE is not the same as ADVERTISED, and conflating them was a
+      // mistake. Advertising a scope tells every discovery client "ask for this"
+      // — and clients routinely request the whole advertised catalog. With
+      // `account:self:*` in the list, a plain note-taking integration asked for
+      // PERMANENT DELETE over every vault, so the scariest grant on the box
+      // became the default ask. Observed live: a consent screen listing six
+      // scopes topped by account-wide admin, for a client that only wanted to
+      // read and write notes.
+      //
+      // Account scopes stay fully requestable — a client that genuinely manages
+      // vaults asks for them explicitly and the consent screen renders them at
+      // risk tier "high". They just aren't in the menu that teaches clients what
+      // to ask for. Discovery advertises the ordinary surface; account-wide
+      // authority is opt-in by intent, not by catalog-copying.
+      .filter((scope) => !scope.toLowerCase().startsWith("account:"))
+      .filter((scope) => {
+        for (const [prefix, short] of OPTIONAL_MODULE_SCOPES) {
+          if (scope.startsWith(prefix) && !installedShorts.has(short)) return false;
+        }
+        return true;
+      })
+  );
 }
 
 /**


### PR DESCRIPTION
Found live: authenticating an ordinary client produced a consent screen **led by**

> `account:self:admin` — Full control of your Parachute account — create and **PERMANENTLY DELETE** any of your vaults…

…for an integration that only wanted to read and write notes.

## My error

In the account-scope PR I made those scopes requestable **and** left them in the advertised catalog. Those are different things, and merging them was wrong.

Advertising a scope tells every discovery client *"ask for this"* — and clients routinely request the entire advertised list. So the scariest grant on the box became the **default ask**.

That's arguably worse than the prohibition it replaced: it trains people to approve account-wide deletion just to get a note-taking app working, which is exactly how consent screens stop being read.

## The fix

Account scopes stay **fully requestable** — a client that genuinely manages vaults asks explicitly, and the consent screen renders it at risk tier `high` with the consequences spelled out. They're simply not in the menu that teaches clients what to ask for.

Discovery advertises the ordinary surface; account-wide authority is opt-in **by intent**, not by catalog-copying.

## Verification

- `bun test ./src` — **4465 pass**, 0 fail · typecheck + biome clean
- New test asserts both halves: still requestable, absent from `scopes_supported`

## Separately, on the same report

`scribe:transcribe` also appeared in that list. The advertising filter is working correctly — **`parachute-scribe` is back in that box's `services.json`.** I removed it earlier today; something re-added it. Worth chasing where (setup wizard offer, or an install/init path), because a retired module resurrecting itself is its own bug. Not fixed here.