### PR TITLE
fix(release): wire the --tag-push override so a tag push bypasses the refuse-guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,10 @@ jobs:
   # `scripts/release-plan.ts` (unit-tested — release logic that can
   # double-publish or drop a release shouldn't be untested shell in a `run:`).
   #
-  # Note the tag-push path is unchanged: an explicit tag still publishes, and
-  # still overrides every check, because a tag is a human saying "release this".
+  # Note the tag-push path: an explicit tag still publishes, and passes
+  # `--tag-push` so `decidePublish`'s tag short-circuit overrides every
+  # refuse-guard (an ambiguous registry response, an older-than-published
+  # version) — because a tag is a human saying "release this". hub#841.
   # ---------------------------------------------------------------------------
   plan:
     name: plan
@@ -109,13 +111,13 @@ jobs:
         with:
           bun-version: 1.3
       - id: hub
-        run: bun scripts/release-plan.ts . @openparachute/hub
+        run: bun scripts/release-plan.ts . @openparachute/hub ${{ github.ref_type == 'tag' && '--tag-push' || '' }}
       - id: scope_guard
-        run: bun scripts/release-plan.ts packages/scope-guard @openparachute/scope-guard
+        run: bun scripts/release-plan.ts packages/scope-guard @openparachute/scope-guard ${{ github.ref_type == 'tag' && '--tag-push' || '' }}
       - id: depcheck
-        run: bun scripts/release-plan.ts packages/depcheck @openparachute/depcheck
+        run: bun scripts/release-plan.ts packages/depcheck @openparachute/depcheck ${{ github.ref_type == 'tag' && '--tag-push' || '' }}
       - id: door_contract
-        run: bun scripts/release-plan.ts packages/door-contract @openparachute/door-contract
+        run: bun scripts/release-plan.ts packages/door-contract @openparachute/door-contract ${{ github.ref_type == 'tag' && '--tag-push' || '' }}
 
   test:
     name: test

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -11,7 +11,7 @@ This repo publishes FOUR npm packages on independent release cadences via [`.git
 
 **Merging a version bump to `main` is the release signal** (hub#790). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
 
-Pushing a tag still works for a deliberate re-release of an **already-published** version: the image republishes (npm rejects republishing an existing version, so the npm job goes red — expected). A tag does **not** bypass `release-plan.ts`'s guards: the workflow never passes `--tag-push`, so an unpublished-older version or an ambiguous registry response fails the plan job and skips every publish (hub#841 tracks whether to wire the override). The merge path is the normal one.
+Pushing a tag is the explicit override: the `plan` job passes `--tag-push`, which makes `release-plan.ts` publish regardless of what the guards would otherwise say — an unpublished-older version, an ambiguous registry response, none of it blocks a tag push, because a tag is a human saying "release this" (hub#841). The one thing a tag can't force is npm itself: republishing an **already-published** version still gets rejected by npm (the npm job goes red — expected), so a deliberate re-release only actually re-pushes the image. The merge path is the normal one; reach for a tag push when you need to bypass the guards on purpose.
 
 ## Version conventions
 

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -230,6 +230,35 @@ describe("release.yml image tags (hub#829)", () => {
 });
 
 /**
+ * The tag-push override (hub#841).
+ *
+ * `decidePublish`'s `isTagPush` short-circuit is unit-tested above, but
+ * unreachable unless the workflow actually passes `--tag-push` on a tag
+ * push. That was the bug: the `plan` steps never passed it, so the flag path
+ * was dead code and a stale comment claimed otherwise. Assert the wiring
+ * directly on the YAML, same rationale as the hub#829 block below — a
+ * `run:` string is otherwise only exercised by shipping a release.
+ */
+describe("release.yml tag-push override (hub#841)", () => {
+  const workflow = readFileSync(
+    join(import.meta.dir, "../../.github/workflows/release.yml"),
+    "utf8",
+  );
+
+  test("every plan step passes --tag-push on a tag push, nothing on a merge", () => {
+    const flag = "${{ github.ref_type == 'tag' && '--tag-push' || '' }}";
+    for (const cmd of [
+      "bun scripts/release-plan.ts . @openparachute/hub",
+      "bun scripts/release-plan.ts packages/scope-guard @openparachute/scope-guard",
+      "bun scripts/release-plan.ts packages/depcheck @openparachute/depcheck",
+      "bun scripts/release-plan.ts packages/door-contract @openparachute/door-contract",
+    ]) {
+      expect(workflow).toContain(`${cmd} ${flag}`);
+    }
+  });
+});
+
+/**
  * The step outputs are the wire between `plan` and every publish job. Losing
  * one is silent — the consuming expression just interpolates to an empty
  * string.


### PR DESCRIPTION
Fixes #841.

## Root cause

`decidePublish`'s tag short-circuit (`scripts/release-plan.ts:110-112`) was unreachable in CI: the `plan` job's four `release-plan.ts` invocations (`release.yml:111-118`) never passed `--tag-push`. So a tag push of an unpublished-older version (or an ambiguous registry response) failed the plan job and skipped every publish — contradicting both the comment above the `plan` job (`release.yml:91-92`, "the tag-push path is unchanged... still overrides every check") and RELEASING.md's description of the flow.

## Decision

Per the issue: wire the flag rather than delete the dead short-circuit. A tag push is an explicit human "release this" and should bypass the refuse-guards, as originally documented.

## What changed

- `release.yml`: pass `${{ github.ref_type == 'tag' && '--tag-push' || '' }}` on all four `release-plan.ts` invocations in the `plan` job.
- Fixed the stale comment above the `plan` job.
- Flipped the `RELEASING.md` paragraph (corrected in #835 to describe the override as non-functional, pointing at this issue) back to describing the real override — keeping the honest note that npm still rejects republishing an already-published version, so a deliberate re-release of an old version only actually re-pushes the image.
- Added a test (`release-plan.test.ts`, "release.yml tag-push override (hub#841)") asserting the workflow itself passes `--tag-push` on all four plan steps — same pattern as the existing hub#829 workflow-text assertions. `decidePublish`'s `isTagPush` behavior and the CLI's `--tag-push` argv parsing were already unit-tested; the gap was specifically that the workflow never invoked the flag.

## Test plan

- `bunx biome check .github/workflows/release.yml RELEASING.md src/__tests__/release-plan.test.ts` — clean (scoped; root has pre-existing biome debt), exit 0
- `bun run typecheck` — clean
- `bun test ./src` — **4485 pass, 1 skip, 0 fail** (4486 across 169 files, 269.77s) — the +1 pass / +4 expect() calls vs a same-box baseline (4484 pass / 40006 expect) are the new test's 4 `toContain` assertions

🤖 Generated with [Claude Code](https://claude.com/claude-code)