### PR TITLE
fix(oauth): root /mcp gets an RFC 8707 resource branch of its own

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -9550,6 +9550,169 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
       cleanup();
     }
   });
+
+  // ─── the ROOT `/mcp` door ────────────────────────────────────────────────
+  //
+  // Root `/mcp` is a vault door too — vault derives the target from the token
+  // and re-dispatches with the audience pin intact (verified live on a hub
+  // with three vaults: one URL, `parachute-vault/alpha` for an alpha token,
+  // `parachute-vault/beta` for a beta one, each 401'ing at the other's
+  // per-vault path). So the same foreign-scope drop applies. What does NOT
+  // apply is the naming: the root resource carries no vault name, so the
+  // picker stays and the existing rewrite names the scopes at consent.
+  //
+  // Before this branch `resolveResourceVault` returned null for `<origin>/mcp`
+  // and the whole binding path no-op'd, leaving the root door as the one place
+  // a client still saw the whole-hub catalog.
+  describe("root /mcp (no vault name in the resource)", () => {
+    /** The whole-hub catalog shape a client over-requests, scribe installed. */
+    const CATALOG = "vault:read vault:write scribe:transcribe";
+
+    async function consentFor(resource?: string) {
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { challenge } = makePkce();
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: CATALOG,
+              ...(resource ? { resource } : {}),
+            }),
+            {
+              headers: {
+                cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+              },
+            },
+          ),
+          RESOURCE_DEPS,
+        );
+        expect(res.status).toBe(200);
+        return await res.text();
+      } finally {
+        cleanup();
+      }
+    }
+
+    test("CONTROL: with no resource the catalog reaches consent intact", async () => {
+      // Without this the drop-assertions below would pass on a consent screen
+      // that never rendered scribe in the first place.
+      const html = await consentFor();
+      expect(html).toContain("scribe:transcribe");
+      expect(html).toContain("Pick a vault");
+    });
+
+    test("resource=<origin>/mcp drops foreign scopes but KEEPS the picker", async () => {
+      const html = await consentFor(`${ISSUER}/mcp`);
+      // The scary-consent fix now reaches the root door.
+      expect(html).not.toContain("scribe:");
+      // …and the vault scopes survive un-narrowed, because the resource names
+      // no vault. The picker supplies the name; naming them here would mean
+      // inventing a vault the client never asked for.
+      expect(html).toContain("Pick a vault");
+      expect(html).not.toContain("vault:jon:read");
+      expect(html).not.toContain("vault:boulder:read");
+    });
+
+    test("the root PRM URL is accepted as the resource too", async () => {
+      // The exact string the root 401 challenge hands a client back:
+      // `resource_metadata=".../.well-known/oauth-protected-resource/mcp"`.
+      const html = await consentFor(`${ISSUER}/.well-known/oauth-protected-resource/mcp`);
+      expect(html).not.toContain("scribe:");
+      expect(html).toContain("Pick a vault");
+    });
+
+    test("an off-origin /mcp drives nothing — same gate as the per-vault path", async () => {
+      const html = await consentFor("https://evil.example/mcp");
+      expect(html).toContain("scribe:transcribe");
+      expect(html).toContain("Pick a vault");
+    });
+
+    test("a hand-crafted consent POST can't smuggle a foreign scope back in", async () => {
+      // The GET handler already narrowed what the form rendered, so an honest
+      // browser never posts `scribe:transcribe` here. This is the defense-in-
+      // depth half — the mirror of the per-vault re-narrow in the POST path.
+      // Without it the minted token carries a scope the consent screen never
+      // showed.
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { verifier, challenge } = makePkce();
+        const consentRes = await handleAuthorizePost(
+          db,
+          new Request(`${ISSUER}/oauth/authorize`, {
+            method: "POST",
+            body: new URLSearchParams({
+              __action: "consent",
+              __csrf: TEST_CSRF,
+              approve: "yes",
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              scope: "vault:read scribe:transcribe",
+              vault_pick: "jon",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              resource: `${ISSUER}/mcp`,
+            }),
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            },
+          }),
+          RESOURCE_DEPS,
+        );
+        expect(consentRes.status).toBe(302);
+        const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+        expect(code).toBeTruthy();
+
+        const tokenRes = await handleToken(
+          db,
+          new Request(`${ISSUER}/oauth/token`, {
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "authorization_code",
+              code: code ?? "",
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              code_verifier: verifier,
+            }),
+            headers: { "content-type": "application/x-www-form-urlencoded" },
+          }),
+          RESOURCE_DEPS,
+        );
+        expect(tokenRes.status).toBe(200);
+        const tok = (await tokenRes.json()) as { scope: string };
+        // scribe dropped; the picker's vault named the surviving vault scope,
+        // which is what makes the token usable at root /mcp at all (an unnamed
+        // `vault:read` / `aud=vault` token is rejected there).
+        expect(tok.scope.split(" ")).not.toContain("scribe:transcribe");
+        expect(tok.scope).toBe("vault:jon:read");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("a per-vault resource still narrows AND names — root did not shadow it", async () => {
+      // Ordering lock: the handler tries `resolveResourceVault` first. If the
+      // root branch ever ran first, this consent would lose the vault name and
+      // regress #461 to the weaker treatment.
+      const html = await consentFor(`${ISSUER}/vault/jon/mcp`);
+      expect(html).toContain("vault:jon:read");
+      expect(html).not.toContain("scribe:");
+      expect(html).not.toContain('name="vault_pick"');
+    });
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────

