### PR TITLE
fix(consent): the scope checkbox must post the WIRE scope, not the display scope

### DIFF
--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -165,3 +165,42 @@ describe("per-scope consent (granular approval)", () => {
     expect(acct.slice(0, 40)).not.toContain("checked");
   });
 });
+
+describe("consent checkbox posts the WIRE scope, not the display scope", () => {
+  test("an unnamed vault scope shown as named still posts unnamed", async () => {
+    // The bug this pins, shipped in #804 and caught by review: the checkbox
+    // carried the DISPLAY form while `handleConsentSubmit` filters the
+    // requested set, which is the WIRE form. `vault:unforced:read` posted
+    // against a requested `vault:read` intersects to nothing — so every
+    // unnamed vault scope was silently dropped and the user got
+    // `access_denied` for a consent they had actually granted.
+    //
+    // My original test passed because it omitted `displayVault`: with no
+    // substitution the two forms coincided, and the mismatch was invisible.
+    // Setting displayVault is the whole point of this test.
+    const { renderConsent } = await import("../oauth-ui.ts");
+    const html = renderConsent({
+      params: {
+        clientId: "c",
+        redirectUri: "https://app.example/cb",
+        responseType: "code",
+        scope: "vault:read vault:write",
+        codeChallenge: "x",
+        codeChallengeMethod: "S256",
+        state: null,
+        resource: null,
+      },
+      csrfToken: "t",
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read", "vault:write"],
+      displayVault: "unforced",
+    });
+    // Posted values are the wire forms the server will filter against.
+    expect(html).toContain('name="granted_scope" value="vault:read"');
+    expect(html).toContain('name="granted_scope" value="vault:write"');
+    // …while the operator still reads the resolved, named form.
+    expect(html).toContain("vault:unforced:read");
+    expect(html).not.toContain('value="vault:unforced:read"');
+  });
+});

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -399,7 +399,7 @@ export function renderConsent(props: ConsentViewProps): string {
         // actually happening and point at the checklist below, which is the
         // only way this flow can produce a useful token.
         `<li class="scope scope-empty">This app didn't ask for any specific access. Choose what to grant below — without a selection its token won't be able to do anything.</li>`
-      : displayedScopes.map(renderScopeRow).join("\n");
+      : scopes.map((wire, i) => renderScopeRow(wire, displayedScopes[i] ?? wire)).join("\n");
   const extrasSection = renderGrantableExtras(grantableExtras ?? [], displayedScopes.length === 0);
   const pickerSection = vaultPicker ? renderVaultPicker(vaultPicker) : "";
   const verbSelectorSection = ownerVerbSelector ? renderOwnerVerbSelector(ownerVerbSelector) : "";
@@ -670,7 +670,9 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
   const scopeRows =
     displayedScopes.length === 0
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
-      : displayedScopes.map(renderScopeRow).join("\n");
+      : requestedScopes
+          .map((wire, i) => renderScopeRow(wire, displayedScopes[i] ?? wire))
+          .join("\n");
   // Wildcard explanation: surface the "the asterisk means the vault is
   // picked later" hint below the scope list when at least one row carries
   // `vault:*:<verb>`. Mirrors the SPA's inline note on
@@ -1045,18 +1047,31 @@ export function renderUnknownClient(props: UnknownClientViewProps): string {
   return baseDocument("Unknown application", body);
 }
 
-function renderScopeRow(scope: string): string {
+/**
+ * One consent row.
+ *
+ * Takes the WIRE scope and the DISPLAY scope separately, and that separation is
+ * load-bearing. The checkbox `value` must be the wire form, because
+ * `handleConsentSubmit` filters the requested set — which is wire-form — against
+ * what the browser posts. Posting the display form (`vault:unforced:read`
+ * against a requested `vault:read`) intersects to nothing, so every unnamed
+ * vault scope is silently dropped and the user gets `access_denied` for a
+ * consent they actually granted. Shipped that way in #804; the render test
+ * missed it by omitting `displayVault`, so no substitution occurred and the two
+ * forms happened to coincide.
+ */
+function renderScopeRow(scope: string, displayScope: string = scope): string {
   // Special-case the `<TBD>` placeholder substituted by `substituteVaultDisplay`
   // when the consent picker hasn't bound a vault yet — `explainScope` doesn't
   // match it because `<` / `>` aren't in the vault-name charset, but the
   // canonical verb-form does. Look up by the unnamed verb form so the
   // explanation + level styling are still correct.
-  const tbdMatch = scope.match(/^vault:<TBD>:(read|write)$/);
-  const lookup = tbdMatch ? `vault:${tbdMatch[1]}` : scope;
+  const tbdMatch = displayScope.match(/^vault:<TBD>:(read|write)$/);
+  const lookup = tbdMatch ? `vault:${tbdMatch[1]}` : displayScope;
   const explanation = explainScope(lookup);
   if (!explanation) {
     return `<li class="scope scope-unknown">
-      <code class="scope-name">${escapeHtml(scope)}</code>
+      <code class="scope-name">${escapeHtml(displayScope)}</code>
       <span class="scope-label scope-label-muted">Defined by the requesting app — no built-in description.</span>
     </li>`;
   }
@@ -1093,7 +1108,7 @@ function renderScopeRow(scope: string): string {
         <input type="checkbox" name="granted_scope" value="${escapeHtml(scope)}"${preChecked} />
         <span class="scope-choice-body">
           <span class="scope-head">
-            <code class="scope-name">${escapeHtml(scope)}</code>
+            <code class="scope-name">${escapeHtml(displayScope)}</code>
             ${badge}
           </span>
           <span class="scope-label">${escapeHtml(explanation.label)}</span>


### PR DESCRIPTION
**Shipped broken in #804, live in `0.7.12-rc.1`.** Any real-browser consent for unnamed vault scopes — the common case — silently fails.

## The bug

The consent screen substitutes an unnamed `vault:read` to the resolved `vault:unforced:read` for display, so the operator sees the shape that will land in their token. The per-scope checkbox I added in #804 used that **substituted** string as its `value`. But `handleConsentSubmit` filters the **requested** set, which is the wire form:

```
posted:    vault:unforced:read
filtered:  vault:read
result:    empty intersection
```

Every unnamed vault scope is dropped. And because declining everything now returns `access_denied` (also #804), a user who approved an ordinary consent is told they denied it.

Reproduced before fixing:

```
checkbox posts: vault:unforced:read
server filters: vault:read
MATCH? NO — every unnamed vault scope is dropped
```

## Why the tests missed it

My render test omitted `displayVault`. With no substitution the wire and display forms **coincide**, so the mismatch was invisible. That's the same shape as the CI failure earlier today: a test that agrees with the code because it never exercised the interesting input.

The new test sets `displayVault` deliberately — that's its entire reason to exist.

## The fix

`renderScopeRow` now takes wire and display scopes separately:

- checkbox `value` → **wire** form (what the server filters against)
- visible `<code>` and explanation lookup → **display** form (what the operator reads)

Both call sites pass them in lockstep. Verified end-to-end: posts `vault:read`, shows `vault:unforced:read`.

## Verification

- `bun test ./src` — **4469 pass**, 0 fail · typecheck + biome clean

## Credit

Found by a review agent reading the diff, not by the suite. Worth noting given it was live on `@rc` — anyone testing per-scope consent against `0.7.12-rc.1` would have hit it.