### PR TITLE
docs: fix stale admin-token chokepoint table in admin-ui-lock design doc

### DIFF
--- a/design/2026-06-17-admin-ui-lock.md
+++ b/design/2026-06-17-admin-ui-lock.md
@@ -30,15 +30,14 @@ don't mistake it for at-rest protection.
 ## The single chokepoint (why the lock cascades for free)
 
 The admin SPA and **every** module config UI obtain their working Bearer from
-one of four cookie-gated mint endpoints, all sharing the identical
+one of three cookie-gated mint endpoints, all sharing the identical
 `parseSessionCookie → findSession → [isFirstAdmin] → signAccessToken` shape:
 
 | Endpoint | Bearer for |
 |---|---|
 | `GET /admin/host-admin-token` | the admin SPA itself (`parachute:host:admin/auth`) |
-| `GET /admin/channel-token` | channel chat + config UIs |
 | `GET /admin/vault-admin-token/<name>` | per-vault admin SPA (`vault:<name>:admin`) |
-| `GET /admin/module-token/<short>` | generic module config UI (`<short>:admin`) |
+| `GET /admin/module-token/<short>` | generic module config UI (`<short>:admin`) — this is also where the agent chat + config UI mints today (`short=agent`); the standalone `/admin/channel-token` endpoint was folded into this generic mint in #646, before the channel→agent module rename (#667) |
 
 Inserting **one gate** — `admin-lock.ts:requireUnlocked(db, sessionId)` — into
 each handler makes the lock cascade to the **entire admin surface with no
@@ -67,7 +66,7 @@ runs a full PKCE `authorize → token` flow that succeeds and yields a valid
 ### Also untouched: friend `/account/*` surfaces
 
 The lock is the **first admin's** screen lock for the **admin console**, keyed
-per-session. The four gated mints are all `isFirstAdmin`-gated, so the lock only
+per-session. The three gated mints are all `isFirstAdmin`-gated, so the lock only
 ever affects the admin's own session. The assigned-user (friend) path —
 `POST /account/vault-admin-token/<name>` and `/account/vault-token/<name>` — is
 a different principal on the `/account/*` home and is **not** gated: the admin's
@@ -156,8 +155,8 @@ the argon2id verify, so a stolen cookie can't grind PINs unbounded.
 - `src/admin-lock.ts` — PIN hash storage, in-memory unlock state, the
   `requireUnlocked` gate, the unlock limiter.
 - `src/api-admin-lock.ts` — the `/api/admin-lock*` management router.
-- `src/admin-{host-admin,channel,vault-admin,module}-token.ts` — the gate
-  inserted into all four mint chokepoints.
+- `src/admin-{host-admin,vault-admin,module}-token.ts` — the gate
+  inserted into all three mint chokepoints.
 - `src/hub-server.ts` — route wiring + CSRF belt.
 - `src/hub-settings.ts` — the two new KV keys.
 - `web/ui/src/components/LockScreen.tsx`, `lib/useAdminLock.ts`,


### PR DESCRIPTION
## Summary

hub#736 flagged the design doc's mint-endpoint table still listing `GET /admin/channel-token`. **The issue's suggested replacement (`/admin/agent-token`) turned out to also be wrong** — verified against the live route table (`src/hub-server.ts`'s dispatch-order docstring) and `src/__tests__/hub-server.test.ts`'s `"retired Agent token endpoints neither mint nor redirect"` test, which pins that **both** `/admin/agent-token` and `/admin/channel-token` 404-equivalent (fall through to the SPA shell, no token minted, no redirect).

Tracing git history: `/admin/channel-token` was retired and folded into the generic `GET /admin/module-token/<short>` mint in #646 (2026-06-09, "retire /admin/channels"), *before* the channel module was later renamed to "agent" in #667. So the real current chokepoint for the agent chat + config UI bearer is `GET /admin/module-token/agent` — one of the *three* existing chokepoints, not a fourth standalone route.

## Changes

- Chokepoint table: four → three, drops the `/admin/channel-token` row, and the `/admin/module-token/<short>` row now notes it's where the agent mint lives today (with the #646 / #667 trail)
- "four gated mints" → "three" (idle-lock section)
- Files list: `src/admin-{host-admin,channel,vault-admin,module}-token.ts` → `src/admin-{host-admin,vault-admin,module}-token.ts` (no `admin-channel-token.ts` file exists anymore)

## Swept for other drift (per the issue's ask)

Checked every other route/file reference in the doc against source — all current, no further drift:
- `/account/vault-admin-token/<name>`, `/account/vault-token/<name>` — match `hub-server.ts`
- `/oauth/authorize|token|register|revoke`, `.well-known/*` — match
- `/api/admin-lock` + subpaths — match `api-admin-lock.ts`'s own route docstring
- 15-min default idle window, 4–12 digit PIN format — match `admin-lock.ts` / `api-admin-lock.ts`
- All files in the "Files" section exist except the one now-corrected entry above

**Side discovery, left out of scope** (not a design doc, so outside this docs-only PR): `src/hub-server.ts:3404` has a source comment — `// the four \`/admin/*-token\` mint handlers` — that has the same "four" drift. Flagging for a follow-up rather than touching source in a docs PR.

## Test plan

- [x] `bunx biome check` scoped to the changed file — clean
- [x] `bun run typecheck` — clean (no source touched)
- Docs-only change; no test file applies

Fixes #736

🤖 Generated with [Claude Code](https://claude.com/claude-code)