--- a/src/__tests__/resource-binding.test.ts
+++ b/src/__tests__/resource-binding.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { narrowResourceVaultScopes, resolveResourceVault } from "../resource-binding.ts";
+import {
+  isRootMcpResource,
+  narrowResourceVaultScopes,
+  narrowRootMcpScopes,
+  resolveResourceVault,
+} from "../resource-binding.ts";
 
 const ORIGIN = "https://hub.example";
 const BOUND = [ORIGIN, "http://127.0.0.1:1939"];
@@ -119,5 +124,95 @@ describe("narrowResourceVaultScopes", () => {
   test("is idempotent over an already-narrowed list", () => {
     const once = narrowResourceVaultScopes(["vault:read"], "jon");
     expect(narrowResourceVaultScopes(once, "jon")).toEqual(once);
+  });
+});
+
+describe("isRootMcpResource", () => {
+  test("recognises the root MCP endpoint", () => {
+    expect(isRootMcpResource(`${ORIGIN}/mcp`, BOUND)).toBe(true);
+    expect(isRootMcpResource(`${ORIGIN}/mcp/`, BOUND)).toBe(true);
+    expect(isRootMcpResource(`${ORIGIN}/mcp?x=1#y`, BOUND)).toBe(true);
+  });
+
+  test("recognises the root PRM document URL", () => {
+    // The path-suffixed shape the root 401 challenge advertises verbatim:
+    // `WWW-Authenticate: Bearer resource_metadata=".../.well-known/oauth-protected-resource/mcp"`.
+    expect(isRootMcpResource(`${ORIGIN}/.well-known/oauth-protected-resource/mcp`, BOUND)).toBe(
+      true,
+    );
+  });
+
+  test("resolves against a non-issuer bound origin (loopback)", () => {
+    expect(isRootMcpResource("http://127.0.0.1:1939/mcp", BOUND)).toBe(true);
+  });
+
+  test("returns false off-origin — same gate as resolveResourceVault", () => {
+    expect(isRootMcpResource("https://evil.example/mcp", BOUND)).toBe(false);
+  });
+
+  test("returns false for absent / malformed / non-root paths", () => {
+    expect(isRootMcpResource(null, BOUND)).toBe(false);
+    expect(isRootMcpResource(undefined, BOUND)).toBe(false);
+    expect(isRootMcpResource("", BOUND)).toBe(false);
+    expect(isRootMcpResource("not a url", BOUND)).toBe(false);
+    expect(isRootMcpResource(`${ORIGIN}/mcp/extra`, BOUND)).toBe(false);
+    expect(isRootMcpResource(`${ORIGIN}/scribe/mcp`, BOUND)).toBe(false);
+    // The BARE PRM (no `/mcp` suffix) describes the hub as a resource, not the
+    // root MCP door — a different document with a different `resource` field.
+    expect(isRootMcpResource(`${ORIGIN}/.well-known/oauth-protected-resource`, BOUND)).toBe(false);
+  });
+
+  test("a per-vault resource is NOT root — the two branches are disjoint", () => {
+    // The authorize handler tries `resolveResourceVault` first and only falls
+    // through to this predicate. If both could answer for one resource, the
+    // vault name would be silently dropped in favour of the weaker root
+    // treatment on any reorder.
+    for (const r of [
+      `${ORIGIN}/vault/jon/mcp`,
+      `${ORIGIN}/vault/jon/.well-known/oauth-protected-resource`,
+    ]) {
+      expect(resolveResourceVault(r, BOUND)).not.toBeNull();
+      expect(isRootMcpResource(r, BOUND)).toBe(false);
+    }
+  });
+});
+
+describe("narrowRootMcpScopes", () => {
+  test("drops non-vault scopes — the root door's scary-consent fix", () => {
+    // Same catalog claude.ai over-requests in the per-vault test above. At the
+    // root door it used to arrive at consent untouched, because
+    // `resolveResourceVault` returned null and the whole binding path no-op'd.
+    expect(
+      narrowRootMcpScopes([
+        "vault:read",
+        "vault:write",
+        "vault:admin",
+        "scribe:admin",
+        "scribe:transcribe",
+        "channel:send",
+        "hub:admin",
+      ]),
+    ).toEqual(["vault:read", "vault:write", "vault:admin"]);
+  });
+
+  test("does NOT name the vault scopes — there is no vault in the resource", () => {
+    // The picker supplies the name; `vault:<name>:<verb>` is minted downstream.
+    // Naming them here would require inventing a vault the client never asked
+    // for. This is the whole reason root is a separate branch and not an entry
+    // in the resolvable set.
+    expect(narrowRootMcpScopes(["vault:read"])).toEqual(["vault:read"]);
+  });
+
+  test("leaves already-named vault scopes untouched", () => {
+    expect(narrowRootMcpScopes(["vault:jon:read", "hub:admin"])).toEqual(["vault:jon:read"]);
+  });
+
+  test("a foreign-only request narrows to empty (authorize refuses invalid_scope)", () => {
+    expect(narrowRootMcpScopes(["hub:admin", "scribe:admin"])).toEqual([]);
+  });
+
+  test("is idempotent", () => {
+    const once = narrowRootMcpScopes(["vault:read", "hub:admin"]);
+    expect(narrowRootMcpScopes(once)).toEqual(once);
   });
 });

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -80,7 +80,12 @@ import {
   loginRateLimiter,
 } from "./rate-limit.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
