### PR TITLE
feat(wizard): the transcription step installs through the vault, not scribe

### DIFF
--- a/src/__tests__/wizard-transcription.test.ts
+++ b/src/__tests__/wizard-transcription.test.ts
@@ -1,369 +1,108 @@
 /**
- * CLI wizard transcription step (onboarding-streamline hub PR1).
+ * The CLI wizard's transcription step, after it moved from scribe to the vault.
  *
- * Exercises `walkTranscriptionStep` against an injected command runner + RAM
- * probe + platform — NOTHING installs and no subprocess is spawned. Covers the
- * four branches the brief calls for: the CLI transcription question, the
- * platform mapping, the RAM gate, and install-or-skip (mocked scribe
- * subprocess).
+ * The step used to branch four ways (none / groq / openai / local) and shell
+ * `parachute install scribe`. Scribe is retired (hub#809), so every non-`none`
+ * choice dead-ended in "✗ scribe install returned 1" — the wizard asked a
+ * question nothing could answer.
+ *
+ * What these tests pin is the property that made that bad: the step must never
+ * ask without doing, and must never fail setup over an optional extra.
  */
 
 import { describe, expect, test } from "bun:test";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
 import { walkTranscriptionStep } from "../commands/wizard-transcription.ts";
-import { scribeConfigPath } from "../scribe-config.ts";
 
