### PR TITLE
fix(install): refuse retired modules at runInstall — closes the wizard bypass

### DIFF
--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -1720,7 +1720,9 @@ describe("handleSetupVaultPost", () => {
       await new Promise((r) => setTimeout(r, 50));
       const cmds = runCalls.map((c) => c.join(" "));
       expect(cmds.some((c) => c.includes("bun add -g @openparachute/vault"))).toBe(true);
-      expect(cmds.some((c) => c.includes("bun add -g @openparachute/scribe"))).toBe(true);
+      // scribe is retired (hub#809). runInstall now refuses at the choke-point,
+      // so the wizard's sub-form no longer installs it — that bypass was the bug.
+      expect(cmds.some((c) => c.includes("bun add -g @openparachute/scribe"))).toBe(false);
     } finally {
       db.close();
     }
@@ -2321,7 +2323,8 @@ describe("handleSetupVaultPost", () => {
     expect(response.status).toBe(303);
     const location = response.headers.get("location") ?? "";
     expect(location).toMatch(/op_scribe=/);
-    expect(runCmds.some((c) => c.includes("bun add -g @openparachute/scribe"))).toBe(true);
+    // Retired (hub#809) — the cleanup path must not resurrect the install either.
+    expect(runCmds.some((c) => c.includes("bun add -g @openparachute/scribe"))).toBe(false);
     const cfg = readScribeConfig(h.dir);
     expect(cfg?.transcribe).toBeUndefined();
     expect(cfg?.cleanup).toEqual({ provider: "anthropic", default: true });
@@ -3216,8 +3219,9 @@ describe("done screen install tiles (hub#272 Item B)", () => {
       const location = post.headers.get("location") ?? "";
       expect(location).toMatch(/^\/admin\/setup\?just_finished=1&op_scribe=/);
       await new Promise((r) => setTimeout(r, 50));
-      expect(runCalls.length).toBeGreaterThan(0);
-      expect(runCalls[0]?.join(" ")).toContain("bun add -g @openparachute/scribe@latest");
+      // The op is still enqueued (the POST accepts, the refusal is async), but
+      // no install command runs — runInstall refuses retired shorts.
+      expect(runCalls.length).toBe(0);
     } finally {
       db.close();
     }

--- a/src/api-modules-ops.ts
+++ b/src/api-modules-ops.ts
@@ -765,6 +765,25 @@ export async function runInstall(
   deps: ApiModulesOpsDeps,
   channelOverride?: string,
 ): Promise<void> {
+  // Retired modules refuse HERE, at the choke-point every install path funnels
+  // through — not only at the two callers that happened to check.
+  //
+  // hub#809 retired scribe and gated the CLI (`install.ts`) and `handleInstall`.
+  // It missed `runInstall` itself, and two live surfaces call it directly: the
+  // browser wizard's vault-step scribe sub-form, and the done-screen install
+  // tile. So a retired module stayed installable through the wizard — which is
+  // the path a NEW operator actually takes, and "stop installing retired
+  // modules on new boxes" was the whole point.
+  //
+  // A test asserted the wizard's `bun add -g @openparachute/scribe` and passed
+  // on main after #809, which is how the hole stayed invisible: the retirement
+  // and the bypass were each internally consistent.
+  if (isRetiredShort(short)) {
+    const note =
+      retirementNote(short) ?? `The "${short}" module is retired and can no longer be installed.`;
+    failOperation(deps.registry ?? defaultRegistry, opId, "install", new Error(note));
+    return;
+  }
   const registry = deps.registry ?? defaultRegistry;
   const run = deps.run ?? defaultRun;
   // Channel resolution (hub#337) — precedence:


### PR DESCRIPTION
**#809's scribe retirement is bypassed on `main` right now.** The browser wizard can still install it.

## The hole

#809 gated two places — the CLI (`install.ts:919`) and `handleInstall` (`api-modules-ops.ts:668`). It missed **`runInstall`**, the function both of those call. Two live surfaces call it *directly*:

- the browser wizard's vault-step **scribe sub-form** (`setup-wizard.ts:2620`)
- the done-screen **install tile** (`setup-wizard.ts:3096`, via `CURATED_MODULES`)

So a retired module stayed installable through **the path a new operator actually takes**. "Stop installing retired modules on new boxes" was the entire point, and the surface that matters most for it was the one still doing it.

## Why nothing caught it

A test asserts the wizard's `bun add -g @openparachute/scribe` — and **passed on main after #809**. The retirement and the bypass were each internally consistent; only tracing callers across both surfaces reveals the gap. Found by a Fable review agent, not by the suite.

## The fix

The refusal moves to the choke-point every install path funnels through, rather than sitting at whichever callers remembered to check. Same lesson as `capScopesToUserAuthority`: put the gate where the paths converge.

## Tests

Three wizard tests asserted scribe installs. **Rewritten to assert it doesn't, rather than deleted** — they still exercise the surrounding flow (config writes, op enqueue, redirect shape), and deleting them would have dropped coverage of everything else those paths do.

- `bun test ./src` — **4467 pass**, 0 fail · typecheck + biome clean

## A diagnosis I got wrong on the way

I first suspected a shared-registry leak and "confirmed" it by running the tests with `-t` against what I thought was `main` — but the working tree already carried my commit, so I compared it against itself. The result meant nothing. The real cause was simply that those tests asserted the bypass.

## Follow-up, deliberately not here

`CURATED_MODULES` still lists scribe, so the wizard renders a tile that now fails on click. Cosmetic, not a hole — removing it cascades into the tile tests, and that belongs with the dead-code deletion (`scribe-config.ts`, `scribe-provider-interactive.ts`, the wizard transcription step), which a Fable plan has scoped at ~91 peak test breakage.