### PR TITLE
feat(consent): retire the verb selector — a read-only agent is expressible again

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -10527,99 +10527,6 @@ describe("hub#689 — owner-on-own-vault verb selector + widening", () => {
   });
 
   // Submit: owner (first admin) + client requested unnamed vault:read + selects
-  // admin → minted vault:<picked>:admin. THE core bug fix.
-  test("owner selects admin on an unnamed vault:read → minted vault:work:admin", async () => {
-    const { db, cleanup } = await makeDb();
-    try {
-      const owner = await createUser(db, "owner", "pw"); // first admin
-      const session = createSession(db, { userId: owner.id });
-      const reg = registerClient(db, {
-        redirectUris: ["https://app.example/cb"],
-        status: "approved",
-      });
-      const { verifier, challenge } = makePkce();
-      const res = await submitConsent(
-        db,
-        session.id,
-        reg.client.clientId,
-        "vault:read",
-        challenge,
-        {
-          vault_pick: "work",
-          verb_select: "admin",
-        },
-      );
-      expect(res.status).toBe(302);
-      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
-      expect(code).toBeTruthy();
-      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
-      expect(scope).toBe("vault:work:admin");
-    } finally {
-      cleanup();
-    }
-  });
-
-  // Submit: owner selects write → vault:<picked>:write.
-  test("owner selects write on an unnamed vault:read → minted vault:work:write", async () => {
-    const { db, cleanup } = await makeDb();
-    try {
-      const owner = await createUser(db, "owner", "pw");
-      const session = createSession(db, { userId: owner.id });
-      const reg = registerClient(db, {
-        redirectUris: ["https://app.example/cb"],
-        status: "approved",
-      });
-      const { verifier, challenge } = makePkce();
-      const res = await submitConsent(
-        db,
-        session.id,
-        reg.client.clientId,
-        "vault:read",
-        challenge,
-        {
-          vault_pick: "work",
-          verb_select: "write",
-        },
-      );
-      expect(res.status).toBe(302);
-      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
-      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
-      expect(scope).toBe("vault:work:write");
-    } finally {
-      cleanup();
-    }
-  });
-
-  // Submit: owner DOWNGRADES — selects read on an unnamed vault:write → read.
-  test("owner selects read on an unnamed vault:write → minted vault:work:read (downgrade)", async () => {
-    const { db, cleanup } = await makeDb();
-    try {
-      const owner = await createUser(db, "owner", "pw");
-      const session = createSession(db, { userId: owner.id });
-      const reg = registerClient(db, {
-        redirectUris: ["https://app.example/cb"],
-        status: "approved",
-      });
-      const { verifier, challenge } = makePkce();
-      const res = await submitConsent(
-        db,
-        session.id,
-        reg.client.clientId,
-        "vault:write",
-        challenge,
-        {
-          vault_pick: "work",
-          verb_select: "read",
-        },
-      );
-      expect(res.status).toBe(302);
-      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
-      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
-      expect(scope).toBe("vault:work:read");
-    } finally {
-      cleanup();
-    }
-  });
 
   // SECURITY: a non-owner who holds only READ on the picked vault forges
   // verb_select=admin → the server re-derives ownership (no admin held) and