-import { narrowResourceVaultScopes, resolveResourceVault } from "./resource-binding.ts";
+import {
+  isRootMcpResource,
+  narrowResourceVaultScopes,
+  narrowRootMcpScopes,
+  resolveResourceVault,
+} from "./resource-binding.ts";
 import {
   ACCOUNT_SELF_ADMIN_SCOPE,
   ACCOUNT_SELF_READ_SCOPE,
@@ -1004,15 +1009,28 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // the URL) so the two never diverge. Re-entry after login re-narrows
   // idempotently (no foreign scopes left to drop).
   //
-  // No resource, or one that isn't a per-vault MCP resource (off-origin,
-  // malformed, non-vault path) → `boundVault` is null and the flow is
+  // The ROOT `/mcp` door takes the same treatment minus the naming. It is a
+  // vault door too (vault derives the target from the token), so foreign
+  // scopes are just as unusable in the token it mints — but the resource
+  // carries no vault name, so there is nothing to narrow the vault scopes TO
+  // and the consent picker still supplies that. Without this branch the root
+  // door was the one place the whole-hub catalog still reached consent.
+  //
+  // No resource, or one that isn't an MCP resource we front (off-origin,
+  // malformed, non-vault path) → neither branch fires and the flow is
   // byte-for-byte the pre-#461 behavior (manual picker, etc.).
-  const boundVault = resolveResourceVault(parsed.resource, resolveBoundOrigins(deps));
+  const boundOrigins = resolveBoundOrigins(deps);
+  const boundVault = resolveResourceVault(parsed.resource, boundOrigins);
   if (boundVault) {
     parsed.scope = narrowResourceVaultScopes(
       parsed.scope.split(" ").filter((s) => s.length > 0),
       boundVault,
     ).join(" ");
+    url.searchParams.set("scope", parsed.scope);
+  } else if (isRootMcpResource(parsed.resource, boundOrigins)) {
+    parsed.scope = narrowRootMcpScopes(parsed.scope.split(" ").filter((s) => s.length > 0)).join(
+      " ",
+    );
     url.searchParams.set("scope", parsed.scope);
   }
 
@@ -1689,13 +1707,19 @@ async function handleConsentSubmit(
   // `resource` field. Re-narrow here so the minted token is always named +
   // correctly-audienced regardless of what the form body claims. Same
   // semantics as the GET path: only when `resource` resolves to one of our
-  // per-vault MCP resources; no-op otherwise (manual-pick path unchanged).
-  const boundVault = resolveResourceVault(params.resource, resolveBoundOrigins(deps));
+  // MCP resources — per-vault (narrow + name) or root (drop foreign scopes,
+  // picker still names); no-op otherwise (manual-pick path unchanged).
+  const boundOrigins = resolveBoundOrigins(deps);
+  const boundVault = resolveResourceVault(params.resource, boundOrigins);
   if (boundVault) {
     params.scope = narrowResourceVaultScopes(
       params.scope.split(" ").filter((s) => s.length > 0),
       boundVault,
     ).join(" ");
+  } else if (isRootMcpResource(params.resource, boundOrigins)) {
+    params.scope = narrowRootMcpScopes(params.scope.split(" ").filter((s) => s.length > 0)).join(
+      " ",
+    );
   }
   const approve = String(form.get("approve") ?? "") === "yes";
   const sessionId = parseSessionCookie(req.headers.get("cookie"));

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -47,6 +47,26 @@ const VAULT_MCP_PATH_RE = /^\/vault\/([^/]+)\/mcp\/?$/;
 const VAULT_PRM_PATH_RE = /^\/vault\/([^/]+)\/\.well-known\/oauth-protected-resource\/?$/;
 
 /**
+ * The same two shapes for the ROOT MCP door, which carries no vault name:
+ *
+ *   - the MCP endpoint:  `<origin>/mcp`
+ *   - the PRM document:  `<origin>/.well-known/oauth-protected-resource/mcp`
+ *     (path-suffixed per the MCP spec's per-resource discovery convention —
+ *     see the handler in `hub-server.ts`, which authors this document from
+ *     the hub's own scope registry).
+ *
+ * Root `/mcp` is not a single-vault endpoint: vault derives the target from
+ * the token (`deriveVaultFromToken`) and re-dispatches through the per-vault
+ * machinery with the audience pin intact. Verified live against a hub with
+ * three vaults — the same URL served `parachute-vault/alpha` to an
+ * `aud=vault.alpha` token and `parachute-vault/beta` to an `aud=vault.beta`
+ * one, and each token 401'd (`audience mismatch`) at the other's per-vault
+ * path.
+ */
+const ROOT_MCP_PATH_RE = /^\/mcp\/?$/;
+const ROOT_PRM_PATH_RE = /^\/\.well-known\/oauth-protected-resource\/mcp\/?$/;
+
+/**
  * Resolve the RFC 8707 `resource` parameter to a vault instance name, or null
  * when it isn't a per-vault MCP resource (absent, malformed, off-origin, or a
  * non-vault path). Off-origin resources return null deliberately: we only
@@ -78,6 +98,35 @@ export function resolveResourceVault(
   const prm = VAULT_PRM_PATH_RE.exec(parsed.pathname);
   if (prm?.[1]) return decodeVaultName(prm[1]);
   return null;
+}
+
+/**
+ * True when the RFC 8707 `resource` names the hub's ROOT MCP door (or its PRM
+ * document). Same origin gate as `resolveResourceVault` — a resource we don't
+ * front can't drive any narrowing.
+ *
+ * This is deliberately a SEPARATE predicate rather than a new return value on
+ * `resolveResourceVault`, because the root door has **no vault name to narrow
+ * to**. `resolveResourceVault` answers "which vault?"; the honest answer for
+ * root is "none yet — the consent picker decides." Folding root into its
+ * return type would hand callers a name-shaped value that isn't a name.
+ *
+ * Callers pair this with `narrowRootMcpScopes`, never with
+ * `narrowResourceVaultScopes`: there is nothing to name the scopes after.
+ */
+export function isRootMcpResource(
+  resource: string | null | undefined,
+  boundOrigins: readonly string[],
+): boolean {
+  if (!resource) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(resource);
+  } catch {
+    return false;
+  }
+  if (!boundOrigins.includes(parsed.origin)) return false;
+  return ROOT_MCP_PATH_RE.test(parsed.pathname) || ROOT_PRM_PATH_RE.test(parsed.pathname);
 }
 
 /** Canonical vault-name shape — mirrors `VAULT_SCOPED_RE`'s name group. */
@@ -146,4 +195,41 @@ export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: 
     }
   }
   return out;
