### PR TITLE
fix(serve): the static-serve shim binds every interface, ignoring PARACHUTE_BIND_HOST

### DIFF
--- a/src/__tests__/bundle-serve.test.ts
+++ b/src/__tests__/bundle-serve.test.ts
@@ -7,6 +7,7 @@ import {
   notesDistCandidates,
   notesFetch,
   notesServeOptions,
+  resolveBindHost,
   resolveBundleDistFrom,
 } from "../bundle-serve.ts";
 
@@ -29,10 +30,34 @@ function req(path: string): Request {
 
 describe("notesServeOptions (hub#399 residual)", () => {
   test("sets idleTimeout: 255 to outlast edge keep-alive pools, matching hub-server.ts", () => {
-    const opts = notesServeOptions(5173, "/tmp/dist", "/notes");
+    const opts = notesServeOptions(5173, "/tmp/dist", "/notes", "127.0.0.1");
     expect(opts.idleTimeout).toBe(255);
     expect(opts.port).toBe(5173);
     expect(typeof opts.fetch).toBe("function");
+  });
+
+  test("passes hostname through to Bun.serve (hub#832 — no hostname = every interface)", () => {
+    expect(notesServeOptions(5173, "/tmp/dist", "/notes", "127.0.0.1").hostname).toBe("127.0.0.1");
+    expect(notesServeOptions(5173, "/tmp/dist", "/notes", "0.0.0.0").hostname).toBe("0.0.0.0");
+  });
+});
+
+describe("resolveBindHost (hub#832)", () => {
+  test("defaults to loopback, matching hub-server.ts", () => {
+    expect(resolveBindHost(undefined, {})).toBe("127.0.0.1");
+  });
+
+  test("honors PARACHUTE_BIND_HOST — one env governs every listener the hub supervises", () => {
+    expect(resolveBindHost(undefined, { PARACHUTE_BIND_HOST: "0.0.0.0" })).toBe("0.0.0.0");
+    expect(resolveBindHost(undefined, { PARACHUTE_BIND_HOST: "127.0.0.1" })).toBe("127.0.0.1");
+  });
+
+  test("--host beats the env", () => {
+    expect(resolveBindHost("127.0.0.1", { PARACHUTE_BIND_HOST: "0.0.0.0" })).toBe("127.0.0.1");
+  });
+
+  test("an empty PARACHUTE_BIND_HOST is unset, not the empty hostname", () => {
+    expect(resolveBindHost(undefined, { PARACHUTE_BIND_HOST: "" })).toBe("127.0.0.1");
   });
 });
 

--- a/src/bundle-serve.ts
+++ b/src/bundle-serve.ts
@@ -13,7 +13,12 @@
  * alongside the other services.
  *
  * Invoked as:
- *   bun <this-file> --port <n> [--dist <path>] [--mount <prefix>] [--package <npmName>]
+ *   bun <this-file> --port <n> [--host <addr>] [--dist <path>] [--mount <prefix>]
+ *                   [--package <npmName>]
+ *
+ * `--host` is the bind address, same contract as hub-server.ts: flag beats
+ * `PARACHUTE_BIND_HOST`, env beats the `127.0.0.1` default. See
+ * `resolveBindHost` for why the default is loopback.
  *
  * `--mount` (default `/notes`) is the path prefix the reverse proxy hands
  * us. We strip it before resolving against `dist/` so a request for
@@ -54,21 +59,55 @@ import { dirname, join, resolve } from "node:path";
  */
 const DEFAULT_PACKAGE = "@openparachute/app";
 
+/**
+ * Bind address when neither `--host` nor `PARACHUTE_BIND_HOST` says otherwise.
+ *
+ * Matches `hub-server.ts`'s `parseArgs` default. The shim used to pass no
+ * `hostname` at all, so `Bun.serve` bound every interface — on a box whose hub
+ * and vault both sat on `127.0.0.1`, the SPA alone answered unauthenticated on
+ * the tailnet/LAN (hub#832). Nothing legitimate needs the wildcard: this shim
+ * is reached through `parachute expose`'s reverse proxy, which connects over
+ * loopback. The container images that DO need every interface set
+ * `PARACHUTE_BIND_HOST=0.0.0.0` (Dockerfile / render.yaml / fly.toml), which
+ * the supervisor passes down to the child through the inherited env.
+ */
+const DEFAULT_BIND_HOST = "127.0.0.1";
+
 interface Args {
   port: number;
+  host?: string;
   dist?: string;
   mount: string;
   pkg: string;
 }
 
+/**
+ * Flag beats env, env beats default — the same precedence hub-server.ts uses
+ * for its own listener, so one `PARACHUTE_BIND_HOST` governs every process the
+ * hub supervises rather than just the hub itself.
+ */
+export function resolveBindHost(
+  host: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  // `||` not `??`, matching hub-server.ts: an empty `PARACHUTE_BIND_HOST=` is
+  // "unset" here, not "bind to the empty string".
+  return host || env.PARACHUTE_BIND_HOST || DEFAULT_BIND_HOST;
+}
+
 function parseArgs(argv: string[]): Args {
   let port = 5173;
+  let host: string | undefined;
   let dist: string | undefined;
   let mount = "/notes";
   let pkg = DEFAULT_PACKAGE;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--port") {
+    if (a === "--host") {
+      const v = argv[++i];
+      if (!v) throw new Error("--host requires a value");
+      host = v;
+    } else if (a === "--port") {
       const v = argv[++i];
       if (!v) throw new Error("--port requires a value");
       const n = Number.parseInt(v, 10);
@@ -92,7 +131,7 @@ function parseArgs(argv: string[]): Args {
       throw new Error(`unknown argument: ${a}`);
     }
   }
-  return { port, dist, mount, pkg };
+  return { port, host, dist, mount, pkg };
 }
 
 export function normalizeMount(raw: string): string {
@@ -375,21 +414,33 @@ export function notesFetch(dist: string, mount: string): (req: Request) => Respo
  * exceeds Render's community-observed ~120s edge pool TTL. Closes the hub#399
  * residual on the second serve entrypoint (the Notes PWA path). Exported so a
  * test can assert the option is set without booting a server.
+ *
+ * `hostname` is REQUIRED rather than optional: omitting it is what let this
+ * shim bind every interface (hub#832), and an optional parameter would let the
+ * same omission come back silently. Callers resolve it via `resolveBindHost`.
  */
 export function notesServeOptions(
   port: number,
   dist: string,
   mount: string,
-): { port: number; idleTimeout: number; fetch: (req: Request) => Response } {
+  hostname: string,
+): {
+  port: number;
+  hostname: string;
+  idleTimeout: number;
+  fetch: (req: Request) => Response;
+} {
   return {
     port,
+    hostname,
     idleTimeout: 255,
     fetch: notesFetch(dist, mount),
   };
 }
 
 if (import.meta.main) {
-  const { port, dist: distArg, mount, pkg } = parseArgs(process.argv.slice(2));
+  const { port, host, dist: distArg, mount, pkg } = parseArgs(process.argv.slice(2));
+  const hostname = resolveBindHost(host);
 
   let dist: string;
   try {
@@ -401,9 +452,9 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  Bun.serve(notesServeOptions(port, dist, mount));
+  Bun.serve(notesServeOptions(port, dist, mount, hostname));
 
   console.log(
-    `static-serve listening on :${port} (pkg=${pkg}, dist=${dist}, mount=${mount || "/"})`,
+    `static-serve listening on ${hostname}:${port} (pkg=${pkg}, dist=${dist}, mount=${mount || "/"})`,
   );
 }


### PR DESCRIPTION
Fixes #832

## Root cause

Exactly as reported: `notesServeOptions()` returned `{ port, idleTimeout, fetch }` with no `hostname`, so `Bun.serve` used its default and bound every interface. Hub (`hub-server.ts:451`) and vault honor `PARACHUTE_BIND_HOST`; the static shim was the one listener that didn't, and had no flag to restrict it either.

## The fix

Thread the bind host through with the **same contract hub-server.ts uses for its own listener** — `--host` beats `PARACHUTE_BIND_HOST` beats the default, `||` not `??` so an empty env value reads as unset:

```ts
export function resolveBindHost(host, env = process.env): string {
  return host || env.PARACHUTE_BIND_HOST || DEFAULT_BIND_HOST; // "127.0.0.1"
}
```

`hostname` is a **required** parameter of `notesServeOptions` rather than an optional one. Omitting it is precisely what caused this, and an optional parameter would let the same omission come back silently. One production call site, one test call site.

The startup log line now names the bind host (`static-serve listening on 127.0.0.1:1944 …`), so `lsof` isn't the only way to find out.

## The default moved: wildcard → loopback

This is the operator-visible half, and it diverges from the issue's "default can stay as-is for compatibility". Deliberate:

- Nothing legitimate needs the wildcard. The shim is reached through `parachute expose`'s reverse proxy, which connects over loopback.
- `managed-unit.ts` already **forces** `PARACHUTE_BIND_HOST=127.0.0.1` into the launchd/systemd hub unit env ("loopback trust model — never 0.0.0.0"). A canonical install already intends loopback; the shim just wasn't listening to it.
- The container images that genuinely need every interface set `PARACHUTE_BIND_HOST=0.0.0.0` explicitly (`Dockerfile:142`, `render.yaml:54`, `fly.toml:53`). The supervisor spawns children with `{ ...process.env, ...req.env }` (`supervisor.ts:1246`) and `buildModuleSpawnRequest` never sets `PARACHUTE_BIND_HOST`, so the container value reaches the shim unchanged.

Net effect: a box that sets `PARACHUTE_BIND_HOST` gets it honored for every listener the hub supervises; a box that sets nothing gets loopback instead of the whole LAN. An operator who genuinely wants `:1944` on a LAN interface sets `PARACHUTE_BIND_HOST` (or the new `--host`) — say the word if you'd rather that showed up in CHANGELOG's upgrade notes as well.

## Verified against a real listener

Ran the shim two ways on this branch and checked `lsof`, rather than trusting the unit assertion:

```
$ bun src/bundle-serve.ts --port 18944 --dist $D --mount /app
static-serve listening on 127.0.0.1:18944 (pkg=@openparachute/app, …)
bun  89962  uni  4u  IPv4  TCP 127.0.0.1:18944 (LISTEN)     # default → loopback

$ PARACHUTE_BIND_HOST=0.0.0.0 bun src/bundle-serve.ts --port 18945 --dist $D --mount /app
static-serve listening on 0.0.0.0:18945 (pkg=@openparachute/app, …)
bun  89963  uni  4u  IPv4  TCP *:18945 (LISTEN)             # env honored → wildcard
```

`curl http://127.0.0.1:18944/app/health` → 200 in the loopback case, so the doctor/status probe is unaffected.

## Tests

`resolveBindHost` precedence (default / env / flag-beats-env / empty-env-is-unset) plus a `notesServeOptions` assertion that `hostname` reaches the serve options. Nothing in `e2e/`, `.github/workflows/`, or the container smoke test reaches `:1944` off-loopback.

## Test run

`bun test ./src` on this branch: **4471 pass, 1 skip, 0 fail** (4472 across 169 files, 429s).
Baseline `origin/next` in a clean worktree on the same box: **4466 pass, 1 skip, 0 fail** (4467) — the +5 are the new cases.

Flake hit on the first run and reported for transparency: `login two-step (TOTP) — hub#473 > (d) re-POSTing /login (new pendingToken) does NOT reset the per-account TOTP floor` failed at **5015.09ms**, i.e. it tripped a 5s timeout on a loaded box. Nothing to do with this diff (no `src/commands/`, auth, or login code is touched), same class as the known #786 slow-runner timeouts. Clean on the retry above, and clean on the baseline run.

Note: `pr-verify.yml` triggers on `pull_request: branches: [main]`, so it does **not** run on PRs based on `next`. Counts above are local.
