### PR TITLE
fix(hub): serve the path-inserted PRM discovery spelling for vaults (#776)

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4194,8 +4194,8 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
     const server = Bun.serve({
       port: 0,
       hostname: "127.0.0.1",
-      fetch: () =>
-        new Response(JSON.stringify({ tag: replyTag }), {
+      fetch: (request) =>
+        new Response(JSON.stringify({ tag: replyTag, pathname: new URL(request.url).pathname }), {
           status: 200,
           headers: { "content-type": "application/json" },
         }),
@@ -4206,6 +4206,219 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
   // Item E / #526 — fake Bun Server handle exposing `requestIP` for the peer-
   // address discriminator (see the proxyToService block for the rationale).
   const fakeServer = (address: string) => ({ requestIP: () => ({ address }) });
+
+  // Mirrors the REAL vault daemon's `handleProtectedResource` (vault's
+  // `src/oauth-discovery.ts`): the document is a pure function of the vault
+  // name + forwarded host, NOT of which well-known spelling the client used
+  // to reach it. `startVaultUpstream` above (which echoes the request
+  // pathname into the body) is right for pinning "the exact path was
+  // forwarded verbatim"; this one is right for pinning "the two spellings
+  // describe the same resource" — using it, the two path-inserted spellings
+  // and the suffix form all collapse to the same bytes, exactly like the
+  // real daemon.
+  function startVaultPrmUpstream(vaultName: string): { port: number; stop: () => void } {
+    const server = Bun.serve({
+      port: 0,
+      hostname: "127.0.0.1",
+      fetch: (request) => {
+        const forwardedHost = request.headers.get("x-forwarded-host");
+        const forwardedProto = request.headers.get("x-forwarded-proto") ?? "http";
+        const base = forwardedHost
+          ? `${forwardedProto}://${forwardedHost}`
+          : new URL(request.url).origin;
+        return Response.json({
+          resource: `${base}/vault/${vaultName}/mcp`,
+          authorization_servers: ["http://hub.example"],
+          scopes_supported: [
+            `vault:${vaultName}:read`,
+            `vault:${vaultName}:write`,
+            `vault:${vaultName}:admin`,
+          ],
+          bearer_methods_supported: ["header"],
+        });
+      },
+    });
+    return { port: server.port as number, stop: () => server.stop(true) };
+  }
+
+  test("path-inserted PRM is byte-identical to the pre-existing suffix-form PRM, both spellings (#776)", async () => {
+    const h = makeHarness();
+    const upstream = startVaultPrmUpstream("private");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-private",
+              port: upstream.port,
+              paths: ["/vault/private"],
+              health: "/vault/private/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+
+      // Ground truth: the suffix/path-append form (`/vault/<name>/.well-
+      // known/...`) is NOT this PR's route — it's routed by the pre-existing
+      // generic `/vault/<name>/*` proxy (`proxyToVault`). It has worked since
+      // #774 and is what the vault instance being "reachable at
+      // /vault/<name>/..." (per #776) means in practice.
+      const suffixRes = await fetcher(req("/vault/private/.well-known/oauth-protected-resource"));
+      expect(suffixRes.status).toBe(200);
+      const suffixBody = await suffixRes.text();
+
+      // Both path-inserted spellings — this PR's new route — must describe
+      // the exact same resource.
+      for (const path of [
+        "/.well-known/oauth-protected-resource/vault/private",
+        "/.well-known/oauth-protected-resource/vault/private/mcp",
+      ]) {
+        const res = await fetcher(req(path));
+        expect(res.status).toBe(200);
+        expect(await res.text()).toBe(suffixBody);
+      }
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("path-inserted per-vault PRM 404s before the vault is registered, 200s after — no hub restart (#776)", async () => {
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-techne");
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+
+      // Before: no service backs "techne" yet — the exact bug shape from
+      // #776 (the hub has no route to reach a vault instance that will,
+      // once created, be reachable at /vault/techne/...).
+      const before = await fetcher(req("/.well-known/oauth-protected-resource/vault/techne"));
+      expect(before.status).toBe(404);
+
+      // Simulate `parachute vault create techne` — services.json mutates,
+      // no hub restart (same dynamism `findVaultUpstream`'s docstring
+      // promises for /vault/<name>/* proxying).
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-techne",
+              port: upstream.port,
+              paths: ["/vault/techne"],
+              health: "/vault/techne/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+
+      // After: same hubFetch instance — the path-inserted form is now
+      // reachable, matching the pre-existing suffix form's dynamism.
+      const after = await fetcher(req("/.well-known/oauth-protected-resource/vault/techne"));
+      expect(after.status).toBe(200);
+      const body = (await after.json()) as { tag: string };
+      expect(body.tag).toBe("vault-techne");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("path-inserted per-vault PRM forwards both forms unchanged with wildcard CORS (#776)", async () => {
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-prm");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-private",
+              port: upstream.port,
+              paths: ["/vault/private"],
+              health: "/vault/private/health",
+              version: "0.4.0",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      for (const path of [
+        "/.well-known/oauth-protected-resource/vault/private",
+        "/.well-known/oauth-protected-resource/vault/private/mcp",
+      ]) {
+        const res = await fetcher(req(path));
+        expect(res.status).toBe(200);
+        expect(res.headers.get("access-control-allow-origin")).toBe("*");
+        expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+        const body = (await res.json()) as { tag: string; pathname: string };
+        expect(body.tag).toBe("vault-prm");
+        expect(body.pathname).toBe(path);
+      }
+
+      const options = await fetcher(
+        req("/.well-known/oauth-protected-resource/vault/private", { method: "OPTIONS" }),
+      );
+      expect(options.status).toBe(204);
+      expect(options.headers.get("access-control-allow-origin")).toBe("*");
+      expect(options.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("path-inserted per-vault PRM returns the vault daemon's not-found shape for unknown names (#776)", async () => {
+    const h = makeHarness();
+    try {
+      writeManifest({ services: [] }, h.manifestPath);
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/oauth-protected-resource/vault/missing"),
+      );
+      expect(res.status).toBe(404);
+      expect(await res.json()).toEqual({ error: "Vault not found", vault: "missing" });
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("path-inserted per-vault PRM applies the loopback publicExposure cloak (#776)", async () => {
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-private");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-private",
+              port: upstream.port,
+              paths: ["/vault/private"],
+              health: "/vault/private/health",
+              version: "0.4.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const res = await hubFetch(h.dir, { manifestPath: h.manifestPath })(
+        req("/.well-known/oauth-protected-resource/vault/private"),
+        fakeServer("198.51.100.4"),
+      );
+      expect(res.status).toBe(404);
+      expect(await res.text()).toBe("not found");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
 
   test("vault publicExposure: loopback + tailnet header → 404", async () => {
     const h = makeHarness();

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -4241,7 +4241,16 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
     return { port: server.port as number, stop: () => server.stop(true) };
   }
 
-  test("path-inserted PRM is byte-identical to the pre-existing suffix-form PRM, both spellings (#776)", async () => {
+  test("hub forwards the path-inserted PRM without mangling it — body matches the suffix-form fetch byte-for-byte, both spellings (#776)", async () => {
+    // This pins that HUB doesn't corrupt/rewrite the body in transit — it
+    // does NOT independently establish that the two well-known spellings
+    // describe "the same resource" at the protocol level. That invariant is
+    // the vault DAEMON's: both spellings route into the same
+    // `handleProtectedResource` call (parachute-vault `src/routing.ts:290-
+    // 323`, the path-insertion block ahead of the path-append route further
+    // down in the same file). Here we just prove hub's proxy is transparent:
+    // whatever the (fake, in-test) upstream returns for the suffix form is
+    // exactly what comes back through hub's new path-inserted route too.
     const h = makeHarness();
     const upstream = startVaultPrmUpstream("private");
     try {
@@ -4367,6 +4376,15 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
       expect(options.status).toBe(204);
       expect(options.headers.get("access-control-allow-origin")).toBe("*");
       expect(options.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+
+      // Advertised Allow-Methods is GET, OPTIONS only — a POST should 405,
+      // not fall through to the proxy (matches the advertised surface).
+      const posted = await fetcher(
+        req("/.well-known/oauth-protected-resource/vault/private", { method: "POST" }),
+      );
+      expect(posted.status).toBe(405);
+      expect(posted.headers.get("allow")).toBe("GET, OPTIONS");
+      expect(posted.headers.get("access-control-allow-origin")).toBe("*");
     } finally {
       upstream.stop();
       h.cleanup();
@@ -4412,8 +4430,69 @@ describe("hubFetch publicExposure layer-gate (proxyToVault)", () => {
         req("/.well-known/oauth-protected-resource/vault/private"),
         fakeServer("198.51.100.4"),
       );
+      // Same shape as the unknown-name 404 below — see the indistinguishability
+      // test for why a different shape here would be a private-vault existence
+      // oracle.
       expect(res.status).toBe(404);
-      expect(await res.text()).toBe("not found");
+      expect(res.headers.get("content-type")).toContain("application/json");
+      expect(await res.json()).toEqual({ error: "Vault not found", vault: "private" });
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+      expect(res.headers.get("access-control-allow-methods")).toBe("GET, OPTIONS");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("path-inserted per-vault PRM: a cloaked private vault's 404 is byte-for-byte indistinguishable from an unknown vault's 404 (#776)", async () => {
+    // The whole point of the loopback cloak is that an unauthenticated /
+    // cross-origin caller cannot use this route to confirm a private vault
+    // exists by name. That requires the cloaked-vault 404 and the
+    // unknown-vault 404 to match on status, body, content-type, AND CORS
+    // headers — any observable difference is a name-existence oracle.
+    const h = makeHarness();
+    const upstream = startVaultUpstream("vault-oracle-check");
+    try {
+      writeManifest(
+        {
+          services: [
+            {
+              name: "parachute-vault-oracle-check",
+              port: upstream.port,
+              paths: ["/vault/oracle-check"],
+              health: "/vault/oracle-check/health",
+              version: "0.4.0",
+              publicExposure: "loopback",
+            },
+          ],
+        },
+        h.manifestPath,
+      );
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+
+      const cloaked = await fetcher(
+        req("/.well-known/oauth-protected-resource/vault/oracle-check"),
+        fakeServer("198.51.100.4"),
+      );
+      const unknown = await fetcher(
+        req("/.well-known/oauth-protected-resource/vault/definitely-does-not-exist"),
+        fakeServer("198.51.100.4"),
+      );
+
+      expect(cloaked.status).toBe(unknown.status);
+      expect(cloaked.headers.get("content-type")).toBe(unknown.headers.get("content-type"));
+      expect(cloaked.headers.get("access-control-allow-origin")).toBe(
+        unknown.headers.get("access-control-allow-origin"),
+      );
+      expect(cloaked.headers.get("access-control-allow-methods")).toBe(
+        unknown.headers.get("access-control-allow-methods"),
+      );
+      // Bodies are only equal after normalizing the vault name back out — the
+      // point is the SHAPE is identical, not that the two names collide.
+      const cloakedBody = (await cloaked.json()) as { error: string; vault: string };
+      const unknownBody = (await unknown.json()) as { error: string; vault: string };
+      expect(cloakedBody.error).toBe(unknownBody.error);
+      expect(Object.keys(cloakedBody).sort()).toEqual(Object.keys(unknownBody).sort());
     } finally {
       upstream.stop();
       h.cleanup();

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -56,6 +56,7 @@
  *                                                FORWARDED from the vault daemon
  *                                                (not built locally like the
  *                                                hub-issued PRM)
+ *   /.well-known/oauth-protected-resource/vault/<name>[/mcp] → RFC 9728 per-vault PRM, forwarded from vault daemon
  *
  *   # OAuth issuer.
  *   /oauth/authorize  (GET + POST)             → login → consent → auth code
@@ -2975,6 +2976,44 @@ export function hubFetch(
           return new Response(null, { status: 204, headers: corsHeaders });
         }
         const res = rootMcpProtectedResourceMetadata(oauthDeps(req));
+        const merged = new Headers(res.headers);
+        for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
+        return new Response(res.body, { status: res.status, headers: merged });
+      }
+
+      // /.well-known/oauth-protected-resource/vault/<name>[/mcp] — the
+      // path-insertion PRM for a per-vault resource. The vault daemon owns this
+      // document because it authors the vault-specific resource URL and scopes;
+      // forward the exact path it expects rather than rebuilding the metadata
+      // in hub.
+      const protectedResourceVaultInsert = pathname.match(
+        /^\/\.well-known\/oauth-protected-resource\/vault\/([^/]+)(?:\/mcp)?$/,
+      );
+      if (protectedResourceVaultInsert) {
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+
+        const vaultName = protectedResourceVaultInsert[1]!;
+        const services = readManifestLenient(manifestPath).services;
+        const match = findVaultUpstream(services, `/vault/${vaultName}`);
+        let res: Response;
+        if (!match) {
+          res = Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
+        } else {
+          if (
+            effectivePublicExposure(match.entry) === "loopback" &&
+            layerOf(req, peerAddr) !== "loopback"
+          ) {
+            return new Response("not found", { status: 404 });
+          }
+          // No targetPath: the vault daemon matches this RFC path verbatim.
+          res = await proxyRequest(req, match.port, "vault", "vault", deps?.supervisor, peerAddr);
+        }
         const merged = new Headers(res.headers);
         for (const [k, v] of Object.entries(corsHeaders)) merged.set(k, v);
         return new Response(res.body, { status: res.status, headers: merged });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -2997,6 +2997,12 @@ export function hubFetch(
         if (req.method === "OPTIONS") {
           return new Response(null, { status: 204, headers: corsHeaders });
         }
+        if (req.method !== "GET") {
+          return new Response("method not allowed", {
+            status: 405,
+            headers: { ...corsHeaders, allow: "GET, OPTIONS" },
+          });
+        }
 
         const vaultName = protectedResourceVaultInsert[1]!;
         const services = readManifestLenient(manifestPath).services;
@@ -3004,13 +3010,18 @@ export function hubFetch(
         let res: Response;
         if (!match) {
           res = Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
+        } else if (
+          effectivePublicExposure(match.entry) === "loopback" &&
+          layerOf(req, peerAddr) !== "loopback"
+        ) {
+          // Cloaked exactly like "no such vault" — same JSON body, status, and
+          // (via the shared merge below) the same CORS headers. A cloaked
+          // private vault must be indistinguishable from an unknown name to an
+          // unauthenticated caller; an early-return with a different body
+          // shape here would turn this route into a private-vault existence
+          // oracle (name it and see whether the 404 looks "loopback-shaped").
+          res = Response.json({ error: "Vault not found", vault: vaultName }, { status: 404 });
         } else {
-          if (
-            effectivePublicExposure(match.entry) === "loopback" &&
-            layerOf(req, peerAddr) !== "loopback"
-          ) {
-            return new Response("not found", { status: 404 });
-          }
           // No targetPath: the vault daemon matches this RFC path verbatim.
           res = await proxyRequest(req, match.port, "vault", "vault", deps?.supervisor, peerAddr);
         }


### PR DESCRIPTION
Closes #776.

## What

The vault daemon serves its protected-resource metadata under both RFC 9728 spellings, but the hub only forwarded the suffix form — the path-inserted form (`/.well-known/oauth-protected-resource/vault/<name>[/mcp]`) 404'd at the hub even when the vault was reachable. Now routed: the hub's regex is character-for-character the daemon's own (`parachute-vault/src/routing.ts:316`), resolved via `findVaultUpstream` (same resolution as `/vault/<name>/*` proxying), forwarded verbatim with the standard well-known CORS posture (`*`, GET/OPTIONS), per the approach the issue suggests.

## Security note from review

The first cut leaked private-vault existence: the `publicExposure: loopback` cloak's 404 differed from the unknown-vault 404 in body, content-type, and CORS headers — an unauthenticated caller could confirm a cloaked vault existed by name. Fixed: cloaked ≡ unknown byte-for-byte, and the *indistinguishability itself* is now a pinned test (verified to fail without the fix). Non-GET/OPTIONS gets a 405 with an accurate `Allow` header rather than being proxied.

Deliberate omission: the authorization-server insert form (`/.well-known/oauth-authorization-server/vault/<name>`) stays unrouted — the hub *is* the authorization server and serves its metadata at the bare well-known path; there is no per-vault AS document to forward.

## Tests (HEAD `6b4dc54`)

Full suite 4446 pass / 1 skip / 0 fail, typecheck clean. Six #776-tagged tests: byte-identity between spellings through the real route, dynamic 404→200 without hub restart, CORS on both spellings incl. OPTIONS, cloak indistinguishability, 405 guard, unknown-vault shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)