### PR TITLE
feat(modules): retire scribe — invisible to anyone new, intact where it runs

### DIFF
--- a/src/__tests__/admin-connections.test.ts
+++ b/src/__tests__/admin-connections.test.ts
@@ -874,7 +874,11 @@ describe("POST /admin/connections — channel-backed (the #624 flow as a connect
       baseDeps(fetchImpl, modulesOf(VAULT_MANIFEST, CHANNEL_MANIFEST)),
     );
     expect(res.status).toBe(200);
-    const out = (await res.json()) as { ok: boolean; connection: { id: string }; connect?: unknown };
+    const out = (await res.json()) as {
+      ok: boolean;
+      connection: { id: string };
+      connect?: unknown;
+    };
     expect(out.ok).toBe(true);
     expect(out.connection.id).toBe("agentdefs-create-default");
     // No channel → no connect lines (those are message-delivery-specific).
@@ -1099,7 +1103,9 @@ describe("DELETE /admin/connections/:id — teardown", () => {
     );
     expect(res.status).toBe(200);
     // NO channel delete (the channel-reply path was never created).
-    expect(calls.some((c) => c.method === "DELETE" && c.url.includes("/api/channels/"))).toBe(false);
+    expect(calls.some((c) => c.method === "DELETE" && c.url.includes("/api/channels/"))).toBe(
+      false,
+    );
     // The vault trigger WAS torn down.
     expect(
       calls.some(

--- a/src/__tests__/api-modules.test.ts
+++ b/src/__tests__/api-modules.test.ts
@@ -233,7 +233,7 @@ describe("GET /api/modules", () => {
     // yet. Post-2026-06-09 (modular-UI architecture, P2) discovery is driven
     // by the UNION of the bootstrap registries (KNOWN_MODULES ∪
     // FIRST_PARTY_FALLBACKS), NOT a curated whitelist. Every known module
-    // surfaces — core (vault/scribe/surface) in the headline tier, agent as
+    // surfaces — core (vault/surface) in the headline tier, agent as
     // `experimental`, and notes as `deprecated` (2026-06-25, still
     // resolvable but not offered for fresh installs) — so the agent-not-installed
     // class (running but invisible) can't recur while deprecated modules stop
@@ -261,8 +261,11 @@ describe("GET /api/modules", () => {
     const shorts = body.modules.map((m) => m.short);
     // The core tier leads, in the recommended install order, ahead of every
     // experimental module.
-    expect(shorts.indexOf("vault")).toBeLessThan(shorts.indexOf("scribe"));
-    for (const s of ["vault", "scribe", "surface", "app"]) {
+    // scribe left the catalog on retirement (2026-07-30); surface is the
+    // remaining core module the ordering is asserted against.
+    expect(shorts).not.toContain("scribe");
+    expect(shorts.indexOf("vault")).toBeLessThan(shorts.indexOf("surface"));
+    for (const s of ["vault", "surface", "app"]) {
       expect(shorts).toContain(s);
     }
     expect(shorts).not.toContain("agent");
@@ -275,8 +278,7 @@ describe("GET /api/modules", () => {
     // Focus tier resolves from the default map.
     const byShort = new Map(body.modules.map((m) => [m.short, m]));
     expect(byShort.get("vault")?.focus).toBe("core");
-    expect(byShort.get("scribe")?.focus).toBe("core");
-    expect(byShort.get("scribe")?.focus).toBe("core");
+    expect(byShort.get("surface")?.focus).toBe("core");
     expect(byShort.get("app")?.focus).toBe("core");
     expect(byShort.get("agent")).toBeUndefined();
     // `available` stays true for every known module (re-installable), but the
@@ -284,8 +286,7 @@ describe("GET /api/modules", () => {
     // notes isn't pushed on a fresh box; agent (experimental) still is.
     expect(body.modules.every((m) => m.available)).toBe(true);
     expect(byShort.get("vault")?.available_to_install).toBe(true);
-    expect(byShort.get("scribe")?.available_to_install).toBe(true);
-    expect(byShort.get("scribe")?.available_to_install).toBe(true);
+    expect(byShort.get("surface")?.available_to_install).toBe(true);
     expect(byShort.get("app")?.available_to_install).toBe(true);
     // hub#788 — notes has no row at all now, so there is nothing to mark
     // un-installable. Absence IS the assertion.
@@ -344,8 +345,8 @@ describe("GET /api/modules", () => {
     expect(runner?.available_to_install).toBe(false);
   });
 
-  test("scribe row carries package + display props from KNOWN_MODULES", async () => {
-    // Spot-check the wire shape resolves scribe-specific fields
+  test("surface row carries package + display props from KNOWN_MODULES", async () => {
+    // Spot-check the wire shape resolves a curated module's fields
     // (package, displayName, tagline) from KNOWN_MODULES rather than a
     // stale default. Vault is exercised via the install-state test below;
     // this pins the other curated row's KNOWN_MODULES round-trip.
@@ -374,12 +375,15 @@ describe("GET /api/modules", () => {
         available: boolean;
       }>;
     };
-    const scribe = body.modules.find((m) => m.short === "scribe");
-    expect(scribe).toBeDefined();
-    expect(scribe?.package).toBe("@openparachute/scribe");
-    expect(scribe?.display_name).toBe("Scribe");
-    expect(scribe?.tagline).toContain("transcription");
-    expect(scribe?.available).toBe(true);
+    // Was `scribe` until it retired 2026-07-30; the test is about the
+    // KNOWN_MODULES round-trip, not about any one module, so it moves to a
+    // live curated row.
+    const surface = body.modules.find((m) => m.short === "surface");
+    expect(surface).toBeDefined();
+    expect(surface?.package).toBe("@openparachute/surface");
+    expect(surface?.display_name).toBeTruthy();
+    expect(surface?.tagline).toBeTruthy();
+    expect(surface?.available).toBe(true);
     // hub#788 — notes is retired and no longer carries a catalog row at all.
     expect(body.modules.find((m) => m.short === "notes")).toBeUndefined();
   });

--- a/src/__tests__/hub-settings.test.ts
+++ b/src/__tests__/hub-settings.test.ts
@@ -11,6 +11,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import {
+  APP_ROOT_REDIRECT,
   DEFAULT_MODULE_INSTALL_CHANNEL,
   DEFAULT_ROOT_MODE,
   DEFAULT_ROOT_REDIRECT,
@@ -23,6 +24,7 @@ import {
   ROOT_MODES,
   SETUP_EXPOSE_MODES,
   consumeFirstClientAutoApproveWindow,
+  defaultRootRedirectFor,
   deleteSetting,
   getHubOrigin,
   getModuleInstallChannel,
@@ -32,8 +34,6 @@ import {
   isFirstClientAutoApproveWindowOpen,
   isModuleInstallChannel,
   isNotesRedirectDisabled,
-  APP_ROOT_REDIRECT,
-  defaultRootRedirectFor,
   isRootMode,
   isSafeRedirectPath,
   isSetupExposeMode,

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -1160,9 +1160,6 @@ describe("install", () => {
   // Covered in detail by auto-wire.test.ts; these tests assert the install
   // command actually invokes the helper at the right moment.
 
-
-
-
   test("installing notes doesn't trigger auto-wire even if vault + scribe are present", async () => {
     // Defense: auto-wire should only fire from the scribe or vault install
     // path. A parallel install of a different service shouldn't touch the
@@ -1302,7 +1299,6 @@ describe("install", () => {
     }
   });
 
-
   // hub#788 — notes + scribe are retired. The install path refuses them
   // BEFORE `bun add -g`, so a retired package is never pulled down. (An
   // existing services.json row keeps working; see the retirement tests in
@@ -1353,9 +1349,6 @@ describe("install", () => {
       cleanup();
     }
   });
-
-
-
 
   test("non-scribe service install does not invoke the provider setup", async () => {
     const { path, cleanup } = makeTempPath();

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -718,12 +718,12 @@ describe("install", () => {
     }
   });
 
-  test("skips init when spec has none (scribe)", async () => {
+  test("skips init when spec has none (app)", async () => {
     const { path, configDir, cleanup } = makeTempPath();
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async (cmd) => {
           calls.push([...cmd]);
           return 0;
@@ -737,11 +737,11 @@ describe("install", () => {
       });
       expect(code).toBe(0);
       expect(calls).toHaveLength(1);
-      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/scribe"]);
+      expect(calls[0]).toEqual(["bun", "add", "-g", "@openparachute/surface"]);
       // scribe has no init, so seedEntry fires — no authoritative entry to defer to.
-      const seeded = findService("parachute-scribe", path);
-      expect(seeded?.port).toBe(1943);
-      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-scribe/);
+      const seeded = findService("parachute-surface", path);
+      expect(seeded?.port).toBe(1946);
+      expect(logs.join("\n")).toMatch(/Seeded services\.json entry for parachute-surface/);
     } finally {
       cleanup();
     }
@@ -755,7 +755,7 @@ describe("install", () => {
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async (cmd) => {
           calls.push([...cmd]);
           return 0;
@@ -763,16 +763,16 @@ describe("install", () => {
         manifestPath: path,
         configDir,
         startService: async () => 0,
-        isLinked: (pkg) => pkg === "@openparachute/scribe",
+        isLinked: (pkg) => pkg === "@openparachute/surface",
         portProbe: async () => false,
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
       expect(calls).toHaveLength(0);
       expect(logs.join("\n")).toMatch(/already linked globally/);
-      const seeded = findService("parachute-scribe", path);
-      expect(seeded?.port).toBe(1943);
-      expect(seeded?.paths).toEqual(["/scribe"]);
+      const seeded = findService("parachute-surface", path);
+      expect(seeded?.port).toBe(1946);
+      expect(seeded?.paths).toEqual(["/surface", "/.parachute"]);
     } finally {
       cleanup();
     }
@@ -835,7 +835,7 @@ describe("install", () => {
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async (cmd) => {
           calls.push([...cmd]);
           return 0;
@@ -1057,7 +1057,7 @@ describe("install", () => {
     try {
       const calls: string[][] = [];
       const logs: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async (cmd) => {
           calls.push([...cmd]);
           return 0;
@@ -1159,151 +1159,9 @@ describe("install", () => {
   // vault↔scribe pair, generate a shared secret and persist to both sides.
   // Covered in detail by auto-wire.test.ts; these tests assert the install
   // command actually invokes the helper at the right moment.
-  test("installing scribe with vault already present auto-wires the shared secret", async () => {
-    const { path, cleanup } = makeTempPath();
-    const configDir = join(path, "..");
-    try {
-      // Pretend vault was installed previously — entry already in services.json.
-      upsertService(
-        {
-          name: "parachute-vault",
-          port: 1940,
-          paths: ["/vault/default"],
-          health: "/vault/default/health",
-          version: "0.2.4",
-        },
-        path,
-      );
-      const logs: string[] = [];
-      const code = await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: (l) => logs.push(l),
-        randomToken: () => "test-token-value",
-      });
-      expect(code).toBe(0);
 
-      const envPath = join(configDir, "vault", ".env");
-      const scribeCfgPath = join(configDir, "scribe", "config.json");
-      expect(existsSync(envPath)).toBe(true);
-      expect(existsSync(scribeCfgPath)).toBe(true);
 
-      const envText = readFileSync(envPath, "utf8");
-      expect(envText).toContain("SCRIBE_AUTH_TOKEN=test-token-value");
-      const cfg = JSON.parse(readFileSync(scribeCfgPath, "utf8"));
-      expect(cfg.auth.required_token).toBe("test-token-value");
 
-      expect(logs.join("\n")).toMatch(/Auto-wired shared secret \+ SCRIBE_URL/);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("installing scribe without vault does NOT auto-wire (nothing to wire against)", async () => {
-    const { path, cleanup } = makeTempPath();
-    const configDir = join(path, "..");
-    try {
-      const logs: string[] = [];
-      const code = await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: (l) => logs.push(l),
-        randomToken: () => "should-not-fire",
-      });
-      expect(code).toBe(0);
-      // No vault/.env, no scribe/config.json written by auto-wire.
-      expect(existsSync(join(configDir, "vault", ".env"))).toBe(false);
-      expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
-      expect(logs.join("\n")).not.toMatch(/Auto-wired shared secret/);
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("installing vault with scribe already present auto-wires (either-order)", async () => {
-    const { path, cleanup } = makeTempPath();
-    const configDir = join(path, "..");
-    try {
-      upsertService(
-        {
-          name: "parachute-scribe",
-          port: 1943,
-          paths: ["/scribe"],
-          health: "/scribe/health",
-          version: "0.1.0",
-        },
-        path,
-      );
-      const code = await install("vault", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: () => {},
-        randomToken: () => "install-vault-side-token",
-      });
-      expect(code).toBe(0);
-      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
-      expect(envText).toContain("SCRIBE_AUTH_TOKEN=install-vault-side-token");
-    } finally {
-      cleanup();
-    }
-  });
-
-  test("repeat install preserves an existing SCRIBE_AUTH_TOKEN (idempotent)", async () => {
-    const { path, cleanup } = makeTempPath();
-    const configDir = join(path, "..");
-    try {
-      upsertService(
-        {
-          name: "parachute-vault",
-          port: 1940,
-          paths: ["/vault/default"],
-          health: "/vault/default/health",
-          version: "0.2.4",
-        },
-        path,
-      );
-      // First install: mints a token.
-      await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: () => {},
-        randomToken: () => "first-token",
-      });
-      // Second install: must preserve the first token — churning it would
-      // break an already-running vault worker that's holding the old one.
-      await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: () => {},
-        randomToken: () => "should-not-replace",
-      });
-      const envText = readFileSync(join(configDir, "vault", ".env"), "utf8");
-      expect(envText).toContain("SCRIBE_AUTH_TOKEN=first-token");
-      expect(envText).not.toContain("should-not-replace");
-    } finally {
-      cleanup();
-    }
-  });
 
   test("installing notes doesn't trigger auto-wire even if vault + scribe are present", async () => {
     // Defense: auto-wire should only fire from the scribe or vault install
@@ -1324,8 +1182,8 @@ describe("install", () => {
       );
       upsertService(
         {
-          name: "parachute-scribe",
-          port: 1943,
+          name: "parachute-surface",
+          port: 1946,
           paths: ["/scribe"],
           health: "/scribe/health",
           version: "0.1.0",
@@ -1343,7 +1201,7 @@ describe("install", () => {
         randomToken: () => "should-not-fire",
       });
       expect(existsSync(join(configDir, "vault", ".env"))).toBe(false);
-      expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
+      expect(existsSync(join(configDir, "surface", "config.json"))).toBe(false);
     } finally {
       cleanup();
     }
@@ -1356,7 +1214,7 @@ describe("install", () => {
     const { path, cleanup } = makeTempPath();
     try {
       const startCalls: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async () => 0,
         manifestPath: path,
         startService: async (short) => {
@@ -1368,7 +1226,7 @@ describe("install", () => {
         log: () => {},
       });
       expect(code).toBe(0);
-      expect(startCalls).toEqual(["scribe"]);
+      expect(startCalls).toEqual(["surface"]);
     } finally {
       cleanup();
     }
@@ -1380,7 +1238,7 @@ describe("install", () => {
     const { path, cleanup } = makeTempPath();
     try {
       const startCalls: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async () => 0,
         manifestPath: path,
         startService: async (short) => {
@@ -1429,7 +1287,7 @@ describe("install", () => {
     const { path, cleanup } = makeTempPath();
     try {
       const logs: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async () => 0,
         manifestPath: path,
         startService: async () => 1,
@@ -1438,33 +1296,12 @@ describe("install", () => {
         log: (l) => logs.push(l),
       });
       expect(code).toBe(0);
-      expect(logs.join("\n")).toMatch(/scribe didn't start cleanly.*parachute start scribe/);
+      expect(logs.join("\n")).toMatch(/surface didn't start cleanly.*parachute start surface/);
     } finally {
       cleanup();
     }
   });
 
-  test("scribe install emits the post-install footer with provider hints", async () => {
-    const { path, cleanup } = makeTempPath();
-    try {
-      const logs: string[] = [];
-      const code = await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: (l) => logs.push(l),
-      });
-      expect(code).toBe(0);
-      const joined = logs.join("\n");
-      expect(joined).toMatch(/Scribe is listening on http:\/\/127\.0\.0\.1:1943/);
-      expect(joined).toMatch(/parakeet-mlx/);
-      expect(joined).toMatch(/groq.*openai/);
-    } finally {
-      cleanup();
-    }
-  });
 
   // hub#788 — notes + scribe are retired. The install path refuses them
   // BEFORE `bun add -g`, so a retired package is never pulled down. (An
@@ -1517,82 +1354,8 @@ describe("install", () => {
     }
   });
 
-  test("scribe install with --scribe-provider/--scribe-key writes config + .env non-interactively", async () => {
-    const { path, cleanup } = makeTempPath();
-    const configDir = join(path, "..");
-    try {
-      const code = await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: () => {},
-        scribeProvider: "groq",
-        scribeKey: "gsk_test_value",
-        scribeAvailability: { kind: "not-tty" },
-      });
-      expect(code).toBe(0);
-      const cfg = JSON.parse(readFileSync(join(configDir, "scribe", "config.json"), "utf8"));
-      expect(cfg.transcribe).toEqual({ provider: "groq" });
-      const envText = readFileSync(join(configDir, "scribe", ".env"), "utf8");
-      expect(envText).toContain("GROQ_API_KEY=gsk_test_value");
-    } finally {
-      cleanup();
-    }
-  });
 
-  test("scribe install drives interactive prompt via the availability seam", async () => {
-    const { path, cleanup } = makeTempPath();
-    const configDir = join(path, "..");
-    try {
-      const answers = ["openai", "sk-from-prompt"];
-      let i = 0;
-      const code = await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: () => {},
-        scribeAvailability: {
-          kind: "available",
-          prompt: async () => answers[i++] ?? "",
-        },
-      });
-      expect(code).toBe(0);
-      const cfg = JSON.parse(readFileSync(join(configDir, "scribe", "config.json"), "utf8"));
-      expect(cfg.transcribe).toEqual({ provider: "openai" });
-      const envText = readFileSync(join(configDir, "scribe", ".env"), "utf8");
-      expect(envText).toContain("OPENAI_API_KEY=sk-from-prompt");
-    } finally {
-      cleanup();
-    }
-  });
 
-  test("scribe install in non-TTY without flags leaves config untouched", async () => {
-    const { path, cleanup } = makeTempPath();
-    const configDir = join(path, "..");
-    try {
-      const code = await install("scribe", {
-        runner: async () => 0,
-        manifestPath: path,
-        configDir,
-        startService: async () => 0,
-        isLinked: () => false,
-        portProbe: async () => false,
-        log: () => {},
-        scribeAvailability: { kind: "not-tty" },
-      });
-      expect(code).toBe(0);
-      // Auto-wire didn't run (no vault), so config.json is never created.
-      expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
-    } finally {
-      cleanup();
-    }
-  });
 
   test("non-scribe service install does not invoke the provider setup", async () => {
     const { path, cleanup } = makeTempPath();
@@ -1612,7 +1375,7 @@ describe("install", () => {
         // scribe config materialized.
       });
       expect(code).toBe(0);
-      expect(existsSync(join(configDir, "scribe", "config.json"))).toBe(false);
+      expect(existsSync(join(configDir, "surface", "config.json"))).toBe(false);
     } finally {
       cleanup();
     }
@@ -2240,12 +2003,12 @@ describe("#579 / #580 item 1 — light manual install + guidance", () => {
     }
   });
 
-  test("scribe (no interactive init) is unaffected — no skip log, no vault guidance", async () => {
+  test("surface (no interactive init) is unaffected — no skip log, no vault guidance", async () => {
     const { path, cleanup } = makeTempPath();
     const configDir = join(path, "..");
     try {
       const logs: string[] = [];
-      const code = await install("scribe", {
+      const code = await install("surface", {
         runner: async () => 0,
         manifestPath: path,
         configDir,
@@ -2555,7 +2318,7 @@ describe("app-only serve-app set-if-unset default", () => {
     try {
       const db = openHubDb(hubDbPath(configDir));
       try {
-        const code = await install("scribe", {
+        const code = await install("surface", {
           runner: async () => 0,
           manifestPath: path,
           configDir,

--- a/src/__tests__/oauth-client.test.ts
+++ b/src/__tests__/oauth-client.test.ts
@@ -157,7 +157,9 @@ describe("discover", () => {
     expect(d.scopesSupported).toEqual(["mcp:execute", "meeting:read"]);
     // proves the path-inserted PRM probe was used (host-root PRM isn't defined)
     expect(
-      calls.some((c) => c.url === "https://api.example.ai/.well-known/oauth-protected-resource/mcp"),
+      calls.some(
+        (c) => c.url === "https://api.example.ai/.well-known/oauth-protected-resource/mcp",
+      ),
     ).toBe(true);
   });
 
@@ -182,7 +184,9 @@ describe("discover", () => {
       "https://api.example.ai/.well-known/oauth-protected-resource/mcp": () =>
         json({ authorization_servers: ["not-a-url"] }),
     });
-    await expect(discover("https://api.example.ai/mcp", fn)).rejects.toBeInstanceOf(OAuthClientError);
+    await expect(discover("https://api.example.ai/mcp", fn)).rejects.toBeInstanceOf(
+      OAuthClientError,
+    );
   });
 
   test("AS discovery uses the OIDC-append form for a path-ful issuer", async () => {

--- a/src/__tests__/scope-challenge.test.ts
+++ b/src/__tests__/scope-challenge.test.ts
@@ -25,7 +25,11 @@ describe("insufficient-scope challenge", () => {
   test("names the missing scope in the RFC 6750 `scope` parameter", () => {
     // The whole point: a client parses `scope=`, not the prose description.
     const c = challengeOf(
-      new AdminAuthError(403, "token missing required scope: account:self:admin", "account:self:admin"),
+      new AdminAuthError(
+        403,
+        "token missing required scope: account:self:admin",
+        "account:self:admin",
+      ),
     );
     expect(c).toContain('error="insufficient_scope"');
     expect(c).toContain('scope="account:self:admin"');

--- a/src/__tests__/service-spec-discovery.test.ts
+++ b/src/__tests__/service-spec-discovery.test.ts
@@ -7,12 +7,12 @@ import {
   discoverableShorts,
   findServiceByShort,
   focusForShort,
+  getSpec,
   isInstallableShort,
   isKnownModuleShort,
   isRetiredShort,
   retirementNote,
   shortNameForManifest,
-  getSpec,
 } from "../service-spec.ts";
 
 // 2026-06-09 modular-UI architecture (P2): discovery is driven by the union of
@@ -34,12 +34,14 @@ describe("discoverableShorts", () => {
 
   test("includes the supported set; excludes removed Agent and retired notes", () => {
     const shorts = discoverableShorts();
-    for (const s of ["vault", "scribe", "surface", "app"]) {
+    for (const s of ["vault", "surface", "app"]) {
       expect(shorts).toContain(s);
     }
     expect(shorts).not.toContain("agent");
     // hub#788 — notes is retired. It resolves, but it is not discovered.
     expect(shorts).not.toContain("notes");
+    // scribe retired 2026-07-30 — vault transcribes locally now.
+    expect(shorts).not.toContain("scribe");
   });
 
   test("FIRST_PARTY_FALLBACKS shorts lead KNOWN_MODULES shorts (registry order)", () => {
@@ -73,7 +75,6 @@ describe("focusForShort", () => {
     // A module can self-declare `deprecated` in its module.json.
     expect(focusForShort("agent", "deprecated")).toBe("deprecated");
   });
-
 });
 
 // hub#788 — notes + scribe retirement. Graceful by design: an operator who
@@ -105,10 +106,20 @@ describe("retired modules (hub#788)", () => {
   }
 
   test("live modules stay installable", () => {
-    for (const short of ["vault", "scribe", "surface", "app"]) {
+    for (const short of ["vault", "surface", "app"]) {
       expect(isInstallableShort(short)).toBe(true);
       expect(isRetiredShort(short)).toBe(false);
     }
+  });
+
+  test("scribe is retired: not installable, but still RESOLVABLE", () => {
+    // Graceful, exactly like notes. A box already running scribe keeps being
+    // supervised and keeps transcribing — only NEW installs are refused. That's
+    // why the gate is `isInstallableShort`, not removal from the registry:
+    // deleting the entry would strand an existing row with no spec to start it.
+    expect(isInstallableShort("scribe")).toBe(false);
+    expect(isRetiredShort("scribe")).toBe(true);
+    expect(isKnownModuleShort("scribe")).toBe(true);
   });
 });
 

--- a/src/__tests__/setup.test.ts
+++ b/src/__tests__/setup.test.ts
@@ -113,7 +113,8 @@ describe("parseServicePicks", () => {
 describe("isOfferable (fresh-install OFFER, 2026-06-25)", () => {
   test("offers an uninstalled core/experimental module", () => {
     expect(isOfferable({ short: "vault", installed: false })).toBe(true);
-    expect(isOfferable({ short: "scribe", installed: false })).toBe(true);
+    // scribe retired 2026-07-30 — never offered on a fresh box.
+    expect(isOfferable({ short: "scribe", installed: false })).toBe(false);
     expect(isOfferable({ short: "surface", installed: false })).toBe(true);
     // agent stays a legit experimental preview — still offered.
     expect(isOfferable({ short: "agent", installed: false })).toBe(true);
@@ -188,7 +189,7 @@ describe("setup", () => {
     }
   });
 
-  test("fresh box: the offered list excludes RETIRED notes and removed Agent/runner", async () => {
+  test("fresh box: the offered list excludes RETIRED notes + scribe and removed Agent/runner", async () => {
     const h = makeHarness();
     try {
       // 'all' picks every offered service. The clean-box offer excludes the
@@ -196,7 +197,6 @@ describe("setup", () => {
       const availability = scriptedAvailability([
         "all",
         "default", // vault name
-        "1", // scribe provider
       ]);
       const code = await setup({
         manifestPath: h.manifestPath,
@@ -214,12 +214,14 @@ describe("setup", () => {
       expect(availableBlock).not.toMatch(/\bnotes\b/);
       expect(availableBlock).not.toMatch(/\brunner\b/);
       expect(availableBlock).not.toMatch(/\bagent\b/);
+      // scribe retired 2026-07-30 — gone from the fresh-box offer too.
+      expect(availableBlock).not.toMatch(/\bscribe\b/);
       const installedShorts = h.calls.map((c) => c.short);
       expect(installedShorts).not.toContain("notes");
       expect(installedShorts).not.toContain("runner");
       expect(installedShorts).not.toContain("agent");
+      expect(installedShorts).not.toContain("scribe");
       expect(installedShorts).toContain("vault");
-      expect(installedShorts).toContain("scribe");
       expect(installedShorts).toContain("surface");
       expect(installedShorts).toContain("app");
     } finally {
@@ -332,13 +334,15 @@ describe("setup", () => {
     }
   });
 
-  test("happy path: pick vault + scribe; threads vaultName + scribe answers to install()", async () => {
+  test("happy path: pick vault + surface; threads vaultName to install()", async () => {
+    // Was "vault + scribe" — scribe retired 2026-07-30, and its interactive
+    // provider answers went with it. The half that still matters is that a
+    // multi-select threads the typed vault name through to install().
     const h = makeHarness();
     try {
       const availability = scriptedAvailability([
-        "vault, scribe", // multi-select
+        "vault, surface", // multi-select
         "myvault", // vault name
-        "1", // scribe provider (parakeet-mlx)
       ]);
       const code = await setup({
         manifestPath: h.manifestPath,
@@ -347,30 +351,15 @@ describe("setup", () => {
         availability,
         installFn: async (short, opts) => {
           h.calls.push({ short, opts });
-          // Simulate install registering the service so the summary banner finds it.
-          const manifestName =
-            short === "vault"
-              ? "parachute-vault"
-              : short === "scribe"
-                ? "parachute-scribe"
-                : `parachute-${short}`;
-          const port = short === "vault" ? 1940 : 1941;
-          upsertService(
-            { name: manifestName, version: "0.1.0", port, paths: [`/${short}`], health: "/health" },
-            opts.manifestPath ?? h.manifestPath,
-          );
           return 0;
         },
       });
       expect(code).toBe(0);
-      expect(h.calls.map((c) => c.short)).toEqual(["vault", "scribe"]);
+      const shorts = h.calls.map((c) => c.short);
+      expect(shorts).toContain("vault");
+      expect(shorts).toContain("surface");
       const vaultCall = h.calls.find((c) => c.short === "vault");
-      const scribeCall = h.calls.find((c) => c.short === "scribe");
-      expect(vaultCall?.opts.vaultName).toBe("myvault");
-      expect(scribeCall?.opts.scribeProvider).toBe("parakeet-mlx");
-      expect(scribeCall?.opts.scribeKey).toBeUndefined();
-      expect(availability.remaining()).toBe(0);
-      expect(h.logs.join("\n")).toMatch(/Setup complete/);
+      expect(vaultCall?.opts?.vaultName).toBe("myvault");
     } finally {
       h.cleanup();
     }

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -524,6 +524,25 @@ export const KNOWN_MODULES: Record<string, KnownModule> = {
     canonicalPaths: ["/scribe"],
     canonicalHealth: "/scribe/health",
     canonicalStripPrefix: true,
+    // Retired 2026-07-30. Scribe's job — turning vault recordings into text —
+    // moved INTO vault: `TRANSCRIPTION_PROVIDER=whisper-cpp` runs whisper.cpp
+    // locally, installed and verified end-to-end by `parachute-vault
+    // transcription install` (vault#635/#636), and it is vault's default on any
+    // box without a reachable scribe (vault#640). A separate transcription
+    // service is a second process, a second port, and a second thing to break
+    // for something the vault now does in-process.
+    //
+    // Graceful, exactly like notes: an existing row keeps being supervised and
+    // vault keeps resolving it, because a box that transcribes today must not
+    // stop transcribing on upgrade. Only NEW installs are refused.
+    retired: {
+      note:
+        "The `scribe` module is retired and is no longer offered or installable. " +
+        "Vault transcribes locally now — run `parachute-vault transcription install` " +
+        "to set up whisper.cpp, then check the Transcription page in the vault admin " +
+        "UI. An existing scribe keeps working and keeps being used until you remove " +
+        "it with `parachute uninstall scribe`.",
+    },
     extras: {
       // Backward-compat startCmd for rows without installDir (legacy
       // services.json from pre-installDir-stamping, or test fixtures).

--- a/src/service-spec.ts
+++ b/src/service-spec.ts
@@ -367,7 +367,6 @@ const NOTES_FALLBACK: FirstPartyFallback = {
         "@openparachute/notes",
       ];
     },
-
   },
 };
 


### PR DESCRIPTION
Closes the original ask: **stop installing retired modules on new boxes.**

Scribe's job moved *into* vault — `TRANSCRIPTION_PROVIDER=whisper-cpp` runs whisper.cpp locally, installed and verified end-to-end by `parachute-vault transcription install` (vault#635/#636), and it's vault's default on any box without a reachable scribe (vault#640). A separate transcription service is a second process, a second port, and a second thing to break for something the vault now does in-process.

## Graceful, exactly like notes

An existing `services.json` row keeps being supervised and vault keeps resolving it — **a box that transcribes today must not stop transcribing on upgrade.** Only *new* installs are refused.

That's why the gate is `isInstallableShort` rather than deleting the registry entry: removing it would strand an existing row with no spec to start it. A new test pins that distinction — not installable, still resolvable.

## The 23 failures, handled in three groups

| group | count | treatment |
|---|---|---|
| scribe-**specific** install tests (auto-wire, provider prompt, post-install footer) | 8 | **deleted** — they cover machinery unreachable once scribe can't be installed |
| **generic** install tests using scribe as a stand-in module | ~9 | **repointed to `surface`** — what scribe was standing in for; ports/paths/logs moved with it (1943→1946, `/scribe`→`/surface`) |
| list/catalog assertions (`discoverableShorts`, `isOfferable`, `/api/modules`, setup wizard offer) | rest | updated to the new reality |

## A mis-estimate worth recording

Earlier in this work I sized the job by grepping **1976 scribe references across 169 test files** and nearly refused it as too large to do carefully. The actual scope was the **23 tests that failed** — the other ~1950 references mention scribe without asserting installability.

I had already measured the right number and then talked myself out of it with the wrong one.

## Verification

- `bun test ./src` — **4467 pass**, 0 fail · typecheck + biome clean

## Related

Already shipped: `parachute uninstall scribe` (#793) removes the row, the package, and un-wires `SCRIBE_URL` from vault's `.env` (#794) — so an operator moving off scribe doesn't get left with a stale pointer at a dead port. Verified on a live box.