### PR TITLE
docs: advertise root /mcp as the canonical MCP URL in operator-facing copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,10 @@ parachute status
 
 Vault is up on `127.0.0.1:1940`; Claude Code picks up the MCP on your next
 session. Point any other local MCP client (Codex, Goose, OpenCode, Cursor, Zed,
-Cline, your own agent) at `http://127.0.0.1:1940/vault/<name>/mcp`.
+Cline, your own agent) at `http://127.0.0.1:1940/mcp` — the canonical,
+vault-agnostic MCP door; the token's audience (picked at OAuth consent, or
+named explicitly) names the target vault. (Per-vault `/vault/<name>/mcp` still
+works if you want to skip the vault picker.)
 
 ### Want the wizard in the terminal instead of the browser?
 

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -2644,7 +2644,7 @@ describe("done screen MCP command — OAuth-default, no auto-mint", () => {
       const html = await res.text();
       // The bare OAuth command is the rendered command.
       expect(html).toContain(
-        "claude mcp add --transport http parachute-default https://hub.example/vault/default/mcp",
+        "claude mcp add --transport http parachute-default https://hub.example/mcp",
       );
       // Load-bearing regression (Austen's report): the rendered COMMAND
       // (the MCP tile's <pre> block) must NOT carry a `--header
@@ -3472,7 +3472,7 @@ describe("typed vault name (hub#267)", () => {
       );
       const html = await res.text();
       expect(html).toContain("parachute-my-personal-vault");
-      expect(html).toContain("/vault/my-personal-vault/mcp");
+      expect(html).toContain("https://hub.example/mcp");
     } finally {
       db.close();
     }

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -1146,10 +1146,18 @@ export function renderDoneStep(props: RenderDoneStepProps): string {
  * default, and baking an admin-scope bearer into a copy-pasted command
  * was a privilege over-grant + a shoulder-surf hazard. The bare OAuth
  * command was always the correct UX; it's now the only one.
+ *
+ * URL shape (hub#777): points at the canonical root `<hubOrigin>/mcp`
+ * rather than the per-vault `/vault/<name>/mcp` form — root `/mcp` is
+ * vault-agnostic (the OAuth consent picks the audience), so it stays
+ * correct even if the operator renames this vault or adds more later.
+ * At this point in the wizard there's exactly one vault, so the OAuth
+ * consent screen has nothing to pick between. The server name stays
+ * `parachute-<vault>` so the connection is still labeled by vault.
  */
 function renderMcpTile(vaultName: string, hubOrigin: string): string {
   const safeVault = escapeHtml(vaultName);
-  const bareCmd = `claude mcp add --transport http parachute-${vaultName} ${hubOrigin}/vault/${vaultName}/mcp`;
+  const bareCmd = `claude mcp add --transport http parachute-${vaultName} ${hubOrigin}/mcp`;
   return `<div class="done-tile">
     <h2>Connect Claude Code (MCP)</h2>
     <p>Wire <code>vault:${safeVault}</code> into Claude Code as an MCP server:</p>


### PR DESCRIPTION
## Summary

hub#777: now that both doors accept canonical root `/mcp` (hub#774, merged — verified live in `src/hub-server.ts`: `/mcp` + `/mcp/*` dispatch to `proxyToVaultDaemon` ahead of the per-vault proxy), operator-facing copy should lead with it over the per-vault `/vault/<name>/mcp` form.

## Changes

- **Wizard done-screen MCP tile** (`src/setup-wizard.ts`'s `renderMcpTile`): the `claude mcp add` command now points at `<hubOrigin>/mcp`. At this point in the flow there's exactly one vault, so the OAuth consent picker (how root `/mcp`'s token gets its vault audience) has nothing to pick between — no UX cost today, and the URL stays correct if the operator adds more vaults later.
- **README** — the "connect any other local MCP client" guide now leads with `http://127.0.0.1:1940/mcp`, noting per-vault still works if you want to skip the picker.

## What I checked and deliberately left alone

The issue asked to keep per-vault forms "only where technically required" — traced each remaining site rather than blanket-replacing:

- **`web/ui/src/components/McpConnectCard.tsx`** (the per-vault admin SPA "Connect" card) and **`account-home-ui.ts`**'s mirror of it — exist specifically so a client lands on the *already-known* vault with zero extra clicks. Switching to root `/mcp` here would trade that for an OAuth vault-picker step even though the surrounding context already knows the answer.
- **`parachute status`'s per-row MCP URL** (`service-spec.ts`'s vault `urlForEntry`, mirrored in `help.ts`'s example) — a multi-vault hub prints one row per vault; root `/mcp` is identical across every row, so using it here would stop the URL from distinguishing rows in exactly the place that needs it.
- **`docs/contracts/oauth-scopes.md`**'s RFC 8707 resource-indicator example — documents the wire mechanism itself (a client can still name a vault explicitly via `resource=`), still accurate and orthogonal to what copy should *advertise*.
- **`hub.html`** (`src/hub.ts`, named in the issue as "the discovery page") — checked: it doesn't render any MCP URL today, only per-module `uiUrl` tiles. Nothing stale to fix.

## Test plan

- [x] `bunx biome check` scoped to changed files — clean (`src/setup-wizard.ts` clean; README.md and the one pre-existing unrelated formatting nit in `src/__tests__/setup-wizard.test.ts` at line 2165 are root debt unrelated to this change — confirmed via `git stash` that the nit exists on `next` before this branch's edits)
- [x] `bun run typecheck` — clean
- [x] `bun test ./src/__tests__/setup-wizard.test.ts` — 112 pass / 1 skip

Fixes #777

🤖 Generated with [Claude Code](https://claude.com/claude-code)