### PR TITLE
fix: repoint stale parachute.computer links at their current pages

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -126,7 +126,7 @@ describe("renderAccountHome", () => {
     });
     expect(html).toContain('data-testid="build-your-own-ui"');
     expect(html).toContain('data-testid="build-your-own-ui-link"');
-    expect(html).toContain("https://parachute.computer/onboarding/surface-build/");
+    expect(html).toContain("https://parachute.computer/surfaces/");
     expect(html).toContain("build you a custom UI");
   });
 
@@ -238,8 +238,8 @@ describe("renderAccountHome", () => {
     // operator setup-wizard's starter-prompts section).
     expect(html).toContain('data-testid="get-started-card"');
     expect(html).toContain("Get started with your AI");
-    expect(html).toContain("https://parachute.computer/onboarding/vault-setup/");
-    expect(html).toContain("https://parachute.computer/onboarding/surface-build/");
+    expect(html).toContain("https://parachute.computer/vault/");
+    expect(html).toContain("https://parachute.computer/surfaces/");
     expect(html).toContain('data-testid="starter-vault-setup"');
     expect(html).toContain('data-testid="starter-surface-build"');
     // External links open safely.
@@ -714,7 +714,7 @@ describe("renderAccountHome", () => {
     expect(html).toContain("claude mcp add");
     // Step ③ links the vault-setup starter prompt.
     expect(html).toContain('data-testid="onboarding-vault-setup-link"');
-    expect(html).toContain("https://parachute.computer/onboarding/vault-setup/");
+    expect(html).toContain("https://parachute.computer/vault/");
   });
 
   test("onboarding checklist — condenses to 'you're connected' when a grant exists", () => {

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -1005,7 +1005,7 @@ describe("handleSetupGet", () => {
       expect(res.status).toBe(200);
       const html = await res.text();
       expect(html).toContain("PARACHUTE_HUB_ORIGIN");
-      expect(html).toContain("parachute.computer/docs/deploy");
+      expect(html).toContain("parachute.computer/start/");
     } finally {
       db.close();
     }

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -410,7 +410,7 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
           <div class="onboarding-step-body">
             <p class="onboarding-step-title">Set up your vault</p>
             <p class="onboarding-step-sub">Open a new Claude chat and paste the
-               <a href="https://parachute.computer/onboarding/vault-setup/" target="_blank"
+               <a href="https://parachute.computer/vault/" target="_blank"
                   rel="noopener" data-testid="onboarding-vault-setup-link">vault-setup prompt</a> —
                your AI interviews you and structures your vault around how you think.</p>
           </div>
@@ -425,8 +425,8 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
 /**
  * The "Get started with your AI" card — the real first stop for a friend
  * landing on `/account/`. Mirrors the operator setup-wizard's
- * `renderStarterPromptsSection` (same two parachute.computer/onboarding/*
- * links + copy) so friends and operators get the same on-ramp. The prompts
+ * `renderStarterPromptsSection` (same two parachute.computer/vault/ and
+ * /surfaces/ links + copy) so friends and operators get the same on-ramp. The prompts
  * live on parachute.computer rather than embedded here so they iterate
  * without a hub release; this card just links.
  *
@@ -442,14 +442,14 @@ function renderGetStartedCard(): string {
         once your vault is connected — they walk you through it, no setup
         knowledge needed.</p>
       <div class="starter-grid">
-        <a class="starter-tile" href="https://parachute.computer/onboarding/vault-setup/"
+        <a class="starter-tile" href="https://parachute.computer/vault/"
            target="_blank" rel="noopener" data-testid="starter-vault-setup">
           <h3>Set up your vault</h3>
           <p>Your AI interviews you about where your notes live now and suggests
             a structure that fits how you think.</p>
           <span class="starter-cta">Open prompt ↗</span>
         </a>
-        <a class="starter-tile" href="https://parachute.computer/onboarding/surface-build/"
+        <a class="starter-tile" href="https://parachute.computer/surfaces/"
            target="_blank" rel="noopener" data-testid="starter-surface-build">
           <h3>Build a custom UI</h3>
           <p>Your AI builds you a little web app for your vault — your own way to
@@ -567,7 +567,7 @@ function renderVaultCard(opts: VaultCardOpts): string {
           </p>
           <p class="vault-build-ui" data-testid="build-your-own-ui">Notes is just one way to see
              your vault — when you're ready, your AI can build you a custom UI for it in a few
-             minutes. <a href="https://parachute.computer/onboarding/surface-build/"
+             minutes. <a href="https://parachute.computer/surfaces/"
              target="_blank" rel="noopener" data-testid="build-your-own-ui-link">Build your own ↗</a></p>
           ${manageBlock}
         </div>`;

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1001,7 +1001,7 @@ export function renderExposeStep(props: RenderExposeStepProps): string {
             <span class="expose-option-title">Public URL (custom domain)</span>
             <span class="expose-option-desc">Run the hub behind a reverse
               proxy on a domain you own. See the
-              <a href="https://parachute.computer/docs/deploy" target="_blank" rel="noopener">deploy guide</a>
+              <a href="https://parachute.computer/start/" target="_blank" rel="noopener">deploy guide</a>
               for nginx / Caddy / Cloudflare Tunnel examples + the env
               vars (<code>PARACHUTE_HUB_ORIGIN</code>) the hub reads for
               its own canonical URL.</span>
@@ -1212,10 +1212,10 @@ function renderStartUsingTile(vaultName: string, hubOrigin: string): string {
  *
  *   1. "Help me set up my vault" — AI interviews the operator about
  *      where their data lives + proposes a tag/path structure
- *      (parachute.computer/onboarding/vault-setup/).
+ *      (parachute.computer/vault/).
  *   2. "Build a custom UI" — AI builds a static SPA against the vault's
  *      HTTP API, hosted on the operator's own GitHub Pages
- *      (parachute.computer/onboarding/surface-build/).
+ *      (parachute.computer/surfaces/).
  *
  * Aaron 2026-05-27 directive: ship these as the "first AI assist"
  * surface so freshly-onboarded operators have a clear next thing to
@@ -1228,12 +1228,12 @@ function renderStarterPromptsSection(): string {
     <h2>Get help from your AI</h2>
     <p class="starter-prompts-subtitle">Two interview-style prompts to paste into Claude Code or Codex once your vault's MCP is wired up.</p>
     <div class="starter-prompts-grid">
-      <a class="starter-prompt-tile" href="https://parachute.computer/onboarding/vault-setup/" target="_blank" rel="noopener">
+      <a class="starter-prompt-tile" href="https://parachute.computer/vault/" target="_blank" rel="noopener">
         <h3>Set up your vault</h3>
         <p>Interview-style. AI asks where your notes live now + proposes a tag &amp; path structure that fits how you actually think.</p>
         <p class="starter-prompt-cta">Open prompt ↗</p>
       </a>
-      <a class="starter-prompt-tile" href="https://parachute.computer/onboarding/surface-build/" target="_blank" rel="noopener">
+      <a class="starter-prompt-tile" href="https://parachute.computer/surfaces/" target="_blank" rel="noopener">
         <h3>Build a custom UI</h3>
         <p>AI generates a static SPA hosted on your own GitHub Pages — talks to your vault over HTTP. Notes UI works as a reference.</p>
         <p class="starter-prompt-cta">Open prompt ↗</p>
@@ -1406,7 +1406,7 @@ function renderReachableTile(mode: SetupExposeMode, hubOrigin: string): string {
       <p class="fine">Wire a reverse proxy on your domain to
         <code>${safeOrigin}</code>, then set <code>PARACHUTE_HUB_ORIGIN</code>
         to your public URL and restart the hub. See the
-        <a href="https://parachute.computer/docs/deploy">deploy guide</a>
+        <a href="https://parachute.computer/start/">deploy guide</a>
         for nginx / Caddy / Cloudflare Tunnel examples.</p>
     </section>`;
 }

--- a/web/ui/src/components/McpConnectCard.test.tsx
+++ b/web/ui/src/components/McpConnectCard.test.tsx
@@ -147,7 +147,7 @@ describe("McpConnectCard", () => {
     render(<McpConnectCard vaultName="work" vaultUrl={VAULT_URL} />);
     expect(screen.getByRole("link", { name: /full connect docs/i })).toHaveAttribute(
       "href",
-      "https://parachute.computer/install#connect-mcp-clients",
+      "https://parachute.computer/start/#connect-mcp-clients",
     );
   });
 });

--- a/web/ui/src/components/McpConnectCard.tsx
+++ b/web/ui/src/components/McpConnectCard.tsx
@@ -35,7 +35,7 @@
 import { useState } from "react";
 import { HttpError, type MintedToken, mintToken } from "../lib/api.ts";
 
-const CONNECT_DOCS_URL = "https://parachute.computer/install#connect-mcp-clients";
+const CONNECT_DOCS_URL = "https://parachute.computer/start/#connect-mcp-clients";
 
 /**
  * Build `<hub-origin>/vault/<name>/mcp` from the vault's published URL.


### PR DESCRIPTION
## Summary

hub#743 reported four `parachute.computer` targets 404ing from the wizard and account-home UI (site#136 dropped `deploy/*`, site#137 dropped `onboarding/*`). Verified live against the site today rather than trusting the issue's URL suggestions blindly:

- `docs/deploy` (301 → `docs/deploy/`) now serves a `noindex` meta-refresh stub to **`/start/`**, and `/start/` itself contains the nginx/Caddy/Cloudflare Tunnel content the wizard's "deploy guide" link promises.
- `onboarding/vault-setup/` similarly stubs to **`/vault/`**, which now contains the exact "paste this prompt, let your AI interview you" vault-setup flow the tile's copy describes.
- `onboarding/surface-build/` stubs to **`/surfaces/`**, containing the equivalent "paste this to your AI" custom-surface-build prompt.

So the fix isn't just avoiding the 404 — the new targets are content-verified matches for what each link's surrounding copy promises (confirmed by fetching and reading the actual page bodies, not just status codes).

## Changes

- `src/setup-wizard.ts` — deploy-guide link (x2) → `/start/`; starter-prompt tiles → `/vault/`, `/surfaces/`
- `src/account-home-ui.ts` — onboarding step 3 link, "Get started with your AI" tiles, "build your own UI" link → same retargets
- `src/__tests__/account-home-ui.test.ts`, `src/__tests__/setup-wizard.test.ts` — updated pinned URL assertions

## Test plan

- [x] `bunx biome check` scoped to changed files — clean
- [x] `bun run typecheck` — clean
- [x] `bun test ./src/__tests__/account-home-ui.test.ts ./src/__tests__/setup-wizard.test.ts` — 142 pass / 1 skip
- [x] Verified all replacement URLs live: fetched `/start/`, `/vault/`, `/surfaces/` and confirmed their content matches the linking copy's promise (not just a 200)

Fixes #743

🤖 Generated with [Claude Code](https://claude.com/claude-code)