### PR TITLE
chore(release): hub 0.7.13 — consent cleanup + root /mcp resource binding

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Bundled release carrying two merged changes:

- #821 — consent-screen cleanup (all four double-listing causes)
- #822 — root `/mcp` endpoint + RFC 8707 `resource` binding at the token endpoint

After merging, publish fires on the tag:

```
gh release create v0.7.13 --repo ParachuteComputer/parachute-hub --target main --title v0.7.13 --generate-notes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)