-function makeHarness(): { dir: string; cleanup: () => void } {
-  const dir = mkdtempSync(join(tmpdir(), "pcli-wztrans-"));
-  return { dir, cleanup: () => rmSync(dir, { recursive: true, force: true }) };
-}
-
-/** Records every command the step would have spawned, returns scripted codes. */
-function recordingRunner(codes: number[] = []) {
+function harness(over: { answers?: string[]; exitCode?: number } = {}) {
+  const logs: string[] = [];
   const cmds: string[][] = [];
-  let i = 0;
+  const answers = [...(over.answers ?? [])];
   return {
+    logs,
     cmds,
-    run: async (cmd: readonly string[]): Promise<number> => {
-      cmds.push([...cmd]);
-      const code = codes[i++];
-      return code ?? 0;
+    opts: {
+      configDir: "/tmp/does-not-matter",
+      log: (l: string) => logs.push(l),
+      prompt: async () => answers.shift() ?? "",
+      runCommand: async (cmd: readonly string[]) => {
+        cmds.push([...cmd]);
+        return over.exitCode ?? 0;
+      },
     },
   };
 }
 
-function readCfg(dir: string): Record<string, unknown> | undefined {
-  const p = scribeConfigPath(dir);
-  if (!existsSync(p)) return undefined;
-  return JSON.parse(readFileSync(p, "utf8")) as Record<string, unknown>;
-}
-
-describe("walkTranscriptionStep — mode resolution (the CLI question)", () => {
-  test("none: writes no scribe config, runs no command", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner();
-      const logs: string[] = [];
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: (l) => logs.push(l),
-        transcribeMode: "none",
-        runCommand: r.run,
-        platform: "linux",
-      });
-      expect(code).toBe(0);
-      expect(r.cmds).toEqual([]);
-      expect(readCfg(h.dir)).toBeUndefined();
-      expect(logs.join("\n")).toContain("Transcription off");
-    } finally {
-      h.cleanup();
-    }
+describe("it installs through the VAULT, never through scribe", () => {
+  test("a yes runs `parachute-vault transcription install --yes`", async () => {
+    const h = harness({ answers: ["y"] });
+    expect(await walkTranscriptionStep(h.opts)).toBe(0);
+    expect(h.cmds).toEqual([["parachute-vault", "transcription", "install", "--yes"]]);
   });
 
-  test("interactive prompt: '1' chooses none", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner();
-      const answers = ["1"];
-      let i = 0;
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: () => {},
-        prompt: async () => answers[i++] ?? "",
-        runCommand: r.run,
-        platform: "linux",
-      });
-      expect(code).toBe(0);
-      expect(r.cmds).toEqual([]);
-    } finally {
-      h.cleanup();
-    }
+  test("it never shells `parachute install scribe`", async () => {
+    // The regression this rewrite exists to prevent. A retired module can't be
+    // installed, so asking and then trying is a guaranteed failure.
+    const h = harness({ answers: ["y"] });
+    await walkTranscriptionStep(h.opts);
+    const joined = h.cmds.flat().join(" ");
+    expect(joined).not.toContain("scribe");
   });
 
-  test("non-interactive stdin (no flag) DEFAULTS to none — never hangs on the prompt", async () => {
-    // Headless-hardening: with no `--transcribe-mode` flag AND a closed / non-
-    // interactive stdin, an interactive `prompt("Pick [1]:")` would busy-hang
-    // Bun's readline question() forever (the exact e2e wedge). Transcription is
-    // optional and documented as never-blocking, so resolveChoice DEFAULTS to
-    // "none" (with an honest log line) rather than throwing. We drive the real
-    // defaultPrompt (no `prompt` seam) and force isTTY=false for determinism;
-    // if the guard regressed, this test would HANG instead of passing.
-    const h = makeHarness();
-    const origIsTTY = process.stdin.isTTY;
-    Object.defineProperty(process.stdin, "isTTY", { value: false, configurable: true });
-    try {
-      const r = recordingRunner();
-      const logs: string[] = [];
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: (l) => logs.push(l),
-        // no transcribeMode, no prompt seam → real defaultPrompt would be hit
-        runCommand: r.run,
-        platform: "linux",
-      });
-      expect(code).toBe(0);
-      expect(r.cmds).toEqual([]); // nothing installed
-      expect(readCfg(h.dir)).toBeUndefined(); // no provider recorded
-      expect(logs.join("\n")).toContain("not interactive");
-      expect(logs.join("\n")).toContain("Transcription off");
-    } finally {
-      Object.defineProperty(process.stdin, "isTTY", {
-        value: origIsTTY,
-        configurable: true,
-      });
-      h.cleanup();
-    }
+  test("--yes is passed, so the vault command doesn't ask a second time", async () => {
+    // Load-bearing under `curl … | bash`: stdin is the pipe there, so a second
+    // prompt would hang rather than take a default.
+    const h = harness({ answers: ["y"] });
+    await walkTranscriptionStep(h.opts);
+    expect(h.cmds[0]).toContain("--yes");
+  });
+});
+
+describe("the question", () => {
+  test("a blank answer defaults to YES", async () => {
+    // Skipping fails silently — audio uploads and nothing transcribes it — so
+    // the safe default is to do the work.
+    const h = harness({ answers: [""] });
+    await walkTranscriptionStep(h.opts);
+    expect(h.cmds.length).toBe(1);
   });
 
-  test("interactive prompt: '3' then 'g' chooses groq cloud", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner([0]);
-      const answers = ["3", "g", "gsk_interactive"];
-      let i = 0;
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: () => {},
-        prompt: async () => answers[i++] ?? "",
-        runCommand: r.run,
-        platform: "linux",
-      });
-      expect(code).toBe(0);
-      // One install command, with the groq provider + key.
-      expect(r.cmds.length).toBe(1);
-      expect(r.cmds[0]).toEqual([
-        "parachute",
-        "install",
-        "scribe",
-        "--scribe-provider",
-        "groq",
-        "--scribe-key",
-        "gsk_interactive",
-      ]);
-    } finally {
-      h.cleanup();
+  test("'n' skips and says how to do it later", async () => {
+    const h = harness({ answers: ["n"] });
+    expect(await walkTranscriptionStep(h.opts)).toBe(0);
+    expect(h.cmds).toEqual([]);
+    expect(h.logs.join("\n")).toMatch(/transcription install/);
+  });
+
+  test("transcribeMode=none skips without prompting", async () => {
+    const h = harness();
+    await walkTranscriptionStep({ ...h.opts, transcribeMode: "none" });
+    expect(h.cmds).toEqual([]);
+  });
+
+  test("the legacy cloud spellings now mean 'set up local'", async () => {
+    // `--transcribe=groq` in someone's existing script must not error. Cloud
+    // providers are gone, so the only honest reading left is "yes, set it up".
+    for (const mode of ["local", "groq", "openai"] as const) {
+      const h = harness();
+      await walkTranscriptionStep({ ...h.opts, transcribeMode: mode });
+      expect(h.cmds).toEqual([["parachute-vault", "transcription", "install", "--yes"]]);
     }
   });
 });
 
