### PR TITLE
fix(account): mint a bounded registered admin token on create, keep CLI bootstrap internal

### DIFF
--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -780,9 +780,10 @@ describe("handleAccountCreateVault", () => {
     }
   });
 
-  // Admin tier is unchanged: it still gets the CLI's own guidance verbatim,
-  // because for admin the route that guidance points at actually works.
-  test("admin-tier create still forwards the CLI token_guidance verbatim", async () => {
+  // hub#827: admin-tier create used to return the raw CLI bootstrap token
+  // (unbounded, unregistered, unrevocable). Mint a bounded registered
+  // vault:admin handoff the same way write-tier does.
+  test("account:self:admin create returns a bounded vault:admin token, not the CLI bootstrap", async () => {
     const h = makeHarness(["default"]);
     try {
       const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
@@ -810,14 +811,29 @@ describe("handleAccountCreateVault", () => {
       );
       expect(res.status).toBe(201);
       const body = (await res.json()) as { vault_token: string; token_guidance?: string };
-      expect(body.vault_token).toBe("hubjwt.work.admin");
-      expect(body.token_guidance).toBe(guidance);
+      expect(body.vault_token).not.toBe("hubjwt.work.admin");
+      expect(JSON.stringify(body)).not.toContain("hubjwt.work.admin");
+      expect(body.token_guidance).not.toBe(guidance);
+      expect(body.token_guidance ?? "").toContain("admin access");
+      expect(body.token_guidance ?? "").toContain("/account/vaults/work/token");
+
+      const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
+      expect(validated.payload.scope).toBe("vault:work:admin");
+      expect(validated.payload.aud).toBe("vault.work");
+      expect(validated.payload.client_id).toBe("parachute-hub-spa");
+      const lifetime = (validated.payload.exp ?? 0) - (validated.payload.iat ?? 0);
+      expect(lifetime).toBe(ACCESS_TOKEN_TTL_SECONDS);
+      expect(lifetime).toBeLessThan(ACCOUNT_VAULT_TOKEN_TTL_SECONDS);
+      const row = findTokenRowByJti(h.db, validated.payload.jti ?? "");
+      expect(row?.createdVia).toBe("cli_mint");
+      expect(row?.clientId).toBe("parachute-hub-spa");
+      expect(row?.scopes).toEqual(["vault:work:admin"]);
     } finally {
       h.cleanup();
     }
   });
 
-  test("201 returns the vault token + services block on a fresh create", async () => {
+  test("201 returns a hub-signed vault token + services block on a fresh create", async () => {
     const h = makeHarness(["default"]);
     try {
       const token = await bearer(h, [HOST_ADMIN_SCOPE]);
@@ -847,7 +863,10 @@ describe("handleAccountCreateVault", () => {
       };
       expect(body.name).toBe("work");
       expect(body.url).toBe(`${ISSUER}/vault/work`);
-      expect(body.vault_token).toBe("hubjwt.work.access");
+      expect(body.vault_token).not.toBe("hubjwt.work.access");
+      expect(JSON.stringify(body)).not.toContain("hubjwt.work.access");
+      const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
+      expect(validated.payload.scope).toBe("vault:work:admin");
       expect(body.services["vault:work"]?.url).toBe(`${ISSUER}/vault/work`);
       expect(body.services["vault:work"]?.version).toBe("0.4.2");
     } finally {
@@ -855,7 +874,7 @@ describe("handleAccountCreateVault", () => {
     }
   });
 
-  test("empty vault_token + token_guidance flow through so the app can fall back", async () => {
+  test("admin-tier create still mints a hub-signed token when the CLI bootstrap is empty", async () => {
     const h = makeHarness(["default"]);
     try {
       const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
@@ -882,8 +901,46 @@ describe("handleAccountCreateVault", () => {
       );
       expect(res.status).toBe(201);
       const body = (await res.json()) as { vault_token: string; token_guidance?: string };
-      expect(body.vault_token).toBe("");
-      expect(body.token_guidance).toBe("no hub origin reachable to mint against");
+      expect(body.vault_token.length).toBeGreaterThan(0);
+      expect(body.token_guidance ?? "").not.toContain("no hub origin reachable");
+      const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
+      expect(validated.payload.scope).toBe("vault:work:admin");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("admin-tier create whose token mint fails returns a distinguishable error and does not leak the CLI token", async () => {
+    const h = makeHarness(["default"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      h.db.run(
+        `CREATE TRIGGER fail_token_insert BEFORE INSERT ON tokens
+         BEGIN SELECT RAISE(ABORT, 'simulated registry failure'); END`,
+      );
+      const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work", "hubjwt.work.admin"), stderr: "" };
+      };
+      const res = await handleAccountCreateVault(
+        jsonReq("/account/vaults", token, "POST", { name: "work" }),
+        deps(h, { runCommand }),
+      );
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: string; vault: string; message: string };
+      expect(body.error).toBe("vault_created_token_mint_failed");
+      expect(body.vault).toBe("work");
+      expect(body.message).toContain("WAS created");
+      expect(JSON.stringify(body)).not.toContain("hubjwt.work.admin");
     } finally {
       h.cleanup();
     }

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -80,9 +80,9 @@ import { isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 const ACCOUNT_API_CLIENT_ID = "parachute-account";
 
 /**
- * Lifetime of the create-time vault credential handed to a WRITE-tier caller
- * (`POST /account/vaults`, the D2 handoff). One access-token lifetime — NOT the
- * 90-day `ACCOUNT_VAULT_TOKEN_TTL_SECONDS` the admin-gated
+ * Lifetime of the create-time vault credential handed on `POST /account/vaults`
+ * (the D2 handoff) for BOTH tiers. One access-token lifetime — NOT the 90-day
+ * `ACCOUNT_VAULT_TOKEN_TTL_SECONDS` the admin-gated
  * `POST /account/vaults/<name>/token` route uses.
  *
  * The write tier's consent label promises the app "cannot ... mint access
@@ -92,7 +92,9 @@ const ACCOUNT_API_CLIENT_ID = "parachute-account";
  * months. Bounding the handoff to one access-token lifetime keeps the
  * credential inside the window the user consented to, and matches cloud, whose
  * `ACCOUNT_VAULT_TOKEN_TTL_SECONDS` IS `ACCESS_TOKEN_TTL_SECONDS`
- * (`workers/identity/src/account-api.ts`).
+ * (`workers/identity/src/account-api.ts`). Admin-tier uses the same bound
+ * because `account:self:admin` is now OAuth-requestable (hub#827); renewal
+ * to the 90-day TTL stays on the admin-gated mint route, which is registered.
  *
  * Bounded residual: the handoff is minted fresh at create time, so it can
  * outlive the caller's *current* bearer by up to one full access-token
@@ -459,23 +461,27 @@ async function parseNameBody(req: Request): Promise<NameBody | BodyErr> {
  * Create a vault and return a ready-to-use vault token (the hinge, D2): the app
  * lands the user IN the vault with zero extra round-trips. Wraps the auth-free
  * `provisionVault` core (this facade already ran the scope gate). The hub's
- * create CLI mints a `vault:<name>:admin` bootstrap token; admin-tier account
- * callers receive that raw token unchanged. A write-tier-only caller instead
- * receives a fresh hub-signed `vault:<name>:{read,write}` token for the new
- * vault, registry-recorded against the REQUESTING client and capped at
- * `WRITE_TIER_VAULT_HANDOFF_TTL_SECONDS`.
+ * create CLI still mints a `vault:<name>:admin` bootstrap token, but that
+ * credential stays INTERNAL — it is never returned on this door (hub#827).
+ * Both tiers receive a hub-signed, registry-recorded handoff capped at
+ * `WRITE_TIER_VAULT_HANDOFF_TTL_SECONDS`, scoped to the granted tier:
+ *   - admin: `vault:<name>:admin`
+ *   - write: `vault:<name>:{read,write}`
  *
- * This is the credential-de-escalation the write tier's consent label
- * requires. Without it the write tier hands back the CLI's full-admin
- * bootstrap credential — an unbounded, hub-registry-invisible
- * `vault:<name>:admin` token — for a grant whose label says the app "cannot
- * ... mint access tokens that outlive this app's access". The de-escalated
- * token matches the tier the user actually granted (write, not admin), lives
- * one access-token lifetime, and is revocable because it has a registry row.
+ * The CLI bootstrap is unbounded, hub-registry-invisible, and therefore
+ * unrevocable. That was fine when account-admin was cookie-minted only;
+ * `account:self:admin` is now OAuth-requestable, so a third-party admin-tier
+ * app would walk away with exactly the credential class the write-tier
+ * branch de-escalates. The handoff matches the granted verb, lives one
+ * access-token lifetime, and is revocable because it has a registry row
+ * against the REQUESTING client. Admin-tier renewal is
+ * `POST /account/vaults/<name>/token` (90-day `ACCOUNT_VAULT_TOKEN_TTL_SECONDS`);
+ * write-tier cannot renew (that route stays admin-gated).
  *
  * Post-`pvt_*`-DROP the CLI token can be `""` when no hub origin was
- * reachable; `token_guidance` remains forwarded verbatim, and an empty CLI
- * token stays empty (nothing to de-escalate).
+ * reachable. Admin-tier still mints a hub-signed handoff (signing does not
+ * need the CLI). Write-tier still returns empty — there is nothing to
+ * de-escalate, and that tier cannot re-mint.
  *
  * ---------------------------------------------------------------------------
  * HUB/CLOUD DRIFT #1 — create-vault authority and the returned credential.
@@ -490,14 +496,15 @@ async function parseNameBody(req: Request): Promise<NameBody | BodyErr> {
  *   - Credential: cloud ALWAYS mints `vault:<name>:{read,write}` and never
  *     returns an admin credential, because it has no host filesystem and no
  *     `parachute-vault create --json` CLI to bootstrap from. Hub's admin-tier
- *     branch below deliberately keeps forwarding the CLI bootstrap token
- *     (existing behavior, hub-only); the write-tier branch converges on
- *     cloud's read+write shape.
+ *     branch mints `vault:<name>:admin` the same way (bounded, registered);
+ *     the write-tier branch converges on cloud's read+write shape. Neither
+ *     tier returns the CLI bootstrap token.
  *   - Lifetime: hub's `ACCOUNT_VAULT_TOKEN_TTL_SECONDS` is 90 days (the
  *     friend-mint default) where cloud's is `ACCESS_TOKEN_TTL_SECONDS`. The
- *     write-tier handoff below uses the cloud value; the admin-gated
- *     `POST /account/vaults/<name>/token` route keeps hub's 90 days. That
- *     older TTL drift is pre-existing and deliberately untouched here.
+ *     create-time handoff below uses the cloud value for BOTH tiers; the
+ *     admin-gated `POST /account/vaults/<name>/token` route keeps hub's 90
+ *     days. That older TTL drift is pre-existing and deliberately untouched
+ *     here.
  */
 export async function handleAccountCreateVault(
   req: Request,
@@ -556,9 +563,17 @@ export async function handleAccountCreateVault(
   const entry = provisioned.entry;
   const meta: VaultMeta = { name: entry.name, url: entry.url, version: entry.version };
   const authorizedWithAdminScope = ADMIN_SCOPES.some((scope) => auth.scopes.includes(scope));
-  let vaultToken = provisioned.createJson?.token ?? "";
-  if (!authorizedWithAdminScope && vaultToken.length > 0) {
-    const scopes = [`vault:${entry.name}:read`, `vault:${entry.name}:write`];
+  // CLI bootstrap token stays INTERNAL. Never returned, never copied into the
+  // error body — a mint-failure consolation that leaked it would undo hub#827.
+  const cliToken = provisioned.createJson?.token ?? "";
+  let vaultToken = "";
+  // Admin-tier always mints (hub signing does not need the CLI). Write-tier
+  // only de-escalates when the CLI actually produced a credential.
+  const mintHandoff = authorizedWithAdminScope || cliToken.length > 0;
+  if (mintHandoff) {
+    const scopes = authorizedWithAdminScope
+      ? [`vault:${entry.name}:admin`]
+      : [`vault:${entry.name}:read`, `vault:${entry.name}:write`];
     // OAuth bearers carry their requesting client_id. Legacy self-issued
     // account bearers may omit it; retain the existing account-surface id only
     // for that fallback while preserving the caller's id whenever present.
@@ -570,10 +585,10 @@ export async function handleAccountCreateVault(
     // destructive action taken on a guess). So a throw here MUST NOT surface as
     // a generic 500: the caller would read it as "create failed", retry, and
     // get a 409 `vault_taken` for a vault it does own but has no credential
-    // for — and at write tier `POST /account/vaults/<name>/token` is
-    // admin-gated, so there is no way to recover a credential. That is a dead
-    // end. The distinguishable error below tells caller and operator exactly
-    // what state the box is in: the vault EXISTS, only the handoff failed.
+    // for. Write tier cannot recover (`POST /account/vaults/<name>/token` is
+    // admin-gated). Admin tier can, via that route. The distinguishable error
+    // below tells caller and operator exactly what state the box is in: the
+    // vault EXISTS, only the handoff failed.
     try {
       const minted = await signAccessToken(deps.db, {
         sub: auth.sub,
@@ -600,7 +615,7 @@ export async function handleAccountCreateVault(
     } catch (err) {
       const detail = err instanceof Error ? err.message : String(err);
       console.error(
-        `[account-api] vault "${entry.name}" was created but the write-tier token handoff failed: ${detail}`,
+        `[account-api] vault "${entry.name}" was created but the token handoff failed: ${detail}`,
       );
       return json(500, {
         error: "vault_created_token_mint_failed",
@@ -609,19 +624,15 @@ export async function handleAccountCreateVault(
       });
     }
   }
-  // `token_guidance` is the CLI's prose for the bootstrap token it returns, and
-  // it points at the admin-gated per-vault mint route. Forwarding it verbatim to
-  // a write-tier caller hands out advice that 403s for that caller (see the
-  // 409 branch above for why that route stays admin-only). Forward it only to
-  // the tier it is true for; write tier gets guidance matching what it actually
-  // holds. This matters most on the empty-token path (no reachable hub origin
-  // for the CLI to mint against), where the response would otherwise be a 201
-  // shaped exactly like a working handoff — empty credential, plus instructions
-  // the caller cannot follow.
+  // Never forward the CLI's `token_guidance` — it describes the bootstrap
+  // token this door no longer returns, and for write-tier it points at a
+  // mint route that 403s. Each tier gets guidance matching the credential
+  // it actually holds.
+  const handoffMinutes = Math.round(WRITE_TIER_VAULT_HANDOFF_TTL_SECONDS / 60);
   const tokenGuidance = authorizedWithAdminScope
-    ? provisioned.createJson?.token_guidance
+    ? `This token grants admin access to this vault only, expires in ${handoffMinutes} minutes, and is registered against this app so it can be revoked. Renew with POST /account/vaults/${entry.name}/token.`
     : vaultToken.length > 0
-      ? `This token grants read+write access to this vault only, and expires in ${Math.round(WRITE_TIER_VAULT_HANDOFF_TTL_SECONDS / 60)} minutes. It is the one credential this vault hands you at creation — it cannot be renewed at this tier.`
+      ? `This token grants read+write access to this vault only, and expires in ${handoffMinutes} minutes. It is the one credential this vault hands you at creation — it cannot be renewed at this tier.`
       : "No access token could be issued for this vault. The vault WAS created, but your grant does not permit minting a credential for it after the fact. Ask an operator to mint one for you.";
   const body: {
     name: string;


### PR DESCRIPTION
Fixes #827

## The problem

Admin-tier `POST /account/vaults` returned the CLI's `vault:<name>:admin` bootstrap token verbatim (`provisioned.createJson.token`). That credential has unbounded TTL, never lands in the hub token registry, and is therefore unrevocable.

That was fine when account-admin was cookie-minted only. `account:self:admin` is now OAuth-requestable, so a third-party admin-tier app walks away with exactly the credential class the write-tier branch (#826) de-escalates one rung down.

## The fix

Both tiers now receive a hub-signed, registry-recorded handoff at `ACCESS_TOKEN_TTL_SECONDS` (15 min), scoped to the granted verb:

- admin: `vault:<name>:admin`, `aud=vault.<name>`, registry row against the requesting `client_id`
- write: `vault:<name>:{read,write}` (unchanged)

The CLI bootstrap stays **internal**. It is never copied into the 201 body and never into the mint-failure 500 (`vault_created_token_mint_failed`). A mint-failure consolation that leaked it would undo the issue.

Admin-tier still mints when the CLI token is empty (hub signing does not need the CLI). Write-tier still returns empty in that case — there is nothing to de-escalate, and that tier cannot re-mint.

Renewal is unchanged: `POST /account/vaults/<name>/token` stays admin-gated and still uses the 90-day `ACCOUNT_VAULT_TOKEN_TTL_SECONDS`. Write-tier cannot renew. That older TTL drift is pre-existing and deliberately untouched.

No version/CHANGELOG bump — workspace rule (feature PRs don't; a release PR does).

## Tests (watch-fail)

New/rewritten admin-tier cases were run **against current `next` (`47f6777`) before the invert** and went red for the stated reason:

- `account:self:admin` create → `vault_token === "hubjwt.work.admin"` (expected not-equal: raw CLI bootstrap)
- host-admin create → `vault_token === "hubjwt.work.access"` (expected hub-signed)
- admin-tier + empty CLI token → `vault_token.length === 0` (expected a hub-signed mint)
- admin-tier mint-failure (registry INSERT abort) → **201** (expected 500: old path never minted, so the trigger never fired)

After the invert, those four go green. Write-tier cases still pass (bounded read+write, empty-CLI guidance, mint-failure distinguishable error with no CLI leak).

## Verification

At `cb2259f` (`origin/next` `47f6777` + this commit), same shell, dirty=0:

- `bun run typecheck` — pass
- `bunx biome check src/account-api.ts src/__tests__/account-api.test.ts` — pass (0 diagnostics)
- `bun test ./src/__tests__/account-api.test.ts` — **43/43 pass**
- `bun test ./src` — **4485 pass / 1 skip / 0 fail** (169 files). The skip is pre-existing: `done screen install tiles (hub#272 Item B)`.
- `bun run lint` — **red on `origin/next` itself** (23 errors, 4 warnings; unchanged by this PR). Changed files are clean under biome.

Did not live-exercise the bun-linked `parachute` create path against the live box (sandbox-only via the test harness's `runCommand` stub).
