### PR TITLE
release: hub 0.7.15 — deploy-safety batch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,5 @@
-# Release workflow — triggered by pushing a semver tag.
+# Release workflow — triggered by a merge to `main` (hub#790), or by pushing a
+# semver tag.
 #
 # This workflow publishes FOUR packages on different tag namespaces:
 #
@@ -8,9 +9,11 @@
 #   - @openparachute/door-contract  ← tag prefix `door-contract-v...` (e.g. door-contract-v0.6.0)
 #
 # All packages have npm Trusted Publisher rules pointing at this workflow
-# file. The jobs below gate on the tag prefix so only one package publishes
-# per tag push. Independent release cadences; hub doesn't have to bump when
-# scope-guard / depcheck / door-contract ship and vice versa.
+# file. On a tag push the jobs below gate on the tag prefix so only one package
+# publishes; on a merge each job gates on its own `plan` output, so a merge can
+# publish several packages at once. Independent release cadences either way;
+# hub doesn't have to bump when scope-guard / depcheck / door-contract ship and
+# vice versa.
 #
 # Tag conventions (matches governance rule 2, https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md):
 #   - rc:     v<X>.<Y>.<Z>-rc.<N>   (e.g. v0.5.13-rc.33)
@@ -22,22 +25,19 @@
 #                                    (depcheck-v0.1.0)
 #                                    (door-contract-v0.6.0)
 #
-# Release flow:
-#   1. When ready to ship: bump version in the relevant package.json on main
-#      (root for hub, packages/scope-guard/ for scope-guard,
+# Release flow (publish-on-merge — the tag path below still works, see `plan`):
+#   1. When ready to ship: open a release PR bumping `version` in the relevant
+#      package.json (root for hub, packages/scope-guard/ for scope-guard,
 #      packages/depcheck/ for depcheck, packages/door-contract/ for
 #      door-contract).
-#   2. Push a matching tag:
-#        # for hub
-#        git tag v$(bun -e "console.log(require('./package.json').version)") && git push --tags
-#        # for scope-guard
-#        git tag scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)") && git push --tags
-#        # for depcheck
-#        git tag depcheck-v$(bun -e "console.log(require('./packages/depcheck/package.json').version)") && git push --tags
-#        # for door-contract
-#        git tag door-contract-v$(bun -e "console.log(require('./packages/door-contract/package.json').version)") && git push --tags
-#   3. CI runs tests once (workspace-wide), then publishes the package matching
-#      the tag prefix. Hub also publishes a container image to ghcr.io.
+#   2. Merge it. That IS the release signal — `plan` compares each
+#      package.json against npm and publishes what's new.
+#   3. CI runs tests once (workspace-wide), then publishes whichever packages
+#      `plan` selected. Hub also publishes a container image to ghcr.io, tagged
+#      from the published VERSION (`:vX.Y.Z` + `:rc`/`:stable` + `:latest`) —
+#      not from the ref, which on a merge run is just `main` (hub#829).
+#   4. `tag-record` pushes `vX.Y.Z` afterwards as a RECORD of what shipped.
+#      Nothing needs to be tagged by hand.
 #
 # Operator setup (one-time) — see RELEASING.md:
 #   - npm Trusted Publisher rules: one per package (hub, scope-guard, depcheck,
@@ -96,6 +96,10 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       hub: ${{ steps.hub.outputs.should_publish }}
+      # The version being shipped, independent of the ref. `publish-image`
+      # derives every image tag from this (hub#829) — on a merge-triggered run
+      # `github.ref_name` is `main`, so a ref-derived tag has no version in it.
+      hub_version: ${{ steps.hub.outputs.version }}
       scope_guard: ${{ steps.scope_guard.outputs.should_publish }}
       depcheck: ${{ steps.depcheck.outputs.should_publish }}
       door_contract: ${{ steps.door_contract.outputs.should_publish }}
@@ -410,6 +414,16 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: guard against an empty version
+        # `plan` always emits `version` (release-plan.ts reads it straight out
+        # of package.json), but an empty one here would silently push `:v` and
+        # a `latest`/`stable` with no versioned peer — exactly the failure mode
+        # hub#829 is about. Fail loudly instead.
+        run: |
+          if [ -z "${{ needs.plan.outputs.hub_version }}" ]; then
+            echo "::error::plan job emitted no hub version — refusing to push untagged images"
+            exit 1
+          fi
       - name: derive tags
         id: meta
         uses: docker/metadata-action@v5
@@ -418,10 +432,27 @@ jobs:
           # ParachuteComputer is mixed-case on github, hence the explicit
           # lowercase here.
           images: ghcr.io/parachutecomputer/parachute-hub
+          # Every tag comes from the VERSION BEING PUBLISHED, never from the
+          # ref — the same lesson as the npm dist-tag fix (hub#792). This used
+          # to be `type=ref,event=tag`, which on a merge-triggered run
+          # (`github.ref_name` == `main`) emitted no version tag at all: the
+          # 0.7.13 merge run pushed `:stable` alone, and its `:v0.7.13` /
+          # `:latest` existed only because someone also pushed a tag by hand.
+          # With the manual tag step gone from release PRs, that left RELEASING.md's
+          # `docker pull …:vX.Y.Z` verify/rollback steps pointing at nothing (hub#829).
+          # Naming the version first also fixes the OCI `image.version` label,
+          # which metadata-action takes from the first tag (it read `stable`).
           tags: |
