### PR TITLE
fix(upgrade): refresh the services.json version after an upgrade + restart

### DIFF
--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -9,7 +9,7 @@ import { compareVersions, defaultRunner, detectChannel, upgrade } from "../comma
 import type { HubUnitDeps, HubUnitManagerOpResult } from "../hub-unit.ts";
 import { defaultHubUnitDeps } from "../hub-unit.ts";
 import type { MigrateOfferResult } from "../migrate-offer.ts";
-import { upsertService } from "../services-manifest.ts";
+import { findService, upsertService } from "../services-manifest.ts";
 
 interface RunCall {
   cmd: string[];
@@ -1835,6 +1835,212 @@ describe("Phase 5b: upgrade module-restart on a no-unit box", () => {
       expect(offerCalls).toBe(1);
       expect(driveModuleOpCalled).toBe(false);
       expect(logs.join("\n")).not.toMatch(/ECONNREFUSED|connection refused/i);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("hub#831: services.json version refresh after upgrade", () => {
+  /** Not-a-git-checkout runner whose `bun add -g` rewrites package.json. */
+  function npmRunner(installDir: string, afterVersion: string | null): UpgradeRunner {
+    return {
+      async run(cmd) {
+        if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g" && afterVersion) {
+          writePackageJson(installDir, { name: "@openparachute/vault", version: afterVersion });
+        }
+        return 0;
+      },
+      async capture(cmd) {
+        if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+          return { code: 128, stdout: "fatal: not a git repository\n" };
+        }
+        return { code: 0, stdout: "" };
+      },
+    };
+  }
+
+  test("npm upgrade + restart refreshes the stale registry row", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: (l) => logs.push(l),
+      });
+
+      expect(code).toBe(0);
+      // The bug: SOURCE re-read 0.5.0 off disk while VERSION kept showing 0.4.0.
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.5.0");
+      expect(logs.join("\n")).toMatch(/services\.json version 0\.4\.0 → 0\.5\.0/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("preserves the rest of the row (port, paths, installDir)", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: () => {},
+      });
+
+      expect(code).toBe(0);
+      const row = findService("parachute-vault", h.manifestPath);
+      expect(row?.port).toBe(1940);
+      expect(row?.paths).toEqual(["/vault/default"]);
+      expect(row?.installDir).toBe(installDir);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("re-reads the row post-restart so a self-registering module isn't clobbered", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        // Stand in for a module that rewrites its own row on boot, adding a
+        // field the pre-restart copy never had.
+        restartFn: async () => {
+          upsertService(
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.5.0",
+              installDir,
+              displayName: "Vault",
+            },
+            h.manifestPath,
+          );
+          return 0;
+        },
+        log: () => {},
+      });
+
+      expect(code).toBe(0);
+      const row = findService("parachute-vault", h.manifestPath);
+      expect(row?.version).toBe("0.5.0");
+      expect(row?.displayName).toBe("Vault");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a failed restart leaves the row alone — the old code is still running", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 1,
+        log: () => {},
+      });
+
+      expect(code).toBe(1);
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.4.0");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("the skip-restart no-op doesn't touch the row", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.3.0");
+
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, null),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: (l) => logs.push(l),
+      });
+
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/already at 0\.4\.0/);
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.3.0");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("bun-linked upgrade + restart refreshes from the checkout's package.json", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      let headCalls = 0;
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          // The pull brings a version bump into the checkout.
+          if (cmd[0] === "git" && cmd[1] === "pull") {
+            writePackageJson(installDir, { name: "@openparachute/vault", version: "0.6.0" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 0, stdout: "true" };
+          }
+          if (cmd[1] === "status") return { code: 0, stdout: "" };
+          if (cmd[1] === "rev-parse" && cmd[2] === "HEAD") {
+            headCalls++;
+            return { code: 0, stdout: headCalls === 1 ? "aaaaaaa" : "bbbbbbb" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: () => {},
+      });
+
+      expect(code).toBe(0);
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.6.0");
     } finally {
       h.cleanup();
     }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -85,7 +85,12 @@ import {
   knownServices,
   shortNameForManifest,
 } from "../service-spec.ts";
-import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import {
+  type ServiceEntry,
+  findService,
+  readManifest,
+  upsertService,
+} from "../services-manifest.ts";
 import { type LifecycleOpts, restart as lifecycleRestart } from "./lifecycle.ts";
 
 export interface UpgradeRunner {
@@ -635,6 +640,52 @@ async function restartTarget(target: ResolvedTarget, r: Resolved): Promise<numbe
   });
 }
 
