### PR TITLE
fix(account): the /account/* 403 names the scope the caller must request

### DIFF
--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -408,6 +408,67 @@ describe("account API — auth gates", () => {
     }
   });
 
+  // LOAD-BEARING (the whole point of not advertising `account:*`).
+  //
+  // Handoff §4 settles that `account:*` stays out of `scopes_supported` — RFC
+  // 8414 §2 / RFC 9728 §2 permit it and MCP's spec wants the minimal set — on
+  // the explicit grounds that discovery happens AT THE POINT OF REFUSAL, via
+  // the RFC 6750 §3 `scope` challenge parameter. `AdminAuthError.requiredScope`
+  // exists solely to carry it (admin-auth.ts:33-50). `requireScope` passed it;
+  // `requireAnyScope` did not, so every `/account/*` route — the exact surface
+  // account scopes were invented for — refused without saying what to ask for.
+  //
+  // The prior 403 test above asserts only the JSON body, which is why the gap
+  // survived: `error_description` is prose for humans, `scope` is the field a
+  // client parses. Assert the HEADER.
+  test("403 names the missing scope in the RFC 6750 `scope` challenge parameter", async () => {
+    const h = makeHarness();
+    try {
+      const token = await bearer(h, ["vault:beta:read"]);
+      const res = await handleAccountListVaults(withBearer("/account/vaults", token), deps(h));
+      expect(res.status).toBe(403);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain('error="insufficient_scope"');
+      // Read the `scope` parameter itself, not the whole header: the prose in
+      // `error_description` does list every acceptable scope, and asserting on
+      // the raw string would pass on that alone — which is the exact
+      // false-negative that let the omission ship.
+      const scopeParam = /(?:^|[\s,])scope="([^"]*)"/.exec(challenge)?.[1];
+      // The narrowest scope an account-door client can actually request — NOT
+      // the host scope it also would have been accepted with, and not a list.
+      expect(scopeParam).toBe(ACCOUNT_READ_SCOPE);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // Mutations advertise the admin scope, not the read one — a client that got
+  // `account:self:read` from the list route and then tried to create a vault
+  // must be told to step UP, not handed the scope it already has.
+  test("a mutation 403 challenges for account:self:admin, not account:self:read", async () => {
+    const h = makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const res = await handleAccountCreateVault(
+        new Request("http://127.0.0.1:1939/account/vaults", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ name: "probe" }),
+        }),
+        deps(h),
+      );
+      expect(res.status).toBe(403);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      const scopeParam = /(?:^|[\s,])scope="([^"]*)"/.exec(challenge)?.[1];
+      expect(scopeParam).toBe(ACCOUNT_ADMIN_SCOPE);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("a plain parachute:host:admin token is accepted (H1-independent)", async () => {
     const h = makeHarness();
     try {

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -74,11 +74,15 @@ const ACCOUNT_API_CLIENT_ID = "parachute-account";
  * carries `account:self:admin`; a plain operator/host-admin token carries
  * `parachute:host:admin`. Either is accepted so H2 works independent of H1's
  * merge order (SCOPE-b).
+ *
+ * ORDER IS LOAD-BEARING: `requireAnyScope` puts `[0]` in the RFC 6750 `scope`
+ * challenge, so the narrowest scope an account-door client should request must
+ * come first.
  */
 const ADMIN_SCOPES: readonly string[] = [ACCOUNT_SELF_ADMIN_SCOPE, HOST_ADMIN_SCOPE];
 /** Scopes that satisfy a `/account/*` READ. `admin ⊇ read`, spelled explicitly
  * because the hub's `requireScope` does an exact-string membership check (no
- * inheritance expansion at validate time). */
+ * inheritance expansion at validate time). Narrowest-first, per ADMIN_SCOPES. */
 const READ_SCOPES: readonly string[] = [
   ACCOUNT_SELF_READ_SCOPE,
   ACCOUNT_SELF_ADMIN_SCOPE,
@@ -139,6 +143,14 @@ function methodNotAllowed(allow: string): Response {
  * a SET of scopes rather than a single required one, so `/account/*` can accept
  * `account:self:*` OR `parachute:host:admin`. Throws `AdminAuthError` (401/403);
  * callers translate via `adminAuthErrorResponse`.
+ *
+ * The 403 carries `acceptable[0]` as `AdminAuthError.requiredScope`, so the
+ * challenge names a scope the caller can actually request. FIRST, not the whole
+ * set: RFC 6750 §3 permits a space-delimited `scope` list, but a list here
+ * would read as "you need all of these" when any ONE suffices — and the other
+ * entries are host scopes an account-door client should never ask for. Both
+ * sets below are ordered narrowest-account-scope-first for exactly this reason;
+ * keep them that way.
  */
 export async function requireAnyScope(
   db: Database,
@@ -160,7 +172,11 @@ export async function requireAnyScope(
   const scopes =
     typeof scopeClaim === "string" ? scopeClaim.split(/\s+/).filter((s) => s.length > 0) : [];
   if (!acceptable.some((s) => scopes.includes(s))) {
-    throw new AdminAuthError(403, `token missing one of required scopes: ${acceptable.join(", ")}`);
+    throw new AdminAuthError(
+      403,
+      `token missing one of required scopes: ${acceptable.join(", ")}`,
+      acceptable[0],
+    );
   }
   const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
   const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;


### PR DESCRIPTION
Account scopes are deliberately kept out of `scopes_supported` (RFC 8414 §2 and RFC 9728 §2 both permit it), and the whole justification is that discovery happens at the point of refusal via the RFC 6750 §3 `scope` challenge parameter. That parameter was not being sent.

`AdminAuthError` carries a `requiredScope` field with 18 lines of comment explaining exactly this design (`src/admin-auth.ts:33-50`), and `buildChallenge` only emits `scope=` when it is set (`admin-auth.ts:145`). There are two throw sites. `requireScope` passes it; `requireAnyScope` (`src/account-api.ts:163`) did not — and `requireAnyScope` guards **every** `/account/*` route, the exact surface the feature was written for. So the discovery mechanism worked everywhere except where account scopes live.

Live before: `POST /account/vaults` → 403 with the missing scope named only in `error_description` prose. After: `scope="account:self:admin"` on a mutation, `scope="account:self:read"` on a read.

RFC 6750 §3 allows a space-delimited list and this guard accepts any *one* of two scopes. I send the single narrower scope rather than the pair: a list reads as "you need all of these" when any one suffices, and the other entry is a host scope an account-door client should never request. That reasoning is in the diff so it can be argued with.

Mutation-tested: revert the one-argument change and both new tests fail. The tests read the `scope` parameter out of the header with a regex rather than substring-matching — the prose lists every acceptable scope, so a naive `toContain` passes on that alone.