+}
+
+/**
+ * The root-`/mcp` counterpart of `narrowResourceVaultScopes`: drop every
+ * non-vault scope, and change nothing else.
+ *
+ * Root `/mcp` is a vault door — whichever vault the token names. So the same
+ * argument that drops `scribe:*` / `agent:send` / `hub:admin` from a per-vault
+ * consent applies verbatim here: the flow ends in a token stamped
+ * `aud=vault.<picked>`, in which those scopes are unusable, and carrying them
+ * only inflates the consent surface. Before this branch existed a `resource`
+ * naming root `/mcp` fell through `resolveResourceVault` to null, the whole
+ * binding path no-op'd, and the root door alone kept showing the entire hub
+ * scope catalog — the exact "scary consent" this module was written to kill,
+ * surviving at one of the two MCP doors.
+ *
+ * What this deliberately does NOT do is name the scopes. Unnamed
+ * `vault:<verb>` is left exactly as requested, because there is no vault in
+ * the resource to name it after; the consent picker supplies the name and the
+ * existing rewrite turns it into `vault:<picked>:<verb>` before the code is
+ * issued (`docs/contracts/oauth-scopes.md`, "Parser rules"). That is also why
+ * the root PRM advertises the bare `vault:read` / `vault:write` /
+ * `vault:admin` shapes: at the root door the bare shape is the correct thing
+ * for a client to *request*, even though it is never the shape that ships in
+ * the minted token.
+ *
+ * Already-named `vault:<name>:<verb>` rides through untouched, same as the
+ * per-vault path — a client that named a vault is not second-guessed here.
+ *
+ * A request that carries ONLY foreign scopes narrows to the empty list, which
+ * the authorize handler already refuses with `invalid_scope` rather than
+ * minting a zero-scope token. Same terminal behaviour as the per-vault path.
+ *
+ * Idempotent: a second pass has nothing left to drop.
+ */
+export function narrowRootMcpScopes(scopes: readonly string[]): string[] {
+  return scopes.filter((s) => s.split(":")[0] === "vault");
 }


