### PR TITLE
feat(oauth): name the missing scope in the insufficient-scope challenge

### DIFF
--- a/src/__tests__/scope-challenge.test.ts
+++ b/src/__tests__/scope-challenge.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The RFC 6750 §3 `scope` parameter on an insufficient-scope challenge.
+ *
+ * This is the standard discovery path for a scope that isn't advertised.
+ * Parachute deliberately keeps `account:*` out of `scopes_supported` — RFC 8414
+ * §2 and RFC 9728 §2 both permit exactly that, and MCP's 2025-11-25
+ * authorization spec goes further, saying `scopes_supported` should be the
+ * MINIMAL set with more obtained through step-up.
+ *
+ * The cost was that an unattended agent had no mechanical way to learn those
+ * scopes exist: the missing scope's name was only in `error_description`, which
+ * is prose. Naming it in the `scope` parameter is what GitHub
+ * (`X-Accepted-OAuth-Scopes`), Slack (`needed`), and the MCP spec all do —
+ * discovery at the point of refusal rather than from the catalog.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { AdminAuthError, adminAuthErrorResponse } from "../admin-auth.ts";
+
+function challengeOf(err: unknown): string {
+  return adminAuthErrorResponse(err).headers.get("www-authenticate") ?? "";
+}
+
+describe("insufficient-scope challenge", () => {
+  test("names the missing scope in the RFC 6750 `scope` parameter", () => {
+    // The whole point: a client parses `scope=`, not the prose description.
+    const c = challengeOf(
+      new AdminAuthError(403, "token missing required scope: account:self:admin", "account:self:admin"),
+    );
+    expect(c).toContain('error="insufficient_scope"');
+    expect(c).toContain('scope="account:self:admin"');
+  });
+
+  test("still carries the human-readable description", () => {
+    // The prose stays — it's what a person reading a log sees.
+    const c = challengeOf(new AdminAuthError(403, "token missing required scope: x", "x"));
+    expect(c).toContain("error_description=");
+  });
+
+  test("a 401 gets invalid_token and NO scope parameter", () => {
+    // `scope` answers "which permission would have worked". On a broken or
+    // absent token that question has no answer, and asserting one would send a
+    // client to request a scope that wasn't the problem.
+    const c = challengeOf(new AdminAuthError(401, "token missing required `sub` claim"));
+    expect(c).toContain('error="invalid_token"');
+    expect(c).not.toContain("scope=");
+  });
+
+  test("a 403 without a known scope omits the parameter rather than inventing one", () => {
+    const c = challengeOf(new AdminAuthError(403, "forbidden"));
+    expect(c).toContain('error="insufficient_scope"');
+    expect(c).not.toContain("scope=");
+  });
+
+  test("a quote in the message can't break the header's quoted-string", () => {
+    // A malformed challenge is worse than a vague one — clients drop the whole
+    // header rather than parse half of it.
+    const c = challengeOf(new AdminAuthError(403, 'bad "quoted" thing', "vault:read"));
+    // The description's own quotes are downgraded to apostrophes, so the
+    // quoted-string stays well-formed and the parameters after it survive.
+    expect(c).toContain("error_description=\"bad 'quoted' thing\"");
+    expect(c).toContain('scope="vault:read"');
+  });
+});

