### PR TITLE
ci(hub): gate PRs on typecheck + unit tests (#735, #773)

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -1,0 +1,38 @@
+# PR verification gate — catches type and hub unit-test regressions before
+# they can merge. Keep the package-build steps in sync with release.yml's
+# `test` job.
+
+name: PR verify
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  typecheck-unit-tests:
+    name: typecheck + unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3
+      - name: install deps
+        run: bun install --frozen-lockfile
+      - name: build depcheck
+        # hub's `tsc` typecheck resolves `@openparachute/depcheck`'s types from
+        # its built `dist/index.d.ts`. The workspace install doesn't build it
+        # (no prepare hook), so build it explicitly before typecheck. At
+        # runtime hub resolves depcheck via the `bun`→src export condition, so
+        # this is only needed for the type-level resolution.
+        run: bun run --cwd packages/depcheck build
+      - name: build door-contract
+        # Same reason as depcheck: hub's `tsc` typecheck + the door-contract
+        # parity test resolve `@openparachute/door-contract` from its built
+        # `dist/`. The frozen-lockfile install doesn't build it, so build it
+        # explicitly before typecheck + tests.
+        run: bun run --cwd packages/door-contract build
+      - name: typecheck
+        run: bun run typecheck
+      - name: hub tests
+        run: bun test ./src


### PR DESCRIPTION
Closes #735, closes #773.

Today a hub PR can merge even when unit tests or typecheck fail — the only PR gate is container-smoke; tests and typecheck run post-merge in `release.yml`. This adds a `pr-verify.yml` workflow that runs typecheck + the unit suite on every PR to `main`.

## What it runs

Mirrors `release.yml`'s `test` job exactly (with a header comment to keep them in sync): pinned bun 1.3 → `bun install --frozen-lockfile` → build `depcheck` + `door-contract` packages → `bun run typecheck` → `bun test ./src`. No `continue-on-error`; the job name `typecheck + unit tests` is distinct from every existing check, and `release.yml`, `container-smoke.yml`, and `e2e.yml` are untouched.

## Verified on the branch

Full sequence run locally: install, package builds, typecheck all exit 0; `bun test ./src` **4440 pass, 1 skip, 0 fail** (169 files, ~9 min). `actionlint` clean.

## After merge — one manual step

GitHub only offers a check as "required" after it has reported once. Once this PR's check runs: Settings → Branches → `main` protection rule → add **`typecheck + unit tests`** to required status checks. That is the moment #735/#773 actually close in practice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