### PR DESCRIPTION
A client connecting to the root MCP door discovers it the same way it discovers a per-vault one: 401 → `resource_metadata=<origin>/.well-known/oauth-protected-resource/mcp` → that document names `resource=<origin>/mcp` → the client echoes it back on `/oauth/authorize`.

`resolveResourceVault` recognises only `/vault/<name>/…`, so root fell through to null and the whole resource-binding path no-op'd. The cost is the one that module exists to prevent: the root door was the last place a friend connecting an MCP client still saw the entire hub scope catalog (`scribe:*`, `hub:admin`) on the consent screen.

Root is a separate branch, not a new entry in the resolvable set, because there is no vault name in `<origin>/mcp` to narrow *to*. Root `/mcp` is not a single-vault endpoint — vault derives the target from the token and re-dispatches with the audience pin intact. So this drops foreign scopes (unusable inside the `aud=vault.<picked>` token the flow mints, exactly as on the per-vault path) and stops there: unnamed `vault:<verb>` rides through untouched and the consent picker supplies the name. That is also why the root PRM advertising the bare shapes is correct rather than a bug.

**The two-vault probe ran first**, per the standing gate, on a live hub with three vaults:

```
T-alpha → /vault/alpha/mcp   200  serverInfo: parachute-vault/alpha
T-alpha → /vault/beta/mcp    401  audience mismatch: expected vault.beta
T-alpha → /mcp   (root)      200  serverInfo: parachute-vault/alpha
T-beta  → /mcp   (root)      200  serverInfo: parachute-vault/beta
```

No cross-vault replay, and root is token-derived — so the external report that root `/mcp` "binds to one vault" is wrong on both counts.

Wired into the authorize GET and the consent POST. Both branches mutation-tested: remove the GET branch and the two narrowing tests fail; remove the POST branch and the minted token carries `scribe:transcribe`, a scope the consent screen never rendered.

Full hub suite with a hub live on :1939 (the `cli lazy-import isolation` test probes that port): `main` 4400 pass / 0 fail, this branch 4417 pass / 0 fail — +17, all of them these.

`/oauth/token` still ignores `resource` entirely (RFC 8707 §2.2). Real, confirmed, and its own diff.