--- a/src/admin-auth.ts
+++ b/src/admin-auth.ts
@@ -30,9 +30,29 @@ export interface AdminAuthContext {
 export class AdminAuthError extends Error {
   override name = "AdminAuthError";
   status: number;
-  constructor(status: number, message: string) {
+  /**
+   * The scope the caller needed, when the failure was an insufficient-scope
+   * 403. Rendered as the RFC 6750 §3 `scope` parameter on the
+   * `WWW-Authenticate` challenge — the field spec-following clients actually
+   * parse, as opposed to `error_description`, which is prose for humans.
+   *
+   * This is the standard discovery path for a scope that isn't advertised.
+   * Parachute deliberately keeps `account:*` out of `scopes_supported` (RFC
+   * 8414 §2 and RFC 9728 §2 both say a server MAY do exactly that, and MCP's
+   * 2025-11-25 authorization spec goes further — `scopes_supported` is meant
+   * to be the MINIMAL set, with more obtained through step-up). The cost was
+   * that an unattended agent had no mechanical way to learn those scopes
+   * exist. Naming the scope in the challenge closes that: attempt the
+   * operation, get a 403 that says which scope to ask for, step up.
+   *
+   * Same shape `git-transport.ts` already emits — this brings the account
+   * surface in line with in-repo precedent.
+   */
+  requiredScope: string | undefined;
+  constructor(status: number, message: string, requiredScope?: string) {
     super(message);
     this.status = status;
+    this.requiredScope = requiredScope;
   }
 }
 
@@ -96,7 +116,7 @@ export async function requireScope(
     typeof scopeClaim === "string" ? scopeClaim.split(/\s+/).filter((s) => s.length > 0) : [];
 
   if (!scopes.includes(requiredScope)) {
-    throw new AdminAuthError(403, `token missing required scope: ${requiredScope}`);
+    throw new AdminAuthError(403, `token missing required scope: ${requiredScope}`, requiredScope);
   }
 
   const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
@@ -111,6 +131,21 @@ export async function requireScope(
  * Convenience for route handlers that want to do
  * `try { ctx = await requireScope(...) } catch (err) { return adminAuthErrorResponse(err); }`.
  */
+/**
+ * Build the `WWW-Authenticate` challenge, including the RFC 6750 §3 `scope`
+ * parameter when we know which scope was missing.
+ *
+ * Quoted-string values can't contain a raw `"`, so the description is
+ * sanitised; the scope token is emitted verbatim because scope values are
+ * already constrained to a safe charset.
+ */
+function buildChallenge(err: AdminAuthError): string {
+  const code = err.status === 403 ? "insufficient_scope" : "invalid_token";
+  const parts = [`Bearer error="${code}"`, `error_description="${err.message.replace(/"/g, "'")}"`];
+  if (err.status === 403 && err.requiredScope) parts.push(`scope="${err.requiredScope}"`);
+  return parts.join(", ");
+}
+
 export function adminAuthErrorResponse(err: unknown): Response {
   if (err instanceof AdminAuthError) {
     return new Response(
@@ -122,7 +157,7 @@ export function adminAuthErrorResponse(err: unknown): Response {
         status: err.status,
         headers: {
           "content-type": "application/json",
-          "www-authenticate": `Bearer error="${err.status === 403 ? "insufficient_scope" : "invalid_token"}", error_description="${err.message.replace(/"/g, "'")}"`,
+          "www-authenticate": buildChallenge(err),
         },
       },
     );


### PR DESCRIPTION
Closes the discoverability gap the hive team raised — an unattended agent had no mechanical way to learn a scope it needs exists.

## The research says our posture is correct, and names the missing piece

Hub deliberately keeps `account:*` out of `scopes_supported` (#803), because clients request the whole advertised catalog and a note-taker was asking for permanent delete across every vault. The hive team's fair critique: a client reading only metadata can't discover those scopes.

Prior-art research says **hiding them is explicitly sanctioned**:

- **RFC 8414 §2**: *"Servers MAY choose not to advertise some supported scope values even when this parameter is used."*
- **RFC 9728 §2**: same language for protected resources.
- **MCP Authorization 2025-11-25** goes further: `scopes_supported` is *"the minimal set of scopes necessary for basic functionality"*, with more obtained through step-up, and clients *"MUST treat the scopes provided in the challenge as authoritative."*

And nobody tiers scopes in metadata:

| provider | advertised scopes | discovery at point of need |
|---|---|---|
| Google | 3 (`openid email profile`) | docs + Console tiers |
| Microsoft | 4 | docs |
| GitHub | *no AS metadata at all* | `X-Accepted-OAuth-Scopes` header |
| Slack | *no AS metadata at all* | `missing_scope` error with `needed` |

Every one does discovery **at the moment of refusal**, not from the catalog.

## The gap was narrower than "metadata is incomplete"

Our 403 already named the scope — but only inside `error_description`, which is prose. The RFC 6750 §3 `scope` parameter is the field clients parse.

**`git-transport.ts:228` already emits exactly this shape.** The account surface never got the twin.

## The change

`AdminAuthError` carries the required scope; the challenge builder emits `scope="account:self:admin"` on a 403.

A **401 deliberately omits it**: `scope` answers *"which permission would have worked"*, and on a broken or absent token that question has no answer — asserting one would send a client to request a scope that wasn't the problem.

The agent's discovery path becomes: attempt the operation → 403 names the exact scope → step up. Exactly how GitHub, Slack, and the MCP spec expect it to work.

## No metadata field invented

A custom `scopes_sensitive`-style field has zero client support today, would re-create the original problem for any client treating it as more catalog to request, and carries a permanent standards-divergence cost. Rejected in favour of the standard mechanism plus documenting the catalog at `resource_documentation`.

## Verification

- `bun test ./src` — **4472 pass**, 0 fail · typecheck clean
- 5 new tests including the quoted-string safety case (a malformed challenge is worse than a vague one — clients drop the whole header)

## Residual limit, stated honestly

An agent that wants an account-scoped credential *without ever attempting an account operation* still has no standard discovery path — that's the ceiling of current practice everywhere, not a Parachute gap.