### PR TITLE
fix(consent): retire dead verb-selector UI, dedup scope rows across naming shapes

### DIFF
--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -203,4 +203,29 @@ describe("consent checkbox posts the WIRE scope, not the display scope", () => {
     expect(html).toContain("vault:unforced:read");
     expect(html).not.toContain('value="vault:unforced:read"');
   });
+
+  test("one consent row survives a named/unnamed vault-scope collision", async () => {
+    const { renderConsent } = await import("../oauth-ui.ts");
+    const html = renderConsent({
+      params: {
+        clientId: "c",
+        redirectUri: "https://app.example/cb",
+        responseType: "code",
+        scope: "vault:unforced:read vault:read",
+        codeChallenge: "x",
+        codeChallengeMethod: "S256",
+        state: null,
+        resource: null,
+      },
+      csrfToken: "t",
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:unforced:read", "vault:read"],
+      displayVault: "unforced",
+    });
+    expect((html.match(/<li class="scope/g) ?? []).length).toBe(1);
+    // The first wire value is retained for the POST, even though both forms
+    // normalize to the same displayed permission.
+    expect(html).toContain('name="granted_scope" value="vault:unforced:read"');
+  });
 });

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -28,6 +28,7 @@ import {
 import {
   authorizationServerMetadata,
   buildServicesCatalog,
+  grantableExtraScopes,
   handleApproveClientPost,
   handleAuthorizeGet,
   handleAuthorizePost,
@@ -9811,6 +9812,36 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
     return { scope: body.scope, aud: payload.aud };
   }
 
+  test("grantable extras suppress an already-requested named vault scope for an admin", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin", "pw");
+      const extras = grantableExtraScopes(db, admin.id, {
+        userIsAdmin: true,
+        requested: ["vault:u:read"],
+        vaultName: undefined,
+      });
+      expect(extras).not.toContain("vault:read");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("grantable extras suppress an already-requested unnamed vault scope when named", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin", "pw");
+      const extras = grantableExtraScopes(db, admin.id, {
+        userIsAdmin: true,
+        requested: ["vault:read"],
+        vaultName: "u",
+      });
+      expect(extras).not.toContain("vault:u:read");
+    } finally {
+      cleanup();
+    }
+  });
+
   // Test 1 — pending client + session → consent renders (200), client flipped approved.
   test("[1] pending client + session → consent renders (200) + client flipped approved", async () => {
     const { db, cleanup } = await makeDb();
@@ -10423,16 +10454,11 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
 });
 
 // ───────────────────────────────────────────────────────────────────────────
-// hub#689 — owner-on-own-vault VERB SELECTOR. The consent screen offers an
-// owner of the picked vault a read/write/admin selector (pre-selected to
-// admin) when the client requested an UNNAMED `vault:read`/`vault:write`. On
-// submit, the owner's selection widens the unnamed verb to the chosen level
-// on the picked vault — BEFORE `capScopesToUserAuthority`, which remains the
-// backstop. The selector value is an UNTRUSTED hint: the handler re-derives
-// ownership of the picked vault server-side, and the cap drops any verb the
-// user doesn't actually hold.
+// Retired consent form field + stale-submit compatibility. The selector was
+// removed from the rendered form, but a cached or forged `verb_select` field
+// must remain harmless because the POST path does not read it.
 // ───────────────────────────────────────────────────────────────────────────
-describe("hub#689 — owner-on-own-vault verb selector + widening", () => {
+describe("retired verb selector form field", () => {
   const TTL_S = Math.floor(SESSION_TTL_MS / 1000);
   const SEL_MANIFEST: ServicesManifest = {
     services: [
@@ -10511,10 +10537,7 @@ describe("hub#689 — owner-on-own-vault verb selector + widening", () => {
     return body.scope;
   }
 
-  // GET render: owner of the picked vault sees the selector. A non-admin
-  // assigned to exactly one vault gets the locked picker → the selector is
-  // offered (they hold admin on their assigned vault).
-  test("selector RENDERED for an owner (assigned user) of the picked vault", async () => {
+  test("an assigned owner consent page never renders the retired selector", async () => {
     const { db, cleanup } = await makeDb();
     try {
       await createUser(db, "owner", "pw"); // consumes the admin slot
@@ -10543,153 +10566,11 @@ describe("hub#689 — owner-on-own-vault verb selector + widening", () => {
       );
       expect(res.status).toBe(200);
       const html = await res.text();
-      expect(html).toContain("Access level");
-      expect(html).toContain('name="verb_select"');
-      // Admin pre-selected, still visibly flagged.
-      expect(html).toMatch(/name="verb_select" value="admin"[^>]*checked/);
-      expect(html).toContain("badge-admin");
+      expect(html.match(/name="verb_select"/g) ?? []).toHaveLength(0);
     } finally {
       cleanup();
     }
   });
-
-  // GET render: a read-only-assigned user (role=read → holds read, NOT admin)
-  // does NOT see the selector — offering admin pre-selected would promise an
-  // upgrade the cap silently demotes. They hold the vault but not admin on it.
-  test("selector NOT rendered for a read-only-assigned user (holds read, not admin)", async () => {
-    const { db, cleanup } = await makeDb();
-    try {
-      await createUser(db, "owner", "pw");
-      const reader = await createUser(db, "reader", "pw", { allowMulti: true });
-      // role=read directly (setUserVaults hardcodes write) → holds read only.
-      db.prepare(
-        "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, 'read', ?)",
-      ).run(reader.id, "work", new Date().toISOString());
-      const session = createSession(db, { userId: reader.id });
-      const reg = registerClient(db, {
-        redirectUris: ["https://app.example/cb"],
-        status: "approved",
-      });
-      const { challenge } = makePkce();
-      const res = handleAuthorizeGet(
-        db,
-        new Request(
-          authorizeUrl({
-            client_id: reg.client.clientId,
-            redirect_uri: "https://app.example/cb",
-            response_type: "code",
-            code_challenge: challenge,
-            code_challenge_method: "S256",
-            scope: "vault:read",
-          }),
-          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
-        ),
-        selDeps,
-      );
-      expect(res.status).toBe(200);
-      const html = await res.text();
-      expect(html).not.toContain("Access level");
-      expect(html).not.toContain('name="verb_select"');
-    } finally {
-      cleanup();
-    }
-  });
-
-  // GET render (hub#703, folded into hub#314): a user with MIXED authority —
-  // admin on vault A (role=write → holds admin) but only read on vault B
-  // (direct INSERT role=read) — does NOT see the selector. The user could pick
-  // either vault, but doesn't own (hold admin on) EVERY pickable vault, so the
-  // `userHoldsAdminOnPickable` predicate (`assignedVaults.every(v => verbs
-  // includes "admin")`) fails on vault B and the selector is suppressed. The
-  // suppression logic already ships + is correct (oauth-handlers.ts ~2963 +
-  // ~1226); this test closes the coverage gap with no code change.
-  test("selector NOT rendered for a mixed-authority user (admin on A, read-only on B)", async () => {
-    const { db, cleanup } = await makeDb();
-    try {
-      await createUser(db, "owner", "pw");
-      const mixed = await createUser(db, "mixed", "pw", { allowMulti: true });
-      // Vault A ("work"): role=write → vaultVerbsForRole maps to [read,write,
-      // admin], so the user holds admin on A. (setUserVaults hardcodes write.)
-      setUserVaults(db, mixed.id, ["work"]);
-      // Vault B ("other"): direct INSERT role=read → holds read only, NOT admin.
-      // setUserVaults DELETEs first, so this INSERT must come after it to keep A.
-      db.prepare(
-        "INSERT INTO user_vaults (user_id, vault_name, role, created_at) VALUES (?, ?, 'read', ?)",
-      ).run(mixed.id, "other", new Date().toISOString());
-      const session = createSession(db, { userId: mixed.id });
-      const reg = registerClient(db, {
-        redirectUris: ["https://app.example/cb"],
-        status: "approved",
-      });
-      const { challenge } = makePkce();
-      const res = handleAuthorizeGet(
-        db,
-        new Request(
-          authorizeUrl({
-            client_id: reg.client.clientId,
-            redirect_uri: "https://app.example/cb",
-            response_type: "code",
-            code_challenge: challenge,
-            code_challenge_method: "S256",
-            scope: "vault:read",
-          }),
-          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
-        ),
-        selDeps,
-      );
-      expect(res.status).toBe(200);
-      const html = await res.text();
-      // Suppressed: the `.every(v => verbs includes "admin")` check fails on B.
-      expect(html).not.toContain("Access level");
-      expect(html).not.toContain('name="verb_select"');
-      // Sanity: the multi-vault picker DID render (two assigned vaults), so the
-      // suppression is specifically the verb selector, not the whole flow.
-      expect(html).toContain('name="vault_pick" value="work"');
-      expect(html).toContain('name="vault_pick" value="other"');
-    } finally {
-      cleanup();
-    }
-  });
-
-  // GET render: a non-owner (non-admin with ZERO assigned vaults) does NOT
-  // see the selector — they can't authorize a vault scope at all.
-  test("selector NOT rendered for a non-owner (zero-vault non-admin)", async () => {
-    const { db, cleanup } = await makeDb();
-    try {
-      await createUser(db, "owner", "pw");
-      const stranger = await createUser(db, "stranger", "pw", { allowMulti: true });
-      // No setUserVaults → zero assignments → not an owner of anything.
-      const session = createSession(db, { userId: stranger.id });
-      const reg = registerClient(db, {
-        redirectUris: ["https://app.example/cb"],
-        status: "approved",
-      });
-      const { challenge } = makePkce();
-      const res = handleAuthorizeGet(
-        db,
-        new Request(
-          authorizeUrl({
-            client_id: reg.client.clientId,
-            redirect_uri: "https://app.example/cb",
-            response_type: "code",
-            code_challenge: challenge,
-            code_challenge_method: "S256",
-            scope: "vault:read",
-          }),
-          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
-        ),
-        selDeps,
-      );
-      expect(res.status).toBe(200);
-      const html = await res.text();
-      expect(html).not.toContain("Access level");
-      expect(html).not.toContain('name="verb_select"');
-    } finally {
-      cleanup();
-    }
-  });
-
-  // Submit: owner (first admin) + client requested unnamed vault:read + selects
 
   // SECURITY: a non-owner who holds only READ on the picked vault forges
   // verb_select=admin → the server re-derives ownership (no admin held) and

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -316,8 +316,7 @@ describe("renderConsent", () => {
     expect(html).not.toContain('value="yes" class="btn btn-primary" disabled');
   });
 
-  // hub#689 — owner-on-own-vault verb selector rendering.
-  test("renders the owner verb selector (read/write/admin), pre-selected to admin", () => {
+  test("never renders the retired verb selector", () => {
     const html = renderConsent({
       params: { ...PARAMS, scope: "vault:read" },
       csrfToken: CSRF,
@@ -325,48 +324,8 @@ describe("renderConsent", () => {
       clientName: "App",
       scopes: ["vault:read"],
       vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
-      ownerVerbSelector: { requestedVerbs: ["read"] },
     });
-    expect(html).toContain("Access level");
-    expect(html).toContain('name="verb_select" value="read"');
-    expect(html).toContain('name="verb_select" value="write"');
-    expect(html).toContain('name="verb_select" value="admin"');
-    // Admin is the pre-selected (checked) option.
-    expect(html).toMatch(/name="verb_select" value="admin"[^>]*checked/);
-    // read/write are NOT pre-checked.
-    expect(html).not.toMatch(/name="verb_select" value="read"[^>]*checked/);
-    expect(html).not.toMatch(/name="verb_select" value="write"[^>]*checked/);
-  });
-
-  test("owner verb selector keeps the admin option visibly flagged (admin badge + red border)", () => {
-    const html = renderConsent({
-      params: { ...PARAMS, scope: "vault:read" },
-      csrfToken: CSRF,
-      clientId: "c",
-      clientName: "App",
-      scopes: ["vault:read"],
-      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
-      ownerVerbSelector: { requestedVerbs: ["read"] },
-    });
-    // The .scope-admin red-border class + the admin badge ride on the admin
-    // radio option so a pre-selected admin grant stays transparent.
-    expect(html).toContain("verb-option-admin");
-    expect(html).toContain("scope-admin");
-    expect(html).toContain("badge-admin");
-  });
-
-  test("does NOT render the verb selector when ownerVerbSelector is absent (non-owner)", () => {
-    const html = renderConsent({
-      params: { ...PARAMS, scope: "vault:read" },
-      csrfToken: CSRF,
-      clientId: "c",
-      clientName: "App",
-      scopes: ["vault:read"],
-      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
-      // ownerVerbSelector omitted → no selector
-    });
-    expect(html).not.toContain("Access level");
-    expect(html).not.toContain('name="verb_select"');
+    expect(html.match(/name="verb_select"/g) ?? []).toHaveLength(0);
   });
 
   // hub#314 — same-hub vs external trust marker. The `.badge-trust-*` class
@@ -535,13 +494,8 @@ describe("substituteVaultDisplay", () => {
     expect(substituteVaultDisplay("vault:other:read", "work")).toBe("vault:other:read");
   });
 
-  test("vault admin (vault:admin) doesn't get narrowed — admin verb stays unnamed", () => {
-    // vault:admin is a full-vault scope; we don't narrow it the same way
-    // because per-vault admin is `vault:<name>:admin` (non-requestable) and
-    // the unnamed vault:admin form is the legacy full-vault grant. Keep the
-    // displayed shape as-is so the operator sees the scope they're
-    // consenting to literally.
-    expect(substituteVaultDisplay("vault:admin", "work")).toBe("vault:admin");
+  test("vault admin (vault:admin) gets the same named display as other verbs", () => {
+    expect(substituteVaultDisplay("vault:admin", "work")).toBe("vault:work:admin");
   });
 
   test("'*' → renders the wildcard display form (vault:*:<verb>)", () => {
@@ -618,6 +572,30 @@ describe("renderConsent displayVault substitution", () => {
     expect(html).toContain("A specific vault is picked below");
     // explainScope label still resolves via the verb-form lookup.
     expect(html).toContain("Read your notes");
+  });
+
+  test("admin displayVault substitution includes the admin verb", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:admin" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:admin"],
+      displayVault: "u",
+    });
+    expect(html).toContain('<code class="scope-name">vault:u:admin</code>');
+  });
+
+  test("display-normalized duplicate vault scopes render one row", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:read vault:unforced:read" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read", "vault:unforced:read"],
+      displayVault: "unforced",
+    });
+    expect((html.match(/<li class="scope/g) ?? []).length).toBe(1);
   });
 
   test("displayVault undefined preserves the legacy raw form (no substitution)", () => {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -65,6 +65,7 @@ import {
 } from "./jwt-sign.ts";
 import {
   type AuthorizeFormParams,
+  canonicalConsentScope,
   renderApprovePending,
   renderConsent,
   renderError,
@@ -1302,20 +1303,6 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     return issueAuthCodeRedirect(db, parsed, requestedScopes, session.userId, deps);
   }
 
-  // hub#689 — does the user hold ADMIN on every vault they could pick? Admin
-  // (isFirstAdmin) owns the whole hub. A non-admin owns a vault only if their
-  // `user_vaults` role grants admin there (today role=write does; a role=read
-  // assignment would NOT). Re-derived from the DB so the owner-verb-selector
-  // is offered only to a genuine owner — the submit path re-checks the PICKED
-  // vault and the cap is the backstop, but rendering it precisely avoids
-  // promising an admin upgrade the cap would silently demote.
-  const userHoldsAdminOnPickable =
-    userIsAdmin ||
-    (assignedVaults.length > 0 &&
-      assignedVaults.every((v) =>
-        (vaultVerbsForUserVault(db, session.userId, v) ?? []).includes("admin"),
-      ));
-
   return htmlResponse(
     renderConsent(
       consentProps(
@@ -1325,7 +1312,6 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
         csrf.token,
         assignedVaults,
         userIsAdmin,
-        userHoldsAdminOnPickable,
         grantableExtraScopes(db, session.userId, {
           userIsAdmin,
           requested: parsed.scope.split(" ").filter((s) => s.length > 0),
@@ -1455,11 +1441,28 @@ export function grantableExtraScopes(
     ACCOUNT_SELF_READ_SCOPE,
     ACCOUNT_SELF_ADMIN_SCOPE,
   ];
-  const already = new Set(opts.requested);
+
+  // Compare both naming shapes in one canonical key space. When an admin's
+  // candidate list is unnamed but the request was already narrowed to a
+  // named vault, include that requested name as a display context too; the
+  // shared normalizer then maps the unnamed candidate to the same key. When a
+  // vault name is resolved, the ordinary context handles the reverse case
+  // (unnamed request versus named candidate).
+  const comparisonVaults: Array<string | undefined> = [v];
+  for (const requested of opts.requested) {
+    const parts = requested.split(":");
+    const requestedVault = parts.length === 3 && parts[0] === "vault" ? parts[1] : undefined;
+    if (requestedVault !== undefined && !comparisonVaults.includes(requestedVault)) {
+      comparisonVaults.push(requestedVault);
+    }
+  }
+  const canonicalKeys = (scope: string): string[] =>
+    comparisonVaults.map((displayVault) => canonicalConsentScope(scope, displayVault));
+  const already = new Set(opts.requested.flatMap(canonicalKeys));
   return capScopesToUserAuthority(
     db,
     userId,
-    candidates.filter((c) => !already.has(c)),
+    candidates.filter((candidate) => canonicalKeys(candidate).every((key) => !already.has(key))),
     { userIsAdmin: opts.userIsAdmin },
   );
 }
@@ -3026,24 +3029,20 @@ function consentProps(
   csrfToken: string,
   assignedVaults: readonly string[],
   userIsAdmin: boolean,
-  // hub#689 — true when the user holds admin on every vault they could pick
-  // (admin owns the hub; an assigned non-admin only if their role grants admin
-  // on each assigned vault). Gates whether the owner-verb-selector renders.
-  userHoldsAdminOnPickable = userIsAdmin,
   // The additional-access menu, already capped to this user's authority.
   // Passed IN rather than computed here because it needs the db + userId,
   // which this pure props builder deliberately doesn't take.
   grantableExtras: readonly string[] = [],
 ) {
-  const scopes = params.scope.split(" ").filter((s) => s.length > 0);
-  const unnamedVerbs = unnamedVaultVerbs(scopes);
+  const requestedScopes = params.scope.split(" ").filter((s) => s.length > 0);
+  const unnamedVerbs = unnamedVaultVerbs(requestedScopes);
   // Zero-vault non-admin can't authorize a vault-scoped request (hub#431).
   // The POST handler already 400s this case ("No vaults assigned"); this
   // flag lets the consent screen render Approve disabled + explain why,
   // instead of showing an enabled button that lands the user on an error.
   // Mirrors the vault-scope detection in `handleConsentSubmit`'s zero-vault
   // gate. Non-vault scopes (`scribe:transcribe`, etc.) stay authorizable.
-  const requestsVaultScope = scopes.some((s) => {
+  const requestsVaultScope = requestedScopes.some((s) => {
     if (s === "vault:read" || s === "vault:write" || s === "vault:admin") return true;
     const parts = s.split(":");
     return (
@@ -3080,7 +3079,7 @@ function consentProps(
   // consent into a token that fails at the resource server.
   const hasNamedStaleVaultScope =
     hasStaleAssignment &&
-    scopes.some((s) => {
+    requestedScopes.some((s) => {
       const parts = s.split(":");
       if (
         parts.length !== 3 ||
@@ -3163,25 +3162,16 @@ function consentProps(
     const only = vaultNames[0];
     if (only) displayVault = only;
   }
-  // hub#689 — owner-on-own-vault verb selector. The client requested an
-  // unnamed `vault:read`/`vault:write` verb, and the consenting user owns
-  // (holds admin on) every vault they could pick — first admin owns the whole
-  // hub; an assigned non-admin holds admin on each of their assigned vaults
-  // (vaultVerbsForRole('write') → [read,write,admin]). Offer the selector so
-  // they can grant the level their client actually needs (or downgrade), with
-  // admin pre-selected. Suppressed when the request can't be authorized (zero-
-  // vault non-admin) or the assignment is stale (no valid vault to own).
-  //
-  // SECURITY: this only DECIDES WHETHER TO RENDER. The actual widening is
-  // re-derived server-side in `handleConsentSubmit` against the *picked* vault
-  // and capped by `capScopesToUserAuthority`. The selector value is a hint.
-  const upgradeableUnnamedVerbs = unnamedVerbs.filter((v) => v === "read" || v === "write");
-  const userOwnsEveryPickableVault =
-    !hasStaleAssignment && userCanAuthorizeRequest && userHoldsAdminOnPickable;
-  const ownerVerbSelector =
-    upgradeableUnnamedVerbs.length > 0 && userOwnsEveryPickableVault
-      ? { requestedVerbs: upgradeableUnnamedVerbs }
-      : undefined;
+  // Keep the first wire value for each display-normalized scope. Resource
+  // narrowing can produce the same named value from distinct requested forms,
+  // and the consent page should offer one row/checkbox for that permission.
+  const seenScopeKeys = new Set<string>();
+  const scopes = requestedScopes.filter((scope) => {
+    const key = canonicalConsentScope(scope, displayVault);
+    if (seenScopeKeys.has(key)) return false;
+    seenScopeKeys.add(key);
+    return true;
+  });
   return {
     params,
     clientId: client.clientId,
@@ -3190,7 +3180,6 @@ function consentProps(
     csrfToken,
     vaultPicker,
     displayVault,
-    ownerVerbSelector,
     staleAssignedVault,
     // Approve stays enabled for non-vault scopes even when assigned_vault
     // is stale — the user can still consent to e.g. `scribe:transcribe`

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -154,21 +154,6 @@ export interface ConsentViewProps {
    */
   userCanAuthorizeRequest?: boolean;
   /**
-   * hub#689 — owner-on-own-vault verb selector. Set when the consenting user
-   * OWNS (holds admin on) every vault they could pick AND the client requested
-   * an unnamed `vault:read`/`vault:write` verb. Renders a read/write/admin
-   * radio group, pre-selected to admin, so the owner can grant the level their
-   * AI client actually needs in-flow (the requested-scope shape was the
-   * blocker, not the user's authority) — or transparently downgrade.
-   *
-   * The submitted `verb_select` is an UNTRUSTED hint: the consent-submit
-   * handler re-derives, server-side, whether the user actually owns the picked
-   * vault before widening, and `capScopesToUserAuthority` remains the backstop
-   * that drops any verb the user doesn't hold. The selector only ever WIDENS
-   * the unnamed verb(s) on the picked vault; it never touches any other scope.
-   */
-  ownerVerbSelector?: OwnerVerbSelector;
-  /**
    * Scopes the consenting user MAY grant beyond what the client requested,
    * already capped to their authority by `grantableExtraScopes`. Rendered as
    * an opt-in checklist so a user can grant access the client didn't know to
@@ -191,16 +176,6 @@ export interface ConsentViewProps {
    * `consentProps` call site in `oauth-handlers.ts`.
    */
   sameHub?: boolean;
-}
-
-export interface OwnerVerbSelector {
-  /**
-   * The unnamed read/write verb(s) the client requested. Only `read`/`write`
-   * are upgradeable here — an unnamed `vault:admin` request already renders
-   * with the admin badge and needs no selector. Used to word the selector
-   * help text ("the app asked for write access").
-   */
-  requestedVerbs: string[];
 }
 
 export interface VaultPicker {
@@ -382,7 +357,6 @@ export function renderConsent(props: ConsentViewProps): string {
     staleAssignedVault,
     blockApproveForStaleAssignment,
     userCanAuthorizeRequest,
-    ownerVerbSelector,
     grantableExtras,
     sameHub,
   } = props;
@@ -390,7 +364,14 @@ export function renderConsent(props: ConsentViewProps): string {
   // the operator sees the scope shape that will appear in the token. Raw
   // `scopes` keeps the wire form for the hidden form fields; only what's
   // rendered changes. See `ConsentViewProps.displayVault`.
-  const displayedScopes = scopes.map((s) => substituteVaultDisplay(s, displayVault));
+  const seenScopeKeys = new Set<string>();
+  const uniqueScopes = scopes.filter((scope) => {
+    const key = canonicalConsentScope(scope, displayVault);
+    if (seenScopeKeys.has(key)) return false;
+    seenScopeKeys.add(key);
+    return true;
+  });
+  const displayedScopes = uniqueScopes.map((scope) => canonicalConsentScope(scope, displayVault));
   const scopeRows =
     displayedScopes.length === 0
       ? // A client may legally omit `scope` (RFC 6749 §3.3), and MCP clients
@@ -399,10 +380,9 @@ export function renderConsent(props: ConsentViewProps): string {
         // actually happening and point at the checklist below, which is the
         // only way this flow can produce a useful token.
         `<li class="scope scope-empty">This app didn't ask for any specific access. Choose what to grant below — without a selection its token won't be able to do anything.</li>`
-      : scopes.map((wire, i) => renderScopeRow(wire, displayedScopes[i] ?? wire)).join("\n");
+      : uniqueScopes.map((wire, i) => renderScopeRow(wire, displayedScopes[i] ?? wire)).join("\n");
   const extrasSection = renderGrantableExtras(grantableExtras ?? [], displayedScopes.length === 0);
   const pickerSection = vaultPicker ? renderVaultPicker(vaultPicker) : "";
-  const verbSelectorSection = ownerVerbSelector ? renderOwnerVerbSelector(ownerVerbSelector) : "";
   // Approve is disabled when the picker can't yield a valid vault. The
   // empty-vault branch (no vaults registered) is the original case. A
   // locked-vault picker (multi-user Phase 1) always has a valid value via
@@ -501,7 +481,6 @@ export function renderConsent(props: ConsentViewProps): string {
         ${renderCsrfHiddenInput(csrfToken)}
         ${renderHiddenInputs(params)}
         ${pickerSection}
-        ${verbSelectorSection}
         ${extrasSection}
         <div class="button-row">
           <button type="submit" name="approve" value="yes" class="btn btn-primary"${approveDisabled}>Approve</button>
@@ -578,60 +557,6 @@ function renderVaultPicker(picker: VaultPicker): string {
 }
 
 /**
- * hub#689 — owner-on-own-vault verb selector. Rendered only when the
- * consenting user owns (holds admin on) every vault they could pick and the
- * client requested an unnamed `vault:read`/`vault:write` verb. Three radios
- * (read / write / admin), pre-selected to **admin** so the common case (the
- * owner's own AI client that needs full access) is one click — but the owner
- * sees and submits the choice, and can downgrade.
- *
- * The `admin` option keeps the `.scope-admin` red border + admin badge so an
- * admin grant stays visibly flagged even when pre-selected. The submitted
- * `verb_select` is an untrusted hint re-checked server-side (ownership
- * re-derivation in `handleConsentSubmit` + `capScopesToUserAuthority` backstop);
- * this template only renders the choice.
- */
-function renderOwnerVerbSelector(selector: OwnerVerbSelector): string {
-  const requested = selector.requestedVerbs.map((v) => `<code>vault:${escapeHtml(v)}</code>`);
-  const requestedList =
-    requested.length === 1
-      ? requested[0]
-      : `${requested.slice(0, -1).join(", ")} and ${requested.at(-1)}`;
-  const option = (
-    verb: "read" | "write" | "admin",
-    title: string,
-    desc: string,
-    checked: boolean,
-  ): string => {
-    const isAdmin = verb === "admin";
-    const cls = `verb-option${isAdmin ? " verb-option-admin scope-admin" : ""}`;
-    const badge = isAdmin ? `<span class="badge badge-admin">admin</span>` : "";
-    return `
-            <label class="${cls}">
-              <input type="radio" name="verb_select" value="${verb}"${checked ? " checked" : ""} />
-              <span class="verb-option-body">
-                <span class="verb-option-head">
-                  <span class="verb-option-title">${escapeHtml(title)}</span>
-                  ${badge}
-                </span>
-                <span class="verb-option-desc">${escapeHtml(desc)}</span>
-              </span>
-            </label>`;
-  };
-  return `
-        <section class="verb-selector">
-          <h2 class="scopes-title">Access level</h2>
-          <p class="picker-help">
-            This app asked for ${requestedList} access to your vault. Because you own
-            this vault, you can grant a different level — admin is selected so your app
-            can do everything it might need; lower it if you'd rather not.
-          </p>
-          <div class="verb-options">${option("read", "Read only", "View notes, tags, attachments, and config.", false)}${option("write", "Read & write", "Create, edit, and delete notes, tags, and attachments.", false)}${option("admin", "Admin", "Full access plus config, triggers/automation, GitHub backup, and minting tokens.", true)}
-          </div>
-        </section>`;
-}
-
-/**
  * "App not yet approved" page (#74). Two branches:
  *
  *   - **Authenticated operator with same-origin posture** (#208): render the
@@ -666,7 +591,7 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
   // approve time no vault has been picked yet — the SPA's
   // `/admin/approve-client/<id>` view uses the same wildcard treatment
   // (see `resolveScopeForDisplay` in `web/ui/src/routes/ApproveClient.tsx`).
-  const displayedScopes = requestedScopes.map((s) => substituteVaultDisplay(s, "*"));
+  const displayedScopes = requestedScopes.map((s) => canonicalConsentScope(s, "*"));
   const scopeRows =
     displayedScopes.length === 0
       ? `<li class="scope scope-empty">No scopes requested — the app gets a session token only.</li>`
@@ -678,7 +603,7 @@ export function renderApprovePending(props: ApprovePendingViewProps): string {
   // `vault:*:<verb>`. Mirrors the SPA's inline note on
   // `/admin/approve-client/<id>`. Omitted when no scope renders with `*`
   // (all scopes are either non-vault or already-named).
-  const wildcardNote = displayedScopes.some((s) => /^vault:\*:(read|write)$/.test(s))
+  const wildcardNote = displayedScopes.some((s) => /^vault:\*:(read|write|admin)$/.test(s))
     ? `
         <p class="scope-wildcard-note">
           <code>*</code> — a specific vault is selected during sign-in via the consent
@@ -844,7 +769,7 @@ function renderUnauthenticatedApproveCtas(
 }
 
 /**
- * Substitute an unnamed `vault:<verb>` scope with the resolved named form
+ * Normalize an unnamed `vault:<verb>` scope to the resolved named form
  * (`vault:<displayVault>:<verb>`) so consent / approval screens render
  * what'll actually appear in the token rather than the raw OAuth request.
  *
@@ -865,11 +790,12 @@ function renderUnauthenticatedApproveCtas(
  *     explanation below the scope list (see `renderApprovePending`).
  *   - `displayVault === "name"` → render as `vault:name:verb` literally.
  *
- * Non-vault scopes pass through untouched. Already-named `vault:<x>:<verb>`
+ * The supported unnamed verbs are `read`, `write`, and `admin`. Non-vault
+ * scopes pass through untouched. Already-named `vault:<x>:<verb>`
  * scopes also pass through — the OAuth request already specified a vault,
  * so there's nothing to resolve.
  */
-export function substituteVaultDisplay(
+export function canonicalConsentScope(
   scope: string,
   displayVault: string | null | undefined,
 ): string {
@@ -877,10 +803,13 @@ export function substituteVaultDisplay(
   const parts = scope.split(":");
   if (parts.length !== 2 || parts[0] !== "vault") return scope;
   const verb = parts[1];
-  if (verb !== "read" && verb !== "write") return scope;
+  if (verb !== "read" && verb !== "write" && verb !== "admin") return scope;
   const vaultLabel = displayVault === null ? "<TBD>" : displayVault;
   return `vault:${vaultLabel}:${verb}`;
 }
+
+/** Backwards-compatible name for the shared consent-scope normalizer. */
+export const substituteVaultDisplay = canonicalConsentScope;
 
 export function renderError(props: ErrorViewProps): string {
   const body = `
@@ -1061,12 +990,12 @@ export function renderUnknownClient(props: UnknownClientViewProps): string {
  * forms happened to coincide.
  */
 function renderScopeRow(scope: string, displayScope: string = scope): string {
-  // Special-case the `<TBD>` placeholder substituted by `substituteVaultDisplay`
+  // Special-case the `<TBD>` placeholder substituted by `canonicalConsentScope`
   // when the consent picker hasn't bound a vault yet — `explainScope` doesn't
   // match it because `<` / `>` aren't in the vault-name charset, but the
   // canonical verb-form does. Look up by the unnamed verb form so the
   // explanation + level styling are still correct.
-  const tbdMatch = displayScope.match(/^vault:<TBD>:(read|write)$/);
+  const tbdMatch = displayScope.match(/^vault:<TBD>:(read|write|admin)$/);
   const lookup = tbdMatch ? `vault:${tbdMatch[1]}` : displayScope;
   const explanation = explainScope(lookup);
   if (!explanation) {
@@ -1463,9 +1392,8 @@ const STYLES = `
     display: block;
   }
   .scope-label-muted { color: ${PALETTE.fgDim}; font-style: italic; }
-  /* Risk tiers carry the colour. .scope-admin is kept (the vault-verb radio
-     picker references it directly) and now matches the elevated tier, so the
-     two can never disagree about how one vault's admin looks. */
+  /* Risk tiers carry the colour. .scope-admin matches the elevated tier, so
+     the two can never disagree about how one vault's admin looks. */
   .scope-admin {
     border-color: ${PALETTE.caution};
     background: ${PALETTE.cautionSoft};
@@ -1572,47 +1500,6 @@ const STYLES = `
     font-size: 0.88rem;
     color: ${PALETTE.fg};
   }
-  /* hub#689 — owner-on-own-vault verb selector. Same card shell as the
-     vault picker; the admin option carries the .scope-admin red border so an
-     admin grant stays visibly flagged even when pre-selected. */
-  .verb-selector {
-    margin: 0 0 1.25rem;
-    padding: 0.75rem 0.85rem;
-    border: 1px solid ${PALETTE.borderLight};
-    border-radius: 6px;
-    background: ${PALETTE.bgSoft};
-  }
-  .verb-selector .scopes-title { margin-bottom: 0.4rem; }
-  .verb-options {
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-  }
-  .verb-option {
-    display: flex;
-    align-items: flex-start;
-    gap: 0.5rem;
-    padding: 0.5rem 0.65rem;
-    border: 1px solid ${PALETTE.border};
-    border-radius: 6px;
-    background: ${PALETTE.cardBg};
-    cursor: pointer;
-    transition: border-color 0.15s ease, background 0.15s ease;
-  }
-  .verb-option:hover { border-color: ${PALETTE.accent}; }
-  .verb-option input[type=radio] { margin-top: 0.25rem; }
-  .verb-option input[type=radio]:focus { outline: 2px solid ${PALETTE.accent}; outline-offset: 2px; }
-  .verb-option-body { display: flex; flex-direction: column; gap: 0.1rem; }
-  .verb-option-head {
-    display: flex;
-    align-items: center;
-    gap: 0.4rem;
-    flex-wrap: wrap;
-  }
-  .verb-option-title { font-weight: 500; color: ${PALETTE.fg}; font-size: 0.9rem; }
-  .verb-option-desc { font-size: 0.82rem; color: ${PALETTE.fgMuted}; }
-  .verb-option-admin .verb-option-title { color: ${PALETTE.danger}; }
-
   .vault-picker-empty .picker-help { color: ${PALETTE.danger}; }
   .vault-picker-empty .picker-help code { color: ${PALETTE.fg}; }
   .vault-picker-locked .picker-help { color: ${PALETTE.fgMuted}; }

--- a/web/ui/src/routes/ApproveClient.tsx
+++ b/web/ui/src/routes/ApproveClient.tsx
@@ -338,5 +338,5 @@ function isUnnamedVaultScope(scope: string): boolean {
   const parts = scope.split(":");
   if (parts.length !== 2 || parts[0] !== "vault") return false;
   const verb = parts[1];
-  return verb === "read" || verb === "write";
+  return verb === "read" || verb === "write" || verb === "admin";
 }


### PR DESCRIPTION
## What (batch C)

The OAuth consent screen double-listed vault permissions through **four independent causes**, all fixed here:

1. **Dead verb selector.** The access-level selector was functionally retired earlier ("a read-only agent is expressible") but its UI was never deleted — dead radios rendered on every consent screen. `ownerVerbSelector`, `renderOwnerVerbSelector`, and all plumbing removed; every forged-`verb_select` SECURITY regression test kept and passing.
2. **Duplicate scope strings** survived to render as duplicate rows. `scopes` now dedup order-preserving in `consentProps` and `renderConsent`.
3. **Admin verb excluded from display substitution**, so the same grant showed in two spellings. The substitution helper — now the shared, exported `canonicalConsentScope(wire, displayVault)` — covers read/write/admin uniformly.
4. **Naming-shape collisions in the extras checklist**: `grantableExtraScopes` compared candidates to requested scopes in one naming shape only, offering as an "extra" what was already requested. Now compared via the same canonical key.

Plus a two-line parity fix from review: the SPA approve page's `isUnnamedVaultScope` matcher extended to `admin` so both surfaces render the same spelling.

**Grant behavior untouched** — dedup/suppression are display-side; hidden form fields still carry raw wire scopes; the mint choke-point re-caps at submit as before.

## Tests

- The research report's worked examples added as tests (dedup to one row, `vault:admin` + displayVault narrowing, named/unnamed extras suppression both directions).
- `bun test ./src` → **4434 pass / 1 skip / 0 fail**; `tsc --noEmit` clean; lint baseline identical to main; web/ui vitest **328 pass** + typecheck clean.

Reviewed by Fable advisor: ship (its one nit is the SPA parity fix, folded in).

Per the new bundling cadence: no release yet — batch D (root /mcp + `resource` param) lands next and both ship as one hub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)