### PR TITLE
feat(consent): per-scope approval — decline what an app asked for without denying it outright

### DIFF
--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -135,3 +135,33 @@ describe("requestable is NOT the same as advertised", () => {
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_READ_SCOPE);
   });
 });
+
+describe("per-scope consent (granular approval)", () => {
+  test("a high-risk scope renders UNCHECKED, ordinary ones pre-checked", async () => {
+    // Account-wide authority should be something a user reaches for
+    // deliberately, not something they inherit by clicking Approve on a list
+    // the app composed. Everything else is pre-checked because approving what
+    // was asked is the common case.
+    const { renderConsent } = await import("../oauth-ui.ts");
+    const html = renderConsent({
+      params: {
+        clientId: "c",
+        redirectUri: "https://app.example/cb",
+        responseType: "code",
+        scope: "vault:read account:self:admin",
+        codeChallenge: "x",
+        codeChallengeMethod: "S256",
+        state: null,
+        resource: null,
+      },
+      csrfToken: "t",
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read", "account:self:admin"],
+    });
+    expect(html).toMatch(/name="granted_scope" value="vault:read" checked/);
+    // The account row must NOT carry `checked`.
+    const acct = html.slice(html.indexOf('value="account:self:admin"'));
+    expect(acct.slice(0, 40)).not.toContain("checked");
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -2465,7 +2465,12 @@ describe("handleToken — full OAuth dance", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "",
+        // Non-vault scope on purpose: these tests exercise code REPLAY and PKCE
+        // mismatch, not scope handling. `scope: ""` used to work here, but an
+        // empty grant no longer mints a token (a zero-scope credential looks like
+        // success and can do nothing), and a vault scope would pull in the vault
+        // picker this test has no manifest for.
+        scope: "surface:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });
@@ -2625,7 +2630,12 @@ describe("handleToken — full OAuth dance", () => {
         client_id: reg.client.clientId,
         redirect_uri: "https://app.example/cb",
         response_type: "code",
-        scope: "",
+        // Non-vault scope on purpose: these tests exercise code REPLAY and PKCE
+        // mismatch, not scope handling. `scope: ""` used to work here, but an
+        // empty grant no longer mints a token (a zero-scope credential looks like
+        // success and can do nothing), and a vault scope would pull in the vault
+        // picker this test has no manifest for.
+        scope: "surface:read",
         code_challenge: challenge,
         code_challenge_method: "S256",
       });

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1752,9 +1752,46 @@ async function handleConsentSubmit(
     .getAll("extra_scope")
     .map((v) => String(v))
     .filter((v) => v.length > 0);
+
+  // Per-scope consent (granular approval). The consent screen renders one
+  // checkbox per REQUESTED scope, so a user can approve the notes access an
+  // app needs while declining the account-wide admin it also asked for —
+  // rather than facing an all-or-nothing choice that pushes people to approve
+  // things they don't want.
+  //
+  // Squarely within OAuth: RFC 6749 §3.3 says the AS MAY issue a token with a
+  // narrower scope than requested, and the token response's `scope` tells the
+  // client what it actually got. Google, GitHub and Slack all ship this.
+  //
+  // Back-compatible by construction: `granted_scope` fields are only honoured
+  // when the form supplies at least one. A programmatic POST (or an older
+  // cached consent page) that omits them entirely keeps the previous
+  // approve-everything-requested behaviour, so no existing flow breaks.
+  const grantedFields = form
+    .getAll("granted_scope")
+    .map((v) => String(v))
+    .filter((v) => v.length > 0);
+  if (grantedFields.length > 0) {
+    const kept = new Set(grantedFields);
+    scopes = scopes.filter((sc) => kept.has(sc));
+  }
+
   if (extraScopes.length > 0) {
     scopes = [...new Set([...scopes, ...extraScopes])];
-    params.scope = scopes.join(" ");
+  }
+  params.scope = scopes.join(" ");
+
+  // Declining everything is a real choice, but it must not mint an empty
+  // token: a zero-scope credential looks like success and can do nothing,
+  // which is the failure mode this whole area keeps producing. Treat it as
+  // the denial it is, using the OAuth error the client already handles.
+  if (approve && scopes.length === 0) {
+    return oauthErrorRedirect(
+      params.redirectUri,
+      "access_denied",
+      "No permissions were granted — every requested scope was declined.",
+      params.state,
+    );
   }
   // Defense-in-depth (#96). The GET handler already rejects non-requestable
   // scopes before consent renders, but a hand-crafted POST could carry one

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -1082,14 +1082,25 @@ function renderScopeRow(scope: string): string {
     risk === "high"
       ? `<span class="scope-risk-note"><strong>Account-wide.</strong> This is not limited to one vault, and tokens this app creates keep working even after you disconnect it.</span>`
       : "";
+  // One checkbox per requested scope — granular consent. Pre-checked for
+  // ordinary scopes (the app asked for them and approving is the common case),
+  // but a `high` tier scope starts UNCHECKED: account-wide authority should be
+  // something a user reaches for deliberately, not something they inherit by
+  // clicking Approve on a list an app composed.
+  const preChecked = risk === "high" ? "" : " checked";
   return `<li class="${cls}">
-      <div class="scope-head">
-        <code class="scope-name">${escapeHtml(scope)}</code>
-        ${badge}
-      </div>
-      <span class="scope-label">${escapeHtml(explanation.label)}</span>
-      ${riskNote}
-      ${pendingNote}
+      <label class="scope-choice">
+        <input type="checkbox" name="granted_scope" value="${escapeHtml(scope)}"${preChecked} />
+        <span class="scope-choice-body">
+          <span class="scope-head">
+            <code class="scope-name">${escapeHtml(scope)}</code>
+            ${badge}
+          </span>
+          <span class="scope-label">${escapeHtml(explanation.label)}</span>
+          ${riskNote}
+          ${pendingNote}
+        </span>
+      </label>
     </li>`;
 }
 
@@ -1459,6 +1470,15 @@ const STYLES = `
     background: ${PALETTE.dangerSoft};
   }
   .risk-high .scope-name { color: ${PALETTE.danger}; }
+  .scope-choice {
+    display: flex;
+    gap: 0.6rem;
+    align-items: flex-start;
+    cursor: pointer;
+  }
+  .scope-choice input { margin-top: 0.3rem; flex: none; }
+  .scope-choice-body { display: block; }
+
   .extras {
     margin: 0 0 1.25rem;
     border: 1px solid ${PALETTE.borderLight};


### PR DESCRIPTION
> *"we should def have per scope opt in/opt out on that, as long as that's not so far away from oauth"*

**It's not a deviation at all.** RFC 6749 §3.3 says the AS **MAY** issue a token with a narrower scope than requested, and the token response's `scope` field exists precisely so the client learns what it actually got. Google, GitHub and Slack all ship granular consent.

## The problem

Consent was all-or-nothing on the client's whole request. An app asking for notes **and** account-wide admin left two choices: grant everything, or grant nothing and have it not work.

That pressure is exactly how consent screens stop being read — and it's what produced the screen Aaron hit, led by `account:self:admin` for an integration that only wanted notes.

## The change

Each requested scope gets its own checkbox.

| tier | default |
|---|---|
| ordinary (`low` / `elevated`) | **checked** — approving what was asked is the common case |
| `high` (account-wide) | **unchecked** — reached for deliberately, never inherited by clicking Approve |

## Back-compatible by construction

`granted_scope` fields are honoured **only when the form supplies at least one**. A programmatic POST, or an older cached consent page, keeps the previous approve-everything-requested behaviour. No existing flow breaks.

## Declining everything is now a real outcome

Returns `access_denied` rather than minting an empty token. A zero-scope credential looks like success and can do nothing — the failure this area keeps reproducing (it's what Aaron hit when a client requested no scopes at all).

## Verification

- `bun test ./src` — **4468 pass**, 0 fail · typecheck + biome clean

Two OAuth-dance tests used `scope: ""` as a convenience fixture and now need a real one — they're about code **replay** and **PKCE mismatch**, not scope handling, so they got a non-vault scope rather than dragging in the vault picker. Their failure was the new guard working: an empty grant stopped producing a token.