### PR TITLE
fix(admin-vaults): mint a bounded registered vault:admin handoff on POST /vaults, keep the CLI bootstrap internal

### DIFF
--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -684,7 +684,8 @@ describe("handleAccountCreateVault", () => {
       expect(lifetime).toBe(ACCESS_TOKEN_TTL_SECONDS);
       expect(lifetime).toBeLessThan(ACCOUNT_VAULT_TOKEN_TTL_SECONDS);
       const row = findTokenRowByJti(h.db, validated.payload.jti ?? "");
-      expect(row?.createdVia).toBe("cli_mint");
+      // hub#848: distinct from `cli_mint` — hub-signed create-time handoff.
+      expect(row?.createdVia).toBe("vault_create_handoff");
       expect(row?.clientId).toBe("parachute-hub-spa");
       expect(row?.scopes).toEqual(["vault:work:read", "vault:work:write"]);
     } finally {
@@ -825,7 +826,8 @@ describe("handleAccountCreateVault", () => {
       expect(lifetime).toBe(ACCESS_TOKEN_TTL_SECONDS);
       expect(lifetime).toBeLessThan(ACCOUNT_VAULT_TOKEN_TTL_SECONDS);
       const row = findTokenRowByJti(h.db, validated.payload.jti ?? "");
-      expect(row?.createdVia).toBe("cli_mint");
+      // hub#848: distinct from `cli_mint` — hub-signed create-time handoff.
+      expect(row?.createdVia).toBe("vault_create_handoff");
       expect(row?.clientId).toBe("parachute-hub-spa");
       expect(row?.scopes).toEqual(["vault:work:admin"]);
     } finally {

--- a/src/__tests__/admin-vaults.test.ts
+++ b/src/__tests__/admin-vaults.test.ts
@@ -10,7 +10,7 @@ import {
   provisionVault,
 } from "../admin-vaults.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { signAccessToken } from "../jwt-sign.ts";
+import { ACCESS_TOKEN_TTL_SECONDS, signAccessToken, validateAccessToken } from "../jwt-sign.ts";
 import { upsertService, writeManifest } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
@@ -395,7 +395,9 @@ describe("POST /vaults — orchestration", () => {
         // `parachute install vault`, which seeds the default vault. The
         // `name` requested by the caller is honored on follow-up calls
         // through the create-with-json branch (above); first-vault-on-host
-        // doesn't currently surface a token (install has no --json yet).
+        // emits no JSON (install has no --json yet), so there are no
+        // `paths` — but hub#848's handoff is hub-signed and needs nothing
+        // from the CLI, so a token IS returned here now.
         writeManifest({ services: [] }, h.manifestPath);
         const calls: Array<readonly string[]> = [];
         const runCommand = async (cmd: readonly string[]): Promise<RunResult> => {
@@ -420,11 +422,16 @@ describe("POST /vaults — orchestration", () => {
         });
         expect(res.status).toBe(201);
         expect(calls).toEqual([["parachute", "install", "vault"]]);
-        // Bootstrap path: response carries name/url/version, no token/paths
-        // (install doesn't emit JSON yet — known gap, follow-up issue).
+        // hub#848: no `paths` (install doesn't emit JSON yet — known gap),
+        // but a hub-signed handoff all the same. A credential-less 201 on
+        // the fresh-box path would strand the operator who just bootstrapped
+        // the host, and hub signing doesn't depend on the CLI.
         const body = (await res.json()) as Record<string, unknown>;
-        expect(body.token).toBeUndefined();
         expect(body.paths).toBeUndefined();
+        expect(typeof body.token).toBe("string");
+        expect((body.token as string).length).toBeGreaterThan(0);
+        const validated = await validateAccessToken(db, body.token as string, ISSUER);
+        expect(validated.payload.scope).toBe("vault:default:admin");
       } finally {
         db.close();
       }
@@ -433,7 +440,12 @@ describe("POST /vaults — orchestration", () => {
     }
   });
 
-  test("201 response includes token + paths from `parachute-vault create --json` stdout", async () => {
+  // hub#848 (finishing hub#827/hub#846 on the host-admin door): the 201 used
+  // to hand back `createJson.token` — the CLI's unbounded, unregistered,
+  // unrevocable bootstrap credential — verbatim. It must now be a hub-signed,
+  // registry-recorded, TTL-bounded `vault:<name>:admin` handoff, and the CLI
+  // bootstrap must appear nowhere in the response.
+  test("201 mints a bounded registered vault:admin handoff, never the CLI bootstrap", async () => {
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
@@ -475,10 +487,32 @@ describe("POST /vaults — orchestration", () => {
         expect(res.status).toBe(201);
         const body = (await res.json()) as {
           name: string;
-          token?: string;
+          token: string;
+          token_guidance?: string;
           paths?: { vault_dir: string; vault_db: string; vault_config: string };
         };
-        expect(body.token).toBe("hubjwt.work.access");
+        // The CLI bootstrap is nowhere in the response — not in `token`, not
+        // smuggled into guidance or any other field.
+        expect(body.token).not.toBe("hubjwt.work.access");
+        expect(JSON.stringify(body)).not.toContain("hubjwt.work.access");
+        // What came back is a hub-signed, vault-audience-bound admin token.
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.scope).toBe("vault:work:admin");
+        expect(validated.payload.aud).toBe("vault.work");
+        expect(validated.payload.vault_scope).toEqual(["work"]);
+        // Bounded: one access-token lifetime, not the bootstrap's forever.
+        const lifetime = (validated.payload.exp ?? 0) - (validated.payload.iat ?? 0);
+        expect(lifetime).toBe(ACCESS_TOKEN_TTL_SECONDS);
+        // Registry-recorded → revocable, and attributed to the CALLER.
+        const row = findTokenRowByJti(db, validated.payload.jti ?? "");
+        expect(row).not.toBeNull();
+        expect(row?.createdVia).toBe("vault_create_handoff");
+        expect(row?.clientId).toBe("test-client");
+        expect(row?.subject).toBe("user-admin");
+        expect(row?.scopes).toEqual(["vault:work:admin"]);
+        // Guidance describes the credential the hub actually handed back.
+        expect(body.token_guidance ?? "").toContain("admin access");
+        expect(body.token_guidance ?? "").toContain("15 minutes");
         expect(body.paths).toEqual({
           vault_dir: "/home/test/.parachute/vault/work",
           vault_db: "/home/test/.parachute/vault/work/vault.db",
@@ -492,11 +526,12 @@ describe("POST /vaults — orchestration", () => {
     }
   });
 
-  test("201 forwards an empty token + token_guidance when the vault couldn't mint (post-DROP)", async () => {
+  test("201 still mints a hub-signed handoff when the CLI bootstrap is empty", async () => {
     // The vault emits `token: ""` + a `token_guidance` reason when no hub
-    // origin was reachable to mint against (e.g. loopback create). The hub
-    // must forward both verbatim so the SPA can render the
-    // created-but-no-token state instead of confusing it with a re-POST.
+    // origin was reachable for IT to mint against (e.g. loopback create).
+    // hub#848: that is the vault's problem, not the hub's — hub signing needs
+    // no origin round-trip, so the door mints anyway. The CLI's guidance is
+    // NOT forwarded: it would claim no token was issued when one was.
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
@@ -537,9 +572,80 @@ describe("POST /vaults — orchestration", () => {
         });
         // Still a fresh create — HTTP 201, NOT 200.
         expect(res.status).toBe(201);
-        const body = (await res.json()) as { token?: string; token_guidance?: string };
-        expect(body.token).toBe("");
-        expect(body.token_guidance).toBe("no hub origin reachable to mint against");
+        const body = (await res.json()) as { token: string; token_guidance?: string };
+        expect(body.token.length).toBeGreaterThan(0);
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.scope).toBe("vault:work:admin");
+        // The CLI's prose never rides along.
+        expect(body.token_guidance ?? "").not.toContain("no hub origin reachable");
+        expect(JSON.stringify(body)).not.toContain("no hub origin reachable");
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("500 vault_created_token_mint_failed when the registry write fails — and no CLI token leaks", async () => {
+    // The provision already committed; a mint failure must be a NAMED 500, not
+    // a generic one (a caller reading "create failed" would retry into the
+    // idempotent 200 and never get a credential). And the failure path must
+    // not fall back to handing out the CLI bootstrap as a consolation — that
+    // would undo the whole fix on exactly the path nobody exercises.
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/health",
+            version: "0.3.5",
+          },
+          h.manifestPath,
+        );
+        const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+          upsertService(
+            {
+              name: "parachute-vault",
+              port: 1940,
+              paths: ["/vault/default", "/vault/work"],
+              health: "/health",
+              version: "0.3.5",
+            },
+            h.manifestPath,
+          );
+          return {
+            exitCode: 0,
+            stdout: vaultCreateJson("work", "hubjwt.work.access"),
+            stderr: "",
+          };
+        };
+        // Make the registry INSERT abort — the mint's non-atomic second step.
+        db.run(
+          `CREATE TRIGGER fail_token_insert BEFORE INSERT ON tokens
+           BEGIN SELECT RAISE(ABORT, 'simulated registry failure'); END`,
+        );
+        const res = await call({
+          db,
+          manifestPath: h.manifestPath,
+          body: { name: "work" },
+          runCommand,
+        });
+        expect(res.status).toBe(500);
+        const body = (await res.json()) as {
+          error: string;
+          vault: string;
+          error_description: string;
+        };
+        expect(body.error).toBe("vault_created_token_mint_failed");
+        expect(body.vault).toBe("work");
+        expect(body.error_description).toContain("WAS created");
+        expect(JSON.stringify(body)).not.toContain("hubjwt.work.access");
       } finally {
         db.close();
       }

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -603,7 +603,10 @@ export async function handleAccountCreateVault(
       const subjectIsUser = getUserById(deps.db, auth.sub) !== null;
       recordTokenMint(deps.db, {
         jti: minted.jti,
-        createdVia: "cli_mint",
+        // hub#848: distinct from `cli_mint` — this row is a hub-signed
+        // create-time handoff, not a CLI mint. Same label the host-admin
+        // door stamps, so registry forensics can find both.
+        createdVia: "vault_create_handoff",
         subject: auth.sub,
         ...(subjectIsUser ? { userId: auth.sub } : {}),
         clientId,

--- a/src/admin-vaults.ts
+++ b/src/admin-vaults.ts
@@ -14,19 +14,27 @@
  *   Content-Type: application/json
  *   { "name": "<vault-name>" }
  *
- *   201 → { name, url, version, token?, token_guidance?, paths? }
- *           // vault freshly created. `token` is a hub-issued ACCESS token
- *           // (a JWT scoped `vault:<name>:admin`) captured from the
- *           // `parachute-vault create --json` branch — NOT a `pvt_*` vault
- *           // token (those were dropped). Post-DROP `token` may be the
- *           // empty string `""` when the bootstrap mint was unavailable
- *           // (e.g. a loopback origin the hub can't mint against); in that
- *           // case `token_guidance` carries the vault's human-readable
- *           // reason, forwarded verbatim so the SPA can explain the gap.
+ *   201 → { name, url, version, token, token_guidance, paths? }
+ *           // vault freshly created. `token` is a HUB-SIGNED, REGISTRY-
+ *           // RECORDED access token (a JWT scoped `vault:<name>:admin`,
+ *           // `aud=vault.<name>`) minted by this handler and bounded to
+ *           // `ACCESS_TOKEN_TTL_SECONDS` (hub#848, mirroring hub#846 on
+ *           // the account door). It is NOT the `parachute-vault create
+ *           // --json` bootstrap credential — that one is unbounded,
+ *           // invisible to the hub token registry, and therefore
+ *           // unrevocable, so it stays INTERNAL to the hub and is never
+ *           // returned on any path of this door, success or error.
+ *           // `token_guidance` is the hub's own prose for the credential
+ *           // it just handed out (never the CLI's, which describes the
+ *           // bootstrap token this door no longer emits).
  *           // `paths` is the new vault's filesystem layout. The
  *           // first-vault-on-host bootstrap (`parachute install vault`)
  *           // doesn't emit JSON yet, so a fresh-box response carries
- *           // name/url/version only.
+ *           // name/url/version + token/token_guidance but no `paths`.
+ *   500 → { error: "vault_created_token_mint_failed", vault, error_description }
+ *           // the vault WAS created but the handoff mint failed. Named
+ *           // distinctly so the caller doesn't read it as "create failed"
+ *           // and retry into a 200 idempotent re-POST with no credential.
  *   200 → { name, url, version }
  *           // idempotent re-POST: existing vault. Never includes `token` —
  *           // the create-time access token isn't retrievable later. The
@@ -58,22 +66,49 @@
  * usually a UI retry, not an error to the caller.
  */
 import type { Database } from "bun:sqlite";
-import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
+import {
+  type AdminAuthContext,
+  type AdminAuthError,
+  adminAuthErrorResponse,
+  requireScope,
+} from "./admin-auth.ts";
 import { type ConnectionsDeps, teardownConnection } from "./admin-connections.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import { readConnections } from "./connections-store.ts";
 import { rewriteGrantsRemovingVault } from "./grants.ts";
 import { revokeInvitesForVault } from "./invites.ts";
-import { revokeTokensNamingVault, signAccessToken } from "./jwt-sign.ts";
+import { inferAudience } from "./jwt-audience.ts";
+import {
+  ACCESS_TOKEN_TTL_SECONDS,
+  recordTokenMint,
+  revokeTokensNamingVault,
+  signAccessToken,
+} from "./jwt-sign.ts";
 import { findService, type readManifest, readManifestLenient } from "./services-manifest.ts";
 import { enrichedPath } from "./spawn-path.ts";
-import { removeVaultAssignments } from "./users.ts";
+import { getUserById, removeVaultAssignments } from "./users.ts";
 import { removeVaultCap } from "./vault-caps.ts";
 import { RESERVED_VAULT_NAMES, VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
 import { type WellKnownVaultEntry, isVaultEntry, vaultInstanceNameFor } from "./well-known.ts";
 
 /** Scope required to call POST /vaults. */
 export const HOST_ADMIN_SCOPE = "parachute:host:admin";
+
+/**
+ * Client id stamped on the create-time handoff when the presented bearer
+ * carries no `client_id` claim (operator tokens, legacy self-issued admin
+ * bearers). Whenever the claim IS present the CALLER's id is preserved, so a
+ * registry row attributes the credential to whoever actually asked for it.
+ * Matches `DELETE_VAULT_CLIENT_ID` below — same door, same SPA.
+ */
+const CREATE_VAULT_CLIENT_ID = "parachute-hub-spa";
+
+/**
+ * Lifetime of the create-time vault credential this door hands back. One
+ * access-token lifetime, the same bound `POST /account/vaults` uses for its
+ * handoff (hub#846). The CLI bootstrap it replaces had NO expiry at all.
+ */
+const CREATE_VAULT_HANDOFF_TTL_SECONDS = ACCESS_TOKEN_TTL_SECONDS;
 
 // Lowercase-only (item I) — single source of truth in vault-name.ts. Vault's
 // init enforces `[a-z0-9_-]`; a hub-side `[a-zA-Z0-9_-]` superset let an
@@ -92,17 +127,26 @@ export interface CreateVaultRequest {
 export interface VaultCreateJson {
   name: string;
   /**
-   * Hub-issued access token (a JWT scoped `vault:<name>:admin`) the vault
-   * minted at create time. Post the pvt_* DROP this is the empty string
-   * `""` when no hub origin was reachable to mint against (e.g. a loopback
-   * create) — the field is always present but may be empty.
+   * The CLI's bootstrap credential — a JWT scoped `vault:<name>:admin` the
+   * vault minted at create time. Post the pvt_* DROP this is the empty
+   * string `""` when no hub origin was reachable to mint against (e.g. a
+   * loopback create) — the field is always present but may be empty.
+   *
+   * INTERNAL to the hub (hub#827 / hub#848). Unbounded TTL, no `tokens`
+   * registry row, therefore unrevocable. No door returns it: both create
+   * doors mint their own bounded, registered handoff instead. The only
+   * remaining reader is `account-api.ts`'s write tier, which uses its
+   * emptiness (never its value) as a "did the CLI have a hub origin to mint
+   * against" predicate.
    */
   token: string;
   /**
    * Vault-supplied human-readable reason no token was minted, present only
    * when `token` is empty (e.g. "no hub origin reachable to mint against").
-   * Optional — older vaults that always minted don't emit it. Forwarded
-   * verbatim to the caller so the SPA can explain the empty-token state.
+   * Optional — older vaults that always minted don't emit it. NOT forwarded
+   * to callers: it describes the bootstrap token no door returns any more.
+   * Each door writes its own guidance for the credential it actually hands
+   * back.
    */
   token_guidance?: string;
   paths: {
@@ -450,8 +494,11 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
 
   // Auth gate: parachute:host:admin scope. Maps an AdminAuthError straight
   // to an RFC 6750 401/403 — the route handler doesn't care which.
+  // The surfaced claims are kept: the create-time handoff is minted against
+  // the CALLER's `sub`/`client_id` so the registry row is attributable.
+  let auth: AdminAuthContext;
   try {
-    await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
+    auth = await requireScope(deps.db, req, HOST_ADMIN_SCOPE, deps.knownIssuers ?? [deps.issuer]);
   } catch (err) {
     return adminAuthErrorResponse(err as AdminAuthError);
   }
@@ -484,27 +531,100 @@ export async function handleCreateVault(req: Request, deps: CreateVaultDeps): Pr
   }
 
   const entry = provisioned.entry;
-  const result = { createJson: provisioned.createJson };
-  // Access token (a `vault:<name>:admin` JWT, possibly empty post-DROP) +
-  // filesystem paths are single-emit at create time. We surface them here so
-  // the caller can immediately bootstrap a connection to the new vault.
-  // `token_guidance` (when the vault couldn't mint) is forwarded verbatim so
-  // the SPA can explain the empty-token state rather than rendering a blank.
-  // Idempotent re-POSTs intentionally never include any of these.
+  // hub#848 (finishing hub#827/hub#846): the `parachute-vault create --json`
+  // bootstrap token stays INTERNAL. It is read nowhere below, never
+  // interpolated into a response body or a log line, and never used as a
+  // fallback on the mint-failure path — a consolation prize that leaked it
+  // would undo the issue. The variable is deliberately not even bound.
+  //
+  // Why it matters even though this door is host-admin only: the CLI
+  // bootstrap has unbounded TTL and no `tokens` registry row, so it is
+  // unrevocable — `revokeTokensNamingVault` (the delete cascade, below) and
+  // the revocation list both miss it, and `parachute auth tokens` can't show
+  // it. `parachute:host:admin` being in NON_REQUESTABLE_SCOPES bounds WHO can
+  // obtain one; it does nothing about what the credential is once handed out.
+  // The replacement is bounded, registered, and attributable, and it dies
+  // with the vault when the delete cascade runs.
+  //
+  // Minted unconditionally on a 201 — including the fresh-box bootstrap
+  // branch where `parachute install vault` emits no JSON at all. Hub signing
+  // needs nothing from the CLI, so an absent or empty CLI token is not a
+  // reason to hand back a credential-less 201 (same call hub#846 made for
+  // its admin tier).
+  const scopes = [`vault:${entry.name}:admin`];
+  // OAuth/SPA bearers carry their requesting client_id; operator tokens and
+  // legacy self-issued admin bearers may omit it. Preserve the caller's id
+  // whenever present so registry forensics name the real requester.
+  const clientId = auth.clientId ?? CREATE_VAULT_CLIENT_ID;
+  let vaultToken: string;
+  // NOT ATOMIC WITH THE PROVISION ABOVE, deliberately surfaced rather than
+  // hidden. `provisionVault` has already committed — the vault exists on disk
+  // and in services.json — and there is no rollback seam (deleting a
+  // just-created vault on a mint failure would be a second destructive action
+  // taken on a guess). So a throw here MUST NOT surface as a generic 500: the
+  // caller would read it as "create failed", retry, and get the idempotent
+  // 200 for a vault it owns but has no credential for. The distinguishable
+  // error below says exactly what state the box is in.
+  try {
+    const minted = await signAccessToken(deps.db, {
+      sub: auth.sub,
+      scopes,
+      audience: inferAudience(scopes), // → `vault.<name>`
+      clientId,
+      issuer: deps.issuer,
+      ttlSeconds: CREATE_VAULT_HANDOFF_TTL_SECONDS,
+      // The token names exactly one vault in `scope`; mirror that in
+      // `vault_scope` so scope-guard sees the same explicit pin rather than
+      // the empty-admin sentinel.
+      vaultScope: [entry.name],
+    });
+    const subjectIsUser = getUserById(deps.db, auth.sub) !== null;
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "vault_create_handoff",
+      subject: auth.sub,
+      ...(subjectIsUser ? { userId: auth.sub } : {}),
+      clientId,
+      scopes,
+      expiresAt: minted.expiresAt,
+    });
+    vaultToken = minted.token;
+  } catch (err) {
+    // `detail` is the registry/signing error text (jti + sqlite message). No
+    // credential material passes through here.
+    const detail = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[admin-vaults] vault "${entry.name}" was created but the token handoff failed: ${detail}`,
+    );
+    return new Response(
+      JSON.stringify({
+        error: "vault_created_token_mint_failed",
+        vault: entry.name,
+        error_description: `The vault "${entry.name}" WAS created, but minting its access token failed. The vault exists — do not retry create (it will return 200 for the existing vault). An operator must mint a credential for it (\`GET /admin/vault-admin-token/${entry.name}\` with an admin session) or delete the vault.`,
+      }),
+      { status: 500, headers: { "content-type": "application/json" } },
+    );
+  }
+
+  const handoffMinutes = Math.round(CREATE_VAULT_HANDOFF_TTL_SECONDS / 60);
+  // The hub's own prose for the credential the hub just signed. The CLI's
+  // `token_guidance` is never forwarded: it describes the bootstrap token
+  // this door no longer returns, so forwarding it would explain the wrong
+  // credential (and, on the empty-CLI-token path, claim no token was issued
+  // when in fact one was).
   const body: WellKnownVaultEntry & {
-    token?: string;
-    token_guidance?: string;
+    token: string;
+    token_guidance: string;
     paths?: VaultCreateJson["paths"];
-  } = result.createJson
-    ? {
-        ...entry,
-        token: result.createJson.token,
-        ...(result.createJson.token_guidance
-          ? { token_guidance: result.createJson.token_guidance }
-          : {}),
-        paths: result.createJson.paths,
-      }
-    : entry;
+  } = {
+    ...entry,
+    token: vaultToken,
+    token_guidance: `This token grants admin access to the "${entry.name}" vault only, expires in ${handoffMinutes} minutes, and is registered with the hub so it can be revoked. Mint a fresh one from the hub admin surface when it expires.`,
+    // Filesystem layout is single-emit at create time and is not a
+    // credential. Absent on the fresh-box bootstrap branch, which emits no
+    // JSON. Idempotent re-POSTs (200, above) never include it.
+    ...(provisioned.createJson ? { paths: provisioned.createJson.paths } : {}),
+  };
 
   return new Response(JSON.stringify(body), {
     status: 201,

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -187,7 +187,18 @@ export type TokenCreatedVia =
   // (in-framework, approval-gated, per-turn-injected) and `cli_mint` (generic),
   // so `parachute surface token list` can show exactly these. Registered here so
   // `surface token revoke` (and the revocation list) can drop it.
-  | "surface_token";
+  | "surface_token"
+  // Create-time vault handoff (hub#846 + hub#848) — the bounded
+  // `vault:<name>:{admin|read,write}` credential a create door hands its
+  // caller in the 201, on BOTH doors: host-admin `POST /vaults`
+  // (`admin-vaults.ts`) and account `POST /account/vaults`
+  // (`account-api.ts`). Distinct from `cli_mint` on purpose: these rows are
+  // hub-SIGNED at the moment of provisioning, not minted through the CLI /
+  // `POST /api/auth/mint-token` path, and hub#846's review flagged that
+  // labelling them `cli_mint` misattributes them in registry forensics —
+  // exactly backwards, since the whole point of both fixes is that the CLI
+  // bootstrap token never leaves the hub.
+  | "vault_create_handoff";
 
 export interface SignedRefreshToken {
   /** Opaque token to return to the client. NOT recoverable from the DB. */


### PR DESCRIPTION
Fixes #848

## The problem

Host-admin `POST /vaults` returned `provisioned.createJson.token` verbatim — the credential `parachute-vault create --json` mints. That token has **unbounded TTL** and **no `tokens` registry row**, so it is unrevocable: `revokeTokensNamingVault` (this same file's delete cascade) misses it, the revocation list misses it, and `parachute auth tokens` can't show it.

`parachute:host:admin` being in `NON_REQUESTABLE_SCOPES` (scope-explanations.ts:253) bounds *who* can obtain one — it says nothing about *what the credential is* once handed out. #827's "keep the bootstrap internal to the hub" principle isn't realized while any door hands it out.

## The fix — same shape as #846

Both create doors now return a hub-signed, registry-recorded, TTL-bounded handoff, and the CLI bootstrap never leaves the hub.

- `vault:<name>:admin`, `aud=vault.<name>` (via `inferAudience`), `vault_scope: [name]`, `ACCESS_TOKEN_TTL_SECONDS` (15 min).
- Registry row against the **caller's** `sub` + `client_id`, falling back to `parachute-hub-spa` only when the bearer carries no `client_id` claim (operator tokens, legacy self-issued admin bearers). `parachute-hub-spa` matches `DELETE_VAULT_CLIENT_ID` already in this file — same door, same SPA.
- `userId` set only when the subject resolves to a real hub user (`getUserById`), matching #846.
- **Minted on every 201**, including the fresh-box bootstrap branch where `parachute install vault` emits no JSON at all. Hub signing needs nothing from the CLI, so an absent or empty CLI token is not a reason to hand back a credential-less 201 — this is the same call #846 made for its admin tier, and a credential-less 201 would strand the operator who just bootstrapped the host. `paths` is still absent there (install has no `--json` yet); that gap is unchanged.
- The CLI's `token_guidance` is **no longer forwarded**. It describes the bootstrap token this door no longer returns, and on the empty-CLI-token path it claims no token was issued when one now is. Each door writes prose for the credential it actually hands back.
- A mint failure is a **distinguishable** `vault_created_token_mint_failed` 500 rather than a generic one: `provisionVault` has already committed with no rollback seam, and a caller reading "create failed" would retry into the idempotent 200 for a vault it owns but has no credential for. The body names the vault and says it EXISTS. It does **not** fall back to the CLI token as a consolation.

## The `createdVia` label (the cosmetic item from #846's review)

New `TokenCreatedVia` member `vault_create_handoff`, applied to **both** doors (`admin-vaults.ts` and `account-api.ts`). `cli_mint` misattributes these rows in registry forensics — exactly backwards, since the point of both fixes is that the CLI bootstrap never leaves the hub. It is not added to `api-tokens.ts`'s `created_via` filter allowlist, matching `connection_credential` / `agent_grant` / `surface_token`, which aren't in it either; adding it would change that endpoint's 400 message and is a separate call.

## Auth-surface leak enumeration

Every path that could carry the CLI bootstrap out of the process, walked the way #846's review did:

| Path | Verdict |
|---|---|
| 201 success body | `token` is the freshly signed JWT. `provisioned.createJson.token` is **never bound to a variable** in the handler — the only surviving reader anywhere is `account-api.ts`'s write tier, which uses its *emptiness* as a predicate, never its value. |
| 201 `token_guidance` | Hub-authored string. The CLI's guidance is dropped, not forwarded. |
| 201 `paths` | Filesystem layout only (`vault_dir` / `vault_db` / `vault_config`). Not a credential. |
| 200 idempotent re-POST | Returns `entry` alone — no token, no guidance, no paths. Unchanged. |
| 400 / 401 / 403 | Emitted before provisioning ever runs. |
| 500 orchestration failure | `orchestrate`'s message carries the command line + a 500-char **stderr** tail. The CLI's token is on **stdout**, which is parsed as JSON and never interpolated into an error. Unchanged by this PR. |
| 500 unparseable-stdout | Message is the `JSON.parse` error text only — it does not echo stdout. Unchanged by this PR. |
| **500 mint-failure (new)** | `{error, vault, error_description}`. `error_description` is a fixed template over the vault name. Asserted token-free in a test. |
| `console.error` (new) | Logs `err.message` — the registry insert error (`jti=… created_via=… : <sqlite message>`). No credential material reaches it. |
| Registry row | Stores `jti`/`scopes`/`clientId`/`expiresAt`, never token bytes — same as every other mint. |

Two things get *better* as a side effect: the handoff now has a registry row, so the vault-delete cascade's `revokeTokensNamingVault` actually revokes it; and it expires in 15 minutes instead of never.

## Tests (watch-fail)

Written first and run against unmodified `origin/next` (`12cfb4f`) in the same worktree with the source changes stashed. **6 red, each for its stated reason:**

```
(fail) 201 mints a bounded registered vault:admin handoff, never the CLI bootstrap
       expect(body.token).not.toBe("hubjwt.work.access")  →  it WAS the CLI token
(fail) 201 still mints a hub-signed handoff when the CLI bootstrap is empty
       expect(body.token.length).toBeGreaterThan(0)  →  Received: 0
(fail) 500 vault_created_token_mint_failed when the registry write fails
       expect(res.status).toBe(500)  →  Received: 201 (old path never minted, so the trigger never fired)
(fail) 201 on bootstrap path … (no token on the fresh-box branch)
(fail) account:self:write create …   expect(row?.createdVia)  →  Received: "cli_mint"
(fail) account:self:admin create …   expect(row?.createdVia)  →  Received: "cli_mint"
```

All 6 green after the change. New coverage: the CLI token absent from the whole serialized body (not just from `token`), JWT scope/audience/`vault_scope`/TTL, the registry row's `createdVia`/`clientId`/`subject`/`scopes`, hub-authored guidance, the empty-CLI-token mint, and the mint-failure 500's non-leak.

## Gates

At `296c174` (`origin/next` `12cfb4f` + this commit), dirty=0:

- `bun run typecheck` — **pass**
- `bunx biome check` on the 5 changed files — **pass** (0 diagnostics)
- `bun test ./src/__tests__/admin-vaults.test.ts ./src/__tests__/account-api.test.ts` — **78/78 pass**
- `bun test ./src` — **4484 pass / 1 skip / 3 fail** (4488 across 169 files, 489s)

The 3 failures are the known load-timeout class, not this diff. The box was at **load average 78** during the run (another session's vitest fleet plus a Virtualization.framework process at 333% CPU). Two failed with the literal `this test timed out after 5000ms`; the third is a `pollUntil` on spawning a real hub process:

```
hub-server.ts startup PID/port registration (#148) …                    [3236.88ms]
POST /account/vault-token/<name> … unassigned vault → 403 …             [7465.95ms]  timed out after 5000ms
POST /account/vault-token/<name> … GET on the mint path → 405 …         [5015.60ms]  timed out after 5000ms
```

One isolated retry of exactly those two files: `bun test ./src/__tests__/hub-server.test.ts ./src/__tests__/account-vault-token.test.ts` — **286/286 pass** (11.9s). Same class as #786 / #837's reported flake.

Baseline `origin/next` (`12cfb4f`), clean worktree, same box: **4486 pass / 1 skip / 0 fail** (4487, 301s). 4488 − 4487 = the one net-new test (the mint-failure case); the rest are rewrites of existing cases.

No version/CHANGELOG bump — workspace rule.

Note: `pr-verify.yml` triggers on `pull_request: branches: [main]`, so it does not run on PRs based on `next`. Counts above are local.

Did not live-exercise `POST /vaults` against the running hub on this box (sandbox-only via the test harness's `runCommand` stub).
