### PR TITLE
fix(release): merge-published images get a versioned ghcr tag; RELEASING.md matches reality

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-# Release workflow — triggered by pushing a semver tag.
+# Release workflow — triggered by a merge to `main` (hub#790), or by pushing a
+# semver tag.
 #
 # This workflow publishes FOUR packages on different tag namespaces:
 #
@@ -8,9 +9,11 @@
 #   - @openparachute/door-contract  ← tag prefix `door-contract-v...` (e.g. door-contract-v0.6.0)
 #
 # All packages have npm Trusted Publisher rules pointing at this workflow
-# file. The jobs below gate on the tag prefix so only one package publishes
-# per tag push. Independent release cadences; hub doesn't have to bump when
-# scope-guard / depcheck / door-contract ship and vice versa.
+# file. On a tag push the jobs below gate on the tag prefix so only one package
+# publishes; on a merge each job gates on its own `plan` output, so a merge can
+# publish several packages at once. Independent release cadences either way;
+# hub doesn't have to bump when scope-guard / depcheck / door-contract ship and
+# vice versa.
 #
 # Tag conventions (matches governance rule 2, https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md):
 #   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.33)
@@ -22,22 +25,19 @@
 #                                    (depcheck-v0.1.0)
 #                                    (door-contract-v0.6.0)
 #
-# Release flow:
-#   1. When ready to ship: bump version in the relevant package.json on main
-#      (root for hub, packages/scope-guard/ for scope-guard,
+# Release flow (publish-on-merge — the tag path below still works, see `plan`):
+#   1. When ready to ship: open a release PR bumping `version` in the relevant
+#      package.json (root for hub, packages/scope-guard/ for scope-guard,
 #      packages/depcheck/ for depcheck, packages/door-contract/ for
 #      door-contract).
-#   2. Push a matching tag:
-#        # for hub
-#        git tag v$(bun -e "console.log(require('./package.json').version)") && git push --tags
-#        # for scope-guard
-#        git tag scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)") && git push --tags
-#        # for depcheck
-#        git tag depcheck-v$(bun -e "console.log(require('./packages/depcheck/package.json').version)") && git push --tags
-#        # for door-contract
-#        git tag door-contract-v$(bun -e "console.log(require('./packages/door-contract/package.json').version)") && git push --tags
-#   3. CI runs tests once (workspace-wide), then publishes the package matching
-#      the tag prefix. Hub also publishes a container image to ghcr.io.
+#   2. Merge it. That IS the release signal — `plan` compares each
+#      package.json against npm and publishes what's new.
+#   3. CI runs tests once (workspace-wide), then publishes whichever packages
+#      `plan` selected. Hub also publishes a container image to ghcr.io, tagged
+#      from the published VERSION (`:vX.Y.Z` + `:rc`/`:stable` + `:latest`) —
+#      not from the ref, which on a merge run is just `main` (hub#829).
+#   4. `tag-record` pushes `vX.Y.Z` afterwards as a RECORD of what shipped.
+#      Nothing needs to be tagged by hand.
 #
 # Operator setup (one-time) — see RELEASING.md:
 #   - npm Trusted Publisher rules: one per package (hub, scope-guard, depcheck,
@@ -96,6 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       hub: ${{ steps.hub.outputs.should_publish }}
+      # The version being shipped, independent of the ref. `publish-image`
+      # derives every image tag from this (hub#829) — on a merge-triggered run
+      # `github.ref_name` is `main`, so a ref-derived tag has no version in it.
+      hub_version: ${{ steps.hub.outputs.version }}
       scope_guard: ${{ steps.scope_guard.outputs.should_publish }}
       depcheck: ${{ steps.depcheck.outputs.should_publish }}
       door_contract: ${{ steps.door_contract.outputs.should_publish }}
@@ -410,6 +414,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: guard against an empty version
+        # `plan` always emits `version` (release-plan.ts reads it straight out
+        # of package.json), but an empty one here would silently push `:v` and
+        # a `latest`/`stable` with no versioned peer — exactly the failure mode
+        # hub#829 is about. Fail loudly instead.
+        run: |
+          if [ -z "${{ needs.plan.outputs.hub_version }}" ]; then
+            echo "::error::plan job emitted no hub version — refusing to push untagged images"
+            exit 1
+          fi
       - name: derive tags
         id: meta
         uses: docker/metadata-action@v5