-            type=ref,event=tag
-            type=raw,value=rc,enable=${{ contains(github.ref_name, '-rc.') }}
-            type=raw,value=stable,enable=${{ !contains(github.ref_name, '-rc.') }}
+            type=raw,value=v${{ needs.plan.outputs.hub_version }}
+            type=raw,value=rc,enable=${{ contains(needs.plan.outputs.hub_version, '-rc.') }}
+            type=raw,value=stable,enable=${{ !contains(needs.plan.outputs.hub_version, '-rc.') }}
+            type=raw,value=latest,enable=${{ !contains(needs.plan.outputs.hub_version, '-rc.') }}
+          # `latest` is declared explicitly above, so turn off metadata-action's
+          # automatic one: `latest=auto` only fires for `type=ref,event=tag` /
+          # `type=semver`, i.e. tag runs only, which is the second half of
+          # hub#829 (`:latest` stuck at 0.7.13 once merges became the trigger).
+          flavor: |
+            latest=false
       - name: build + push
         uses: docker/build-push-action@v5
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.15] - 2026-08-21
+
+**Deploy safety: published images get real version tags, `status` stops
+lying after upgrades, and the app door stops answering the whole network.**
+Four PRs over 0.7.14, all independently reviewed with sandboxed full-suite
+runs (CI does not yet gate `next`-targeted PRs — hub#838).
+
+- **Merge-published images get a versioned ghcr tag (#835, closes hub#829).**
+  Merge-triggered publishes derived image tags with `type=ref,event=tag`, so
+  on a merge run only `:stable` was pushed — rollback-by-tag had nothing to
+  roll back to. Every publish now emits `:vX.Y.Z` derived from the release
+  plan's version, `:rc` or `:stable`+`:latest` gated on prerelease-ness, with
+  a guard that fails the job if the version is ever empty. Along the way a
+  latent bug got fixed: `release-plan.ts` emitted its outputs with
+  `Bun.write`, which truncates — of three sequential outputs only the last
+  survived into `$GITHUB_OUTPUT` (hub#830 item 3; the other two #830 items
+  remain open). RELEASING.md now describes the flow as wired, including the
+  fact that a tag push does **not** bypass the release-plan guards (hub#841).
+
+- **`status` VERSION refreshes after an upgrade (#836, closes hub#831).**
+  The VERSION column reads the cached services.json row, which only a
+  module's own boot ever wrote — and shim-served modules (`app`, `notes`)
+  have no boot, so their row stayed stale forever (`0.22.10 active … npm
+  (0.22.11)` on a real deploy). `upgrade` now refreshes the row, only after
+  a successful restart, re-reading it post-restart so a self-registering
+  module is never clobbered. The `isStale()` warning still can't fire for
+  npm installs — hub#839 tracks that separately.
+
+- **Changed: the app/notes static server (`:1944`) binds `127.0.0.1` by
+  default instead of all interfaces (#837, closes hub#832).** It ignored
+  `PARACHUTE_BIND_HOST` entirely and bound `*`. It now honors `--host`, then
+  `PARACHUTE_BIND_HOST`, then loopback — the same precedence as the hub
+  server. Reach the app through the hub front door (`:1939/app`) or
+  `parachute expose` as documented; if you intentionally accessed `:1944`
+  from off-box, set `PARACHUTE_BIND_HOST` (or pass `--host`) to restore the
+  wider bind. Every packaged deployment path (managed unit, Docker, Render,
+  Fly) already sets the bind host explicitly and is unaffected.
+
+- **Init tests stub the real installer (#834, closes hub#786).** Eleven
+  init/init-exposure tests shared a real `bun add -g` (network + disk) and
+  timed out together at 5000ms on slow runners, once blocking a stable
+  publish. `initForTest()` stubs the vault+app install by default; the real
+  install path stays covered by the e2e tag-push workflow and the container
+  smoke.
+
 ## [0.7.14] - 2026-08-12
 
 **The account verb ladder grows a middle rung, and strict MCP clients can

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -2,99 +2,65 @@
 
 This repo publishes FOUR npm packages on independent release cadences via [`.github/workflows/release.yml`](./.github/workflows/release.yml):
 
-| Package | Tag prefix | Container image |
+| Package | Git tag prefix (recorded by CI; also accepted as a manual release trigger) | Container image |
 |---|---|---|
 | `@openparachute/hub` | `v...` (e.g. `v0.5.13-rc.33`) | yes — `ghcr.io/parachutecomputer/parachute-hub` |
 | `@openparachute/scope-guard` | `scope-guard-v...` (e.g. `scope-guard-v0.4.0`) | no |
 | `@openparachute/depcheck` | `depcheck-v...` (e.g. `depcheck-v0.1.1`) | no |
 | `@openparachute/door-contract` | `door-contract-v...` (e.g. `door-contract-v0.6.0`) | no |
 
-Pushing a tag triggers CI which runs `bun run typecheck` + `bun test ./src`, then publishes the package matching the tag prefix.
+**Merging a version bump to `main` is the release signal** (hub#790). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
 
-## Tag conventions
+Pushing a tag still works for a deliberate re-release of an **already-published** version: the image republishes (npm rejects republishing an existing version, so the npm job goes red — expected). A tag does **not** bypass `release-plan.ts`'s guards: the workflow never passes `--tag-push`, so an unpublished-older version or an ambiguous registry response fails the plan job and skips every publish (hub#841 tracks whether to wire the override). The merge path is the normal one.
+
+## Version conventions
 
 Per [governance rule 2](https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md):
 
-| Tag shape | Example | npm `dist-tag` | ghcr image tags (hub only) |
-|---|---|---|---|
-| `vX.Y.Z-rc.N` | `v0.5.13-rc.33` | `rc` | `:v0.5.13-rc.33`, `:rc` |
-| `vX.Y.Z` | `v0.5.13` | `latest` | `:v0.5.13`, `:stable` |
-| `scope-guard-vX.Y.Z-rc.N` | `scope-guard-v0.4.0-rc.2` | `rc` | — |
-| `scope-guard-vX.Y.Z` | `scope-guard-v0.4.0` | `latest` | — |
-| `depcheck-vX.Y.Z-rc.N` | `depcheck-v0.1.1-rc.1` | `rc` | — |
-| `depcheck-vX.Y.Z` | `depcheck-v0.1.1` | `latest` | — |
-| `door-contract-vX.Y.Z-rc.N` | `door-contract-v0.6.0-rc.1` | `rc` | — |
-| `door-contract-vX.Y.Z` | `door-contract-v0.6.0` | `latest` | — |
+| `package.json` version | Example | npm `dist-tag` | Recorded git tag | ghcr image tags (hub only) |
+|---|---|---|---|---|
+| hub `X.Y.Z-rc.N` | `0.7.14-rc.1` | `rc` | `v0.7.14-rc.1` | `:v0.7.14-rc.1`, `:rc` |
+| hub `X.Y.Z` | `0.7.14` | `latest` | `v0.7.14` | `:v0.7.14`, `:stable`, `:latest` |
+| scope-guard `X.Y.Z-rc.N` | `0.4.0-rc.2` | `rc` | `scope-guard-v0.4.0-rc.2` | — |
+| scope-guard `X.Y.Z` | `0.4.0` | `latest` | `scope-guard-v0.4.0` | — |
+| depcheck `X.Y.Z-rc.N` | `0.1.1-rc.1` | `rc` | `depcheck-v0.1.1-rc.1` | — |
+| depcheck `X.Y.Z` | `0.1.1` | `latest` | `depcheck-v0.1.1` | — |
+| door-contract `X.Y.Z-rc.N` | `0.7.0-rc.1` | `rc` | `door-contract-v0.7.0-rc.1` | — |
+| door-contract `X.Y.Z` | `0.7.0` | `latest` | `door-contract-v0.7.0` | — |
 
-The workflow auto-detects rc vs stable from the `-rc.` substring in the tag.
+rc vs stable is detected from the `-rc.` substring in **the version being published**, never from the ref — on a merge-triggered run the ref is `main`, which matches no version pattern at all. Reading the ref is what once put `0.7.9-rc.3` on `@latest` (hub#792) and what left merge-published images with a bare `:stable` and no `:vX.Y.Z` (hub#829).
 
 ## Release flow
 
-Per [governance rule 2 (updated 2026-05-24)](https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md), PRs do NOT bump version per-commit. Bump + tag together only when you intend to ship.
+Per [governance rule 2 (updated 2026-05-24)](https://github.com/ParachuteComputer/parachute-workspace/blob/main/docs/process/governance.md), feature PRs do NOT bump version. A release PR does, and merging it publishes.
 
 ### Releasing hub
 
 ```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./package.json (rc.N or drop -rc for stable), commit, push.
-VERSION="v$(bun -e "console.log(require('./package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
+git fetch && git checkout -b release/hub-X.Y.Z origin/main
+# Bump the version in ./package.json (rc.N or drop -rc for stable) + CHANGELOG.
+git commit -am "chore(release): hub X.Y.Z — <what shipped>"
+gh pr create
 ```
 
-CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
-- npm gets the new version with appropriate dist-tag
-- ghcr gets a new image at `:vX.Y.Z` plus `:rc` or `:stable`
+Merge it to `main`. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
+- npm gets the new version with the appropriate dist-tag
+- ghcr gets a new image at `:vX.Y.Z` plus `:rc`, or `:stable` + `:latest`
+- a `vX.Y.Z` git tag is pushed as a record
 
-### Releasing scope-guard
+### Releasing scope-guard / depcheck / door-contract
 
-```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./packages/scope-guard/package.json, commit, push.
-VERSION="scope-guard-v$(bun -e "console.log(require('./packages/scope-guard/package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
-```
+Same shape: bump the version in `./packages/<name>/package.json` and merge. Each package's publish job gates on its own `plan` output, so bumping one publishes only that one — but a single merge that bumps several publishes all of them. The hub package is NOT republished unless its own version moved.
 
-The hub package is NOT republished. scope-guard runs on its own cadence.
-
-### Releasing depcheck
-
-```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./packages/depcheck/package.json, commit, push.
-VERSION="depcheck-v$(bun -e "console.log(require('./packages/depcheck/package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
-```
-
-### Releasing door-contract
-
-`@openparachute/door-contract` is the shared OAuth-issuer + `/account/*` wire
-contract both doors implement. Hub currently consumes it as a `workspace:*`
-dep, which is fine for the bun-linked local install but unresolvable in the
-published hub tarball (`packages/` isn't shipped) — so door-contract must be a
-real npm dependency before hub can boot from npm. This section makes the
-publish path exist; the hub-dep flip is a follow-on PR.
-
-```sh
-git fetch && git checkout main && git pull --ff-only
-# Bump the version in ./packages/door-contract/package.json, commit, push.
-VERSION="door-contract-v$(bun -e "console.log(require('./packages/door-contract/package.json').version)")"
-git tag "$VERSION"
-git push origin "$VERSION"
-```
-
-The hub package is NOT republished. depcheck / door-contract run on their own
-cadence.
+`@openparachute/door-contract` is the shared OAuth-issuer + `/account/*` wire contract both doors implement. Hub consumes it as a real npm dependency (`^0.7.0`) as of #826 — it used to be a `workspace:*` dep, which was unresolvable in the published hub tarball since `packages/` isn't shipped. So a door-contract change that hub depends on needs **two** releases: publish door-contract first, then bump hub's dependency range and release hub.
 
 ### Promoting an rc chain to stable
 
-Open a PR (or commit directly) that drops the `-rc.N` suffix from the relevant `package.json`, merge, then tag the bare version. CI publishes with `dist-tag=latest`.
+Open a release PR that drops the `-rc.N` suffix from the relevant `package.json` and merge it. CI publishes with `dist-tag=latest` (and, for hub, moves `:stable` + `:latest` on ghcr).
 
 ### Doc-only PRs
 
-Per governance, doc-only PRs DO NOT bump version. They merge straight to main; the changes get folded into whatever the next ship-driven version bump captures.
+Per governance, doc-only PRs DO NOT bump version. They merge straight through; the changes get folded into whatever the next ship-driven version bump captures.
 
 ## One-time setup (operator)
 
@@ -108,7 +74,9 @@ Before the workflow can publish, this repo needs:
 
    All rules point at the SAME workflow file. The jobs gate on tag prefix to decide which package to publish. No `NPM_TOKEN` secret needed — the workflow uses OIDC.
 
-2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`. First push of the image will create the package as **private by default**. After that first push, go to [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) → "Change visibility" → **Public**. Until you do this, any deploy target that pulls the image (Render, etc.) will 403 on `docker pull` unless you supply a `GHCR_PAT` read token. Doing it once at first-push time is the simplest path.
+2. **ghcr.io permissions**: no secret needed — the workflow uses the runner's auto-provisioned `GITHUB_TOKEN`.
+
+   **The `parachute-hub` container package is `private`, deliberately, and stays that way until something outside this org needs to pull it.** Private costs one `docker login` for the verify/rollback steps below; public is a one-way-ish door on a package nobody currently deploys from. When a deploy target does need it (Render, a customer box), flip it once: [package settings](https://github.com/orgs/ParachuteComputer/packages/container/parachute-hub/settings) → "Change visibility" → **Public**. Until then, an unauthenticated `docker pull` 403s — that's expected, not a broken release.
 
 ## Verifying a release
 
@@ -120,10 +88,14 @@ npm view @openparachute/scope-guard dist-tags
 npm view @openparachute/depcheck dist-tags
 npm view @openparachute/door-contract dist-tags
 
-# ghcr (hub only)
-docker pull ghcr.io/parachutecomputer/parachute-hub:<tag>
-docker inspect ghcr.io/parachutecomputer/parachute-hub:<tag> | jq '.[].Config.Labels'
+# ghcr (hub only). The package is private — authenticate first with a PAT
+# carrying `read:packages`:
+echo "$GHCR_PAT" | docker login ghcr.io -u <your-github-username> --password-stdin
+docker pull ghcr.io/parachutecomputer/parachute-hub:v<version>
+docker inspect ghcr.io/parachutecomputer/parachute-hub:v<version> | jq '.[].Config.Labels'
 ```
+
+Every publish pushes a versioned `:vX.Y.Z` tag alongside the moving `:rc` / `:stable` / `:latest` ones, so `docker pull …:v<version>` resolves for merge-published releases too (hub#829). The OCI `org.opencontainers.image.version` label carries the same version — if `docker inspect` shows `stable` there, the image predates that fix.
 
 The npm tarball page links to the GitHub Actions run that produced it (provenance attestation).
 
@@ -132,17 +104,23 @@ The npm tarball page links to the GitHub Actions run that produced it (provenanc
 There's no "unpublish" path for either npm (npm has a strict 72-hour unpublish policy that you should avoid for published packages anyway) or ghcr (containers are append-only). To roll back:
 
 - Cut a new patch from a known-good commit (e.g. `0.5.13` → `0.5.14` reverting the bad change).
-- Optionally re-point `:stable` ghcr tag to an older image so existing deploys pull the safe version. If you've already pruned the older image locally, pull it first:
+- Optionally re-point the moving ghcr tags at an older image so existing deploys pull the safe version. Re-point `:latest` as well as `:stable` — both move on a stable publish. If you've already pruned the older image locally, pull it first:
   ```sh
   docker pull ghcr.io/parachutecomputer/parachute-hub:v0.5.10
-  docker tag ghcr.io/parachutecomputer/parachute-hub:v0.5.10 ghcr.io/parachutecomputer/parachute-hub:stable
-  docker push ghcr.io/parachutecomputer/parachute-hub:stable
+  for MOVING in stable latest; do
+    docker tag ghcr.io/parachutecomputer/parachute-hub:v0.5.10 \
+               "ghcr.io/parachutecomputer/parachute-hub:$MOVING"
+    docker push "ghcr.io/parachutecomputer/parachute-hub:$MOVING"
+  done
   ```
 
 ## Troubleshooting
 
-- **Workflow doesn't trigger**: confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`; depcheck: `depcheck-v[0-9]+...`; door-contract: `door-contract-v[0-9]+...`).
-- **`version mismatch` error in publish-npm**: the relevant `package.json` version differs from the tag. Re-tag the correct commit, or fix the version in `package.json`.
+- **Workflow ran but nothing published**: the `plan` job decided there was nothing to do — read its log. `<pkg>@<version> is already on npm` means the version wasn't bumped. `plan` also warns (never fails) when commits sit on `main` that no published version contains; that warning is the cue to cut a release PR.
+- **`plan` failed with "refusing to guess" / "is OLDER than the current"**: an ambiguous npm response, or two release PRs merged out of version order so the merge would move a dist-tag backwards. Bump past the published version and re-merge.
+- **Workflow doesn't trigger at all**: for the merge path, confirm the merge landed on `main`. For a tag push, confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`; depcheck: `depcheck-v[0-9]+...`; door-contract: `door-contract-v[0-9]+...`).
+- **`version mismatch` error in publish-npm**: tag path only — the relevant `package.json` version differs from the tag. Re-tag the correct commit, or fix the version in `package.json`.
+- **Image published with no `:vX.Y.Z` tag**: pre-hub#829 behaviour, where the image tags came from the ref (`main` on a merge run). Fixed by deriving every tag from `plan`'s `hub_version`.
 - **`npm ERR! 403 You do not have permission to publish`**: Trusted Publisher rule on npm doesn't match this workflow. Verify org/repo/workflow filename are exactly `ParachuteComputer` / `parachute-hub` / `release.yml`. If the workflow file was renamed, the rule needs updating on npm.
 - **`npm ERR! 401 Unauthorized` with no OIDC token**: the workflow is missing `permissions: id-token: write` at the job level. Verify the YAML.
 - **ghcr push fails with 403**: confirm `permissions.packages: write` is in the publish-image job (it is).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {
@@ -11,8 +11,16 @@
   "bin": {
     "parachute": "src/cli.ts"
   },
-  "workspaces": ["packages/*"],
-  "files": ["src", "web/ui/dist", "scripts/git-credential-parachute", "README.md", "LICENSE"],
+  "workspaces": [
+    "packages/*"
+  ],
+  "files": [
+    "src",
+    "web/ui/dist",
+    "scripts/git-credential-parachute",
+    "README.md",
+    "LICENSE"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-hub.git"

--- a/package.json
+++ b/package.json
@@ -11,16 +11,8 @@
   "bin": {
     "parachute": "src/cli.ts"
   },
-  "workspaces": [
-    "packages/*"
-  ],
-  "files": [
-    "src",
-    "web/ui/dist",
-    "scripts/git-credential-parachute",
-    "README.md",
-    "LICENSE"
-  ],
+  "workspaces": ["packages/*"],
+  "files": ["src", "web/ui/dist", "scripts/git-credential-parachute", "README.md", "LICENSE"],
   "repository": {
     "type": "git",
     "url": "https://github.com/ParachuteComputer/parachute-hub.git"

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -25,6 +25,32 @@
  * via an explicit tag push, which takes the tag branch below.)
  */
 
+import { appendFileSync } from "node:fs";
+
+/**
+ * Append `key=value` lines to a GitHub Actions output file.
+ *
+ * APPEND, not write. This used to be `Bun.write`, which TRUNCATES — so
+ * emitting three outputs in a row left only the last one in `$GITHUB_OUTPUT`.
+ * `version` and `dist_tag` never reached the workflow at all; only
+ * `should_publish` did, which is why nothing noticed (it's the one output
+ * anything consumed). Latent until hub#829 made `publish-image` derive its
+ * image tags from `version`.
+ *
+ * Exported so the append behaviour is testable without spawning the CLI (which
+ * would need the network to read the registry).
+ */
+export function emitOutputs(
+  path: string | undefined,
+  entries: ReadonlyArray<readonly [string, string]>,
+  log: (line: string) => void = console.log,
+): void {
+  for (const [key, value] of entries) {
+    if (path) appendFileSync(path, `${key}=${value}\n`);
+    log(`${key}=${value}`);
+  }
+}
+
 /** Where a version stands relative to what's already published. */
 export type PublishDecision =
   | { publish: true; reason: string }
@@ -185,12 +211,6 @@ if (import.meta.main) {
     isTagPush: rest.includes("--tag-push"),
   });
 
-  const out = process.env.GITHUB_OUTPUT;
-  const emit = async (k: string, v: string) => {
-    if (out) await Bun.write(out, `${k}=${v}\n`, { createPath: false });
-    console.log(`${k}=${v}`);
-  };
-
   if ("refuse" in decision) {
     console.error(`::error::${npmName}@${version}: ${decision.reason}`);
     process.exit(1);
@@ -222,8 +242,10 @@ if (import.meta.main) {
       // clone just means we can't tell, not that something is wrong.
     }
   }
-  await emit("version", version);
-  await emit("dist_tag", distTagFor(version));
-  await emit("should_publish", String(decision.publish));
+  emitOutputs(process.env.GITHUB_OUTPUT, [
+    ["version", version],
+    ["dist_tag", distTagFor(version)],
+    ["should_publish", String(decision.publish)],
+  ]);
   console.log(`${npmName}@${version}: ${decision.reason}`);
 }

--- a/src/__tests__/bundle-serve.test.ts
+++ b/src/__tests__/bundle-serve.test.ts
@@ -7,6 +7,7 @@ import {
   notesDistCandidates,
   notesFetch,
   notesServeOptions,
+  resolveBindHost,
   resolveBundleDistFrom,
 } from "../bundle-serve.ts";
 
@@ -29,10 +30,34 @@ function req(path: string): Request {
 
 describe("notesServeOptions (hub#399 residual)", () => {
   test("sets idleTimeout: 255 to outlast edge keep-alive pools, matching hub-server.ts", () => {
-    const opts = notesServeOptions(5173, "/tmp/dist", "/notes");
+    const opts = notesServeOptions(5173, "/tmp/dist", "/notes", "127.0.0.1");
     expect(opts.idleTimeout).toBe(255);
     expect(opts.port).toBe(5173);
     expect(typeof opts.fetch).toBe("function");
+  });
+
+  test("passes hostname through to Bun.serve (hub#832 — no hostname = every interface)", () => {
+    expect(notesServeOptions(5173, "/tmp/dist", "/notes", "127.0.0.1").hostname).toBe("127.0.0.1");
+    expect(notesServeOptions(5173, "/tmp/dist", "/notes", "0.0.0.0").hostname).toBe("0.0.0.0");
+  });
+});
+
+describe("resolveBindHost (hub#832)", () => {
+  test("defaults to loopback, matching hub-server.ts", () => {
+    expect(resolveBindHost(undefined, {})).toBe("127.0.0.1");
+  });
+
+  test("honors PARACHUTE_BIND_HOST — one env governs every listener the hub supervises", () => {
+    expect(resolveBindHost(undefined, { PARACHUTE_BIND_HOST: "0.0.0.0" })).toBe("0.0.0.0");
+    expect(resolveBindHost(undefined, { PARACHUTE_BIND_HOST: "127.0.0.1" })).toBe("127.0.0.1");
+  });
+
+  test("--host beats the env", () => {
+    expect(resolveBindHost("127.0.0.1", { PARACHUTE_BIND_HOST: "0.0.0.0" })).toBe("127.0.0.1");
+  });
+
+  test("an empty PARACHUTE_BIND_HOST is unset, not the empty hostname", () => {
+    expect(resolveBindHost(undefined, { PARACHUTE_BIND_HOST: "" })).toBe("127.0.0.1");
   });
 });
 

--- a/src/__tests__/init.test.ts
+++ b/src/__tests__/init.test.ts
@@ -8,6 +8,7 @@ import {
   looksLikeServer,
   resolveAdminUrl,
   resolveInitChannel,
+  type InitOpts,
 } from "../commands/init.ts";
 import type { ExposeState } from "../expose-state.ts";
 import { writeHubPort } from "../hub-control.ts";
@@ -39,6 +40,25 @@ function makeHarness(): Harness {
  * etc.) can override this with their own stub.
  */
 const noopVaultInstall = async (_configDir: string, _manifestPath: string): Promise<number> => 0;
+const noopAppInstall = async (_configDir: string, _manifestPath: string): Promise<number> => 0;
+
+/**
+ * Call `init` with both module-install steps stubbed.
+ *
+ * Production defaults `bun add -g` vault and app. Tests that forget to
+ * override those seams share that wait, and on a slow runner the cluster
+ * all time out at the 5000ms ceiling together (hub#786 — 11 init /
+ * init-exposure tests, byte-identical to a version-bump tag). Stubbing
+ * here is the default; a test that needs a seed-write still passes its
+ * own `installVaultModuleImpl` and it wins the spread.
+ */
+async function initForTest(opts: InitOpts = {}): Promise<number> {
+  return init({
+    installVaultModuleImpl: noopVaultInstall,
+    installAppModuleImpl: noopAppInstall,
+    ...opts,
+  });
+}
 
 function seedVault(manifestPath: string): void {
   writeFileSync(
@@ -90,7 +110,7 @@ describe("init", () => {
     try {
       const calls: string[] = [];
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -138,7 +158,7 @@ describe("init", () => {
       writeHubPort(1939, h.configDir);
       const calls: string[] = [];
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -186,7 +206,7 @@ describe("init", () => {
 
       const calls: string[] = [];
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -238,7 +258,7 @@ describe("init", () => {
       };
 
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -269,7 +289,7 @@ describe("init", () => {
     try {
       writeHubPort(1939, h.configDir);
       const opened: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -309,7 +329,7 @@ describe("init", () => {
     try {
       writeHubPort(1939, h.configDir);
       const opened: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -352,7 +372,7 @@ describe("init", () => {
       writeHubPort(1939, h.configDir);
       const opened: string[] = [];
       let prompted = false;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -392,7 +412,7 @@ describe("init", () => {
     try {
       writeHubPort(1939, h.configDir);
       let prompted = false;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -426,7 +446,7 @@ describe("init", () => {
     try {
       writeHubPort(1939, h.configDir);
       const opened: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -467,7 +487,7 @@ describe("init", () => {
       writeHubPort(1939, h.configDir);
       const opened: string[] = [];
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -508,7 +528,7 @@ describe("init", () => {
     try {
       writeHubPort(1939, h.configDir);
       const opened: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -545,7 +565,7 @@ describe("init", () => {
     const h = makeHarness();
     try {
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -581,7 +601,7 @@ describe("init — version-check-and-restart at the hub adoption point (#590)", 
     try {
       const logs: string[] = [];
       let seenPort: number | undefined;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => logs.push(l),
@@ -623,7 +643,7 @@ describe("init — version-check-and-restart at the hub adoption point (#590)", 
     try {
       const logs: string[] = [];
       let exposeRan = false;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => logs.push(l),
@@ -667,7 +687,7 @@ describe("init — version-check-and-restart at the hub adoption point (#590)", 
     try {
       const logs: string[] = [];
       let exposeRan = false;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => logs.push(l),
@@ -712,7 +732,7 @@ describe("init — version-check-and-restart at the hub adoption point (#590)", 
     const h = makeHarness();
     try {
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         manifestPath: h.manifestPath,
         log: (l) => logs.push(l),
@@ -765,7 +785,7 @@ describe("init bootstrap-token first-claim (hub#576)", () => {
       writeHubPort(1939, h.configDir);
       const probed: string[] = [];
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -806,7 +826,7 @@ describe("init bootstrap-token first-claim (hub#576)", () => {
       writeHubPort(1939, h.configDir);
       let probedCount = 0;
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -841,7 +861,7 @@ describe("init bootstrap-token first-claim (hub#576)", () => {
     try {
       writeHubPort(1939, h.configDir);
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -875,7 +895,7 @@ describe("init bootstrap-token first-claim (hub#576)", () => {
     try {
       writeHubPort(1939, h.configDir);
       const wizardUrls: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -971,7 +991,7 @@ describe("init --hub-origin (Caddy-direct zero-SSH boot, onboarding-streamline 2
     const h = makeHarness();
     try {
       const order: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -1008,7 +1028,7 @@ describe("init --hub-origin (Caddy-direct zero-SSH boot, onboarding-streamline 2
   test("default impl writes hub_settings.hub_origin to the real DB", async () => {
     const h = makeHarness();
     try {
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -1048,7 +1068,7 @@ describe("init --hub-origin (Caddy-direct zero-SSH boot, onboarding-streamline 2
     const h = makeHarness();
     try {
       let setCalls = 0;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -1081,7 +1101,7 @@ describe("init --hub-origin (Caddy-direct zero-SSH boot, onboarding-streamline 2
     const h = makeHarness();
     try {
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -1120,7 +1140,7 @@ describe("init exposure chain", () => {
     try {
       writeHubPort(1939, h.configDir);
       const promptCalls: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1160,7 +1180,7 @@ describe("init exposure chain", () => {
       writeHubPort(1939, h.configDir);
       let exposureChained = false;
       const promptCalls: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1213,7 +1233,7 @@ describe("init exposure chain", () => {
       let tailnetCalls = 0;
       let cloudflareCalls = 0;
       const promptCalls: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1263,7 +1283,7 @@ describe("init exposure chain", () => {
       writeHubPort(1939, h.configDir);
       let tailnetCalls = 0;
       let cloudflareCalls = 0;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1304,7 +1324,7 @@ describe("init exposure chain", () => {
       writeHubPort(1939, h.configDir);
       let tailnetCalls = 0;
       let cloudflareCalls = 0;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1353,7 +1373,7 @@ describe("init exposure chain", () => {
       const setChained = (v: ExposeChoice) => {
         chained[0] = v;
       };
-      await init({
+      await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1394,7 +1414,7 @@ describe("init exposure chain", () => {
       // Server: Linux + SSH → default is "3" (cloudflare).
       promptLog = [];
       setChained("none");
-      await init({
+      await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1450,7 +1470,7 @@ describe("init exposure chain", () => {
       const promptCalls: string[] = [];
       let chained = false;
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1500,7 +1520,7 @@ describe("init exposure chain", () => {
     try {
       writeHubPort(1939, h.configDir);
       let chained = false;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1538,7 +1558,7 @@ describe("init exposure chain", () => {
     try {
       writeHubPort(1939, h.configDir);
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1581,7 +1601,7 @@ describe("init exposure chain", () => {
     try {
       writeHubPort(1939, h.configDir);
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1622,7 +1642,7 @@ describe("init exposure chain", () => {
     const h = makeHarness();
     try {
       const order: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1674,7 +1694,7 @@ describe("init exposure chain", () => {
       // No operator.token yet.
       expect(await readOperatorTokenFile(h.configDir)).toBeNull();
 
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1718,7 +1738,7 @@ describe("init exposure chain", () => {
       // Plant a sentinel token on disk.
       await writeOperatorTokenFile("SENTINEL.PRE-EXISTING.TOKEN", h.configDir);
 
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1753,7 +1773,7 @@ describe("init exposure chain", () => {
       const { readOperatorTokenFile } = await import("../operator-token.ts");
       // No user seeded — the common fresh-box case where init runs before the
       // wizard creates first-admin.
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1786,7 +1806,7 @@ describe("init exposure chain", () => {
     const h = makeHarness();
     try {
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1835,7 +1855,7 @@ describe("init exposure chain", () => {
         hubOrigin: "https://box.tailnet.ts.net",
       };
       const logs: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         // #590: keep the version-check a no-op in init tests — NEVER let the
         // production default fire a real /health fetch + restart the live unit.
@@ -1891,7 +1911,7 @@ describe("init hub#694 — vault seeded before the supervisor boot scan (bug 1)"
     const h = makeHarness();
     try {
       const order: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -1928,7 +1948,7 @@ describe("init hub#694 — vault seeded before the supervisor boot scan (bug 1)"
     const h = makeHarness();
     try {
       const order: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -1968,13 +1988,16 @@ describe("init hub#694 — vault seeded before the supervisor boot scan (bug 1)"
   });
 
   test("real seed: vault row is in services.json by the time ensureHub runs", async () => {
-    // End-to-end-ish: drive the REAL defaultInstallVaultModule (bun-linked vault
-    // short-circuits the bun-add) and assert the services.json row exists when
-    // ensureHub is invoked — i.e. the boot scan would find it.
+    // The thing under test is ORDERING: the vault row must exist when
+    // ensureHub runs, so the supervisor's one-time boot scan finds it.
+    // The previous version drove production `defaultInstallVaultModule`
+    // (`bun add -g`), which is what clustered 11 tests at 5000ms on a
+    // slow runner (hub#786). A stub that performs the seed-write still
+    // pins the ordering; the bun-add is not the contract.
     const h = makeHarness();
     try {
       let vaultRowAtEnsure: boolean | undefined;
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -1984,6 +2007,10 @@ describe("init hub#694 — vault seeded before the supervisor boot scan (bug 1)"
         manifestPath: h.manifestPath,
         log: () => {},
         alive: () => false,
+        installVaultModuleImpl: async (_configDir, manifestPath) => {
+          seedVault(manifestPath);
+          return 0;
+        },
         ensureHub: async () => {
           // At hub-unit-boot time the services.json must already carry vault.
           const { findService } = await import("../services-manifest.ts");
@@ -1994,8 +2021,6 @@ describe("init hub#694 — vault seeded before the supervisor boot scan (bug 1)"
         readExposeStateFn: () => undefined,
         isTty: false,
         platform: "linux",
-        // NOTE: no installVaultModuleImpl override — exercise the real install
-        // so we prove the seed write lands before ensureHub, not just the stub.
       });
       expect(code).toBe(0);
       expect(vaultRowAtEnsure).toBe(true);
@@ -2009,7 +2034,7 @@ describe("init hub#694 — vault seeded before the supervisor boot scan (bug 1)"
     try {
       seedVault(h.manifestPath);
       const order: string[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -2046,7 +2071,7 @@ describe("init hub#694 — install channel (bug 2)", () => {
     const h = makeHarness();
     try {
       const channels: (string | undefined)[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -2080,7 +2105,7 @@ describe("init hub#694 — install channel (bug 2)", () => {
     const h = makeHarness();
     try {
       const channels: (string | undefined)[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -2116,7 +2141,7 @@ describe("init hub#694 — install channel (bug 2)", () => {
     const h = makeHarness();
     try {
       const channels: (string | undefined)[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -2150,7 +2175,7 @@ describe("init hub#694 — install channel (bug 2)", () => {
     const h = makeHarness();
     try {
       const channels: (string | undefined)[] = [];
-      const code = await init({
+      const code = await initForTest({
         configDir: h.configDir,
         ensureHubVersion: async () => ({
           outcome: "match" as const,
@@ -2246,6 +2271,7 @@ describe("init --vault-name (#478 Part 2)", () => {
       isTty: false,
       platform: "linux" as const,
       installVaultModuleImpl: noopVaultInstall,
+      installAppModuleImpl: noopAppInstall,
       noBrowser: true,
       noExposePrompt: true,
       noWizardPrompt: true,

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -7,10 +7,14 @@
  */
 
 import { describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   compareVersions,
   decidePublish,
   distTagFor,
+  emitOutputs,
   readRegistry,
   unpublishedDrift,
 } from "../../scripts/release-plan.ts";
@@ -174,5 +178,107 @@ describe("unpublishedDrift", () => {
 
   test("blank lines from git's trailing newline don't inflate the count", () => {
     expect(unpublishedDrift(["abc one", ""]).count).toBe(1);
+  });
+});
+
+/**
+ * hub#829: the ghcr image tags are part of the release contract too.
+ *
+ * The `publish-image` job used to derive its version tag from the ref
+ * (`type=ref,event=tag`). On a merge-triggered run the ref is `main`, so the
+ * 0.7.13 merge published a bare `:stable` with an `image.version=stable`
+ * label, and `:v0.7.13` / `:latest` existed only because someone pushed a tag
+ * by hand afterwards. Once that manual step went away, RELEASING.md's
+ * `docker pull …:vX.Y.Z` verify + rollback instructions pointed at nothing.
+ *
+ * Same class of bug as the dist-tag one above, and the same rule fixes it:
+ * derive from the VERSION BEING PUBLISHED, never from the ref. Asserted here
+ * rather than left to review because a YAML `run:`/`with:` block is otherwise
+ * only exercised by shipping a release.
+ */
+describe("release.yml image tags (hub#829)", () => {
+  const workflow = readFileSync(
+    join(import.meta.dir, "../../.github/workflows/release.yml"),
+    "utf8",
+  );
+
+  test("the plan job exposes the hub version, not just the publish decision", () => {
+    expect(workflow).toContain("hub_version: ${{ steps.hub.outputs.version }}");
+  });
+
+  test("every publish pushes a versioned image tag", () => {
+    expect(workflow).toContain("type=raw,value=v${{ needs.plan.outputs.hub_version }}");
+  });
+
+  test("no image tag is derived from the ref — on a merge run the ref is `main`", () => {
+    // Anchored so the prose in the surrounding comment (which names the old
+    // `type=ref,event=tag` it replaced) doesn't trip it.
+    expect(workflow).not.toMatch(/^\s*type=ref/m);
+    // The rc/stable/latest gates have to read the version too, or a
+    // merge-published rc lands on `:stable`.
+    expect(workflow).not.toMatch(/type=raw,value=(rc|stable|latest),enable=.*github\.ref_name/);
+  });
+
+  test("`latest` moves on a stable publish, and only on a stable publish", () => {
+    expect(workflow).toContain(
+      "type=raw,value=latest,enable=${{ !contains(needs.plan.outputs.hub_version, '-rc.') }}",
+    );
+    // metadata-action's own `latest=auto` only fires on tag runs, which is the
+    // half of #829 that left `:latest` stuck at 0.7.13.
+    expect(workflow).toMatch(/flavor:\s*\|\s*\n\s*latest=false/);
+  });
+});
+
+/**
+ * The step outputs are the wire between `plan` and every publish job. Losing
+ * one is silent — the consuming expression just interpolates to an empty
+ * string.
+ */
+describe("emitOutputs", () => {
+  test("APPENDS every output — `Bun.write` truncated, keeping only the last", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-release-plan-"));
+    try {
+      const out = join(dir, "github_output");
+      writeFileSync(out, "");
+      emitOutputs(
+        out,
+        [
+          ["version", "0.7.15"],
+          ["dist_tag", "latest"],
+          ["should_publish", "true"],
+        ],
+        () => {},
+      );
+      expect(readFileSync(out, "utf8")).toBe(
+        "version=0.7.15\ndist_tag=latest\nshould_publish=true\n",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("keeps whatever an earlier step already wrote to the file", () => {
+    const dir = mkdtempSync(join(tmpdir(), "phub-release-plan-"));
+    try {
+      const out = join(dir, "github_output");
+      writeFileSync(out, "earlier=kept\n");
+      emitOutputs(out, [["version", "0.7.15"]], () => {});
+      expect(readFileSync(out, "utf8")).toBe("earlier=kept\nversion=0.7.15\n");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("logs every output even with no output file (local runs)", () => {
+    const lines: string[] = [];
+    emitOutputs(
+      undefined,
+      [
+        ["version", "0.7.15"],
+        ["dist_tag", "latest"],
+      ],
+      (l) => lines.push(l),
+    );
+    expect(lines).toEqual(["version=0.7.15", "dist_tag=latest"]);
   });
 });

--- a/src/__tests__/upgrade.test.ts
+++ b/src/__tests__/upgrade.test.ts
@@ -9,7 +9,7 @@ import { compareVersions, defaultRunner, detectChannel, upgrade } from "../comma
 import type { HubUnitDeps, HubUnitManagerOpResult } from "../hub-unit.ts";
 import { defaultHubUnitDeps } from "../hub-unit.ts";
 import type { MigrateOfferResult } from "../migrate-offer.ts";
-import { upsertService } from "../services-manifest.ts";
+import { findService, upsertService } from "../services-manifest.ts";
 
 interface RunCall {
   cmd: string[];
@@ -1835,6 +1835,212 @@ describe("Phase 5b: upgrade module-restart on a no-unit box", () => {
       expect(offerCalls).toBe(1);
       expect(driveModuleOpCalled).toBe(false);
       expect(logs.join("\n")).not.toMatch(/ECONNREFUSED|connection refused/i);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("hub#831: services.json version refresh after upgrade", () => {
+  /** Not-a-git-checkout runner whose `bun add -g` rewrites package.json. */
+  function npmRunner(installDir: string, afterVersion: string | null): UpgradeRunner {
+    return {
+      async run(cmd) {
+        if (cmd[0] === "bun" && cmd[1] === "add" && cmd[2] === "-g" && afterVersion) {
+          writePackageJson(installDir, { name: "@openparachute/vault", version: afterVersion });
+        }
+        return 0;
+      },
+      async capture(cmd) {
+        if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+          return { code: 128, stdout: "fatal: not a git repository\n" };
+        }
+        return { code: 0, stdout: "" };
+      },
+    };
+  }
+
+  test("npm upgrade + restart refreshes the stale registry row", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: (l) => logs.push(l),
+      });
+
+      expect(code).toBe(0);
+      // The bug: SOURCE re-read 0.5.0 off disk while VERSION kept showing 0.4.0.
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.5.0");
+      expect(logs.join("\n")).toMatch(/services\.json version 0\.4\.0 → 0\.5\.0/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("preserves the rest of the row (port, paths, installDir)", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: () => {},
+      });
+
+      expect(code).toBe(0);
+      const row = findService("parachute-vault", h.manifestPath);
+      expect(row?.port).toBe(1940);
+      expect(row?.paths).toEqual(["/vault/default"]);
+      expect(row?.installDir).toBe(installDir);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("re-reads the row post-restart so a self-registering module isn't clobbered", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        // Stand in for a module that rewrites its own row on boot, adding a
+        // field the pre-restart copy never had.
+        restartFn: async () => {
+          upsertService(
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default"],
+              health: "/vault/default/health",
+              version: "0.5.0",
+              installDir,
+              displayName: "Vault",
+            },
+            h.manifestPath,
+          );
+          return 0;
+        },
+        log: () => {},
+      });
+
+      expect(code).toBe(0);
+      const row = findService("parachute-vault", h.manifestPath);
+      expect(row?.version).toBe("0.5.0");
+      expect(row?.displayName).toBe("Vault");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("a failed restart leaves the row alone — the old code is still running", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, "0.5.0"),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 1,
+        log: () => {},
+      });
+
+      expect(code).toBe(1);
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.4.0");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("the skip-restart no-op doesn't touch the row", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.3.0");
+
+      const logs: string[] = [];
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner: npmRunner(installDir, null),
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: (l) => logs.push(l),
+      });
+
+      expect(code).toBe(0);
+      expect(logs.join("\n")).toMatch(/already at 0\.4\.0/);
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.3.0");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("bun-linked upgrade + restart refreshes from the checkout's package.json", async () => {
+    const h = makeHarness();
+    try {
+      const installDir = join(h.installRoot, "vault");
+      writePackageJson(installDir, { name: "@openparachute/vault", version: "0.4.0" });
+      seedVault(h.manifestPath, installDir, "0.4.0");
+
+      let headCalls = 0;
+      const runner: UpgradeRunner = {
+        async run(cmd) {
+          // The pull brings a version bump into the checkout.
+          if (cmd[0] === "git" && cmd[1] === "pull") {
+            writePackageJson(installDir, { name: "@openparachute/vault", version: "0.6.0" });
+          }
+          return 0;
+        },
+        async capture(cmd) {
+          if (cmd[1] === "rev-parse" && cmd[2] === "--is-inside-work-tree") {
+            return { code: 0, stdout: "true" };
+          }
+          if (cmd[1] === "status") return { code: 0, stdout: "" };
+          if (cmd[1] === "rev-parse" && cmd[2] === "HEAD") {
+            headCalls++;
+            return { code: 0, stdout: headCalls === 1 ? "aaaaaaa" : "bbbbbbb" };
+          }
+          return { code: 0, stdout: "" };
+        },
+      };
+
+      const code = await upgrade("vault", {
+        manifestPath: h.manifestPath,
+        configDir: h.configDir,
+        runner,
+        findGlobalInstall: () => join(installDir, "package.json"),
+        restartFn: async () => 0,
+        log: () => {},
+      });
+
+      expect(code).toBe(0);
+      expect(findService("parachute-vault", h.manifestPath)?.version).toBe("0.6.0");
     } finally {
       h.cleanup();
     }

--- a/src/bundle-serve.ts
+++ b/src/bundle-serve.ts
@@ -13,7 +13,12 @@
  * alongside the other services.
  *
  * Invoked as:
- *   bun <this-file> --port <n> [--dist <path>] [--mount <prefix>] [--package <npmName>]
+ *   bun <this-file> --port <n> [--host <addr>] [--dist <path>] [--mount <prefix>]
+ *                   [--package <npmName>]
+ *
+ * `--host` is the bind address, same contract as hub-server.ts: flag beats
+ * `PARACHUTE_BIND_HOST`, env beats the `127.0.0.1` default. See
+ * `resolveBindHost` for why the default is loopback.
  *
  * `--mount` (default `/notes`) is the path prefix the reverse proxy hands
  * us. We strip it before resolving against `dist/` so a request for
@@ -54,21 +59,55 @@ import { dirname, join, resolve } from "node:path";
  */
 const DEFAULT_PACKAGE = "@openparachute/app";
 
+/**
+ * Bind address when neither `--host` nor `PARACHUTE_BIND_HOST` says otherwise.
+ *
+ * Matches `hub-server.ts`'s `parseArgs` default. The shim used to pass no
+ * `hostname` at all, so `Bun.serve` bound every interface — on a box whose hub
+ * and vault both sat on `127.0.0.1`, the SPA alone answered unauthenticated on
+ * the tailnet/LAN (hub#832). Nothing legitimate needs the wildcard: this shim
+ * is reached through `parachute expose`'s reverse proxy, which connects over
+ * loopback. The container images that DO need every interface set
+ * `PARACHUTE_BIND_HOST=0.0.0.0` (Dockerfile / render.yaml / fly.toml), which
+ * the supervisor passes down to the child through the inherited env.
+ */
+const DEFAULT_BIND_HOST = "127.0.0.1";
+
 interface Args {
   port: number;
+  host?: string;
   dist?: string;
   mount: string;
   pkg: string;
 }
 
+/**
+ * Flag beats env, env beats default — the same precedence hub-server.ts uses
+ * for its own listener, so one `PARACHUTE_BIND_HOST` governs every process the
+ * hub supervises rather than just the hub itself.
+ */
+export function resolveBindHost(
+  host: string | undefined,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  // `||` not `??`, matching hub-server.ts: an empty `PARACHUTE_BIND_HOST=` is
+  // "unset" here, not "bind to the empty string".
+  return host || env.PARACHUTE_BIND_HOST || DEFAULT_BIND_HOST;
+}
+
 function parseArgs(argv: string[]): Args {
   let port = 5173;
+  let host: string | undefined;
   let dist: string | undefined;
   let mount = "/notes";
   let pkg = DEFAULT_PACKAGE;
   for (let i = 0; i < argv.length; i++) {
     const a = argv[i];
-    if (a === "--port") {
+    if (a === "--host") {
+      const v = argv[++i];
+      if (!v) throw new Error("--host requires a value");
+      host = v;
+    } else if (a === "--port") {
       const v = argv[++i];
       if (!v) throw new Error("--port requires a value");
       const n = Number.parseInt(v, 10);
@@ -92,7 +131,7 @@ function parseArgs(argv: string[]): Args {
       throw new Error(`unknown argument: ${a}`);
     }
   }
-  return { port, dist, mount, pkg };
+  return { port, host, dist, mount, pkg };
 }
 
 export function normalizeMount(raw: string): string {
@@ -375,21 +414,33 @@ export function notesFetch(dist: string, mount: string): (req: Request) => Respo
  * exceeds Render's community-observed ~120s edge pool TTL. Closes the hub#399
  * residual on the second serve entrypoint (the Notes PWA path). Exported so a
  * test can assert the option is set without booting a server.
+ *
+ * `hostname` is REQUIRED rather than optional: omitting it is what let this
+ * shim bind every interface (hub#832), and an optional parameter would let the
+ * same omission come back silently. Callers resolve it via `resolveBindHost`.
  */
 export function notesServeOptions(
   port: number,
   dist: string,
   mount: string,
-): { port: number; idleTimeout: number; fetch: (req: Request) => Response } {
+  hostname: string,
+): {
+  port: number;
+  hostname: string;
+  idleTimeout: number;
+  fetch: (req: Request) => Response;
+} {
   return {
     port,
+    hostname,
     idleTimeout: 255,
     fetch: notesFetch(dist, mount),
   };
 }
 
 if (import.meta.main) {
-  const { port, dist: distArg, mount, pkg } = parseArgs(process.argv.slice(2));
+  const { port, host, dist: distArg, mount, pkg } = parseArgs(process.argv.slice(2));
+  const hostname = resolveBindHost(host);
 
   let dist: string;
   try {
@@ -401,9 +452,9 @@ if (import.meta.main) {
     process.exit(1);
   }
 
-  Bun.serve(notesServeOptions(port, dist, mount));
+  Bun.serve(notesServeOptions(port, dist, mount, hostname));
 
   console.log(
-    `static-serve listening on :${port} (pkg=${pkg}, dist=${dist}, mount=${mount || "/"})`,
+    `static-serve listening on ${hostname}:${port} (pkg=${pkg}, dist=${dist}, mount=${mount || "/"})`,
   );
 }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -85,7 +85,12 @@ import {
   knownServices,
   shortNameForManifest,
 } from "../service-spec.ts";
-import { type ServiceEntry, readManifest } from "../services-manifest.ts";
+import {
+  type ServiceEntry,
+  findService,
+  readManifest,
+  upsertService,
+} from "../services-manifest.ts";
 import { type LifecycleOpts, restart as lifecycleRestart } from "./lifecycle.ts";
 
 export interface UpgradeRunner {
@@ -635,6 +640,52 @@ async function restartTarget(target: ResolvedTarget, r: Resolved): Promise<numbe
   });
 }
 
+/**
+ * Bring the services.json row's `version` back in line with what's installed,
+ * after an upgrade+restart (hub#831).
+ *
+ * `entry.version` is a CACHE of the running version: services own the write
+ * side of services.json and stamp it on their own boot (see CLAUDE.md). That
+ * works for modules with a server of their own — and not at all for the ones
+ * hub serves through the `bundle-serve.ts` static shim (`app`, `notes`), which
+ * have no boot of their own to do the stamping. Their row keeps whatever it
+ * last had, so `parachute status` reported `parachute-app 1944 0.22.10 …
+ * npm (0.22.11)` — VERSION from the stale cache, SOURCE re-read live off disk
+ * on every invocation. Cosmetic, except that "status shows expected versions"
+ * is the deploy verification step.
+ *
+ * Deliberately AFTER a successful restart, never before: until the restart
+ * lands, the old code is still the code that's running, and writing the new
+ * version early would turn a stale row into a lying one. For the same reason
+ * the skip-restart paths ("already at X", "already up to date") don't call
+ * this — nothing restarted, so nothing about the running version changed.
+ *
+ * Re-reads the row instead of reusing `target.entry`: a self-registering
+ * module rewrites its whole row during the restart we just awaited, and
+ * spreading the pre-restart copy would clobber what it just wrote. The
+ * version-differs guard then makes this a no-op for exactly those modules —
+ * they already stamped the right version themselves — so in practice only the
+ * shim-served rows get written here.
+ */
+function refreshManifestVersion(target: ResolvedTarget, sourceDir: string, r: Resolved): void {
+  const installed = readPackageVersion(join(sourceDir, "package.json"));
+  if (!installed) return;
+  const fresh = findService(target.entry.name, r.manifestPath);
+  if (!fresh || fresh.version === installed) return;
+  try {
+    upsertService({ ...fresh, version: installed }, r.manifestPath);
+    r.log(`${target.short}: services.json version ${fresh.version} → ${installed}.`);
+  } catch (err) {
+    // Never fail an otherwise-successful upgrade over the bookkeeping write —
+    // the package is installed and the service is running either way. Say so
+    // rather than leaving the operator to wonder why status disagrees.
+    r.log(
+      `⚠ ${target.short}: upgraded + restarted, but couldn't refresh the services.json version ` +
+        `(${err instanceof Error ? err.message : String(err)}). \`status\` may show the old version.`,
+    );
+  }
+}
+
 async function upgradeLinked(
   target: ResolvedTarget,
   sourceDir: string,
@@ -693,7 +744,9 @@ async function upgradeLinked(
   }
 
   r.log(`${target.short}: ${before.sha.slice(0, 7)} → ${after.sha.slice(0, 7)}; restarting…`);
-  return await restartTarget(target, r);
+  const restarted = await restartTarget(target, r);
+  if (restarted === 0) refreshManifestVersion(target, sourceDir, r);
+  return restarted;
 }
 
 /**
@@ -858,7 +911,9 @@ async function upgradeNpm(target: ResolvedTarget, sourceDir: string, r: Resolved
   }
 
   r.log(`${target.short}: ${beforeVersion ?? "?"} → ${afterVersion ?? "?"}; restarting…`);
-  return await restartTarget(target, r);
+  const restarted = await restartTarget(target, r);
+  if (restarted === 0) refreshManifestVersion(target, sourceDir, r);
+  return restarted;
 }
 
 async function upgradeOne(target: ResolvedTarget, r: Resolved): Promise<number> {


### PR DESCRIPTION
One-click release batch: four reviewed PRs + the version/changelog commit. **Merge with a merge commit (not squash),** per governance.

## What's in it
| PR | Closes | What |
|---|---|---|
| #835 | hub#829 | Merge-published images get a real `:vX.Y.Z` ghcr tag (rollback-by-tag works again); fixes a latent `Bun.write` truncation that ate release-plan outputs (hub#830 item 3); RELEASING.md now matches wired behavior |
| #836 | hub#831 | `status` VERSION column refreshes after upgrade+restart — no more `0.22.10 active … npm (0.22.11)` |
| #837 | hub#832 | **Behavior change:** app/notes static server (`:1944`) now binds `127.0.0.1` by default instead of every interface; honors `--host`/`PARACHUTE_BIND_HOST`. All packaged deploy paths already set the host explicitly — verified path-by-path in review |
| #834 | hub#786 | Init tests stub the real `bun add -g` — kills the 11-test timeout flake that once blocked a stable publish |

## Review record
Every PR: independent sandboxed review with full-suite runs (baseline control 4466/4467 → final 4473/4474; deltas = added tests exactly), mutation/live-repro probes, one fold cycle on #835 (RELEASING.md tag-push claim corrected — hub#841). CI note: pr-verify does not run on `next`-targeted PRs (hub#838), so those sandboxed suites are the test gate for this batch.

## What to test after deploy (2 min)
1. `~/.bun/bin/parachute status` — VERSION column should match SOURCE for app after the next upgrade.
2. `curl -s -o /dev/null -w '%{http_code}' https://uni.taildf9ce2.ts.net/` → 200 (funnel unaffected by the bind change — it fronts :1939).
3. After the npm publish lands: ghcr should show `:v0.7.15` alongside `:stable`/`:latest`.

## Filed along the way
hub#838 (CI gate gap), hub#839 (isStale npm arm), hub#840 (test suite touches live services.json), hub#841 (dead --tag-push override), plus hub#830 reconciled (item 3 fixed, 1–2 open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)