### PR TITLE
fix(lifecycle): start <svc> on a clean box exits 1 in silence

### DIFF
--- a/src/__tests__/lifecycle.test.ts
+++ b/src/__tests__/lifecycle.test.ts
@@ -446,6 +446,63 @@ describe("§7.5 no-unit path in start/stop/restart", () => {
     }
   });
 
+  // LOAD-BEARING: the offer is ENABLED (which is what cli.ts always passes) and
+  // returns `no-offer` — the one outcome that returns without logging anything
+  // (migrate-offer.ts:160,162: a supervised box, or a CLEAN box with no
+  // prior-detached evidence). A clean box is every container and every fresh
+  // install, so this is the common shape, not an edge case.
+  //
+  // Gating the fallback print on `enabled` instead of on "did the offer say
+  // anything" made `parachute start <svc>` exit 1 with ZERO bytes on stdout and
+  // stderr there — reproduced live before this fix. The test above only covers
+  // the offer-DISABLED path, which is why the gap survived; and the declined /
+  // migrate-failed tests below pass `log: () => {}`, discarding the evidence.
+  test("no unit + offer enabled but silent (no-offer) → still surfaces the actionable error", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const log: string[] = [];
+      const offerStub = makeOfferStub("no-offer");
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(1);
+      expect(offerStub.calls).toBe(1);
+      // Never exit non-zero in silence.
+      expect(log.length).toBeGreaterThan(0);
+      expect(log.join("\n")).toMatch(/No supervised hub unit is installed/);
+      expect(log.join("\n")).toMatch(/parachute migrate --to-supervised/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // The other half of the contract: an outcome that DID speak for itself must not
+  // be followed by the generic line. Without this, "always print" would pass the
+  // test above while double-printing at the operator.
+  test("declined → the verb does NOT double-print the generic migrate error", async () => {
+    const h = makeHarness();
+    try {
+      seedVault(h.manifestPath);
+      const log: string[] = [];
+      const offerStub = makeOfferStub("declined");
+      const code = await start("vault", {
+        configDir: h.configDir,
+        manifestPath: h.manifestPath,
+        log: (l) => log.push(l),
+        migrateOffer: { enabled: true, offer: offerStub.offer },
+      });
+      expect(code).toBe(1);
+      expect(offerStub.calls).toBe(1);
+      expect(log.join("\n")).not.toMatch(/No supervised hub unit is installed/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("start: accept+migrate → dispatches through the supervisor (no detached spawn)", async () => {
     const h = makeHarness();
     try {

--- a/src/commands/lifecycle.ts
+++ b/src/commands/lifecycle.ts
@@ -286,19 +286,32 @@ function resolveSupervisor(opts: LifecycleOpts["supervisor"]): ResolvedSuperviso
  * Called when a verb finds NO hub unit installed (Phase 5b removed the detached
  * spawners, so there is no detached arm to fall back to). When the offer is
  * enabled, it runs `offerMigrateToSupervised` (which itself checks "no unit +
- * prior detached" and prompts / prints). Returns `true` ONLY when the operator
+ * prior detached" and prompts / prints). `ready` is true ONLY when the operator
  * accepted AND the cutover succeeded — i.e. the box is NOW supervised, so the
  * caller can dispatch through the supervisor path. Every other outcome (offer
- * disabled, no-offer, declined, printed in a non-TTY, migrate-failed) returns
- * `false` → the caller surfaces the actionable "run `parachute migrate
- * --to-supervised`" error (NOT a detached spawn — that path is gone).
+ * disabled, no-offer, declined, printed in a non-TTY, migrate-failed) leaves
+ * `ready` false and the verb exits non-zero (NOT a detached spawn — that path
+ * is gone). WHO tells the operator why is the second flag's job, below.
  *
- * The migrate-failed case deliberately returns `false`: a failed cutover leaves
+ * The migrate-failed case deliberately returns not-ready: a failed cutover leaves
  * the box un-migrated (the cutover is fail-safe + re-runnable), so the verb
  * surfaces the error rather than dispatching into a supervisor that isn't up.
+ *
+ * `surfaced` reports whether the offer printed anything, so the caller knows
+ * whether it still owes the operator a message. `no-offer` is the ONE outcome
+ * that returns in silence (`migrate-offer.ts:160,162` — a supervised box, or a
+ * clean box with no prior-detached evidence); `printed` / `declined` /
+ * `migrate-failed` each log their own guidance.
  */
-async function maybeOfferAndMigrate(r: Resolved): Promise<boolean> {
-  if (!r.migrateOffer.enabled) return false;
+interface OfferAttempt {
+  /** The box is now supervised — dispatch through the supervisor arm. */
+  ready: boolean;
+  /** The offer already told the operator something; don't double-print. */
+  surfaced: boolean;
+}
+
+async function maybeOfferAndMigrate(r: Resolved): Promise<OfferAttempt> {
+  if (!r.migrateOffer.enabled) return { ready: false, surfaced: false };
   const result = await r.migrateOffer.offer({
     configDir: r.configDir,
     manifestPath: r.manifestPath,
@@ -309,9 +322,9 @@ async function maybeOfferAndMigrate(r: Resolved): Promise<boolean> {
     // takes the supervisor arm (the unit is freshly installed; `unitInstalled`
     // was resolved as false before the offer).
     r.sup.unitInstalled = true;
-    return true;
+    return { ready: true, surfaced: true };
   }
-  return false;
+  return { ready: false, surfaced: result.outcome !== "no-offer" };
 }
 
 /**
@@ -336,12 +349,17 @@ async function maybeOfferAndMigrate(r: Resolved): Promise<boolean> {
  */
 async function requireSupervisedOrOffer(r: Resolved): Promise<boolean> {
   if (r.sup.unitInstalled) return true;
-  const migrated = await maybeOfferAndMigrate(r);
-  if (migrated) return true;
-  // No unit and not migrated. If the offer was enabled it already surfaced its
-  // own guidance (prompt / printed command / declined note); otherwise print the
-  // actionable command so a script on a never-migrated box isn't left guessing.
-  if (!r.migrateOffer.enabled) {
+  const attempt = await maybeOfferAndMigrate(r);
+  if (attempt.ready) return true;
+  // No unit and not migrated. Print the actionable command UNLESS the offer
+  // already surfaced its own guidance (prompt / printed command / declined
+  // note). Gating on `surfaced` rather than on `enabled` is load-bearing: the
+  // verbs all pass `migrateOffer: { enabled: true }` (cli.ts), and the offer
+  // returns `no-offer` in SILENCE on a clean box with no prior-detached
+  // evidence — which is every container / fresh install. Gating on `enabled`
+  // meant `parachute start <svc>` there exited 1 with nothing on stdout or
+  // stderr.
+  if (!attempt.surfaced) {
     r.log(
       "No supervised hub unit is installed. Run `parachute migrate --to-supervised` to install it,",
     );


### PR DESCRIPTION
```
$ parachute start vault
EXIT=1   [stdout 0 bytes]   [stderr 0 bytes]
```

`requireSupervisedOrOffer` (`src/commands/lifecycle.ts`) documents in its own comment that the actionable `parachute migrate --to-supervised` line prints whenever the offer surfaced no guidance, and lists "no prior-detached evidence" among those cases. The code gated on `!r.migrateOffer.enabled` instead — and `cli.ts` passes `migrateOffer: { enabled: true }` for start, stop and restart, so that branch is dead in production.

`offerMigrateToSupervised` returns `no-offer` without logging anything (`migrate-offer.ts:160,162`) on a clean box with no prior-detached install — which is every container and every fresh install. The one outcome that says nothing was the one outcome the caller assumed had spoken.

Ships with its converse test too — a declined offer must NOT double-print — so "just always print it" cannot pass in its place.