@@ -418,10 +432,27 @@ jobs:
           # ParachuteComputer is mixed-case on github, hence the explicit
           # lowercase here.
           images: ghcr.io/parachutecomputer/parachute-hub
+          # Every tag comes from the VERSION BEING PUBLISHED, never from the
+          # ref — the same lesson as the npm dist-tag fix (hub#792). This used
+          # to be `type=ref,event=tag`, which on a merge-triggered run
+          # (`github.ref_name` == `main`) emitted no version tag at all: the
+          # 0.7.13 merge run pushed `:stable` alone, and its `:v0.7.13` /
+          # `:latest` existed only because someone also pushed a tag by hand.
+          # With the manual tag step gone from release PRs, that left RELEASING.md's
+          # `docker pull …:vX.Y.Z` verify/rollback steps pointing at nothing (hub#829).
+          # Naming the version first also fixes the OCI `image.version` label,
+          # which metadata-action takes from the first tag (it read `stable`).
           tags: |
-            type=ref,event=tag
-            type=raw,value=rc,enable=${{ contains(github.ref_name, '-rc.') }}
-            type=raw,value=stable,enable=${{ !contains(github.ref_name, '-rc.') }}
+            type=raw,value=v${{ needs.plan.outputs.hub_version }}
+            type=raw,value=rc,enable=${{ contains(needs.plan.outputs.hub_version, '-rc.') }}
+            type=raw,value=stable,enable=${{ !contains(needs.plan.outputs.hub_version, '-rc.') }}
+            type=raw,value=latest,enable=${{ !contains(needs.plan.outputs.hub_version, '-rc.') }}
+          # `latest` is declared explicitly above, so turn off metadata-action's
+          # automatic one: `latest=auto` only fires for `type=ref,event=tag` /
+          # `type=semver`, i.e. tag runs only, which is the second half of
+          # hub#829 (`:latest` stuck at 0.7.13 once merges became the trigger).
+          flavor: |
+            latest=false
       - name: build + push
         uses: docker/build-push-action@v5
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,99 +2,65 @@
 
 This repo publishes FOUR npm packages on independent release cadences via [`.github/workflows/release.yml`](./.github/workflows/release.yml):
 
-| Package | Tag prefix | Container image |
+| Package | Git tag prefix (recorded by CI; also accepted as a manual release trigger) | Container image |
 |---|---|---|
 | `@openparachute/hub` | `v...` (e.g. `v0.5.13-rc.33`) | yes — `ghcr.io/parachutecomputer/parachute-hub` |
 | `@openparachute/scope-guard` | `scope-guard-v...` (e.g. `scope-guard-v0.4.0`) | no |
 | `@openparachute/depcheck` | `depcheck-v...` (e.g. `depcheck-v0.1.1`) | no |
 | `@openparachute/door-contract` | `door-contract-v...` (e.g. `door-contract-v0.6.0`) | no |
 
