### PR TITLE
fix(ci): pr-verify gates next-targeted PRs, not just main

### DIFF
--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -6,7 +6,7 @@ name: PR verify
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, next]
 
 jobs:
   typecheck-unit-tests:


### PR DESCRIPTION
Fixes #838.

## What was broken

`pr-verify.yml` triggered on `pull_request: branches: [main]` only. Since the merge train (2026-08-14) routes every feature PR to `next`, typecheck + unit tests never ran in CI for hub PRs — observed on #834, #835, #836, #837 (no checks reported).

## The fix

Add `next` to the trigger branches. Checked the rest of the workflow for other main-specific assumptions (base-ref reads, branch-conditional steps) — there are none; it's a plain checkout + typecheck + test job, so the trigger was the only gap.

## Audit (report-only, no changes in this PR)

Per the issue, checked whether vault and cloud have the same gap:

- **parachute-vault: same gap.** `.github/workflows/ci.yml:29-30` — `pull_request: branches: [main]`, no `next`. Confirmed empirically: PR #652 (`baseRefName: next`) has an empty `statusCheckRollup` — no CI ran, same failure mode as hub.
- **parachute-cloud: no gap.** `.github/workflows/ci.yml:32` — `pull_request:` with **no** `branches:` filter, so it triggers on PRs against any base branch (broader than just gating `next`). Confirmed empirically: recent `next`-targeted cloud PRs (#245, #243) show passing status checks (identity worker, vault worker, control plane).

vault's gap isn't fixed here (cross-repo, out of scope for this PR) — flagging for a follow-up issue in vault.

## Test plan

- `bunx biome check .github/workflows/pr-verify.yml` — clean (scoped; root has pre-existing biome debt)
- `bun run typecheck` — clean
- `bun test ./src` — **4484 pass, 1 skip, 0 fail** (4485 across 169 files, 327.68s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)