+/**
+ * Bring the services.json row's `version` back in line with what's installed,
+ * after an upgrade+restart (hub#831).
+ *
+ * `entry.version` is a CACHE of the running version: services own the write
+ * side of services.json and stamp it on their own boot (see CLAUDE.md). That
+ * works for modules with a server of their own — and not at all for the ones
+ * hub serves through the `bundle-serve.ts` static shim (`app`, `notes`), which
+ * have no boot of their own to do the stamping. Their row keeps whatever it
+ * last had, so `parachute status` reported `parachute-app 1944 0.22.10 …
+ * npm (0.22.11)` — VERSION from the stale cache, SOURCE re-read live off disk
+ * on every invocation. Cosmetic, except that "status shows expected versions"
+ * is the deploy verification step.
+ *
+ * Deliberately AFTER a successful restart, never before: until the restart
+ * lands, the old code is still the code that's running, and writing the new
+ * version early would turn a stale row into a lying one. For the same reason
+ * the skip-restart paths ("already at X", "already up to date") don't call
+ * this — nothing restarted, so nothing about the running version changed.
+ *
+ * Re-reads the row instead of reusing `target.entry`: a self-registering
+ * module rewrites its whole row during the restart we just awaited, and
+ * spreading the pre-restart copy would clobber what it just wrote. The
+ * version-differs guard then makes this a no-op for exactly those modules —
+ * they already stamped the right version themselves — so in practice only the
+ * shim-served rows get written here.
+ */
+function refreshManifestVersion(target: ResolvedTarget, sourceDir: string, r: Resolved): void {
+  const installed = readPackageVersion(join(sourceDir, "package.json"));
+  if (!installed) return;
+  const fresh = findService(target.entry.name, r.manifestPath);
+  if (!fresh || fresh.version === installed) return;
+  try {
+    upsertService({ ...fresh, version: installed }, r.manifestPath);
+    r.log(`${target.short}: services.json version ${fresh.version} → ${installed}.`);
+  } catch (err) {
+    // Never fail an otherwise-successful upgrade over the bookkeeping write —
+    // the package is installed and the service is running either way. Say so
+    // rather than leaving the operator to wonder why status disagrees.
+    r.log(
+      `⚠ ${target.short}: upgraded + restarted, but couldn't refresh the services.json version ` +
+        `(${err instanceof Error ? err.message : String(err)}). \`status\` may show the old version.`,
+    );
+  }
+}
+
 async function upgradeLinked(
   target: ResolvedTarget,
   sourceDir: string,
@@ -693,7 +744,9 @@ async function upgradeLinked(
   }
 
   r.log(`${target.short}: ${before.sha.slice(0, 7)} → ${after.sha.slice(0, 7)}; restarting…`);
-  return await restartTarget(target, r);
+  const restarted = await restartTarget(target, r);
+  if (restarted === 0) refreshManifestVersion(target, sourceDir, r);
+  return restarted;
 }
 
 /**
@@ -858,7 +911,9 @@ async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved
   }
 
   r.log(`${target.short}: ${beforeVersion ?? "?"} → ${afterVersion ?? "?"}; restarting…`);
-  return await restartTarget(target, r);
+  const restarted = await restartTarget(target, r);
+  if (restarted === 0) refreshManifestVersion(target, sourceDir, r);
+  return restarted;
 }
 
 async function upgradeOne(target: ResolvedTarget, r: Resolved): Promise<number> {


### PR DESCRIPTION
Fixes #831

## Root cause

The two columns read different sources:

- **SOURCE** — `detectInstallSource` re-reads `<installDir>/package.json` on every `status` invocation (`src/install-source.ts:193`). Always fresh.
- **VERSION** — `entry.version` straight off the `services.json` row (`src/commands/status.ts`, all three module-row branches).

That row is a *cache of the running version*, and services own its write side: each module stamps it on its own boot. Modules hub serves through the `bundle-serve.ts` static shim — `app` and `notes` — **have no boot of their own to do the stamping**, so their row keeps whatever it last had, indefinitely. `upgrade` never wrote it either: `upgradeNpm` reads the post-`bun add -g` version purely to decide whether to restart, and `upgradeLinked` compares SHAs.

Hence `parachute-app 1944 0.22.10 active 8670 npm (0.22.11)`.

Worth noting the `STALE:` continuation line can't catch this: `isStale()` returns false for anything that isn't `kind === "bun-linked"`, on the (now false) premise that "NPM-installed services don't have a 'live' source separate from the cached version". Left alone here — it's a separate, narrower call.

## The fix

`upgrade` writes the installed version back to the row, on the one path where we know what's running: **after a successful restart**.

- **Not before.** Until the restart lands, the old code is still the code that's running; an early write turns a stale row into a lying one.
- **Not on the skip-restart paths** ("already at X", "already up to date") — nothing restarted, so nothing about the running version changed.
- **Not on a failed restart** — same reason.
- **The row is re-read after the restart**, not spread from the pre-restart copy: a self-registering module rewrites its whole row during the restart we just awaited, and spreading a stale copy would clobber what it wrote. The version-differs guard then makes this a no-op for exactly those modules — they already stamped the right version themselves — so in practice only the shim-served rows get written here.
- A write failure logs a warning and does not fail the upgrade: the package is installed and the service is running either way.

Both arms are covered (npm and bun-linked), since both can leave the row behind.

`upgrade hub` is unaffected: hub's synthetic `ResolvedTarget` carries `name: "@openparachute/hub"`, which matches no services.json row, so the lookup no-ops. The hub row in `status` already reads the live package.json.

## Tests

Six new cases in `src/__tests__/upgrade.test.ts` (`describe("hub#831: …")`): npm upgrade+restart refreshes the row; the rest of the row survives; a self-registered post-restart row isn't clobbered; a failed restart leaves the row alone; the skip-restart no-op leaves it alone; the bun-linked arm refreshes from the checkout's package.json.

## Test run

`bun test ./src` on this branch: **4472 pass, 1 skip, 0 fail** (4473 across 169 files, 386s).
Baseline `origin/next` in a clean worktree on the same box: **4466 pass, 1 skip, 0 fail** (4467) — the +6 are the new cases. No flakes hit (#786's init/init-exposure timeouts didn't fire on either run).

Note: `pr-verify.yml` triggers on `pull_request: branches: [main]`, so it does **not** run on PRs based on `next`. Counts above are local.