-Pushing a tag triggers CI which runs `bun run typecheck` + `bun test ./src`, then publishes the package matching the tag prefix.
+**Merging a version bump to `main` is the release signal** (hub#790). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
 
-## Tag conventions
+Pushing a tag still works and still publishes: a tag is a human saying "release this", and it overrides every check `release-plan.ts` makes (including the refuse-to-go-backwards guard). Use it for a deliberate re-release; the merge path is the normal one.
+
+## Version conventions
 
 Per [governance rule 2](https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md):
 
-| Tag shape | Example | npm `dist-tag` | ghcr image tags (hub only) |
-|---|---|---|---|
-| `vX.Y.Z-rc.N` | `v0.5.13-rc.33` | `rc` | `:v0.5.13-rc.33`, `:rc` |
-| `vX.Y.Z` | `v0.5.13` | `latest` | `:v0.5.13`, `:stable` |
-| `scope-guard-vX.Y.Z-rc.N` | `scope-guard-v0.4.0-rc.2` | `rc` | — |
-| `scope-guard-vX.Y.Z` | `scope-guard-v0.4.0` | `latest` | — |
-| `depcheck-vX.Y.Z-rc.N` | `depcheck-v0.1.1-rc.1` | `rc` | — |
-| `depcheck-vX.Y.Z` | `depcheck-v0.1.1` | `latest` | — |
-| `door-contract-vX.Y.Z-rc.N` | `door-contract-v0.6.0-rc.1` | `rc` | — |
-| `door-contract-vX.Y.Z` | `door-contract-v0.6.0` | `latest` | — |
+| `package.json` version | Example | npm `dist-tag` | Recorded git tag | ghcr image tags (hub only) |
+|---|---|---|---|---|
+| hub `X.Y.Z-rc.N` | `0.7.14-rc.1` | `rc` | `v0.7.14-rc.1` | `:v0.7.14-rc.1`, `:rc` |
+| hub `X.Y.Z` | `0.7.14` | `latest` | `v0.7.14` | `:v0.7.14`, `:stable`, `:latest` |
+| scope-guard `X.Y.Z-rc.N` | `0.4.0-rc.2` | `rc` | `scope-guard-v0.4.0-rc.2` | — |
+| scope-guard `X.Y.Z` | `0.4.0` | `latest` | `scope-guard-v0.4.0` | — |
+| depcheck `X.Y.Z-rc.N` | `0.1.1-rc.1` | `rc` | `depcheck-v0.1.1-rc.1` | — |
+| depcheck `X.Y.Z` | `0.1.1` | `latest` | `depcheck-v0.1.1` | — |
+| door-contract `X.Y.Z-rc.N` | `0.7.0-rc.1` | `rc` | `door-contract-v0.7.0-rc.1` | — |
+| door-contract `X.Y.Z` | `0.7.0` | `latest` | `door-contract-v0.7.0` | — |
 
-The workflow auto-detects rc vs stable from the `-rc.` substring in the tag.
+rc vs stable is detected from the `-rc.` substring in **the version being published**, never from the ref — on a merge-triggered run the ref is `main`, which matches no version pattern at all. Reading the ref is what once put `0.7.9-rc.3` on `@latest` (hub#792) and what left merge-published images with a bare `:stable` and no `:vX.Y.Z` (hub#829).
 
 ## Release flow
 
-Per [governance rule 2 (updated 2026-05-24)](https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md), PRs do NOT bump version per-commit. Bump + tag together only when you intend to ship.
+Per [governance rule 2 (updated 2026-05-24)](https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md), feature PRs do NOT bump version. A release PR does, and merging it publishes.
 
 ### Releasing hub
 
 ```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./package.json (rc.N or drop -rc for stable), commit, push.
-VERSION="v$(bun -e "console.log(require('./package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
+git fetch && git checkout -b release/hub-X.Y.Z origin/main
+# Bump the version in ./package.json (rc.N or drop -rc for stable) + CHANGELOG.
+git commit -am "chore(release): hub X.Y.Z — <what shipped>"
+gh pr create
 ```
 
-CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
-- npm gets the new version with appropriate dist-tag
-- ghcr gets a new image at `:vX.Y.Z` plus `:rc` or `:stable`
+Merge it to `main`. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
+- npm gets the new version with the appropriate dist-tag
+- ghcr gets a new image at `:vX.Y.Z` plus `:rc`, or `:stable` + `:latest`
+- a `vX.Y.Z` git tag is pushed as a record
 
-### Releasing scope-guard
+### Releasing scope-guard / depcheck / door-contract
 
-```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./packages/scope-guard/package.json, commit, push.
-VERSION="scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
-```
+Same shape: bump the version in `./packages/<name>/package.json` and merge. Each package's publish job gates on its own `plan` output, so bumping one publishes only that one — but a single merge that bumps several publishes all of them. The hub package is NOT republished unless its own version moved.
 
-The hub package is NOT republished. scope-guard runs on its own cadence.
-
-### Releasing depcheck
-
-```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./packages/depcheck/package.json, commit, push.
-VERSION="depcheck-v$(bun -e "console.log(require('./packages/depcheck/package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
-```
-
-### Releasing door-contract
-
-`@openparachute/door-contract` is the shared OAuth-issuer + `/account/*` wire
-contract both doors implement. Hub currently consumes it as a `workspace:*`
-dep, which is fine for the bun-linked local install but unresolvable in the
-published hub tarball (`packages/` isn't shipped) — so door-contract must be a
-real npm dependency before hub can boot from npm. This section makes the
-publish path exist; the hub-dep flip is a follow-on PR.
-
-```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./packages/door-contract/package.json, commit, push.
-VERSION="door-contract-v$(bun -e "console.log(require('./packages/door-contract/package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
-```
-
-The hub package is NOT republished. depcheck / door-contract run on their own
-cadence.
+`@openparachute/door-contract` is the shared OAuth-issuer + `/account/*` wire contract both doors implement. Hub consumes it as a real npm dependency (`^0.7.0`) as of #826 — it used to be a `workspace:*` dep, which was unresolvable in the published hub tarball since `packages/` isn't shipped. So a door-contract change that hub depends on needs **two** releases: publish door-contract first, then bump hub's dependency range and release hub.
 
 ### Promoting an rc chain to stable
 
-Open a PR (or commit directly) that drops the `-rc.N` suffix from the relevant `package.json`, merge, then tag the bare version. CI publishes with `dist-tag=latest`.
+Open a release PR that drops the `-rc.N` suffix from the relevant `package.json` and merge it. CI publishes with `dist-tag=latest` (and, for hub, moves `:stable` + `:latest` on ghcr).
 
 ### Doc-only PRs
 
-Per governance, doc-only PRs DO NOT bump version. They merge straight to main; the changes get folded into whatever the next ship-driven version bump captures.
+Per governance, doc-only PRs DO NOT bump version. They merge straight through; the changes get folded into whatever the next ship-driven version bump captures.
 
 ## One-time setup (operator)
 
@@ -108,7 +74,9 @@ Before the workflow can publish, this repo needs:
 
    All rules point at the SAME workflow file. The jobs gate on tag prefix to decide which package to publish. No `NPM_TOKEN` secret needed — the workflow uses OIDC.
 
-2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`. First push of the image will create the package as **private by default**. After that first push, go to [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) → "Change visibility" → **Public**. Until you do this, any deploy target that pulls the image (Render, etc.) will 403 on `docker pull` unless you supply a `GHCR_PAT` read token. Doing it once at first-push time is the simplest path.
+2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`.
+
+   **The `parachute-hub` container package is `private`, deliberately, and stays that way until something outside this org needs to pull it.** Private costs one `docker login` for the verify/rollback steps below; public is a one-way-ish door on a package nobody currently deploys from. When a deploy target does need it (Render, a customer box), flip it once: [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) → "Change visibility" → **Public**. Until then, an unauthenticated `docker pull` 403s — that's expected, not a broken release.
 
 ## Verifying a release
 
@@ -120,10 +88,14 @@ npm view @openparachute/scope-guard dist-tags
 npm view @openparachute/depcheck dist-tags
 npm view @openparachute/door-contract dist-tags
 
-# ghcr (hub only)
-docker pull ghcr.io/parachutecomputer/parachute-hub:<tag>
-docker inspect ghcr.io/parachutecomputer/parachute-hub:<tag> | jq '.[].Config.Labels'
+# ghcr (hub only). The package is private — authenticate first with a PAT
+# carrying `read:packages`:
+echo "$GHCR_PAT" | docker login ghcr.io -u <your-github-username> --password-stdin
+docker pull ghcr.io/parachutecomputer/parachute-hub:v<version>
+docker inspect ghcr.io/parachutecomputer/parachute-hub:v<version> | jq '.[].Config.Labels'
 ```
+
+Every publish pushes a versioned `:vX.Y.Z` tag alongside the moving `:rc` / `:stable` / `:latest` ones, so `docker pull …:v<version>` resolves for merge-published releases too (hub#829). The OCI `org.opencontainers.image.version` label carries the same version — if `docker inspect` shows `stable` there, the image predates that fix.
 
 The npm tarball page links to the GitHub Actions run that produced it (provenance attestation).
 
@@ -132,17 +104,23 @@ The npm tarball page links to the GitHub Actions run that produced it (provenanc
 There's no "unpublish" path for either npm (npm has a strict 72-hour unpublish policy that you should avoid for published packages anyway) or ghcr (containers are append-only). To roll back:
 
 - Cut a new patch from a known-good commit (e.g. `0.5.13` → `0.5.14` reverting the bad change).
-- Optionally re-point `:stable` ghcr tag to an older image so existing deploys pull the safe version. If you've already pruned the older image locally, pull it first:
+- Optionally re-point the moving ghcr tags at an older image so existing deploys pull the safe version. Re-point `:latest` as well as `:stable` — both move on a stable publish. If you've already pruned the older image locally, pull it first:
   ```sh
   docker pull ghcr.io/parachutecomputer/parachute-hub:v0.5.10
-  docker tag ghcr.io/parachutecomputer/parachute-hub:v0.5.10 ghcr.io/parachutecomputer/parachute-hub:stable
-  docker push ghcr.io/parachutecomputer/parachute-hub:stable
+  for MOVING in stable latest; do
+    docker tag ghcr.io/parachutecomputer/parachute-hub:v0.5.10 \
+               "ghcr.io/parachutecomputer/parachute-hub:$MOVING"
+    docker push "ghcr.io/parachutecomputer/parachute-hub:$MOVING"
+  done
   ```
 
 ## Troubleshooting
 
-- **Workflow doesn't trigger**: confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`; depcheck: `depcheck-v[0-9]+...`; door-contract: `door-contract-v[0-9]+...`).
-- **`version mismatch` error in publish-npm**: the relevant `package.json` version differs from the tag. Re-tag the correct commit, or fix the version in `package.json`.
+- **Workflow ran but nothing published**: the `plan` job decided there was nothing to do — read its log. `<pkg>@<version> is already on npm` means the version wasn't bumped. `plan` also warns (never fails) when commits sit on `main` that no published version contains; that warning is the cue to cut a release PR.
+- **`plan` failed with "refusing to guess" / "is OLDER than the current"**: an ambiguous npm response, or two release PRs merged out of version order so the merge would move a dist-tag backwards. Bump past the published version and re-merge.
+- **Workflow doesn't trigger at all**: for the merge path, confirm the merge landed on `main`. For a tag push, confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`; depcheck: `depcheck-v[0-9]+...`; door-contract: `door-contract-v[0-9]+...`).
+- **`version mismatch` error in publish-npm**: tag path only — the relevant `package.json` version differs from the tag. Re-tag the correct commit, or fix the version in `package.json`.
+- **Image published with no `:vX.Y.Z` tag**: pre-hub#829 behaviour, where the image tags came from the ref (`main` on a merge run). Fixed by deriving every tag from `plan`'s `hub_version`.
 - **`npm ERR! 403 You do not have permission to publish`**: Trusted Publisher rule on npm doesn't match this workflow. Verify org/repo/workflow filename are exactly `ParachuteComputer` / `parachute-hub` / `release.yml`. If the workflow file was renamed, the rule needs updating on npm.
 - **`npm ERR! 401 Unauthorized` with no OIDC token**: the workflow is missing `permissions: id-token: write` at the job level. Verify the YAML.
 - **ghcr push fails with 403**: confirm `permissions.packages: write` is in the publish-image job (it is).

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ This repo publishes FOUR npm packages on independent release cadences via [`.git
 
 **Merging a version bump to `main` is the release signal** (hub#790). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
 
-Pushing a tag still works and still publishes: a tag is a human saying "release this", and it overrides every check `release-plan.ts` makes (including the refuse-to-go-backwards guard). Use it for a deliberate re-release; the merge path is the normal one.
+Pushing a tag still works for a deliberate re-release of an **already-published** version: the image republishes (npm rejects republishing an existing version, so the npm job goes red — expected). A tag does **not** bypass `release-plan.ts`'s guards: the workflow never passes `--tag-push`, so an unpublished-older version or an ambiguous registry response fails the plan job and skips every publish (hub#841 tracks whether to wire the override). The merge path is the normal one.
 
 ## Version conventions
 

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -25,6 +25,32 @@
  * via an explicit tag push, which takes the tag branch below.)
  */
 
+import { appendFileSync } from "node:fs";
+
+/**
+ * Append `key=value` lines to a GitHub Actions output file.
+ *
+ * APPEND, not write. This used to be `Bun.write`, which TRUNCATES — so
+ * emitting three outputs in a row left only the last one in `$GITHUB_OUTPUT`.
+ * `version` and `dist_tag` never reached the workflow at all; only
+ * `should_publish` did, which is why nothing noticed (it's the one output
+ * anything consumed). Latent until hub#829 made `publish-image` derive its
+ * image tags from `version`.
+ *
+ * Exported so the append behaviour is testable without spawning the CLI (which
+ * would need the network to read the registry).
+ */
+export function emitOutputs(
+  path: string | undefined,
+  entries: ReadonlyArray<readonly [string, string]>,
+  log: (line: string) => void = console.log,
+): void {
+  for (const [key, value] of entries) {
+    if (path) appendFileSync(path, `${key}=${value}\n`);
+    log(`${key}=${value}`);
+  }
+}
+
 /** Where a version stands relative to what's already published. */
 export type PublishDecision =
   | { publish: true; reason: string }
@@ -185,12 +211,6 @@ if (import.meta.main) {
     isTagPush: rest.includes("--tag-push"),
   });
 
-  const out = process.env.GITHUB_OUTPUT;
-  const emit = async (k: string, v: string) => {
-    if (out) await Bun.write(out, `${k}=${v}\n`, { createPath: false });
-    console.log(`${k}=${v}`);
-  };
-
   if ("refuse" in decision) {
     console.error(`::error::${npmName}@${version}: ${decision.reason}`);
     process.exit(1);
@@ -222,8 +242,10 @@ if (import.meta.main) {
       // clone just means we can't tell, not that something is wrong.
     }
   }
-  await emit("version", version);
-  await emit("dist_tag", distTagFor(version));
-  await emit("should_publish", String(decision.publish));
+  emitOutputs(process.env.GITHUB_OUTPUT, [
+    ["version", version],
+    ["dist_tag", distTagFor(version)],
+    ["should_publish", String(decision.publish)],
+  ]);
   console.log(`${npmName}@${version}: ${decision.reason}`);
 }

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -7,12 +7,14 @@
  */
 
 import { describe, expect, test } from "bun:test";
-import { readFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   compareVersions,
   decidePublish,
   distTagFor,
+  emitOutputs,
   readRegistry,
   unpublishedDrift,
 } from "../../scripts/release-plan.ts";
@@ -209,7 +211,9 @@ describe("release.yml image tags (hub#829)", () => {
   });
 
   test("no image tag is derived from the ref — on a merge run the ref is `main`", () => {
-    expect(workflow).not.toContain("type=ref,event=tag");
+    // Anchored so the prose in the surrounding comment (which names the old
+    // `type=ref,event=tag` it replaced) doesn't trip it.
+    expect(workflow).not.toMatch(/^\s*type=ref/m);
     // The rc/stable/latest gates have to read the version too, or a
     // merge-published rc lands on `:stable`.
     expect(workflow).not.toMatch(/type=raw,value=(rc|stable|latest),enable=.*github\.ref_name/);
@@ -222,5 +226,59 @@ describe("release.yml image tags (hub#829)", () => {
     // metadata-action's own `latest=auto` only fires on tag runs, which is the
     // half of #829 that left `:latest` stuck at 0.7.13.
     expect(workflow).toMatch(/flavor:\s*\|\s*\n\s*latest=false/);
+  });
+});
+
+/**
+ * The step outputs are the wire between `plan` and every publish job. Losing
+ * one is silent — the consuming expression just interpolates to an empty
+ * string.
+ */
+describe("emitOutputs", () => {
+  test("APPENDS every output — `Bun.write` truncated, keeping only the last", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-release-plan-"));
+    try {
+      const out = join(dir, "github_output");
+      writeFileSync(out, "");
+      emitOutputs(
+        out,
+        [
+          ["version", "0.7.15"],
+          ["dist_tag", "latest"],
+          ["should_publish", "true"],
+        ],
+        () => {},
+      );
+      expect(readFileSync(out, "utf8")).toBe(
+        "version=0.7.15\ndist_tag=latest\nshould_publish=true\n",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps whatever an earlier step already wrote to the file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-release-plan-"));
+    try {
+      const out = join(dir, "github_output");
+      writeFileSync(out, "earlier=kept\n");
+      emitOutputs(out, [["version", "0.7.15"]], () => {});
+      expect(readFileSync(out, "utf8")).toBe("earlier=kept\nversion=0.7.15\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("logs every output even with no output file (local runs)", () => {
+    const lines: string[] = [];
+    emitOutputs(
+      undefined,
+      [
+        ["version", "0.7.15"],
+        ["dist_tag", "latest"],
+      ],
+      (l) => lines.push(l),
+    );
+    expect(lines).toEqual(["version=0.7.15", "dist_tag=latest"]);
   });
 });

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -7,6 +7,8 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 import {
   compareVersions,
   decidePublish,
@@ -174,5 +176,51 @@ describe("unpublishedDrift", () => {
 
   test("blank lines from git's trailing newline don't inflate the count", () => {
     expect(unpublishedDrift(["abc one", ""]).count).toBe(1);
+  });
+});
+
+/**
+ * hub#829: the ghcr image tags are part of the release contract too.
+ *
+ * The `publish-image` job used to derive its version tag from the ref
+ * (`type=ref,event=tag`). On a merge-triggered run the ref is `main`, so the
+ * 0.7.13 merge published a bare `:stable` with an `image.version=stable`
+ * label, and `:v0.7.13` / `:latest` existed only because someone pushed a tag
+ * by hand afterwards. Once that manual step went away, RELEASING.md's
+ * `docker pull …:vX.Y.Z` verify + rollback instructions pointed at nothing.
+ *
+ * Same class of bug as the dist-tag one above, and the same rule fixes it:
+ * derive from the VERSION BEING PUBLISHED, never from the ref. Asserted here
+ * rather than left to review because a YAML `run:`/`with:` block is otherwise
+ * only exercised by shipping a release.
+ */
+describe("release.yml image tags (hub#829)", () => {
+  const workflow = readFileSync(
+    join(import.meta.dir, "../../.github/workflows/release.yml"),
+    "utf8",
+  );
+
+  test("the plan job exposes the hub version, not just the publish decision", () => {
+    expect(workflow).toContain("hub_version: ${{ steps.hub.outputs.version }}");
+  });
+
+  test("every publish pushes a versioned image tag", () => {
+    expect(workflow).toContain("type=raw,value=v${{ needs.plan.outputs.hub_version }}");
+  });
+
+  test("no image tag is derived from the ref — on a merge run the ref is `main`", () => {
+    expect(workflow).not.toContain("type=ref,event=tag");
+    // The rc/stable/latest gates have to read the version too, or a
+    // merge-published rc lands on `:stable`.
+    expect(workflow).not.toMatch(/type=raw,value=(rc|stable|latest),enable=.*github\.ref_name/);
+  });
+
+  test("`latest` moves on a stable publish, and only on a stable publish", () => {
+    expect(workflow).toContain(
+      "type=raw,value=latest,enable=${{ !contains(needs.plan.outputs.hub_version, '-rc.') }}",
+    );
+    // metadata-action's own `latest=auto` only fires on tag runs, which is the
+    // half of #829 that left `:latest` stuck at 0.7.13.
+    expect(workflow).toMatch(/flavor:\s*\|\s*\n\s*latest=false/);
   });
 });


### PR DESCRIPTION
Fixes #829

## What was broken

`publish-image`'s `derive tags` step used `type=ref,event=tag` for the version tag. On a merge-triggered run (publish-on-merge, hub#790) `github.ref_name` is `main`, so **no versioned tag was emitted at all**. The 0.7.13 merge run ([31425232464](https://github.com/ParachuteComputer/parachute-hub/actions/runs/31425232464)) logged `DOCKER_METADATA_OUTPUT_TAGS: ghcr.io/parachutecomputer/parachute-hub:stable` and an OCI `image.version=stable` label; its `:v0.7.13` and `:latest` existed only because a manual tag push created them. With that manual step correctly gone from release PR bodies, 0.7.14+ would have published no versioned image and left `:latest` pinned at 0.7.13 — and RELEASING.md's `docker pull …:vX.Y.Z` verify/rollback instructions would point at nothing.

Same class of bug as the npm dist-tag one (hub#792): **reading the ref instead of the version being published.**

## The fix

- `plan` now exposes `hub_version` (it already computed it — `release-plan.ts` emits `version` from package.json).
- Every image tag derives from `needs.plan.outputs.hub_version`:
  - `type=raw,value=v${version}` — unconditional, so both the merge path and the tag path get a versioned tag
  - `:rc` when the version contains `-rc.`, `:stable` + `:latest` when it doesn't
- `flavor: latest=false`. metadata-action's `latest=auto` only fires for `type=ref,event=tag` / `type=semver` — i.e. tag runs — which is the second half of the gap. `latest` is now explicit and version-gated, so it moves on both paths.
- `type=ref,event=tag` is **dropped**, not kept alongside: on a tag push it produced the same string the raw tag now produces, and keeping a ref-derived tag is what the bug was.
- A guard step fails the job if `hub_version` comes back empty, rather than pushing a bare `:v`.
- Naming the version first also fixes the OCI `org.opencontainers.image.version` label — metadata-action takes it from the first tag, which is why 0.7.13's image says `stable`.

RELEASING.md rewritten around merge-as-signal (tag path documented as the deliberate-re-release escape hatch it still is), plus the stale door-contract paragraph — hub consumes it as `^0.7.0` from npm since #826, not `workspace:*`.

## A latent bug this fix depended on (second commit)

`release-plan.ts`'s `emit` used `Bun.write`, which **truncates**. Three emits in a row left only the last line in `$GITHUB_OUTPUT`:

```
$ GITHUB_OUTPUT=$T bun scripts/release-plan.ts . @openparachute/hub
version=0.7.14      # ← logged
dist_tag=latest     # ← logged
should_publish=false
$ cat $T
should_publish=false   # ← that's all that reached the workflow
```

Invisible until now, because `should_publish` is emitted last and is the only output anything consumed. `needs.plan.outputs.hub_version` would have interpolated to the empty string and every image tag with it. Fixed by appending, via an exported `emitOutputs` so the behaviour is unit-testable without spawning the CLI (which needs the network to read the registry).

## Design calls worth a second opinion

1. **`:latest` on hub image publishes.** The issue asked for it. It moves only on a stable version, never on an rc — matching the npm dist-tag rule. If you'd rather ghcr had no `:latest` at all, say so and I'll drop it; the versioned tag is the load-bearing half.
2. **Version source is package.json (via `plan`), not the tag name.** On a tag push where the tag disagrees with package.json, the image now carries the *package.json* version. `publish-hub-npm` has a mismatch guard that fails in that case, but the two jobs run in parallel, so the image could be pushed before npm's guard trips. Deriving from the ref instead would reintroduce the merge-path bug, so this is the lesser evil — and package.json is what actually ships inside the image.
3. **ghcr visibility (issue checkbox 4): keep it private.** Nothing outside the org deploys from this package today. The doc now states that and folds `docker login` into the verify/rollback steps, instead of leaving a never-done "make it public" step that would widen access on a package with no consumer. One line to flip when a real deploy target needs it.

## Tests

New `describe("release.yml image tags (hub#829)")` in `src/__tests__/release-plan.test.ts` — reads the workflow and asserts no image tag is ref-derived, the versioned tag exists, and `latest=false` is set. Meta, but the repo already unit-tests release logic on the grounds that "release logic that can double-publish or drop a release shouldn't be untested shell in a `run:`", and a `with:` block is otherwise only exercised by shipping a release.

## Test run

`bun test ./src` on this branch: **4473 pass, 1 skip, 0 fail** (4474 across 169 files, 477s).
Baseline `origin/next` in a clean worktree on the same box: **4466 pass, 1 skip, 0 fail** (4467) — the +7 are the new cases. No flakes hit (#786's init/init-exposure timeouts didn't fire on either run).

Note: `pr-verify.yml` triggers on `pull_request: branches: [main]`, so it does **not** run on PRs based on `next`. Counts above are local.