@@ -10723,6 +10630,100 @@ describe("hub#689 — owner-on-own-vault verb selector + widening", () => {
           vault_pick: "work",
           // no verb_select
         },
+      );
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope).toBe("vault:work:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  // The selector is retired (2026-07-30). Its two jobs now live elsewhere, and
+  // these tests pin that the CAPABILITY survived the removal.
+
+  test("a forged verb_select is IGNORED, not honoured", async () => {
+    // The old block treated verb_select as an untrusted hint and re-derived
+    // ownership. Now it isn't read at all, which fails narrower: a stale or
+    // hand-crafted field mints what was requested rather than widening it.
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        {
+          vault_pick: "work",
+          verb_select: "admin",
+        },
+      );
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      // read was requested; read is what is minted. NOT admin.
+      expect(scope).toBe("vault:work:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("a multi-verb request survives instead of collapsing to admin", async () => {
+    // The capability gap this retirement exists to close: three requested verbs
+    // used to become `vault:work:admin` three times, so a read-only agent could
+    // not be expressed. Now each requested verb is preserved and named.
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read vault:write",
+        challenge,
+        { vault_pick: "work" },
+      );
+      expect(res.status).toBe(302);
+      const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");
+      const scope = await redeemScope(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ").sort()).toEqual(["vault:work:read", "vault:work:write"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("duplicate requested scopes are deduped in the minted set", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const res = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read vault:read",
+        challenge,
+        { vault_pick: "work" },
       );
       expect(res.status).toBe(302);
       const code = new URL(res.headers.get("location") ?? "").searchParams.get("code");

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -1488,6 +1488,18 @@ function issueAuthCodeRedirect(
   // everywhere by construction.
   const userIsAdmin = isFirstAdmin(db, userId);
   const cappedScopes = capScopesToUserAuthority(db, userId, scopes, { userIsAdmin });
+  // Dedup HERE, after the cap, at the single mint choke-point every path funnels
+  // through — so the auth-code row, the JWT `scope` claim, the refresh row, the
+  // token response, and the recorded grant all carry the same set.
+  //
+  // Three requested verbs that converge on one string used to stay three
+  // strings: nothing on this path deduped (map → map → filter). A token reading
+  // `vault:x:admin vault:x:admin vault:x:admin` is cosmetic, but it made the
+  // scope claim hard to read and trivially wrong-looking in a bug report.
+  //
+  // After the cap, never before: deduping the pre-cap set would change what the
+  // cap sees and could mask a dropped verb.
+  const dedupedScopes = [...new Set(cappedScopes)];
 
   // Drop-not-refuse UX, with one hard floor: if capping leaves an EMPTY set
   // (e.g. a non-owner requested ONLY `vault:<name>:admin`, which they don't
@@ -1506,13 +1518,13 @@ function issueAuthCodeRedirect(
 
   // Record the grant with the CAPPED scopes (single source of truth) so
   // skip-consent re-entry can never widen back to an un-held verb.
-  recordGrant(db, userId, params.clientId, cappedScopes, deps.now?.() ?? new Date());
+  recordGrant(db, userId, params.clientId, dedupedScopes, deps.now?.() ?? new Date());
 
   const code = issueAuthCode(db, {
     clientId: params.clientId,
     userId,
     redirectUri: params.redirectUri,
-    scopes: cappedScopes,
+    scopes: dedupedScopes,
     codeChallenge: params.codeChallenge,
     codeChallengeMethod: params.codeChallengeMethod,
     now: deps.now,
@@ -1905,44 +1917,27 @@ async function handleConsentSubmit(
         400,
       );
     }
-    // hub#689 — owner-on-own-vault verb widening. The consent screen offers
-    // owners a read/write/admin selector (pre-selected to admin) for an
-    // unnamed `vault:read`/`vault:write` request, so an owner whose AI client
-    // asked for read-only can grant the level it actually needs in-flow. The
-    // submitted `verb_select` is an UNTRUSTED hint — we re-derive ownership of
-    // the PICKED vault server-side here, and `capScopesToUserAuthority` (inside
-    // issueAuthCodeRedirect) is the backstop that drops any verb the user
-    // doesn't actually hold. This only ever rewrites the unnamed read/write
-    // verb(s) to the selected level on the picked vault; named scopes and every
-    // other scope are untouched. A forged `verb_select=admin` from a user who
-    // doesn't own the picked vault gets capped back to what they hold (or, for
-    // a vault outside a pinned user's assignment, never reaches here — the
-    // mismatch checks above already 400'd it).
-    const selectedVerb = String(form.get("verb_select") ?? "").trim();
-    if (selectedVerb === "read" || selectedVerb === "write" || selectedVerb === "admin") {
-      // Re-derive, server-side, whether THIS user owns (holds admin on) the
-      // PICKED vault. Owner === first admin (holds admin everywhere) OR an
-      // assigned user whose role grants admin on this vault. Never trust the
-      // client-submitted selector to establish authority.
-      const heldOnPicked = vaultVerbsForUserVault(db, session.userId, pickedVault);
-      const ownsPicked = userIsAdmin || (heldOnPicked?.includes("admin") ?? false);
-      if (ownsPicked) {
-        scopes = scopes.map((s) => {
-          const parts = s.split(":");
-          // Only widen the unnamed read/write verbs the selector was offered
-          // for — leave an unnamed `vault:admin`, named scopes, and non-vault
-          // scopes exactly as requested.
-          if (
-            parts.length === 2 &&
-            parts[0] === "vault" &&
-            (parts[1] === "read" || parts[1] === "write")
-          ) {
-            return `vault:${selectedVerb}`;
-          }
-          return s;
-        });
-      }
-    }
+    // hub#689's owner verb-widening selector is GONE (retired 2026-07-30).
+    //
+    // It was one radio applied to every requested verb, so a multi-verb request
+    // could not survive it: `vault:read vault:write vault:admin` with the
+    // selector's admin default rewrote to `vault:admin` three times. Observed
+    // live by an external team — a read-only research agent was simply not
+    // expressible, because both agents got admin or neither ran.
+    //
+    // Worse, it now CONTRADICTS per-scope consent (#804): a user unchecks
+    // write and admin, and this block rewrote their surviving `vault:read`
+    // back to admin. The checkboxes said read-only; the token said admin.
+    //
+    // Both of the selector's jobs are covered elsewhere now:
+    //   - downgrade → uncheck the scope row (per-scope consent)
+    //   - upgrade   → tick it in the additional-access list, which
+    //                 `grantableExtraScopes` builds through the SAME cap the
+    //                 mint uses, so it can't offer more than the user holds
+    //
+    // A stale `verb_select` from a cached consent page is now simply ignored,
+    // which fails NARROWER — it mints what was requested and checked. That's
+    // the safe direction for an unread field.
     scopes = narrowVaultScopes(scopes, pickedVault);
   }
 


### PR DESCRIPTION
Closes the capability gap the hive team reported:

```
requested : vault:read vault:write vault:admin
granted   : vault:unforced:admin vault:unforced:admin vault:unforced:admin
```

## Why it collapsed

The owner verb selector (hub#689) was **one radio applied to N requested verbs**, pre-selected to admin. A multi-verb request could not survive it — every unnamed `vault:read`/`vault:write` was rewritten to the selected level.

That's not cosmetic. **An agent that should search a vault and never write to it cannot be given a credential that says so.** Their read-only research agent and their writing agent both got admin, or neither ran.

## And it contradicted per-scope consent

Since #804, a user can uncheck `write` and `admin`. This block then rewrote the surviving `vault:read` **back to admin**. The checkboxes said read-only; the token said admin. The newer control lost to the older one, silently.

## Both of its jobs already have homes

| selector's job | now |
|---|---|
| downgrade | uncheck the scope row (#804) |
| upgrade — owner's client hard-codes `vault:read` but needs admin (hub#689's actual requirement) | tick it in the additional-access list, built by `grantableExtraScopes` through the **same cap the mint uses**, so it can never offer more than the user holds |

`verb_select` is now simply unread. A stale field from a cached consent page **fails narrower** — it mints what was requested and checked. Safe direction for an unread field.

## Also: dedup at the choke-point

Nothing on the mint path deduped (map → map → filter), so converging verbs stayed duplicated in the token's `scope` claim. Now deduped in `issueAuthCodeRedirect` — **after** the cap, never before, since deduping earlier would change what the cap sees.

## Tests

The three selector-driven hub#689 tests are replaced by ones pinning the new contract:

- a **forged `verb_select` is ignored**, not honoured — mints `vault:work:read` for a read request
- a **multi-verb request survives** instead of collapsing
- **duplicates dedup**

I also deleted a placeholder I'd written that asserted `expect(true).toBe(true)` — it documented nothing and would have rotted.

- `bun test ./src` — **4469 pass**, 0 fail · typecheck + biome clean

## Provenance

Designed by a Fable planning agent, which also caught the #804 wire-vs-display bug that had to land first (#806) — the checkbox posted the display scope while the server filtered the wire scope, silently dropping every unnamed vault scope.

## For the hive team

After this, requesting `vault:read` alone mints read. There's also a workaround available **today** without upgrading: request **named** scopes (`vault:<name>:read`), which skip the picker and selector entirely.