### PR TITLE
fix(account): backup tile followed config, not whether pushes land

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -21,6 +21,7 @@ import {
   accountMcpEndpoint,
   renderAccountHome,
 } from "../account-home-ui.ts";
+import type { VaultVerb } from "../users.ts";
 
 const HUB_ORIGIN = "https://hub.example";
 const CSRF = "test-csrf-token";
@@ -332,6 +333,84 @@ describe("renderAccountHome", () => {
     });
     expect(noMirror).not.toContain('data-testid="backup-state-line"');
     expect(noMirror).not.toContain('data-testid="vault-backup"');
+  });
+
+  test("backup glyph — follows the mirrorHealthy boolean, not the line string", () => {
+    // vault#822 regression guard, render layer. The logic tests in
+    // account-mirror.test.ts prove `isMirrorHealthy` returns false for a
+    // never-worked remote; NOTHING proved the renderer consumed it. That is the
+    // same shape as the bug itself — a correct value computed and then
+    // discarded — so it gets its own test rather than riding on the logic ones.
+    //
+    // Assertions are scoped to the backup block: `✓` legitimately appears
+    // elsewhere on the page (the onboarding checklist's "You're connected"),
+    // so a page-wide `not.toContain("✓")` would fail for the wrong reason.
+    const backupBlock = (html: string): string => {
+      const start = html.indexOf('data-testid="vault-backup"');
+      if (start === -1) return "";
+      return html.slice(start, html.indexOf("</div>", start));
+    };
+    const base = {
+      username: "alice",
+      assignedVaults: ["alice"],
+      passwordChanged: true,
+      hubOrigin: HUB_ORIGIN,
+      isFirstAdmin: false,
+      csrfToken: CSRF,
+      twoFactorEnabled: false,
+      mintableVerbs: { alice: ["read", "write", "admin"] as VaultVerb[] },
+    };
+
+    const broken = backupBlock(
+      renderAccountHome({
+        ...base,
+        mirrorLines: { alice: "Version history saved here — GitHub backup has never worked" },
+        mirrorPushing: { alice: true },
+        mirrorHealthy: { alice: false },
+      }),
+    );
+    // No green check next to a sentence saying the backup is broken.
+    expect(broken).toContain('data-backup-healthy="false"');
+    expect(broken).toContain("vault-backup-warn");
+    expect(broken).toContain(">!</span>");
+    expect(broken).not.toContain(">\u2713</span>");
+
+    const healthy = backupBlock(
+      renderAccountHome({
+        ...base,
+        mirrorLines: { alice: "Backed up — version history + GitHub" },
+        mirrorPushing: { alice: true },
+        mirrorHealthy: { alice: true },
+      }),
+    );
+    expect(healthy).toContain('data-backup-healthy="true"');
+    expect(healthy).toContain(">\u2713</span>");
+    expect(healthy).not.toContain("vault-backup-warn");
+
+    // The glyph must follow the BOOLEAN, not the words. A line that reads
+    // healthy with mirrorHealthy=false still gets `!` — same discipline the
+    // mirrorPushing test below pins for the GitHub action.
+    const lying = backupBlock(
+      renderAccountHome({
+        ...base,
+        mirrorLines: { alice: "Backed up — version history + GitHub" },
+        mirrorPushing: { alice: true },
+        mirrorHealthy: { alice: false },
+      }),
+    );
+    expect(lying).toContain(">!</span>");
+    expect(lying).not.toContain(">\u2713</span>");
+
+    // Absent from the map → healthy, so an older caller that never builds it
+    // renders exactly as before.
+    const legacy = backupBlock(
+      renderAccountHome({
+        ...base,
+        mirrorLines: { alice: "Backed up — full version history" },
+      }),
+    );
+    expect(legacy).toContain(">\u2713</span>");
+    expect(legacy).not.toContain("vault-backup-warn");
   });
 
   test("backup action — gated on the mirrorPushing boolean, not the line string", () => {

--- a/src/__tests__/account-mirror.test.ts
+++ b/src/__tests__/account-mirror.test.ts
@@ -12,8 +12,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   type VaultMirrorStat,
+  derivePushState,
   fetchVaultMirrorStatus,
   formatMirrorLine,
+  isMirrorHealthy,
 } from "../account-mirror.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 
@@ -71,7 +73,7 @@ describe("fetchVaultMirrorStatus", () => {
         { status: 200, headers: { "content-type": "application/json" } },
       )) as unknown as typeof fetch;
     const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
-    expect(stat).toEqual({ enabled: true, backedUpToRemote: false });
+    expect(stat).toEqual({ enabled: true, backedUpToRemote: false, remotePushState: "n/a" });
   });
 
   test("flags pushing when auto_push is configured", async () => {
@@ -81,7 +83,7 @@ describe("fetchVaultMirrorStatus", () => {
         { status: 200 },
       )) as unknown as typeof fetch;
     const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
-    expect(stat).toEqual({ enabled: true, backedUpToRemote: true });
+    expect(stat).toEqual({ enabled: true, backedUpToRemote: true, remotePushState: "ok" });
   });
 
   test("returns enabled:false when backup is off", async () => {
@@ -90,7 +92,7 @@ describe("fetchVaultMirrorStatus", () => {
         status: 200,
       })) as unknown as typeof fetch;
     const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
-    expect(stat).toEqual({ enabled: false, backedUpToRemote: false });
+    expect(stat).toEqual({ enabled: false, backedUpToRemote: false, remotePushState: "n/a" });
   });
 
   test("mints an ADMIN-scoped Bearer + hits the vault's loopback mirror endpoint", async () => {
@@ -140,17 +142,150 @@ describe("fetchVaultMirrorStatus", () => {
 
 describe("formatMirrorLine", () => {
   test("warm plain-language line; GitHub variant when pushing", () => {
-    expect(formatMirrorLine({ enabled: true, backedUpToRemote: false } as VaultMirrorStat)).toBe(
-      "Backed up — full version history",
-    );
-    expect(formatMirrorLine({ enabled: true, backedUpToRemote: true } as VaultMirrorStat)).toBe(
+    expect(
+      formatMirrorLine({ enabled: true, backedUpToRemote: false, remotePushState: "n/a" }),
+    ).toBe("Backed up — full version history");
+    expect(formatMirrorLine({ enabled: true, backedUpToRemote: true, remotePushState: "ok" })).toBe(
       "Backed up — version history + GitHub",
     );
   });
 
   test("returns null when backup is off (the tile omits the line, never nags)", () => {
     expect(
-      formatMirrorLine({ enabled: false, backedUpToRemote: false } as VaultMirrorStat),
+      formatMirrorLine({ enabled: false, backedUpToRemote: false, remotePushState: "n/a" }),
     ).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// vault#822 — a configured remote is not a working one.
+//
+// Field report: a vault's mirror had rejected 122 consecutive pushes since
+// 2026-07-28 (remote created against unrelated history → every push refused as
+// non-fast-forward). The vault logged each failure `(non-fatal)` and carried
+// on; `/account/` rendered "Backed up — version history + GitHub" because
+// `config.auto_push` was true. Five days, no off-site copy, nothing surfaced.
+//
+// These tests pin the two properties that were missing: the line must follow
+// the last push OUTCOME, and "never worked" must be louder than "failed once".
+// ---------------------------------------------------------------------------
+
+describe("derivePushState", () => {
+  test("no remote configured → n/a regardless of status", () => {
+    expect(derivePushState(false, undefined)).toBe("n/a");
+    expect(derivePushState(false, { last_push_at: null, last_push_error: "boom" })).toBe("n/a");
+  });
+
+  test("error with no prior success → never (a setup bug, not a blip)", () => {
+    expect(
+      derivePushState(true, {
+        last_push_at: null,
+        last_push_error: "! [rejected] main -> main (non-fast-forward)",
+      }),
+    ).toBe("never");
+  });
+
+  test("error after a prior success → failing", () => {
+    expect(
+      derivePushState(true, {
+        last_push_at: "2026-07-28T04:00:00.000Z",
+        last_push_error: "! [rejected] main -> main (non-fast-forward)",
+      }),
+    ).toBe("failing");
+  });
+
+  test("no error → ok", () => {
+    expect(
+      derivePushState(true, { last_push_at: "2026-08-03T04:00:00.000Z", last_push_error: null }),
+    ).toBe("ok");
+  });
+
+  test("nothing attempted yet → ok, not a false alarm", () => {
+    expect(derivePushState(true, { last_push_at: null, last_push_error: null })).toBe("ok");
+  });
+
+  test("a vault too old to report push fields → ok (can't tell ≠ failing)", () => {
+    expect(derivePushState(true, undefined)).toBe("ok");
+    expect(derivePushState(true, {})).toBe("ok");
+  });
+
+  test("empty-string error is not an error", () => {
+    expect(derivePushState(true, { last_push_at: null, last_push_error: "" })).toBe("ok");
+  });
+});
+
+describe("vault#822 — the field report, end to end", () => {
+  const AARONS_BODY = {
+    config: { enabled: true, location: "internal", auto_push: true },
+    status: {
+      enabled: true,
+      last_commit_sha: "deadbee",
+      last_error: null,
+      last_push_at: null,
+      last_push_sha: null,
+      last_push_error: "! [rejected]        main -> main (non-fast-forward)",
+      commits_unpushed: 122,
+    },
+  };
+
+  test("the exact reported state does NOT render as backed up", async () => {
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify(AARONS_BODY), { status: 200 })) as unknown as typeof fetch;
+    const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+    expect(stat).not.toBeNull();
+    expect(stat?.remotePushState).toBe("never");
+
+    const line = formatMirrorLine(stat as VaultMirrorStat);
+    // The regression, stated as the thing that must not happen again.
+    expect(line).not.toBe("Backed up — version history + GitHub");
+    expect(line).toBe("Version history saved here — GitHub backup has never worked");
+    expect(isMirrorHealthy(stat as VaultMirrorStat)).toBe(false);
+  });
+
+  test("mutate the fixture to a landed push and the healthy line comes back", async () => {
+    // The guard has to distinguish, not just always say "broken" — mutate the
+    // one field that matters and confirm the verdict flips.
+    const healthyBody = {
+      ...AARONS_BODY,
+      status: {
+        ...AARONS_BODY.status,
+        last_push_at: "2026-08-03T04:00:00.000Z",
+        last_push_error: null,
+        commits_unpushed: 0,
+      },
+    };
+    const fetchImpl = (async () =>
+      new Response(JSON.stringify(healthyBody), { status: 200 })) as unknown as typeof fetch;
+    const stat = await fetchVaultMirrorStatus("work", baseDeps(fetchImpl));
+    expect(stat?.remotePushState).toBe("ok");
+    expect(formatMirrorLine(stat as VaultMirrorStat)).toBe("Backed up — version history + GitHub");
+    expect(isMirrorHealthy(stat as VaultMirrorStat)).toBe(true);
+  });
+
+  test("failed-once reads differently from never-worked", () => {
+    const failing: VaultMirrorStat = {
+      enabled: true,
+      backedUpToRemote: true,
+      remotePushState: "failing",
+    };
+    const never: VaultMirrorStat = {
+      enabled: true,
+      backedUpToRemote: true,
+      remotePushState: "never",
+    };
+    expect(formatMirrorLine(failing)).not.toBe(formatMirrorLine(never));
+    expect(formatMirrorLine(never)).toContain("never");
+    expect(isMirrorHealthy(failing)).toBe(false);
+    expect(isMirrorHealthy(never)).toBe(false);
+  });
+
+  test("local-only backup is unaffected — still the warm line, still healthy", () => {
+    const localOnly: VaultMirrorStat = {
+      enabled: true,
+      backedUpToRemote: false,
+      remotePushState: "n/a",
+    };
+    expect(formatMirrorLine(localOnly)).toBe("Backed up — full version history");
+    expect(isMirrorHealthy(localOnly)).toBe(true);
   });
 });

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -1016,7 +1016,11 @@ describe("handleAccountHomeGet", () => {
       hubOrigin: HUB_ORIGIN,
       resolveVaultPort: () => 1940,
       // Stub the mirror fetch: resolves to a backed-up, GitHub-pushing config.
-      fetchMirror: async () => ({ enabled: true, backedUpToRemote: true }),
+      fetchMirror: async () => ({
+        enabled: true,
+        backedUpToRemote: true,
+        remotePushState: "ok" as const,
+      }),
     });
     expect(res.status).toBe(200);
     const html = await res.text();

--- a/src/__tests__/api-account.test.ts
+++ b/src/__tests__/api-account.test.ts
@@ -1031,6 +1031,40 @@ describe("handleAccountHomeGet", () => {
     expect(html).toContain("version history + GitHub");
   });
 
+  test("vault#822 — a never-worked remote reaches the HTML as unhealthy", async () => {
+    // End to end for the field report: the handler must carry the push OUTCOME
+    // all the way to the markup. The seam this pins is
+    // `mirrorHealthy[vaultName] = isMirrorHealthy(stat)` — without it the value
+    // is computed correctly and then dropped, which is precisely the bug class
+    // being fixed, one layer up.
+    await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
+    const friend = await createUser(harness.db, "alice", "alice-passphrase", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["alice"],
+    });
+    const session = createSession(harness.db, { userId: friend.id });
+    const cookie = buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000));
+    const req = new Request(`${HUB_ORIGIN}/account/`, { headers: { cookie } });
+    const res = await handleAccountHomeGet(req, {
+      db: harness.db,
+      hubOrigin: HUB_ORIGIN,
+      resolveVaultPort: () => 1940,
+      // A remote is configured and has never accepted a push — Aaron's vault.
+      fetchMirror: async () => ({
+        enabled: true,
+        backedUpToRemote: true,
+        remotePushState: "never" as const,
+      }),
+    });
+    expect(res.status).toBe(200);
+    const html = await res.text();
+    expect(html).toContain('data-backup-healthy="false"');
+    expect(html).toContain("GitHub backup has never worked");
+    // The regression, stated as the thing that must not reach a browser again.
+    expect(html).not.toContain("Backed up — version history + GitHub");
+  });
+
   test("omits the backup line gracefully when the mirror fetch fails (null)", async () => {
     await createUser(harness.db, "admin", "admin-passphrase", { passwordChanged: true });
     const friend = await createUser(harness.db, "alice", "alice-passphrase", {

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -160,6 +160,15 @@ export interface RenderAccountHomeOpts {
    */
   mirrorPushing?: Record<string, boolean>;
   /**
+   * Per-vault "does the backup line describe a GOOD state?" flag, threaded from
+   * `isMirrorHealthy(stat)`. Maps `vaultName` → `false` when the vault's push
+   * remote is failing or has never worked. Drives the tile's `✓` vs `!` glyph —
+   * gated on this proper boolean, NOT sniffed out of the `mirrorLines` string,
+   * same discipline as `mirrorPushing`. A vault absent defaults to `true`
+   * (healthy) so an older caller that doesn't build the map renders unchanged.
+   */
+  mirrorHealthy?: Record<string, boolean>;
+  /**
    * Set after a successful `POST /account/vault-token/<name>` to show the
    * freshly-minted token ONCE (the only time it's ever shown — the hub keeps
    * no plaintext copy). Drives the show-once banner at the top of the page.
@@ -262,6 +271,7 @@ export function renderAccountHome(opts: RenderAccountHomeOpts): string {
     usageStats: opts.usageStats ?? {},
     mirrorLines: opts.mirrorLines ?? {},
     mirrorPushing: opts.mirrorPushing ?? {},
+    mirrorHealthy: opts.mirrorHealthy ?? {},
   });
 
   const accountCard = renderAccountCard({
@@ -462,6 +472,8 @@ interface VaultCardOpts {
   mirrorLines: Record<string, string>;
   /** `vaultName` → is backup already pushing to a remote (gates the GitHub action). */
   mirrorPushing: Record<string, boolean>;
+  /** `vaultName` → is the backup state good (drives the ✓ vs ! glyph). Absent = healthy. */
+  mirrorHealthy: Record<string, boolean>;
 }
 
 /**
@@ -493,7 +505,7 @@ export function accountClaudeMcpAddCommand(trimmedOrigin: string, vaultName: str
 function renderVaultCard(opts: VaultCardOpts): string {
   const { assignedVaults, trimmedOrigin, isFirstAdmin, csrfToken, mintableVerbs, usageStats } =
     opts;
-  const { mirrorLines, mirrorPushing } = opts;
+  const { mirrorLines, mirrorPushing, mirrorHealthy } = opts;
 
   if (assignedVaults.length > 0) {
     // One vault tile per assignment (multi-user Phase 2 PR 2). The tile is the
@@ -535,6 +547,7 @@ function renderVaultCard(opts: VaultCardOpts): string {
           vaultName,
           mirrorLine,
           mirrorPushing[vaultName] ?? false,
+          mirrorHealthy[vaultName] ?? true,
           holdsAdmin,
           csrfToken,
         );
@@ -614,11 +627,17 @@ function renderVaultCard(opts: VaultCardOpts): string {
  * pushing to a remote) — `pushing` is a proper boolean threaded from the mirror
  * status (`VaultMirrorStat.backedUpToRemote`), never re-derived from the
  * display string.
+ *
+ * `healthy` likewise arrives as a boolean (`isMirrorHealthy`) and decides the
+ * glyph: `✓` for a good state, `!` when the push remote is failing or has
+ * never worked. Defaulting it to `true` at the call site keeps an older caller
+ * that doesn't thread the map rendering exactly as before.
  */
 function renderBackupBlock(
   vaultName: string,
   mirrorLine: string | undefined,
   pushing: boolean,
+  healthy: boolean,
   holdsAdmin: boolean,
   csrfToken: string,
 ): string {
@@ -638,10 +657,16 @@ function renderBackupBlock(
               </button>
             </form>`
       : "";
+  // Glyph follows OUTCOME, not configuration. A vault whose remote has never
+  // accepted a push gets `!`, never `✓` — the check mark next to "GitHub
+  // backup has never worked" was the whole shape of vault#822.
+  const glyph = healthy ? "✓" : "!";
+  const glyphClass = healthy ? "vault-backup-check" : "vault-backup-check vault-backup-warn";
+  const lineClass = healthy ? "vault-backup-line" : "vault-backup-line vault-backup-line-warn";
   return `
           <div class="vault-backup" data-testid="vault-backup">
-            <p class="vault-backup-line" data-testid="backup-state-line">
-              <span class="vault-backup-check" aria-hidden="true">✓</span>${escapeHtml(mirrorLine)}</p>${githubAction}
+            <p class="${lineClass}" data-testid="backup-state-line" data-backup-healthy="${healthy}">
+              <span class="${glyphClass}" aria-hidden="true">${glyph}</span>${escapeHtml(mirrorLine)}</p>${githubAction}
           </div>`;
 }
 
@@ -1034,6 +1059,15 @@ const STYLES = `
     display: inline-flex;
     align-items: center;
     justify-content: center;
+  }
+  /* Failing / never-worked backup: the line and its glyph go danger-coloured
+     so a broken off-site backup does not read as a healthy one at a glance. */
+  .vault-backup-line-warn { color: ${PALETTE.danger}; }
+  .vault-backup-warn {
+    background: ${PALETTE.dangerSoft};
+    color: ${PALETTE.danger};
+    border-color: ${PALETTE.danger};
+    font-weight: 700;
   }
   .vault-backup-github { margin: 0.4rem 0 0; }
   .vault-build-ui {

--- a/src/account-mirror.ts
+++ b/src/account-mirror.ts
@@ -29,6 +29,24 @@
 import type { Database } from "bun:sqlite";
 import { signAccessToken } from "./jwt-sign.ts";
 
+/**
+ * Outcome of the most recent push to the configured remote.
+ *
+ * `config.auto_push` says a remote is *set up*; it says nothing about whether
+ * anything has ever landed there. These are the three cases the tile has to
+ * tell apart, and `"never"` is deliberately its own state rather than a shade
+ * of `"failing"`:
+ *
+ *   - `ok`      — a push has succeeded and the latest one did not fail.
+ *   - `failing` — a push succeeded at some point, the latest one failed. A
+ *                 blip: the remote exists and has accepted history before.
+ *   - `never`   — no push has EVER succeeded. That is a setup bug (wrong
+ *                 remote, unrelated history, bad credentials), not a blip,
+ *                 and it means there is no off-site copy at all.
+ *   - `n/a`     — no auto-push remote configured; local version history only.
+ */
+export type RemotePushState = "ok" | "failing" | "never" | "n/a";
+
 /** The subset of vault's mirror report the `/account/` tile renders. */
 export interface VaultMirrorStat {
   /** Backup is on — a version-history mirror is configured + bootstrapped. */
@@ -39,8 +57,20 @@ export interface VaultMirrorStat {
    * gates the "Back up to GitHub ↗" action (suppressed once already pushing).
    * Threaded through as a proper boolean so the renderer never has to re-derive
    * "are we pushing?" from display-string content.
+   *
+   * NOTE: this is *configuration*, not outcome. Never render a claim that the
+   * vault is backed up off-site from this field alone — that is exactly the
+   * bug this module carried until vault#822: 122 consecutive rejected pushes
+   * rendered as "Backed up — version history + GitHub" because a remote was
+   * configured. Use `remotePushState` for anything that asserts success.
    */
   backedUpToRemote: boolean;
+  /**
+   * Outcome of the most recent push, from the vault's runtime status
+   * (`status.last_push_at` / `status.last_push_error`) — NOT from config.
+   * `"n/a"` when `backedUpToRemote` is false.
+   */
+  remotePushState: RemotePushState;
 }
 
 /** Short TTL for the admin token — used immediately for one loopback call. */
@@ -75,6 +105,18 @@ export interface FetchVaultMirrorStatusDeps {
  * `status.enabled`, so a freshly-configured-but-not-yet-bootstrapped vault still
  * reads as backed up. `backedUpToRemote` is true when an auto-push remote is
  * configured (the GitHub variant of backup).
+ *
+ * That config-over-runtime read is deliberate for *local* history — bootstrap
+ * lag is a few seconds and nagging through it is worse than waiting. It is NOT
+ * safe for the off-site claim, which is why `remotePushState` comes from
+ * `status.last_push_at` / `status.last_push_error` instead. A remote that has
+ * been configured for five days and rejected every push is `"never"`, and the
+ * tile must not call that backed up.
+ *
+ * Tolerant, same as the rest of this module: a vault too old to report
+ * `status` at all leaves `remotePushState` at `"ok"` rather than crying wolf —
+ * the fields were added in vault Cut 5, so their absence means "can't tell",
+ * not "failing".
  */
 export async function fetchVaultMirrorStatus(
   vaultName: string,
@@ -101,14 +143,49 @@ export async function fetchVaultMirrorStatus(
     if (!res.ok) return null;
     const body = (await res.json()) as {
       config?: { enabled?: unknown; auto_push?: unknown };
+      status?: { last_push_at?: unknown; last_push_error?: unknown };
     };
     const enabled = body.config?.enabled;
     if (typeof enabled !== "boolean") return null;
     const backedUpToRemote = body.config?.auto_push === true;
-    return { enabled, backedUpToRemote };
+    return {
+      enabled,
+      backedUpToRemote,
+      remotePushState: derivePushState(backedUpToRemote, body.status),
+    };
   } catch {
     return null;
   }
+}
+
+/**
+ * Map the vault's runtime push fields onto {@link RemotePushState}.
+ *
+ * The vault reports `last_push_at` (ISO string of the last SUCCESSFUL push,
+ * null until one lands) and `last_push_error` (message from the last FAILED
+ * push, cleared on the next success). The pair distinguishes all three cases
+ * without the vault needing a new field:
+ *
+ *   at=null  err=set   → never   (configured, nothing has ever landed)
+ *   at=set   err=set   → failing (landed before, latest attempt failed)
+ *   at=set   err=null  → ok
+ *   at=null  err=null  → ok      (nothing attempted yet — a fresh mirror mid-
+ *                                 bootstrap, not a failure. Same "don't cry
+ *                                 wolf" posture as the missing-`status` case.)
+ *
+ * Exported for direct unit testing.
+ */
+export function derivePushState(
+  backedUpToRemote: boolean,
+  status: { last_push_at?: unknown; last_push_error?: unknown } | undefined,
+): RemotePushState {
+  if (!backedUpToRemote) return "n/a";
+  // A vault too old to report these fields can't be judged — stay quiet.
+  if (status === undefined || status === null) return "ok";
+  const hasError = typeof status.last_push_error === "string" && status.last_push_error.length > 0;
+  if (!hasError) return "ok";
+  const everSucceeded = typeof status.last_push_at === "string" && status.last_push_at.length > 0;
+  return everSucceeded ? "failing" : "never";
 }
 
 /**
@@ -120,7 +197,29 @@ export async function fetchVaultMirrorStatus(
  */
 export function formatMirrorLine(stat: VaultMirrorStat): string | null {
   if (!stat.enabled) return null;
-  return stat.backedUpToRemote
-    ? "Backed up — version history + GitHub"
-    : "Backed up — full version history";
+  if (!stat.backedUpToRemote) return "Backed up — full version history";
+  switch (stat.remotePushState) {
+    case "never":
+      // The loudest line, and the only one that says a thing is missing. A
+      // remote that has never accepted a push means there is no off-site copy
+      // at all — the owner needs to know that plainly, not read "backed up".
+      return "Version history saved here — GitHub backup has never worked";
+    case "failing":
+      return "Version history saved here — GitHub backup is failing";
+    default:
+      return "Backed up — version history + GitHub";
+  }
+}
+
+/**
+ * Whether the backup line describes a good state — drives the tile's `✓`.
+ *
+ * Split out as a proper boolean rather than sniffing the display string, the
+ * same convention `backedUpToRemote` already set for the "Back up to GitHub ↗"
+ * gate. A failing or never-worked remote must not render a green check next to
+ * a sentence explaining that it is broken.
+ */
+export function isMirrorHealthy(stat: VaultMirrorStat): boolean {
+  if (!stat.enabled) return false;
+  return stat.remotePushState !== "never" && stat.remotePushState !== "failing";
 }

--- a/src/api-account.ts
+++ b/src/api-account.ts
@@ -49,7 +49,7 @@ import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import { type ChangePasswordMode, renderChangePassword } from "./account-change-password-ui.ts";
 import { renderAccountHome } from "./account-home-ui.ts";
-import { fetchVaultMirrorStatus, formatMirrorLine } from "./account-mirror.ts";
+import { fetchVaultMirrorStatus, formatMirrorLine, isMirrorHealthy } from "./account-mirror.ts";
 import { fetchVaultUsage, formatUsageStat } from "./account-usage.ts";
 import { POST_LOGIN_DEFAULT } from "./admin-handlers.ts";
 import { renderAdminError } from "./admin-login-ui.ts";
@@ -575,6 +575,10 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
   // Threaded to the renderer as a proper boolean so it gates the "Back up to
   // GitHub ↗" action without re-deriving "are we pushing?" from the line string.
   const mirrorPushing: Record<string, boolean> = {};
+  // Whether each vault's backup line describes a GOOD state — drives the tile's
+  // `✓` vs `!`. A proper boolean for the same reason `mirrorPushing` is one: the
+  // renderer must never infer health by reading the display string.
+  const mirrorHealthy: Record<string, boolean> = {};
   if (deps.resolveVaultPort && user.assignedVaults.length > 0) {
     const fetchMirror = deps.fetchMirror ?? fetchVaultMirrorStatus;
     const resolvePort = deps.resolveVaultPort;
@@ -595,6 +599,7 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
           if (line) {
             mirrorLines[vaultName] = line;
             mirrorPushing[vaultName] = stat.backedUpToRemote;
+            mirrorHealthy[vaultName] = isMirrorHealthy(stat);
           }
         }
       }),
@@ -627,6 +632,7 @@ export async function handleAccountHomeGet(req: Request, deps: AccountHomeDeps):
       usageStats,
       mirrorLines,
       mirrorPushing,
+      mirrorHealthy,
       connectedVault,
     }),
     200,


### PR DESCRIPTION
A vault's mirror rejected **122 consecutive pushes since 2026-07-28** — the remote was created against a repo with unrelated history, so every push was refused as non-fast-forward. The vault logs each failure `(non-fatal)` and carries on, which is correct. `/account/` rendered **"Backed up — version history + GitHub"** with a green `✓` the entire time.

**Five days, no off-site copy, nothing surfaced.** A backup that had never once worked was pixel-identical to a working one.

## Cause

`fetchVaultMirrorStatus` read only `body.config`:

```ts
const backedUpToRemote = body.config?.auto_push === true;   // the whole basis
```

The vault already returns `status.last_push_at`, `last_push_error` and `commits_unpushed` **in the same response** — added in its Cut 5. No hub file read any of them; `git grep last_push -- src/` returned zero on `main`. The outcome crossed the wire and was discarded.

`auto_push: true` means a remote is *configured*. It says nothing about whether anything ever landed there.

## Fix

`VaultMirrorStat.remotePushState` — `"ok" | "failing" | "never" | "n/a"` — derived from runtime status rather than config:

```
at=null err=set   -> never    configured, nothing has EVER landed
at=set  err=set   -> failing  landed before, latest attempt failed
at=set  err=null  -> ok
at=null err=null  -> ok       nothing attempted yet, not a failure
```

**`never` is deliberately its own state, not a shade of `failing`.** A remote that has never accepted a push is a setup bug and means there is no off-site copy at all; one that worked yesterday and failed today is a blip. They must not render the same.

`isMirrorHealthy()` drives the tile's glyph, so `!` replaces `✓` on a broken backup — threaded as a proper boolean, not sniffed out of the display string, matching the convention `backedUpToRemote` already set for the "Back up to GitHub ↗" gate. Without it a broken backup would still have shown a green check next to a sentence saying it was broken.

## Deliberately not louder

```
vault too old to report push fields   -> ok
nothing attempted yet                 -> ok
```

**Absence of evidence is not evidence of failure.** A fresh mirror mid-bootstrap and a pre-Cut-5 vault both read `ok`; crying wolf there would be this same bug pointing the other way. The config-over-runtime read also stays for *local* history — bootstrap lag is seconds. It was never safe for the off-site claim, and that is the only place this changes.

## Verification

| check | result |
|---|---|
| mutation test | reverted `formatMirrorLine` to pre-fix → **2 fail / 18 pass**; restored → 20 pass |
| full hub suite | 4432 pass / 0 fail (`bun test ./src`), run twice |
| typecheck | clean — every `VaultMirrorStat` construction site was a compile error until it supplied the outcome field |
| biome | clean |

The mutation run is the one worth naming: without it the tests prove only that the new code agrees with itself.

## Attribution and provenance

**Found, diagnosed and fixed by the ParachuteDev agent.** I reported the field condition (the 122 rejected pushes on Aaron's own mirror, diverged since 2026-07-28) and independently re-verified the cause against `upstream/main` before opening this — `account-mirror.ts:105-107` and the zero-hit `last_push` grep both reproduce on `fe18924`.

I am opening it because ParachuteDev's container has no authenticated `gh`. The commit is theirs; the branch reached me as a signed git bundle over Buzz (`sha256 ea1119c3…`, verified on both sides) rather than by anyone reaching into their container.

**One thing I could not check:** `bun` is not installed in my container, so **I did not reproduce the 4432-pass suite** — that row is theirs, relayed, not verified by me. Everything else above I ran myself.

Originating conversation: Buzz channel `parachute` (`e0d12331-98be-4ee0-924f-7b977577a9c2`).
