### PR TITLE
fix(status): flag npm VERSION/SOURCE drift as STALE, not just bun-linked

### DIFF
--- a/src/__tests__/install-source.test.ts
+++ b/src/__tests__/install-source.test.ts
@@ -9,6 +9,7 @@ import {
   isStale,
   servedDivergenceNote,
 } from "../install-source.ts";
+import { SEED_VERSION } from "../service-spec.ts";
 
 /**
  * Stub helpers for the detect path. Production reads the operator's bun
@@ -161,7 +162,7 @@ describe("isStale", () => {
     ).toBe(false);
   });
 
-  test("does not flag npm-installed services (cached version IS the source)", () => {
+  test("does not flag an npm install whose cached version matches the package", () => {
     expect(
       isStale("0.4.2-rc.1", {
         kind: "npm",
@@ -169,6 +170,63 @@ describe("isStale", () => {
         livePackageVersion: "0.4.2-rc.1",
       }),
     ).toBe(false);
+  });
+
+  // hub#839 — isStale used to `return false` for every non-bun-linked source,
+  // so npm VERSION/SOURCE drift never produced a STALE line. Both cases below
+  // are real (they are the two named in the issue), and both used to be silent.
+  describe("hub#839: npm installs drift too", () => {
+    test("out-of-band `bun add -g <pkg>@newer` with no restart → STALE", () => {
+      // The package on disk moved to 0.22.11. The row still carries 0.22.10 —
+      // the version the still-running old process stamped on ITS boot. This is
+      // a deploy that looks applied and isn't; it must not be silent.
+      expect(
+        isStale("0.22.10", {
+          kind: "npm",
+          path: "/home/op/.bun/install/global/node_modules/@openparachute/app",
+          livePackageVersion: "0.22.11",
+        }),
+      ).toBe(true);
+    });
+
+    test("hub#836 refresh-write-failure leaves a lying row → STALE", () => {
+      // `upgrade` installed 0.23.0 and restarted successfully, but the
+      // post-restart services.json write failed (deliberately non-fatal in
+      // #836 — the package IS installed and the service IS running). The row
+      // is now behind the process it describes. This is the one #836 case
+      // #836 itself could not cover.
+      expect(
+        isStale("0.22.11", {
+          kind: "npm",
+          path: "/home/op/.bun/install/global/node_modules/@openparachute/app",
+          livePackageVersion: "0.23.0",
+        }),
+      ).toBe(true);
+    });
+
+    test("does not flag an npm row still at SEED_VERSION (installed, no instance yet)", () => {
+      // The CLI seeds a missing entry at SEED_VERSION post-install; the
+      // service's own boot overwrites it. That row isn't claiming a running
+      // version, so a mismatch isn't drift — otherwise every fresh install
+      // would render a STALE line.
+      expect(
+        isStale(SEED_VERSION, {
+          kind: "npm",
+          path: "/home/op/.bun/install/global/node_modules/@openparachute/app",
+          livePackageVersion: "0.22.11",
+        }),
+      ).toBe(false);
+    });
+
+    test("does not flag an npm row whose package.json could not be read", () => {
+      expect(
+        isStale("0.22.10", {
+          kind: "npm",
+          path: "/home/op/.bun/install/global/node_modules/@openparachute/app",
+          // livePackageVersion absent — nothing to compare against.
+        }),
+      ).toBe(false);
+    });
   });
 
   test("does not flag when live version is unavailable", () => {

--- a/src/__tests__/status.test.ts
+++ b/src/__tests__/status.test.ts
@@ -189,6 +189,80 @@ describe("status — table + hub row", () => {
       cleanup();
     }
   });
+
+  // hub#839: `isStale` short-circuited on anything not bun-linked, so an
+  // npm-installed module whose package moved out from under its
+  // services.json row rendered a clean table — VERSION saying one thing,
+  // SOURCE saying another, and no STALE line to reconcile them. That is the
+  // hub#831 shape (`parachute-app 1944 0.22.10 active 8670 npm (0.22.11)`),
+  // and it defeats the operator's deploy-verification glance.
+  describe("hub#839: npm VERSION/SOURCE drift renders a STALE line", () => {
+    /**
+     * Install-source deps that classify a row as npm (its `installDir` sits
+     * under the stubbed bun-global prefix) and report `liveVersion` as the
+     * installed package's version.
+     */
+    function npmInstallSource(liveVersion: string) {
+      return {
+        bunGlobalPrefixes: () => ["/bun/global/node_modules"],
+        resolveBunGlobal: () => null,
+        readJson: () => ({ version: liveVersion }),
+        readGitHead: () => undefined,
+      };
+    }
+
+    const NPM_INSTALL_DIR = "/bun/global/node_modules/@openparachute/vault";
+
+    async function renderNpmRow(rowVersion: string, liveVersion: string): Promise<string> {
+      const { path, configDir, cleanup } = makeTempPath();
+      try {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 1940,
+            paths: ["/vault/default"],
+            health: "/vault/default/health",
+            version: rowVersion,
+            installDir: NPM_INSTALL_DIR,
+          },
+          path,
+        );
+        const lines: string[] = [];
+        await status({
+          ...supervisorOpts(configDir, path, {
+            moduleStates: {
+              supervisorAvailable: true,
+              modules: [runningModule("vault", rowVersion)],
+            },
+          }),
+          installSourceDeps: npmInstallSource(liveVersion),
+          print: (l) => lines.push(l),
+        });
+        return lines.join("\n");
+      } finally {
+        cleanup();
+      }
+    }
+
+    test("out-of-band `bun add -g` without a restart is flagged", async () => {
+      const out = await renderNpmRow("0.22.10", "0.22.11");
+      // SOURCE already told the truth; VERSION didn't. Now they're reconciled.
+      expect(out).toMatch(/npm \(0\.22\.11\)/);
+      expect(out).toMatch(/STALE: services\.json cached 0\.22\.10; live package\.json 0\.22\.11/);
+    });
+
+    test("hub#836's refresh-write-failure leaves a row that is now flagged", async () => {
+      // upgrade installed 0.23.0 and restarted; only the row write failed.
+      const out = await renderNpmRow("0.22.11", "0.23.0");
+      expect(out).toMatch(/STALE: services\.json cached 0\.22\.11; live package\.json 0\.23\.0/);
+    });
+
+    test("an npm row in agreement with its package renders no STALE line", async () => {
+      const out = await renderNpmRow("0.22.11", "0.22.11");
+      expect(out).toMatch(/npm \(0\.22\.11\)/);
+      expect(out).not.toMatch(/STALE:/);
+    });
+  });
 });
 
 describe("status — per-module URL deep-links (manifestRowBase / urlForEntry)", () => {

--- a/src/help.ts
+++ b/src/help.ts
@@ -374,9 +374,12 @@ What it does:
   as STATE=failing and exit 1.
 
   A "STALE: services.json cached … live package.json …" continuation line
-  appears under a row when a bun-linked service has been rebuilt but the
-  manifest's cached version hasn't caught up — re-install (\`parachute
-  install <pkg>\`) refreshes the row.
+  appears under a row when the version the manifest has cached (what the
+  running process last stamped) has fallen behind the version installed on
+  disk. Two ways to get there: a bun-linked service rebuilt without the
+  manifest catching up, or an npm module whose package was upgraded out of
+  band without a restart. Either way \`parachute restart <svc>\` (or a
+  re-install, \`parachute install <pkg>\`) refreshes the row.
 
 Exit codes:
   0   all probed services healthy (or none running)

--- a/src/install-source.ts
+++ b/src/install-source.ts
@@ -18,7 +18,12 @@ import { readFileSync, realpathSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { resolveBundleDistFrom } from "./bundle-serve.ts";
-import { FIRST_PARTY_FALLBACKS, KNOWN_MODULES, shortNameForManifest } from "./service-spec.ts";
+import {
+  FIRST_PARTY_FALLBACKS,
+  KNOWN_MODULES,
+  SEED_VERSION,
+  shortNameForManifest,
+} from "./service-spec.ts";
 
 export type InstallSourceKind = "bun-linked" | "npm" | "unknown";
 
@@ -32,9 +37,9 @@ export interface InstallSource {
   /** Short git HEAD hash for bun-linked sources where the path is a git repo. */
   readonly gitHead?: string;
   /**
-   * Version from the live `package.json` at `path`. For bun-linked sources
-   * this can differ from the entry's cached `services.json.version` — that's
-   * the drift case we surface.
+   * Version from the live `package.json` at `path`. For EITHER kind this can
+   * differ from the entry's cached `services.json.version` — that's the drift
+   * case we surface (see `isStale`; npm drift is hub#839).
    */
   readonly livePackageVersion?: string;
 }
@@ -251,17 +256,45 @@ function findNearestPackageDir(
 
 /**
  * True when an entry's cached `services.json` version differs from the live
- * `package.json` version at its bun-linked path. The single drift case the
- * operator can act on — `parachute upgrade <svc>` for the bun-linked path
- * doesn't refresh `services.json` on rebuild, so a freshly-built source can
- * still report the pre-rebuild version through status.
+ * `package.json` version at its install path.
  *
- * Only meaningful for `kind === "bun-linked"`. NPM-installed services
- * don't have a "live" source separate from the cached version.
+ * The `services.json` version is a CACHE of the running version — services
+ * own its write side and stamp it on their own boot. The `package.json` at
+ * `source.path` is what is installed on disk right now. When the two
+ * disagree, what `status` prints in VERSION is not what SOURCE points at,
+ * and the operator's deploy-verification step ("did my new build land?")
+ * silently answers the wrong question.
+ *
+ * hub#839 — this used to bail out for anything that wasn't `bun-linked`, on
+ * the premise that "NPM-installed services don't have a live source separate
+ * from the cached version." hub#831 falsified that: the npm arm drifts too,
+ * in two ways nobody was warned about.
+ *
+ *   1. An out-of-band `bun add -g @openparachute/<svc>@<newer>` with no
+ *      restart. The package on disk moves; the row keeps the version the
+ *      still-running old process stamped. This is the exact shape of a
+ *      deploy that looks applied and isn't.
+ *   2. hub#836's refresh-write-failure path. `upgrade` writes the installed
+ *      version back to the row after a successful restart, but a write
+ *      failure there is deliberately non-fatal (the package IS installed and
+ *      the service IS running). That leaves a correct install behind a lying
+ *      row, and it was the one case #836 could not itself cover.
+ *
+ * Neither case is bun-link-specific, and neither produced a `STALE:` line.
+ * The check is now source-agnostic; the two guards that remain are the ones
+ * that would be false positives rather than drift:
+ *
+ *   - No `livePackageVersion` (an `unknown` row, or a `package.json` we
+ *     couldn't read) — nothing to compare, so nothing to claim.
+ *   - `SEED_VERSION` — the "module installed, no instance yet" sentinel the
+ *     CLI writes post-install. That row isn't asserting a running version at
+ *     all, so a mismatch against the installed package isn't drift; flagging
+ *     it would put a STALE line under every freshly installed module.
  */
 export function isStale(entryVersion: string, source: InstallSource): boolean {
-  if (source.kind !== "bun-linked") return false;
+  if (source.kind === "unknown") return false;
   if (!source.livePackageVersion) return false;
+  if (entryVersion === SEED_VERSION) return false;
   return source.livePackageVersion !== entryVersion;
 }
 


### PR DESCRIPTION
Fixes #839

## Root cause

`isStale()` bailed out on the first line for anything that wasn't bun-linked:

```ts
if (source.kind !== "bun-linked") return false;
```

on the premise — falsified by #831 — that "NPM-installed services don't have a 'live' source separate from the cached version." They do. The two columns read different sources:

- **VERSION** is `services.json`'s row: a *cache of the running version*, stamped by each service on its own boot.
- **SOURCE** is `detectInstallSource`, which re-reads `<installDir>/package.json` on every `status` invocation: what is *installed on disk right now*.

Nothing makes those agree across a package change without a restart, and that is true for npm exactly as it is for a bun-linked checkout.

## The two cases from the issue

1. **Out-of-band `bun add -g @openparachute/<svc>@<newer>` without a restart.** The package moves; the row keeps whatever the still-running old process stamped. A deploy that looks applied and isn't.
2. **#836's refresh-write-failure path.** `upgrade` writes the installed version back to the row after a successful restart, but that write is deliberately non-fatal — the package IS installed and the service IS running either way. A failure there leaves a correct install behind a lying row. This is the one #836 case #836 could not cover itself.

Both rendered a clean table: VERSION saying one thing, SOURCE saying another, and no `STALE:` line to reconcile them — the exact hub#831 shape, `parachute-app 1944 0.22.10 active 8670 npm (0.22.11)`.

## The fix

The check is now source-agnostic. Two guards remain, and they are the cases that would be false positives rather than drift:

```ts
export function isStale(entryVersion: string, source: InstallSource): boolean {
  if (source.kind === "unknown") return false;
  if (!source.livePackageVersion) return false;
  if (entryVersion === SEED_VERSION) return false;
  return source.livePackageVersion !== entryVersion;
}
```

- **No readable `livePackageVersion`** — nothing to compare, so don't claim anything. (`unknown` never carries one; the explicit check keeps the documented "unknown → never stale" contract from depending on that.)
- **`SEED_VERSION`** (`"0.0.0-linked"`) is the "module installed, no instance yet" sentinel the CLI writes post-install, before the service's own boot overwrites it. That row isn't asserting a running version at all, so a mismatch against the installed package isn't drift. Without this guard every freshly installed module would render a STALE line — the noise that would get the whole signal ignored.

The `STALE:` message itself is unchanged: "services.json cached X; live package.json Y" was already accurate for both kinds. `parachute help status` gets the npm case added to its prose, and now points at `parachute restart <svc>` alongside re-install.

## Tests (watch-fail)

Run against unmodified `origin/next` (`12cfb4f`) with the source changes stashed. **4 red**, two unit and two through the real status renderer:

```
(fail) isStale > hub#839 > out-of-band `bun add -g <pkg>@newer` with no restart → STALE
       expect(...).toBe(true)  →  Received: false
(fail) isStale > hub#839 > hub#836 refresh-write-failure leaves a lying row → STALE
       expect(...).toBe(true)  →  Received: false
(fail) status > hub#839 > out-of-band `bun add -g` without a restart is flagged
(fail) status > hub#839 > hub#836's refresh-write-failure leaves a row that is now flagged
```

The rendering failure is worth quoting, because the pre-fix output is the issue verbatim:

```
Expected pattern: /STALE: services\.json cached 0\.22\.10; live package\.json 0\.22\.11/
Received:
SERVICE                   PORT  VERSION  STATE   PID   UPTIME  LATENCY  SOURCE
parachute-vault           1940  0.22.10  active  5151  -       -        npm (0.22.11)
  → http://127.0.0.1:1940/vault/default/mcp
```

VERSION and SOURCE openly disagreeing, no continuation line. All 4 green after the change.

Also added: the SEED_VERSION no-flag case, the unreadable-package.json case, and a rendering test that an npm row *in agreement* with its package emits no STALE line (so the fix can't have turned into a blanket flag). The existing "does not flag npm-installed services" case still passes unchanged — its versions were equal — and is renamed to say what it actually asserts.

## Gates

At `ab44a59` (`origin/next` `12cfb4f` + this commit), dirty=0:

- `bun run typecheck` — **pass**
- `bunx biome check` on the 4 changed files — **pass** (0 diagnostics)
- `bun test ./src/__tests__/install-source.test.ts ./src/__tests__/status.test.ts` — **40/40 pass**
- `bun test ./src` — **4493 pass / 1 skip / 0 fail** (4494 across 169 files, 336s). No flakes.

Baseline `origin/next` (`12cfb4f`), clean worktree, same box: **4486 pass / 1 skip / 0 fail** (4487, 301s) — the +7 are the new cases.

No version/CHANGELOG bump — workspace rule.

Note: `pr-verify.yml` triggers on `pull_request: branches: [main]`, so it does not run on PRs based on `next`. Counts above are local.

## Surprising, worth a reviewer's eye

The SEED_VERSION guard is the one judgement call here, and it isn't in the issue. Without it, every shim-served module (`app`, `notes` — no boot of their own to stamp the row, per #836) would carry a permanent STALE line from install until the first `upgrade` + restart wrote the row. That is arguably "true" — the row *is* lying — but a warning that fires on a correct fresh install is a warning operators learn to skip, which would cost the signal the issue is trying to buy. Say the word if you'd rather it flagged there too.