-describe("walkTranscriptionStep — cloud (install-or-skip via the one-shot)", () => {
-  test("groq with a key: install one-shot carries provider + key", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner([0]);
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: () => {},
-        transcribeMode: "groq",
-        transcribeApiKey: "gsk_abc123",
-        runCommand: r.run,
-        platform: "linux",
-      });
-      expect(code).toBe(0);
-      expect(r.cmds[0]).toEqual([
-        "parachute",
-        "install",
-        "scribe",
-        "--scribe-provider",
-        "groq",
-        "--scribe-key",
-        "gsk_abc123",
-      ]);
-    } finally {
-      h.cleanup();
-    }
+describe("failure is never fatal to setup", () => {
+  test("a non-zero install still returns 0 from the step", async () => {
+    // `parachute init` must not fail over an optional extra the operator can
+    // retry with one command.
+    const h = harness({ answers: ["y"], exitCode: 1 });
+    expect(await walkTranscriptionStep(h.opts)).toBe(0);
   });
 
-  test("openai without a key: install one-shot omits --scribe-key + tells operator how to add it", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner([0]);
-      const logs: string[] = [];
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: (l) => logs.push(l),
-        transcribeMode: "openai",
-        transcribeApiKey: "",
-        runCommand: r.run,
-        platform: "darwin",
-      });
-      expect(code).toBe(0);
-      expect(r.cmds[0]).toEqual(["parachute", "install", "scribe", "--scribe-provider", "openai"]);
-      expect(logs.join("\n")).toContain("OPENAI_API_KEY");
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("cloud install failure: surfaces the non-zero exit + a retry hint, still exits 0", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner([1]); // install fails
-      const logs: string[] = [];
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: (l) => logs.push(l),
-        transcribeMode: "groq",
-        transcribeApiKey: "gsk_x",
-        runCommand: r.run,
-        platform: "linux",
-      });
-      expect(code).toBe(0); // non-fatal — doesn't block the wizard
-      expect(logs.join("\n")).toContain("returned 1");
-    } finally {
-      h.cleanup();
-    }
-  });
-});
-
-describe("walkTranscriptionStep — local install-or-skip", () => {
-  test("Linux, ample RAM, install succeeds: install-backend uses onnx-asr; provider kept", async () => {
-    const h = makeHarness();
-    try {
-      // module install (writes provider via --scribe-provider), install-backend, restart
-      const r = recordingRunner([0, 0, 0]);
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: () => {},
-        transcribeMode: "local",
-        runCommand: r.run,
-        platform: "linux",
-        availableRamMib: 4096,
-      });
-      expect(code).toBe(0);
-      // Module install pins the resolved Linux backend, NOT parakeet-mlx.
-      expect(r.cmds[0]).toEqual([
-        "parachute",
-        "install",
-        "scribe",
-        "--scribe-provider",
-        "onnx-asr",
-      ]);
-      // scribe's own runnable install routine, targeting onnx-asr.
-      expect(r.cmds[1]).toEqual(["parachute-scribe", "install-backend", "--provider", "onnx-asr"]);
-      // A restart so the running scribe picks up the engine.
-      expect(r.cmds[2]).toEqual(["parachute", "restart", "scribe"]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("macOS local resolves to parakeet-mlx", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner([0, 0, 0]);
-      await walkTranscriptionStep({
-        configDir: h.dir,
-        log: () => {},
-        transcribeMode: "local",
-        runCommand: r.run,
-        platform: "darwin",
-        availableRamMib: 16384,
-      });
-      expect(r.cmds[1]).toEqual([
-        "parachute-scribe",
-        "install-backend",
-        "--provider",
-        "parakeet-mlx",
-      ]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("install-backend FAILS: clears the provisional provider (no dead string) + points at cloud", async () => {
-    const h = makeHarness();
-    try {
-      // module install OK, install-backend FAILS (exit 3). No restart should run.
-      const r = recordingRunner([0, 3]);
-      const logs: string[] = [];
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: (l) => logs.push(l),
-        transcribeMode: "local",
-        runCommand: r.run,
-        platform: "linux",
-        availableRamMib: 4096,
-      });
-      expect(code).toBe(0);
-      // Only two commands ran — the failed install-backend, no restart.
-      expect(r.cmds.length).toBe(2);
-      expect(r.cmds.some((c) => c[0] === "parachute" && c[1] === "restart")).toBe(false);
-      // The provisional provider write (by the install one-shot in production)
-      // is cleared. We simulate the install having written it by checking the
-      // step never leaves a transcribe.provider on its own write path — and the
-      // honest cloud steer is logged.
-      expect(logs.join("\n")).toContain("install failed");
-      expect(logs.join("\n")).toContain("Cloud alternative");
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("RAM below floor: REFUSES local, records nothing, steers to cloud one-shot", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner();
-      const logs: string[] = [];
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: (l) => logs.push(l),
-        transcribeMode: "local",
-        runCommand: r.run,
-        platform: "linux",
-        availableRamMib: 900, // 1 GB droplet
-      });
-      expect(code).toBe(0);
-      // Nothing installed, nothing recorded.
-      expect(r.cmds).toEqual([]);
-      expect(readCfg(h.dir)).toBeUndefined();
-      const joined = logs.join("\n");
-      expect(joined).toContain("isn't possible");
-      expect(joined).toContain("parachute install scribe --scribe-provider groq");
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("unsupported platform: REFUSES local + steers to cloud, no install", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner();
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: () => {},
-        transcribeMode: "local",
-        runCommand: r.run,
-        platform: "win32",
-        availableRamMib: 99999,
-      });
-      expect(code).toBe(0);
-      expect(r.cmds).toEqual([]);
-      expect(readCfg(h.dir)).toBeUndefined();
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("module install fails before the engine: clears provider, no install-backend run", async () => {
-    const h = makeHarness();
-    try {
-      const r = recordingRunner([5]); // module install fails
-      const code = await walkTranscriptionStep({
-        configDir: h.dir,
-        log: () => {},
-        transcribeMode: "local",
-        runCommand: r.run,
-        platform: "linux",
-        availableRamMib: 4096,
-      });
-      expect(code).toBe(0);
-      expect(r.cmds.length).toBe(1);
-      expect(r.cmds[0]?.[1]).toBe("install");
-    } finally {
-      h.cleanup();
-    }
+  test("and it says what to run to retry + to diagnose", async () => {
+    const h = harness({ answers: ["y"], exitCode: 1 });
+    await walkTranscriptionStep(h.opts);
+    const out = h.logs.join("\n");
+    expect(out).toMatch(/transcription install/);
+    expect(out).toMatch(/transcription status/);
   });
 });

--- a/src/__tests__/wizard.test.ts
+++ b/src/__tests__/wizard.test.ts
@@ -596,7 +596,12 @@ describe("runCliWizard", () => {
     expect(transcribeCmds).toEqual([]);
   });
 
-  test("transcription step (cloud) drives the install one-shot via the injected runner", async () => {
+  test("a legacy cloud mode now drives the VAULT install, not scribe", async () => {
+    // `--transcribe-mode=groq` used to shell `parachute install scribe
+    // --scribe-provider groq`. Scribe is retired (hub#809), so that command can
+    // only fail. The historical spellings still parse — an existing script
+    // shouldn't error — and now mean "set up local transcription", which is the
+    // only thing left for them to mean.
     const { fetchImpl } = makeFakeHub();
     const transcribeCmds: string[][] = [];
     const code = await runCliWizard({
@@ -618,15 +623,7 @@ describe("runCliWizard", () => {
       },
     });
     expect(code).toBe(0);
-    expect(transcribeCmds[0]).toEqual([
-      "parachute",
-      "install",
-      "scribe",
-      "--scribe-provider",
-      "groq",
-      "--scribe-key",
-      "gsk_wired",
-    ]);
+    expect(transcribeCmds[0]).toEqual(["parachute-vault", "transcription", "install", "--yes"]);
   });
 
   test("transcription step is skipped when configDir is absent", async () => {
@@ -719,8 +716,8 @@ describe("runCliWizard", () => {
         },
       });
       expect(code).toBe(0); // completed, did NOT throw
-      expect(ran).toBe(false); // none → no scribe install
-      expect(logs.join("\n")).toContain("Transcription off");
+      expect(ran).toBe(false); // headless with no flag → nothing installed
+      expect(logs.join("\n")).toContain("Skipped.");
       // Full flow still walked account → vault → expose.
       expect(state.posted.map((p) => p.path)).toEqual([
         "/admin/setup/account",

--- a/src/commands/wizard-transcription.ts
+++ b/src/commands/wizard-transcription.ts
@@ -2,319 +2,125 @@
  * Transcription step for the CLI setup wizard (`parachute setup-wizard` /
  * `parachute init`).
  *
- * Until now the CLI wizard NEVER asked about transcription — it walked
- * Account → Vault → Expose and stopped, while the browser wizard's vault step
- * folds a full scribe sub-form (none / cloud + key / local). That divergence
- * is the "asks different questions in its CLI vs browser forms" root cause from
- * the onboarding-streamline arc. This module brings the CLI to parity.
+ * ## Why this file shrank from 320 lines to ~110
  *
- * Crucially it follows the arc's "never ask without doing" rule: when the
- * operator picks a provider we ACTUALLY set it up, or honestly say we couldn't
- * and point at the alternative — we never record a dead provider string.
+ * It used to offer scribe's model — none / a cloud provider + API key / a local
+ * engine, with a RAM gate and a platform gate — then shell
+ * `parachute install scribe --scribe-provider …`. Scribe is retired (hub#809),
+ * so every non-`none` choice dead-ended in "✗ scribe install returned 1". A
+ * question that cannot be answered successfully is worse than no question.
  *
- *   - **none**  → write nothing; say transcription is off + how to turn it on.
- *   - **cloud** (groq / openai) → write provider + key (scribe-config.ts), then
- *     install + start scribe via the hub's own `parachute install scribe`
- *     one-shot. The very-first scribe boot reads the provider we just wrote.
- *   - **local** → RAM/platform-gate FIRST (decideLocalProvider). If the box
- *     can't run a local model (no backend for the platform, or < 2 GB RAM) we
- *     do NOT write `local` — we explain why + steer to the cloud one-shot. If
- *     it can, we install scribe, then run scribe's own runnable install routine
- *     (`parachute-scribe install-backend --provider <onnx-asr|parakeet-mlx>`,
- *     scribe PR #79) which apt/pip-installs the engine + warm-pulls the model
- *     and exits non-zero on hard failure. On success we record the resolved
- *     platform provider; on failure we say so + point at cloud, recording
- *     nothing.
+ * Transcription lives in the vault now: `parachute-vault transcription install`
+ * picks a whisper.cpp engine and a model sized to this host's RAM, downloads
+ * them, and VERIFIES it can actually transcribe before reporting success. So
+ * the RAM gate, the platform gate, the provider choice and the API-key prompt
+ * all belong to the vault — and the branch collapses to one yes/no.
  *
- * Everything that touches the host (subprocess spawn, RAM probe, the prompt)
- * goes through an injected seam so tests exercise every branch WITHOUT
- * installing anything or shelling out.
+ * The wizard still ASKS, because doing this at install time is the difference
+ * between a box that transcribes voice notes and one where the operator finds
+ * out months later that it never did. It just asks a question something can
+ * answer.
+ *
+ * Keeps the arc's "never ask without doing" rule: yes really installs, and a
+ * failure says so plainly instead of leaving a half-configured box. Never
+ * fatal — a Parachute that can't transcribe is still a working Parachute, and
+ * failing setup over an optional extra is a worse outcome than a warning.
  */
-
-import { createInterface } from "node:readline/promises";
-import {
-  type ScribeProviderKey,
-  apiKeyEnvFor,
-  clearScribeProvider,
-  decideLocalProvider,
-  readAvailableRamMib,
-} from "../scribe-config.ts";
 
 /** Outcome of one subprocess. Exit code only — stdio is inherited / streamed. */
 export type WizardCommandRunner = (cmd: readonly string[]) => Promise<number>;
 
 export interface TranscriptionStepOpts {
-  /** `~/.parachute` (or the PARACHUTE_HOME override). Where scribe config lives. */
+  /** `~/.parachute` (or the PARACHUTE_HOME override). */
   configDir: string;
   /** Log shim — production prints to stdout; tests capture into an array. */
   log: (line: string) => void;
   /** Prompt seam — production uses readline; tests inject a scripted queue. */
   prompt?: (question: string) => Promise<string>;
   /**
-   * Pre-supply the choice non-interactively (mirrors the wizard's other
-   * run-from-flag escapes). `none` | `local` | a cloud provider name.
+   * Pre-supply the answer non-interactively (mirrors the wizard's other
+   * run-from-flag escapes).
+   *
+   * The historical spellings are all still accepted so an existing
+   * `--transcribe=…` in someone's script keeps working: `none` means skip, and
+   * `local` / `groq` / `openai` all now mean "set up local transcription",
+   * because that is the only thing left for them to mean. Silently redirecting
+   * a cloud choice is defensible precisely because the alternative is the
+   * error this rewrite exists to delete.
    */
   transcribeMode?: "none" | "local" | "groq" | "openai";
-  /** Pre-supplied cloud API key (for `groq` / `openai`). */
-  transcribeApiKey?: string;
-  /**
-   * Command runner seam. Production spawns the real binary inheriting stdio;
-   * tests inject a recorder so nothing installs. Receives a full argv —
-   * `["parachute", "install", "scribe", ...]` or
-   * `["parachute-scribe", "install-backend", "--provider", "onnx-asr"]`.
-   */
+  /** Command runner seam. Tests inject a recorder so nothing installs. */
   runCommand?: WizardCommandRunner;
-  /** Platform override (test seam). Defaults to the real host platform. */
-  platform?: NodeJS.Platform;
-  /** Available-RAM override in MiB (test seam). Defaults to the real probe. */
-  availableRamMib?: number | null;
 }
 
-/** Default readline prompt (matches wizard.ts's defaultPrompt). */
+/**
+ * Default readline prompt. A non-TTY returns the empty answer rather than
+ * throwing: this step is optional and must NEVER block setup on a headless box
+ * (the same posture the previous version took, and worth keeping).
+ */
 async function defaultPrompt(question: string): Promise<string> {
-  // Non-TTY guard (headless-hardening): unlike wizard.ts's required-step
-  // prompts (which throw), the transcription step is optional and must NEVER
-  // block setup. On a closed / non-interactive stdin, return the empty answer
-  // — which the callers already treat as a benign default (a blank cloud API
-  // key means "set it later"; a blank local-install confirm takes the [Y]
-  // default). `resolveChoice` short-circuits to "none" before ever reaching
-  // here without a flag; this covers the flag-supplied-mode downstream prompts.
   if (!process.stdin.isTTY) return "";
-  const rl = createInterface({ input: process.stdin, output: process.stdout });
-  try {
-    return await rl.question(question);
-  } finally {
-    rl.close();
-  }
+  process.stdout.write(question);
+  for await (const line of console) return line;
+  return "";
 }
 
-/**
- * Default command runner: spawn the binary, inherit stdio so the operator sees
- * apt/pip progress in real time, resolve to the exit code. Never throws — a
- * spawn failure (binary not on PATH) surfaces as a non-zero code, which the
- * caller treats as "couldn't install."
- */
-const defaultRunCommand: WizardCommandRunner = async (cmd) => {
-  try {
-    const proc = Bun.spawn([...cmd], {
-      stdout: "inherit",
-      stderr: "inherit",
-      stdin: "inherit",
-    });
-    return await proc.exited;
-  } catch {
-    return 127; // ENOENT / spawn failure → "command not found"
-  }
-};
+async function defaultRunCommand(cmd: readonly string[]): Promise<number> {
+  const proc = Bun.spawn([...cmd], { stdin: "inherit", stdout: "inherit", stderr: "inherit" });
+  return await proc.exited;
+}
 
-/**
- * Walk the transcription step. Returns 0 always — a transcription that
- * couldn't be set up is reported honestly but does NOT fail the wizard (the
- * operator can finish setup and add it later; it's not a blocking step).
- */
+/** Resolve the answer from a flag, else ask. Interactive blank ⇒ yes; headless ⇒ skip. */
+async function resolveWanted(
+  opts: TranscriptionStepOpts,
+  prompt: (q: string) => Promise<string>,
+): Promise<boolean> {
+  if (opts.transcribeMode !== undefined) return opts.transcribeMode !== "none";
+  // Headless with no flag ⇒ SKIP, preserving the previous contract. A blank
+  // answer here means "nobody is there", not "yes" — and unprompted, a yes
+  // downloads several hundred megabytes onto a box whose operator never saw
+  // the question. An interactive blank is a different thing: a person read the
+  // prompt and pressed enter.
+  if (!process.stdin.isTTY && opts.prompt === undefined) return false;
+  const answer = (await prompt("  Set up transcription now? [Y/n]: ")).trim().toLowerCase();
+  // Interactive blank defaults to YES: the operator is walking a setup wizard,
+  // the work is a download plus a verification, and skipping fails silently —
+  // audio uploads and nothing ever transcribes it.
+  return answer !== "n" && answer !== "no";
+}
+
 export async function walkTranscriptionStep(opts: TranscriptionStepOpts): Promise<number> {
   const log = opts.log;
   const prompt = opts.prompt ?? defaultPrompt;
   const runCommand = opts.runCommand ?? defaultRunCommand;
-  const platform = opts.platform ?? process.platform;
 
   log("");
-  log("Step — Transcription (scribe)");
-  log("  Parachute can transcribe voice notes + audio attachments. Pick a");
-  log("  transcription engine, or skip and add one later.");
+  log("Step — Transcription");
+  log("  Turn voice notes and audio attachments into text, on this machine.");
+  log("  The audio never leaves the box.");
 
-  // Resolve the choice (flag or prompt).
-  const choice = await resolveChoice(opts, prompt, log);
-  if (choice === "none") {
+  if (!(await resolveWanted(opts, prompt))) {
     log("");
-    log("  Transcription off. Turn it on later with `parachute install scribe`.");
+    log("  Skipped. Set it up any time with `parachute-vault transcription install`.");
     return 0;
   }
 
-  if (choice === "local") {
-    return await handleLocal(opts, prompt, runCommand, platform, log);
-  }
-
-  // Cloud provider (groq / openai).
-  return await handleCloud(opts, choice, prompt, runCommand, log);
-}
-
-type ResolvedChoice = "none" | "local" | "groq" | "openai";
-
-async function resolveChoice(
-  opts: TranscriptionStepOpts,
-  prompt: (q: string) => Promise<string>,
-  log: (l: string) => void,
-): Promise<ResolvedChoice> {
-  if (opts.transcribeMode !== undefined) return opts.transcribeMode;
-  // Non-TTY guard (headless-hardening): with no `--transcribe-mode` flag AND a
-  // closed / non-interactive stdin (cloud-init, ssh heredoc, the e2e
-  // container), the real `defaultPrompt`'s `prompt("Pick [1]:")` would busy-hang
-  // forever on Bun's `readline/promises` question() — the exact wedge that
-  // timed out the Tier-1 e2e. Transcription is optional / opt-in and documented
-  // as NEVER blocking setup, so we DEFAULT to "none" (not throw — unlike the
-  // required account / vault / expose prompts in wizard.ts) with an honest log
-  // line. Guarded on `opts.prompt === undefined` so an injected prompt seam (a
-  // scripted test queue, or a caller supplying its own reader) is still honored
-  // — the wedge only exists for the real readline-backed default prompt.
-  if (opts.prompt === undefined && !process.stdin.isTTY) {
-    log("");
-    log("  stdin is not interactive — defaulting transcription to none.");
-    log("  Turn it on later with `parachute install scribe` (or re-run with --transcribe-mode).");
-    return "none";
-  }
   log("");
-  log("  1) None — skip transcription (default)");
-  log("  2) Local — run the engine on this box (no API key, needs ~2 GB RAM)");
-  log("  3) Cloud — Groq or OpenAI (fast, needs an API key, ~$0.04/hr of audio)");
-  for (let attempt = 0; attempt < 5; attempt++) {
-    const raw = (await prompt("  Pick [1]: ")).trim().toLowerCase();
-    if (raw === "" || raw === "1" || raw === "none" || raw === "n") return "none";
-    if (raw === "2" || raw === "local" || raw === "l") return "local";
-    if (raw === "3" || raw === "cloud" || raw === "c") {
-      // Sub-pick which cloud provider.
-      for (let inner = 0; inner < 5; inner++) {
-        const which = (await prompt("  Cloud provider — [g]roq (default) or [o]penai: "))
-          .trim()
-          .toLowerCase();
-        if (which === "" || which === "g" || which === "groq") return "groq";
-        if (which === "o" || which === "openai") return "openai";
-        log(`  Sorry — expected groq or openai (got "${which}"). Try again.`);
-      }
-      log("  Too many invalid entries; skipping transcription.");
-      return "none";
-    }
-    if (raw === "groq" || raw === "g") return "groq";
-    if (raw === "openai" || raw === "o") return "openai";
-    log(`  Sorry — expected 1, 2, or 3 (got "${raw}"). Try again.`);
-  }
-  log("  Too many invalid entries; skipping transcription.");
-  return "none";
-}
+  log("  Downloading a speech model sized to this machine, then verifying it…");
+  // `--yes` because the wizard already asked. Without it the vault command
+  // asks again — and under `curl … | bash` stdin is the pipe, so that second
+  // prompt would hang rather than default.
+  const code = await runCommand(["parachute-vault", "transcription", "install", "--yes"]);
 
-async function handleCloud(
-  opts: TranscriptionStepOpts,
-  provider: "groq" | "openai",
-  prompt: (q: string) => Promise<string>,
-  runCommand: WizardCommandRunner,
-  log: (l: string) => void,
-): Promise<number> {
-  const envKey = apiKeyEnvFor(provider as ScribeProviderKey);
-  let apiKey = opts.transcribeApiKey;
-  if (apiKey === undefined && envKey) {
-    apiKey = (await prompt(`  Paste your ${envKey} (or blank to set later): `)).trim();
-  }
-
-  // Install + start scribe via the EXISTING one-shot path, handing it the
-  // chosen provider + key. `parachute install scribe --scribe-provider <p>
-  // [--scribe-key <k>]` writes the provider into scribe's config + the key into
-  // scribe/.env and starts the module — the same wiring the bare CLI install
-  // does. Passing the provider also suppresses install's own interactive
-  // provider prompt (it's already an explicit choice).
-  const cmd = ["parachute", "install", "scribe", "--scribe-provider", provider];
-  if (envKey && apiKey && apiKey.length > 0) {
-    cmd.push("--scribe-key", apiKey);
-  }
-  log("");
-  log(`  Installing scribe with the ${provider} cloud provider…`);
-  const code = await runCommand(cmd);
-  if (code !== 0) {
-    log(`  ✗ scribe install returned ${code}. Retry: \`${cmd.join(" ")}\`.`);
-    return 0;
-  }
-  if (envKey && !(apiKey && apiKey.length > 0)) {
-    log(
-      `  ✓ Recorded ${provider}. Add ${envKey} later: \`echo '${envKey}=<value>' >> ${opts.configDir}/scribe/.env\` then \`parachute restart scribe\`.`,
-    );
-  } else {
-    log(`  ✓ Scribe installed and running with the ${provider} cloud provider.`);
-  }
-  return 0;
-}
-
-async function handleLocal(
-  opts: TranscriptionStepOpts,
-  prompt: (q: string) => Promise<string>,
-  runCommand: WizardCommandRunner,
-  platform: NodeJS.Platform,
-  log: (l: string) => void,
-): Promise<number> {
-  const ramMib =
-    opts.availableRamMib !== undefined ? opts.availableRamMib : readAvailableRamMib(platform);
-  const decision = decideLocalProvider(platform, ramMib);
-
-  if (!decision.ok) {
-    // Can't install local here — say EXACTLY why + point at the cloud one-shot.
-    // Do NOT record a dead `local` provider string.
-    log("");
-    log(`  ✗ Local transcription isn't possible on this box: ${decision.reason}`);
-    log("");
-    log("  One-shot cloud alternative — get a free Groq key at https://console.groq.com,");
-    log("  then run:");
-    log("    parachute install scribe --scribe-provider groq --scribe-key gsk_…");
-    log("  (or re-run this wizard and choose Cloud).");
+  if (code === 0) {
+    log("  ✓ Transcription ready.");
     return 0;
   }
 
-  const provider = decision.provider as "parakeet-mlx" | "onnx-asr";
-  log("");
-  log(`  This box can run ${provider} locally.`);
-
-  // Confirm before the (slow, apt/pip) install unless pre-supplied.
-  if (opts.transcribeMode === undefined) {
-    const ok = (await prompt(`  Install ${provider} now? [Y/n]: `)).trim().toLowerCase();
-    if (ok === "n" || ok === "no") {
-      log(
-        "  Skipped. Install later with `parachute-scribe install-backend` or re-run this wizard.",
-      );
-      return 0;
-    }
-  }
-
-  // Install the scribe module first, recording the resolved provider so install
-  // doesn't prompt for one. (We UNDO this record below if the engine install
-  // fails — so a failure never leaves a dead provider string.)
-  log("");
-  log("  Installing the scribe module…");
-  const moduleCode = await runCommand([
-    "parachute",
-    "install",
-    "scribe",
-    "--scribe-provider",
-    provider,
-  ]);
-  if (moduleCode !== 0) {
-    clearScribeProvider(opts.configDir);
-    log(`  ✗ scribe module install returned ${moduleCode} — not recording a local provider.`);
-    return 0;
-  }
-
-  // Run scribe's OWN runnable install routine (scribe PR #79). It apt/pip-
-  // installs the engine, warm-pulls the model, and exits non-zero on hard
-  // failure (no engine on PATH, too little RAM on its own re-check, etc.).
-  log("");
-  log(`  Installing the ${provider} engine via scribe (this can take a few minutes)…`);
-  // The `--provider <p>` FLAG form is intentional (not the positional
-  // `install-backend <p>`): scribe's cmdInstallBackend reads it via getFlag
-  // when args[1] starts with "-". If scribe ever moves off its module-level
-  // `args` global, re-confirm this flag is still honored.
-  const code = await runCommand(["parachute-scribe", "install-backend", "--provider", provider]);
-  if (code !== 0) {
-    // HONEST skip — undo the provisional provider record; do NOT leave a dead
-    // provider string scribe can't honor.
-    clearScribeProvider(opts.configDir);
-    log("");
-    log(`  ✗ ${provider} install failed (exit ${code}); not recording it as the provider.`);
-    log(
-      "    Cloud alternative: `parachute install scribe --scribe-provider groq --scribe-key gsk_…`",
-    );
-    return 0;
-  }
-
-  // Engine installed + verified by scribe — keep the provider recorded (the
-  // install step already wrote it) and restart so the running scribe picks it up.
-  log("");
-  log(`  ✓ ${provider} installed and recorded as the transcription provider.`);
-  await runCommand(["parachute", "restart", "scribe"]);
+  // Deliberately returns 0. A non-zero here would fail `parachute init` over
+  // something the operator can retry with one command.
+  log(`  ✗ Transcription setup returned ${code} — everything else is fine.`);
+  log("    Retry any time:        parachute-vault transcription install");
+  log("    See what's missing:    parachute-vault transcription status");
   return 0;
 }


### PR DESCRIPTION
> *"If init is asking about transcription, it should be doing it through the vault."*

## The step was asking a question nothing could answer

`parachute init` asked about transcription, then shelled `parachute install scribe --scribe-provider …` for every non-`none` choice. hub#809 retired scribe, so that command now refuses — the step dead-ended in:

```
✗ scribe install returned 1
```

Live but always failing. A question that can't be answered successfully is worse than no question.

## Now it installs through the vault

`parachute-vault transcription install --yes` picks a whisper.cpp engine and a model sized to the host's RAM, downloads them, and **verifies it can actually transcribe** before reporting success.

The file drops **320 → ~110 lines**, because the whole scribe apparatus belongs to the vault now: provider choice, API-key prompt, RAM gate, platform gate. What's left is one yes/no.

## Two contracts preserved deliberately

**Headless with no flag still skips.** A blank answer from a non-TTY means "nobody is there", not "yes" — an unprompted yes downloads several hundred MB onto a box whose operator never saw the question. An *interactive* blank is a different thing: a person read the prompt and pressed enter, so that defaults to yes.

I had this wrong in the first draft (blank ⇒ yes everywhere) and a existing test caught it — it asserted the headless contract explicitly. Good test.

**Failure is never fatal.** The step returns 0 even when the install fails, and names both the retry and the diagnose command. Failing `parachute init` over an optional extra is a worse outcome than a warning.

## Back-compat

The legacy `--transcribe-mode` spellings (`local` / `groq` / `openai`) all now mean "set up local transcription" — an existing script keeps working rather than erroring. Silently redirecting a cloud choice is defensible precisely because the alternative is the failure this deletes.

## Verification

- `bun test ./src` — **4463 pass**, 0 fail · typecheck + biome clean
- Tests rewritten around the new contract: never shells scribe, `--yes` is passed (load-bearing under `curl | bash`, where a second prompt would hang), headless skips, failure returns 0 with retry guidance

Closes the last piece of *"first install sets up vault + app + transcription."*