### PR TITLE
feat(oauth): root /mcp endpoint + RFC 8707 resource binding

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -345,8 +345,9 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
     expect(body.scopes_supported as string[]).not.toContain("parachute:host:admin");
   });
 
-  test("shares the bare PRM's scope set, so the two documents can't drift apart", async () => {
-    // The point of authoring locally: one registry, one filter, two documents.
+  test("shares the bare PRM's requestable-scope filter, narrowed further to vault-only", async () => {
+    // Both documents start from one registry and requestable-scope filter; the
+    // root document applies its additional vault-only door constraint.
     const root = (await call().json()) as Record<string, unknown>;
     const bare = (await protectedResourceMetadata({
       issuer: ISSUER,
@@ -356,6 +357,25 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
     expect([...(root.scopes_supported as string[])].sort()).toEqual(
       [...(bare.scopes_supported as string[])].sort(),
     );
+  });
+
+  test("narrows the bare PRM's requestable catalog to vault scopes at the root door", async () => {
+    // `agent:send` represents a requestable module-defined scope that the bare
+    // hub resource can advertise, while the root `/mcp` authorize branch drops
+    // it because root tokens are vault-audience tokens.
+    const declaredWithModuleScope = new Set([...declared, "agent:send"]);
+    const root = (await rootMcpProtectedResourceMetadata({
+      issuer: ISSUER,
+      loadDeclaredScopes: () => declaredWithModuleScope,
+      loadServicesManifest: fixtureLoadServicesManifest,
+    }).json()) as Record<string, unknown>;
+    const bare = (await protectedResourceMetadata({
+      issuer: ISSUER,
+      loadDeclaredScopes: () => declaredWithModuleScope,
+      loadServicesManifest: fixtureLoadServicesManifest,
+    }).json()) as Record<string, unknown>;
+    expect(bare.scopes_supported as string[]).toContain("agent:send");
+    expect(root.scopes_supported as string[]).not.toContain("agent:send");
   });
 
   test("conforms to the door contract, same as its sibling", async () => {
@@ -9266,6 +9286,245 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
     });
   }
 
+  /**
+   * Drive a real resource-bound authorize → consent exchange and return the
+   * one-use code. Each caller owns the returned database cleanup so token
+   * tests can exercise a fresh grant without hand-crafting auth artifacts.
+   */
+  async function setupJonAuthorizationCode() {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const cookie = `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
+      const registrationRes = await handleRegister(
+        db,
+        new Request(`${ISSUER}/oauth/register`, {
+          method: "POST",
+          body: JSON.stringify({
+            redirect_uris: ["https://app.example/cb"],
+            scope: "vault:read vault:write",
+          }),
+          headers: { "content-type": "application/json" },
+        }),
+        RESOURCE_DEPS,
+      );
+      expect(registrationRes.status).toBe(201);
+      const registration = (await registrationRes.json()) as { client_id: string };
+      approveClient(db, registration.client_id);
+
+      const resource = `${ISSUER}/vault/jon/mcp`;
+      const { verifier, challenge } = makePkce();
+      const authorizeRes = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: registration.client_id,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "vault:read vault:write",
+            resource,
+          }),
+          { headers: { cookie } },
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(authorizeRes.status).toBe(200);
+      const consentHtml = await authorizeRes.text();
+      expect(consentHtml).toContain("vault:jon:read");
+      expect(consentHtml).toContain("vault:jon:write");
+
+      const consentRes = await handleAuthorizePost(
+        db,
+        new Request(`${ISSUER}/oauth/authorize`, {
+          method: "POST",
+          body: new URLSearchParams({
+            __action: "consent",
+            __csrf: TEST_CSRF,
+            approve: "yes",
+            client_id: registration.client_id,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            scope: "vault:jon:read vault:jon:write",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            resource,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded", cookie },
+        }),
+        RESOURCE_DEPS,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+      return {
+        db,
+        cleanup,
+        clientId: registration.client_id,
+        code: code ?? "",
+        verifier,
+        resource,
+      };
+    } catch (err) {
+      cleanup();
+      throw err;
+    }
+  }
+
+  function resourceTokenRequest(form: URLSearchParams): Request {
+    return new Request(`${ISSUER}/oauth/token`, {
+      method: "POST",
+      body: form,
+      headers: { "content-type": "application/x-www-form-urlencoded" },
+    });
+  }
+
+  test("token resource matching the authorization binding → 200 with explicit vault audience", async () => {
+    const flow = await setupJonAuthorizationCode();
+    try {
+      const tokenRes = await handleToken(
+        flow.db,
+        resourceTokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code: flow.code,
+            client_id: flow.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: flow.verifier,
+            resource: flow.resource,
+          }),
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(tokenRes.status).toBe(200);
+      const token = (await tokenRes.json()) as {
+        access_token: string;
+        scope: string;
+      };
+      expect(token.scope).toBe("vault:jon:read vault:jon:write");
+      const { payload } = await validateAccessToken(flow.db, token.access_token, ISSUER);
+      expect(payload.aud).toBe("vault.jon");
+      expect(payload.scope).toBe("vault:jon:read vault:jon:write");
+    } finally {
+      flow.cleanup();
+    }
+  });
+
+  test("token resource that is off-origin or not an MCP resource → 400 invalid_target", async () => {
+    const flow = await setupJonAuthorizationCode();
+    try {
+      const tokenRes = await handleToken(
+        flow.db,
+        resourceTokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code: flow.code,
+            client_id: flow.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: flow.verifier,
+            resource: "https://evil.example/vault/jon/mcp",
+          }),
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(tokenRes.status).toBe(400);
+      const error = (await tokenRes.json()) as { error: string; error_description: string };
+      expect(error.error).toBe("invalid_target");
+      expect(error.error_description).toContain("https://evil.example/vault/jon/mcp");
+    } finally {
+      flow.cleanup();
+    }
+  });
+
+  test("token resource naming another vault than the authorization grant → 400 invalid_target", async () => {
+    const flow = await setupJonAuthorizationCode();
+    try {
+      const tokenRes = await handleToken(
+        flow.db,
+        resourceTokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code: flow.code,
+            client_id: flow.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: flow.verifier,
+            resource: `${ISSUER}/vault/boulder/mcp`,
+          }),
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(tokenRes.status).toBe(400);
+      const error = (await tokenRes.json()) as { error: string };
+      expect(error.error).toBe("invalid_target");
+    } finally {
+      flow.cleanup();
+    }
+  });
+
+  test("refresh_token resource validation matches the row's named vault and rejects another vault", async () => {
+    const flow = await setupJonAuthorizationCode();
+    try {
+      const initialRes = await handleToken(
+        flow.db,
+        resourceTokenRequest(
+          new URLSearchParams({
+            grant_type: "authorization_code",
+            code: flow.code,
+            client_id: flow.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: flow.verifier,
+          }),
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(initialRes.status).toBe(200);
+      const initial = (await initialRes.json()) as { refresh_token: string };
+
+      // A rejected target is checked before rotation, so the same refresh row
+      // remains usable for the matching resource immediately afterward.
+      const mismatchRes = await handleToken(
+        flow.db,
+        resourceTokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: initial.refresh_token,
+            client_id: flow.clientId,
+            resource: `${ISSUER}/vault/boulder/mcp`,
+          }),
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(mismatchRes.status).toBe(400);
+      const mismatch = (await mismatchRes.json()) as { error: string };
+      expect(mismatch.error).toBe("invalid_target");
+
+      const matchingRes = await handleToken(
+        flow.db,
+        resourceTokenRequest(
+          new URLSearchParams({
+            grant_type: "refresh_token",
+            refresh_token: initial.refresh_token,
+            client_id: flow.clientId,
+            resource: flow.resource,
+          }),
+        ),
+        RESOURCE_DEPS,
+      );
+      expect(matchingRes.status).toBe(200);
+      const matching = (await matchingRes.json()) as {
+        access_token: string;
+        scope: string;
+      };
+      expect(matching.scope).toBe("vault:jon:read vault:jon:write");
+      const { payload } = await validateAccessToken(flow.db, matching.access_token, ISSUER);
+      expect(payload.aud).toBe("vault.jon");
+    } finally {
+      flow.cleanup();
+    }
+  });
+
   test("E2E GATE: DCR → /authorize?resource=…/vault/jon/mcp → consent → code → /token mints aud=vault.jon + NAMED narrow scopes that a current-line vault accepts", async () => {
     const { db, cleanup } = await makeDb();
     try {
@@ -9609,6 +9868,45 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
       const html = await consentFor();
       expect(html).toContain("scribe:transcribe");
       expect(html).toContain("Pick a vault");
+    });
+
+    test("root-only non-vault request redirects with invalid_scope instead of rendering empty consent", async () => {
+      // CONTROL: the no-resource test above proves this same catalog reaches
+      // consent normally; only the root resource's vault-only narrowing makes
+      // this request unusable.
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { challenge } = makePkce();
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: "scribe:transcribe agent:send",
+              resource: `${ISSUER}/mcp`,
+            }),
+            {
+              headers: {
+                cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+              },
+            },
+          ),
+          RESOURCE_DEPS,
+        );
+        expect(res.status).toBe(302);
+        const location = res.headers.get("location");
+        expect(location).toBeTruthy();
+        expect(new URL(location ?? "").searchParams.get("error")).toBe("invalid_scope");
+      } finally {
+        cleanup();
+      }
     });
 
     test("resource=<origin>/mcp drops foreign scopes but KEEPS the picker", async () => {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -502,12 +502,18 @@ function advertisedScopes(declared: ReadonlySet<string>, manifest: ServicesManif
  *     Admin is what MCP clients need to manage tag schemas, so the gap made a
  *     core workflow unreachable over MCP.
  *
- *   - **Hub-level scopes could never appear at all.** Vault has no concept of
- *     them, so no edit to vault could have surfaced them here.
+ *   - **Hub-level scopes now have an explicit door boundary.** The root PRM
+ *     starts from hub's authoritative requestable/module-installed catalog,
+ *     then filters to vault scopes because root `/mcp` only accepts
+ *     vault-audience tokens. This keeps the root advertisement honest while
+ *     the bare PRM continues to describe the full hub resource.
  *
- * Sharing `advertisedScopes` with the bare PRM is the point: one scope
- * registry, filtered by one rule (requestable ∧ module-installed), so the two
- * documents cannot drift apart again.
+ * Both documents start from `advertisedScopes`: one scope registry, filtered
+ * by one rule (requestable ∧ module-installed). The root document then applies
+ * `narrowRootMcpScopes` because the root door only ever mints vault-audience
+ * tokens; advertising a non-vault scope that this authorize branch drops would
+ * mislead a spec-following client into requesting something the door cannot
+ * accept.
  */
 export function rootMcpProtectedResourceMetadata(deps: OAuthDeps): Response {
   const iss = deps.issuer;
@@ -518,9 +524,8 @@ export function rootMcpProtectedResourceMetadata(deps: OAuthDeps): Response {
     // matches against the endpoint it got the 401 from.
     resource: `${iss}/mcp`,
     authorization_servers: [iss],
-    scopes_supported: advertisedScopes(
-      declared,
-      (deps.loadServicesManifest ?? readServicesManifest)(),
+    scopes_supported: narrowRootMcpScopes(
+      advertisedScopes(declared, (deps.loadServicesManifest ?? readServicesManifest)()),
     ),
     bearer_methods_supported: ["header"],
     resource_documentation: "https://parachute.computer",
@@ -587,6 +592,81 @@ export function authorizationServerMetadata(deps: OAuthDeps): Response {
 /** Find any requested scopes that the public flow refuses to mint. */
 function findNonRequestableScopes(scopes: readonly string[]): string[] {
   return scopes.filter(isNonRequestableScope);
+}
+
+/** Every `vault:<name>:<verb>` name actually present in `scopes` (verb ∈ VAULT_VERBS). */
+function namedVaultScopeNames(scopes: readonly string[]): Set<string> {
+  const out = new Set<string>();
+  for (const s of scopes) {
+    const parts = s.split(":");
+    if (
+      parts.length === 3 &&
+      parts[0] === "vault" &&
+      parts[1] &&
+      parts[2] &&
+      VAULT_VERBS.has(parts[2])
+    ) {
+      out.add(parts[1]);
+    }
+  }
+  return out;
+}
+
+function invalidTargetResponse(resource: string): Response {
+  return jsonResponse(
+    {
+      error: "invalid_target",
+      error_description: `resource "${resource}" does not match the resource this token was granted for`,
+    },
+    400,
+  );
+}
+
+/**
+ * RFC 8707 §2.2 resource validation + audience resolution at /oauth/token.
+ * `requestResource` is optional; absent → return `fallbackAudience`
+ * UNCHANGED (today's `inferAudience` behavior, byte-for-byte — no client
+ * that never sends `resource` observes any difference).
+ *
+ * When present, it must resolve (via `resolveResourceVault` /
+ * `isRootMcpResource`, the SAME shape-recognition the authorize side uses)
+ * to a resource this token can actually serve:
+ *   - names a specific vault → that vault's name must be among
+ *     `grantedVaultNames`; audience becomes `vault.<name>` EXPLICITLY
+ *     (this is the "override inferAudience" the design calls for: a grant
+ *     can legally carry more than one named vault scope — a client can ask
+ *     for e.g. `vault:read` bound to one resource while also naming another
+ *     vault's scope explicitly — and inferAudience's first-scope-wins scan
+ *     can't tell which one the CALLER wants THIS token bound to; an explicit
+ *     `resource` disambiguates).
+ *   - names the vault-agnostic root door → allowed as long as at least one
+ *     named vault scope is present (root tokens are vault tokens whose
+ *     target the resource server derives from the token itself); audience
+ *     stays `fallbackAudience` (unchanged — root doesn't rename anything).
+ *   - resolves to neither (off-origin, malformed, non-MCP path, or a vault
+ *     name not in `grantedVaultNames`) → reject.
+ */
+function resolveTokenResourceAudience(
+  requestResource: string | null,
+  grantedVaultNames: ReadonlySet<string>,
+  boundOrigins: readonly string[],
+  fallbackAudience: string,
+): { audience: string } | { errorResponse: Response } {
+  if (!requestResource) return { audience: fallbackAudience };
+  const boundVault = resolveResourceVault(requestResource, boundOrigins);
+  if (boundVault) {
+    if (!grantedVaultNames.has(boundVault)) {
+      return { errorResponse: invalidTargetResponse(requestResource) };
+    }
+    return { audience: `vault.${boundVault}` };
+  }
+  if (isRootMcpResource(requestResource, boundOrigins)) {
+    if (grantedVaultNames.size === 0) {
+      return { errorResponse: invalidTargetResponse(requestResource) };
+    }
+    return { audience: fallbackAudience };
+  }
+  return { errorResponse: invalidTargetResponse(requestResource) };
 }
 
 // --- /oauth/authorize ------------------------------------------------------
@@ -1020,6 +1100,7 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // No resource, or one that isn't an MCP resource we front (off-origin,
   // malformed, non-vault path) → neither branch fires and the flow is
   // byte-for-byte the pre-#461 behavior (manual picker, etc.).
+  let rootNarrowedToEmpty = false;
   const boundOrigins = resolveBoundOrigins(deps);
   const boundVault = resolveResourceVault(parsed.resource, boundOrigins);
   if (boundVault) {
@@ -1029,9 +1110,10 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
     ).join(" ");
     url.searchParams.set("scope", parsed.scope);
   } else if (isRootMcpResource(parsed.resource, boundOrigins)) {
-    parsed.scope = narrowRootMcpScopes(parsed.scope.split(" ").filter((s) => s.length > 0)).join(
-      " ",
-    );
+    const preNarrow = parsed.scope.split(" ").filter((s) => s.length > 0);
+    const narrowed = narrowRootMcpScopes(preNarrow);
+    rootNarrowedToEmpty = preNarrow.length > 0 && narrowed.length === 0;
+    parsed.scope = narrowed.join(" ");
     url.searchParams.set("scope", parsed.scope);
   }
 
@@ -1074,6 +1156,15 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
       parsed.redirectUri,
       "invalid_request",
       "PKCE S256 is required",
+      parsed.state,
+    );
+  }
+
+  if (rootNarrowedToEmpty) {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "invalid_scope",
+      "none of the requested scopes are usable at the root MCP resource",
       parsed.state,
     );
   }
@@ -1712,6 +1803,7 @@ async function handleConsentSubmit(
   // semantics as the GET path: only when `resource` resolves to one of our
   // MCP resources — per-vault (narrow + name) or root (drop foreign scopes,
   // picker still names); no-op otherwise (manual-pick path unchanged).
+  let rootNarrowedToEmpty = false;
   const boundOrigins = resolveBoundOrigins(deps);
   const boundVault = resolveResourceVault(params.resource, boundOrigins);
   if (boundVault) {
@@ -1720,9 +1812,10 @@ async function handleConsentSubmit(
       boundVault,
     ).join(" ");
   } else if (isRootMcpResource(params.resource, boundOrigins)) {
-    params.scope = narrowRootMcpScopes(params.scope.split(" ").filter((s) => s.length > 0)).join(
-      " ",
-    );
+    const preNarrow = params.scope.split(" ").filter((s) => s.length > 0);
+    const narrowed = narrowRootMcpScopes(preNarrow);
+    rootNarrowedToEmpty = preNarrow.length > 0 && narrowed.length === 0;
+    params.scope = narrowed.join(" ");
   }
   const approve = String(form.get("approve") ?? "") === "yes";
   const sessionId = parseSessionCookie(req.headers.get("cookie"));
@@ -1769,6 +1862,14 @@ async function handleConsentSubmit(
       "Redirect mismatch",
       "The redirect_uri does not match any URI registered for this app.",
       400,
+    );
+  }
+  if (rootNarrowedToEmpty) {
+    return oauthErrorRedirect(
+      params.redirectUri,
+      "invalid_scope",
+      "none of the requested scopes are usable at the root MCP resource",
+      params.state,
     );
   }
   if (!approve) {
@@ -2439,7 +2540,15 @@ async function handleTokenAuthorizationCode(
       400,
     );
   }
-  const audience = inferAudience(redeemed.scopes);
+  const requestResource = (form.get("resource") as string | null) ?? null;
+  const audienceResolution = resolveTokenResourceAudience(
+    requestResource,
+    namedVaultScopeNames(redeemed.scopes),
+    resolveBoundOrigins(deps),
+    inferAudience(redeemed.scopes),
+  );
+  if ("errorResponse" in audienceResolution) return audienceResolution.errorResponse;
+  const audience = audienceResolution.audience;
   const access = await signAccessToken(db, {
     sub: redeemed.userId,
     scopes: redeemed.scopes,
@@ -2498,6 +2607,7 @@ async function handleTokenRefresh(
 ): Promise<Response> {
   const refreshToken = String(form.get("refresh_token") ?? "");
   const clientId = String(form.get("client_id") ?? "");
+  const requestResource = (form.get("resource") as string | null) ?? null;
   if (!refreshToken || !clientId) {
     return jsonResponse(
       { error: "invalid_request", error_description: "missing required parameter" },
@@ -2574,7 +2684,7 @@ async function handleTokenRefresh(
       // hand the client the new pair — it converges on the current lineage
       // (single live token preserved), no family revocation. Equivalent to
       // what the client would have received had it presented the tip itself.
-      return await rotateAndRespond(db, tip, deps, now);
+      return await rotateAndRespond(db, tip, deps, now, requestResource);
     }
     // Genuine theft (or a too-late replay): revoke every descendant so the
     // attacker can't keep refreshing, and force re-authorization.
@@ -2590,7 +2700,7 @@ async function handleTokenRefresh(
       400,
     );
   }
-  return await rotateAndRespond(db, row, deps, now);
+  return await rotateAndRespond(db, row, deps, now, requestResource);
 }
 
 /**
@@ -2609,6 +2719,7 @@ async function rotateAndRespond(
   row: RefreshTokenRow,
   deps: OAuthDeps,
   now: Date,
+  requestResource: string | null,
 ): Promise<Response> {
   const refreshUserId = row.userId ?? "";
   // Mint the access token *before* opening the rotation transaction. JWT
@@ -2618,7 +2729,17 @@ async function rotateAndRespond(
   // (revoke old) + INSERT (mint new refresh row) + link (rotated_to) commit
   // or roll back as a unit, so a mid-rotation crash can't
   // dead-old-without-replacement (#107).
-  const audience = inferAudience(row.scopes);
+  // A refresh row has no separate authorization artifact to consult. Its
+  // final named vault scopes are the resource binding already baked into the
+  // grant, so resource validation derives from the row itself.
+  const audienceResolution = resolveTokenResourceAudience(
+    requestResource,
+    namedVaultScopeNames(row.scopes),
+    resolveBoundOrigins(deps),
+    inferAudience(row.scopes),
+  );
+  if ("errorResponse" in audienceResolution) return audienceResolution.errorResponse;
+  const audience = audienceResolution.audience;
   const access = await signAccessToken(db, {
     sub: refreshUserId,
     scopes: row.scopes,

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -224,9 +224,11 @@ export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: 
  * Already-named `vault:<name>:<verb>` rides through untouched, same as the
  * per-vault path — a client that named a vault is not second-guessed here.
  *
- * A request that carries ONLY foreign scopes narrows to the empty list, which
- * the authorize handler already refuses with `invalid_scope` rather than
- * minting a zero-scope token. Same terminal behaviour as the per-vault path.
+ * A request that carries ONLY foreign scopes narrows to the empty list. The
+ * root authorize handler refuses that case with `invalid_scope` rather than
+ * reaching a zero-scope consent screen; the per-vault path deliberately keeps
+ * its empty narrowed list and renders consent, because that existing behavior
+ * is part of its contract.
  *
  * Idempotent: a second pass has nothing left to drop.
  */


### PR DESCRIPTION
## What

One MCP endpoint for every vault, with tokens bound to the vault a client names:

- **Root `/mcp` endpoint** — clients connect to one URL instead of one per vault; the vault is selected by the token, not the path.
- **RFC 8707 `resource` parameter honored at the token endpoint** — a token minted for one vault is scoped to that vault; requests naming a different resource are rejected with RFC-compliant errors.

## Verification

- Full hub suite + SPA suite green on this exact tree (4434 + 328).
- Fable review verdict: ship.

Stacked on #821 (now merged) and rebased onto main — the rebased tree hash is byte-identical to the reviewed/tested tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)