### PR TITLE
feat(serve): own an explicit 127.0.0.1 guard bind against loopback hijack

### DIFF
--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -143,6 +143,7 @@ describe("armLoopbackGuardBind (hub#741)", () => {
       serveImpl: () => {
         throw new Error("EADDRINUSE: address already in use 127.0.0.1:1939");
       },
+      platform: "darwin",
     });
     expect(guard).toBeNull();
     const out = lines.join("\n");

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -4,11 +4,14 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { _resetBootstrapTokenForTests, getBootstrapToken } from "../bootstrap-token.ts";
 import {
+  LOOPBACK_GUARD_HOST,
+  armLoopbackGuardBind,
   armServeDbWatchdog,
   formatBootstrapTokenBanner,
   formatListeningBanner,
   hubPortConflictMessage,
   hubServeOptions,
+  isWildcardBindHost,
   resolveStartupIssuer,
   seedInitialAdminIfNeeded,
 } from "../commands/serve.ts";
@@ -39,6 +42,233 @@ describe("hubServeOptions — the production listener wires the WS bridge", () =
     expect(o.hostname).toBe("0.0.0.0");
     expect(o.idleTimeout).toBe(255);
     expect(o.fetch).toBe(fakeFetch);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// hub#741 — the loopback guard bind (prevention half of hub#737).
+// ---------------------------------------------------------------------------
+describe("armLoopbackGuardBind (hub#741)", () => {
+  const fakeFetch = (() => new Response("ok")) as unknown as Parameters<
+    typeof hubServeOptions
+  >[0]["fetch"];
+
+  function harness(hostname: string, port: number) {
+    const serveOptions = hubServeOptions({ port, hostname, fetch: fakeFetch });
+    const seen: Array<ReturnType<typeof hubServeOptions>> = [];
+    const lines: string[] = [];
+    let stopped = 0;
+    const serveImpl = (o: ReturnType<typeof hubServeOptions>) => {
+      seen.push(o);
+      return {
+        stop: () => {
+          stopped++;
+        },
+      };
+    };
+    return {
+      serveOptions,
+      seen,
+      lines,
+      stoppedCount: () => stopped,
+      arm: () =>
+        armLoopbackGuardBind({
+          port,
+          hostname,
+          serveOptions,
+          log: (l) => lines.push(l),
+          serveImpl,
+        }),
+    };
+  }
+
+  test("wildcard bind → claims a second socket on 127.0.0.1 at the SAME port", () => {
+    const h = harness("0.0.0.0", 1939);
+    const guard = h.arm();
+    expect(guard).not.toBeNull();
+    expect(h.seen).toHaveLength(1);
+    expect(h.seen[0]?.hostname).toBe(LOOPBACK_GUARD_HOST);
+    expect(h.seen[0]?.port).toBe(1939);
+    expect(h.lines.join("\n")).toContain("loopback guard bind held");
+  });
+
+  // THE self-inflicted-outage guard. A specific bind WINS loopback routing
+  // over a wildcard bind in the same process, so a guard socket serving a stub
+  // handler would steal every module's hub call and cause the exact hub#737
+  // outage it exists to prevent. The guard must serve the primary's own
+  // handler set.
+  test("the guard serves the REAL fetch + WS handler, not a stub", () => {
+    const h = harness("0.0.0.0", 1939);
+    h.arm();
+    const guardOptions = h.seen[0];
+    expect(guardOptions?.fetch).toBe(h.serveOptions.fetch);
+    expect(guardOptions?.websocket).toBe(h.serveOptions.websocket);
+    expect(guardOptions?.idleTimeout).toBe(h.serveOptions.idleTimeout);
+    // hostname is the ONLY difference from the primary listener.
+    expect({ ...guardOptions, hostname: h.serveOptions.hostname }).toEqual(h.serveOptions);
+  });
+
+  test("explicit bind host → skipped (the operator already owns a specific bind)", () => {
+    for (const host of ["127.0.0.1", "192.168.1.10", "::1"]) {
+      const h = harness(host, 1939);
+      expect(h.arm()).toBeNull();
+      expect(h.seen).toHaveLength(0);
+    }
+  });
+
+  test("`::` counts as wildcard", () => {
+    expect(isWildcardBindHost("::")).toBe(true);
+    expect(isWildcardBindHost("0.0.0.0")).toBe(true);
+    expect(isWildcardBindHost("127.0.0.1")).toBe(false);
+  });
+
+  test("ephemeral port 0 → skipped (a guard would land on a different port)", () => {
+    const h = harness("0.0.0.0", 0);
+    expect(h.arm()).toBeNull();
+    expect(h.seen).toHaveLength(0);
+  });
+
+  // The ordering prevention cannot cover: a rogue already holds the specific
+  // bind at hub startup. The hub must still come up — a degraded hub beats no
+  // hub, and hub#737's self-probe is what reports this case.
+  test("a failed guard bind is NON-fatal and logs the hijack shape loudly", () => {
+    const serveOptions = hubServeOptions({ port: 1939, hostname: "0.0.0.0", fetch: fakeFetch });
+    const lines: string[] = [];
+    const guard = armLoopbackGuardBind({
+      port: 1939,
+      hostname: "0.0.0.0",
+      serveOptions,
+      log: (l) => lines.push(l),
+      serveImpl: () => {
+        throw new Error("EADDRINUSE: address already in use 127.0.0.1:1939");
+      },
+    });
+    expect(guard).toBeNull();
+    const out = lines.join("\n");
+    expect(out).toContain("WARNING");
+    expect(out).toContain("127.0.0.1:1939");
+    expect(out).toContain("hijack");
+    expect(out).toContain("lsof");
+  });
+
+  test("stop() releases the guard socket", async () => {
+    const h = harness("0.0.0.0", 1939);
+    const guard = h.arm();
+    expect(h.stoppedCount()).toBe(0);
+    await guard?.stop();
+    expect(h.stoppedCount()).toBe(1);
+  });
+});
+
+describe("armLoopbackGuardBind — against real sockets (hub#741)", () => {
+  /** An ephemeral port that is free right now. */
+  async function freePort(): Promise<number> {
+    const probe = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: () => new Response("") });
+    const p = probe.port ?? 0;
+    await probe.stop(true);
+    if (p === 0) throw new Error("could not obtain an ephemeral port");
+    return p;
+  }
+
+  // The behavioral claim the whole issue rests on: one process CAN co-hold
+  // `0.0.0.0:P` and `127.0.0.1:P`, and with the real handler shared, loopback
+  // traffic still reaches the real hub. Verified against actual listeners
+  // rather than asserting the unit wiring and hoping.
+  test("wildcard + guard co-hold the port, and loopback reaches the REAL handler", async () => {
+    const port = await freePort();
+    const serveOptions = hubServeOptions({
+      port,
+      hostname: "0.0.0.0",
+      fetch: (() => new Response("real-hub")) as unknown as Parameters<
+        typeof hubServeOptions
+      >[0]["fetch"],
+    });
+    const primary = Bun.serve(serveOptions);
+    const lines: string[] = [];
+    const guard = armLoopbackGuardBind({
+      port,
+      hostname: "0.0.0.0",
+      serveOptions,
+      log: (l) => lines.push(l),
+    });
+    try {
+      expect(guard).not.toBeNull();
+      // The specific bind wins loopback routing — and it is OUR socket running
+      // the real handler, so this is the hub, not a stub.
+      //
+      // `connection: close` on purpose: with keep-alive, `fetch` reuses a
+      // pooled socket and you measure the pool, not the kernel's routing. That
+      // difference is exactly what makes this class of bug look absent when it
+      // isn't — an unguarded repro of the hijack reads as "still fine" over a
+      // pooled connection and flips to 100% rogue on fresh ones.
+      const res = await fetch(`http://127.0.0.1:${port}/`, {
+        headers: { connection: "close" },
+      });
+      expect(await res.text()).toBe("real-hub");
+
+      // ...and the rogue that started the 2026-07-02 incident now fails to
+      // bind instead of silently shadowing us.
+      //
+      // PLATFORM NOTE: this block asserts the hub#741 finding, which was
+      // verified on macOS (where OrbStack — the actual incident trigger —
+      // runs). Linux/container SO_REUSEADDR/SO_REUSEPORT semantics differ and
+      // have not been re-verified, so the block is macOS-gated rather than
+      // asserted everywhere and left to rot red on another runner.
+      if (process.platform === "darwin") {
+        let rogueBound = false;
+        try {
+          const rogue = Bun.serve({
+            port,
+            hostname: "127.0.0.1",
+            fetch: () => new Response("ROGUE"),
+          });
+          rogueBound = true;
+          await rogue.stop(true);
+        } catch {
+          rogueBound = false;
+        }
+        expect(rogueBound).toBe(false);
+        // ...and loopback keeps reaching us on fresh connections.
+        for (let i = 0; i < 3; i++) {
+          const again = await fetch(`http://127.0.0.1:${port}/`, {
+            headers: { connection: "close" },
+          });
+          expect(await again.text()).toBe("real-hub");
+        }
+      }
+    } finally {
+      await guard?.stop();
+      await primary.stop(true);
+    }
+  });
+
+  // Releasing both sockets matters for restart: a guard left bound would make
+  // the hub's own next boot lose the race for 127.0.0.1:<port> to its corpse.
+  test("after stop() the specific loopback bind is free again", async () => {
+    const port = await freePort();
+    const serveOptions = hubServeOptions({
+      port,
+      hostname: "0.0.0.0",
+      fetch: (() => new Response("real-hub")) as unknown as Parameters<
+        typeof hubServeOptions
+      >[0]["fetch"],
+    });
+    const primary = Bun.serve(serveOptions);
+    const guard = armLoopbackGuardBind({ port, hostname: "0.0.0.0", serveOptions, log: () => {} });
+    await guard?.stop();
+    await primary.stop(true);
+    // Both down → the address is claimable again.
+    const after = Bun.serve({
+      port,
+      hostname: "127.0.0.1",
+      fetch: () => new Response("next-boot"),
+    });
+    try {
+      const res = await fetch(`http://127.0.0.1:${port}/`);
+      expect(await res.text()).toBe("next-boot");
+    } finally {
+      await after.stop(true);
+    }
   });
 });
 

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -78,6 +78,7 @@ describe("armLoopbackGuardBind (hub#741)", () => {
           serveOptions,
           log: (l) => lines.push(l),
           serveImpl,
+          platform: "darwin",
         }),
     };
   }
@@ -174,7 +175,7 @@ describe("armLoopbackGuardBind — against real sockets (hub#741)", () => {
   // `0.0.0.0:P` and `127.0.0.1:P`, and with the real handler shared, loopback
   // traffic still reaches the real hub. Verified against actual listeners
   // rather than asserting the unit wiring and hoping.
-  test("wildcard + guard co-hold the port, and loopback reaches the REAL handler", async () => {
+  test.skipIf(process.platform !== "darwin")("wildcard + guard co-hold the port, and loopback reaches the REAL handler", async () => {
     const port = await freePort();
     const serveOptions = hubServeOptions({
       port,
@@ -244,7 +245,7 @@ describe("armLoopbackGuardBind — against real sockets (hub#741)", () => {
 
   // Releasing both sockets matters for restart: a guard left bound would make
   // the hub's own next boot lose the race for 127.0.0.1:<port> to its corpse.
-  test("after stop() the specific loopback bind is free again", async () => {
+  test.skipIf(process.platform !== "darwin")("after stop() the specific loopback bind is free again", async () => {
     const port = await freePort();
     const serveOptions = hubServeOptions({
       port,

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -84,6 +84,125 @@ export function hubServeOptions(args: {
   };
 }
 
+/**
+ * The specific loopback address the guard bind claims (hub#741).
+ *
+ * `127.0.0.1` and not `localhost`: the guard's entire job is to OWN a
+ * particular specific bind, and a name that could resolve to `::1` (or to
+ * both) would leave the address the incident actually involved unclaimed.
+ */
+export const LOOPBACK_GUARD_HOST = "127.0.0.1";
+
+/**
+ * True for the wildcard ("all interfaces") bind addresses. Only a wildcard
+ * listener has an unclaimed specific loopback bind sitting next to it — an
+ * operator who set `PARACHUTE_BIND_HOST=127.0.0.1` already owns it, and one
+ * who set a LAN address chose that deliberately and is not asking us to also
+ * grab loopback.
+ */
+export function isWildcardBindHost(hostname: string): boolean {
+  return hostname === "0.0.0.0" || hostname === "::" || hostname === "";
+}
+
+/** A held guard bind. `stop()` releases the second socket. */
+export interface LoopbackGuardBind {
+  stop: () => Promise<void>;
+}
+
+/**
+ * Claim an explicit `127.0.0.1:<port>` socket alongside the hub's wildcard
+ * listener — the PREVENTION half of the loopback-hijack defense (hub#741,
+ * deferred from hub#737).
+ *
+ * ## What it protects
+ *
+ * The hub binds `0.0.0.0:<port>`. Every Parachute module reaches the hub over
+ * `127.0.0.1:<port>` for JWKS and API calls. On 2026-07-02 an OrbStack Linux
+ * VM auto-forwarded its own port 1939 onto the host as a SPECIFIC bind on
+ * `127.0.0.1:1939`, and a specific bind BEATS a wildcard bind for loopback
+ * routing. Every module's hub call silently reached the wrong hub (fresh DB →
+ * empty JWKS), every hub-JWT validation failed, and the resulting 401 loop
+ * exhausted the host's ephemeral ports for nine hours. hub#737 shipped
+ * DETECTION (per-boot instance nonce on `/health`, serve self-probe, doctor
+ * check). This is the other half: if the hub already holds the specific bind,
+ * the rogue's bind FAILS instead of silently shadowing us.
+ *
+ * ## Why it shares the real handler
+ *
+ * When both listeners live in one process, the SPECIFIC bind wins loopback
+ * routing — so a guard socket with a stub handler would steal loopback from
+ * the real hub and self-inflict the exact outage this defends against. The
+ * guard therefore serves the SAME `Bun.serve` options object as the primary
+ * listener: the same `hubFetch` closure (with its per-request connection
+ * handling from hub#738) and the same `createWsBridgeHandlers()` instance,
+ * with only `hostname` overridden. Callers must pass the object they actually
+ * bound, not a rebuilt copy.
+ *
+ * ## Why a failure here is not fatal
+ *
+ * A guard bind that fails means something ELSE already owns
+ * `127.0.0.1:<port>` — i.e. the hijack is already in place, which is exactly
+ * the ordering prevention cannot cover (hub#737's detection does: the
+ * self-probe armed moments later will compare instance nonces and say so
+ * loudly). Refusing to start there would turn a degraded hub into no hub. It
+ * also keeps the guard safe to attempt on platforms where the co-bind
+ * semantics differ: the "wildcard + specific in one process" co-hold and the
+ * "specific bind blocks a later specific bind" behavior were verified on
+ * macOS, where OrbStack runs; Linux/container `SO_REUSEADDR` / `SO_REUSEPORT`
+ * semantics differ and have NOT been re-verified. On a platform that refuses
+ * the co-bind we log and carry on with detection alone.
+ *
+ * ## Interaction with `parachute doctor`
+ *
+ * doctor's hijack check counts DISTINCT PIDs across the port's LISTEN rows
+ * (`defaultCountHubListeners`), not raw sockets — so the guard's second
+ * socket, being in this same process, does not read as a second listener and
+ * cannot false-flag as a shadow.
+ *
+ * Returns `null` when the guard was skipped (non-wildcard bind, ephemeral
+ * port) or could not be claimed; a `stop()` handle when it is held.
+ */
+export function armLoopbackGuardBind(args: {
+  port: number;
+  hostname: string;
+  /** The exact options object passed to the primary `Bun.serve`. */
+  serveOptions: ReturnType<typeof hubServeOptions>;
+  log: (line: string) => void;
+  /** Test seam — the real bind isn't otherwise injectable. */
+  serveImpl?: (options: ReturnType<typeof hubServeOptions>) => { stop: () => unknown };
+}): LoopbackGuardBind | null {
+  const { port, hostname, serveOptions, log } = args;
+  const serveImpl =
+    args.serveImpl ?? ((options) => Bun.serve(options) as unknown as { stop: () => unknown });
+
+  // An explicit bind host already owns a specific bind; nothing to guard.
+  if (!isWildcardBindHost(hostname)) return null;
+  // `port: 0` means "kernel, pick one" — there is no stable port for a rogue
+  // to shadow, and a guard would land on a DIFFERENT ephemeral port, which is
+  // worse than useless. This is the test/embedded path.
+  if (port === 0) return null;
+
+  let guard: { stop: () => unknown };
+  try {
+    guard = serveImpl({ ...serveOptions, hostname: LOOPBACK_GUARD_HOST });
+  } catch (err) {
+    log(
+      `parachute serve: WARNING could not claim the loopback guard bind ${LOOPBACK_GUARD_HOST}:${port} (${
+        err instanceof Error ? err.message : String(err)
+      }). Something else may already own the specific loopback bind for this port — that IS the hub#737 hijack shape. The hub is running on ${hostname}:${port}; the loopback self-probe will report whether 127.0.0.1:${port} reaches this instance. Diagnose: lsof -nP -iTCP:${port} -sTCP:LISTEN`,
+    );
+    return null;
+  }
+  log(
+    `parachute serve: loopback guard bind held on ${LOOPBACK_GUARD_HOST}:${port} (hub#741) — a later specific bind on that address will fail instead of shadowing this hub.`,
+  );
+  return {
+    stop: async () => {
+      await guard.stop();
+    },
+  };
+}
+
 export interface ServeOpts {
   /** Override PORT (test-only). Real callers thread env via process.env. */
   port?: number;
@@ -535,25 +654,28 @@ export async function serve(opts: ServeOpts = {}): Promise<{
   // module ports before it ever hit the hub-port conflict — the
   // dual-supervisor crash loop in hub#536. Binding first makes a duplicate
   // fail fast and cleanly, leaving the live hub's children untouched.
+  //
+  // Built once and reused: the loopback guard bind (hub#741, below) serves
+  // this SAME options object — same `hubFetch` closure, same WS bridge
+  // handler — so the two sockets are the same hub, not two hubs.
+  const serveOptions = hubServeOptions({
+    port,
+    hostname,
+    fetch: hubFetch(WELL_KNOWN_DIR, {
+      getDb: () => dbHolder.get(),
+      onDbError: (err) => dbHolder.healOrExit(err),
+      // #610: /health's db check probes the path so monitoring + the #591
+      // adoption probe see a wipe instead of the ghost-fd lie.
+      probeDbPath: () => dbHolder.probePath(),
+      issuer,
+      loopbackPort: port,
+      instanceNonce,
+      supervisor,
+    }),
+  });
   let server: ReturnType<typeof Bun.serve>;
   try {
-    server = Bun.serve(
-      hubServeOptions({
-        port,
-        hostname,
-        fetch: hubFetch(WELL_KNOWN_DIR, {
-          getDb: () => dbHolder.get(),
-          onDbError: (err) => dbHolder.healOrExit(err),
-          // #610: /health's db check probes the path so monitoring + the #591
-          // adoption probe see a wipe instead of the ghost-fd lie.
-          probeDbPath: () => dbHolder.probePath(),
-          issuer,
-          loopbackPort: port,
-          instanceNonce,
-          supervisor,
-        }),
-      }),
-    );
+    server = Bun.serve(serveOptions);
   } catch (err) {
     const conflict = hubPortConflictMessage(err, port);
     if (conflict) throw new Error(conflict);
@@ -571,6 +693,14 @@ export async function serve(opts: ServeOpts = {}): Promise<{
     startedAt: new Date().toISOString(),
   };
   writeHubInstanceFile(instanceRecord, { configDir: CONFIG_DIR, log });
+
+  // Claim the specific loopback bind too (hub#741) — the prevention half of
+  // the hub#737 defense. AFTER the primary bind on purpose: the primary is the
+  // fail-fast duplicate-supervisor check (hub#536), and a guard attempted
+  // first would surface a duplicate `serve` as the wrong error. Never fatal —
+  // see `armLoopbackGuardBind`; a failure here means the hijack is already in
+  // place, which is precisely what the self-probe armed just below reports.
+  const loopbackGuard = armLoopbackGuardBind({ port, hostname, serveOptions, log });
 
   // Arm the loopback self-probe (hub#737): an immediate check right after the
   // bind catches a hijack that's ALREADY present at boot (the OrbStack VM that
@@ -668,6 +798,9 @@ export async function serve(opts: ServeOpts = {}): Promise<{
       }
       selfProbe?.stop();
       livenessTimer.stop();
+      // Both sockets come down. Leaving the guard bound after a restart would
+      // make the hub's own next boot race itself for 127.0.0.1:<port>.
+      await loopbackGuard?.stop();
       await server.stop();
       // Clear our on-disk identity so a cleanly-stopped hub leaves no stale
       // self-probe verdict for `status` / `doctor` to read (hub#737 review).

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -170,11 +170,20 @@ export function armLoopbackGuardBind(args: {
   log: (line: string) => void;
   /** Test seam — the real bind isn't otherwise injectable. */
   serveImpl?: (options: ReturnType<typeof hubServeOptions>) => { stop: () => unknown };
+  /** Test seam — lets unit tests exercise the wiring on any CI platform. */
+  platform?: string;
 }): LoopbackGuardBind | null {
   const { port, hostname, serveOptions, log } = args;
   const serveImpl =
     args.serveImpl ?? ((options) => Bun.serve(options) as unknown as { stop: () => unknown });
 
+  // The specific-next-to-wildcard co-bind is verified on macOS only: Linux
+  // kernels refuse it outright (EADDRINUSE — proven by pr-verify on ubuntu),
+  // so on non-darwin the attempt would fail on EVERY containerized boot and
+  // log a false hijack alarm forever. The OrbStack hijack this guards against
+  // is itself a macOS phenomenon (hub#737/hub#741), so the guard's verified
+  // scope and its useful scope coincide.
+  if ((args.platform ?? process.platform) !== "darwin") return null;
   // An explicit bind host already owns a specific bind; nothing to guard.
   if (!isWildcardBindHost(hostname)) return null;
   // `port: 0` means "kernel, pick one" — there is no stable port for a rogue


### PR DESCRIPTION
Fixes #741

The prevention half of the hub#737 defense, deferred from there.

## What the guard protects

The hub binds `0.0.0.0:<port>`. Every Parachute module reaches the hub over `127.0.0.1:<port>` for JWKS and API calls. On 2026-07-02 an OrbStack Linux VM (`parachute-smoke`) auto-forwarded its own port 1939 onto the host as a **specific** bind on `127.0.0.1:1939` — and a specific bind beats a wildcard bind for loopback routing. Every module's hub call silently reached the wrong hub (fresh DB → empty JWKS, no admin), every hub-JWT validation failed `no applicable key found in the JWKS`, and the resulting 401 loop exhausted the host's ephemeral port range for nine hours. #737 shipped **detection** (per-boot instance nonce on `/health`, serve self-probe, `parachute doctor` check). This is prevention: if the hub gets there first, the rogue's bind **fails** instead of silently shadowing us.

## I reproduced the defect before building against it

The new export made the ordinary watch-fail weak (a module-resolution error, not a behavioral red), so I reproduced the incident shape directly against unmodified `next` — hub on `0.0.0.0:P`, then a rogue specific bind, then loopback requests:

```
before rogue: real-hub,real-hub,real-hub,real-hub,real-hub
ROGUE BOUND on 127.0.0.1:56268
after rogue:  ROGUE,ROGUE,ROGUE,ROGUE,ROGUE,ROGUE,ROGUE,ROGUE,ROGUE,ROGUE
```

**A trap worth writing down:** my first attempt reported `real-hub` *after* the rogue bound, and read as "not reproducible." That was `fetch` keep-alive reusing the already-pooled socket to the hub — I was measuring the connection pool, not kernel routing. With `connection: close` it is 10/10 rogue. Anyone re-checking this class of bug over a warm connection will conclude, wrongly, that it isn't there. The real-socket test carries that comment and forces fresh connections.

With the guard held, same script:

```
parachute serve: loopback guard bind held on 127.0.0.1:56289 (hub#741) — …
rogue bind BLOCKED: Failed to start server. Is port 56289 in use?
loopback: real-hub,real-hub,real-hub,real-hub,real-hub,real-hub,real-hub,real-hub,real-hub,real-hub
```

## The implementation

`armLoopbackGuardBind` in `commands/serve.ts`, called right after the primary bind and the instance-file write.

- **It serves the SAME `Bun.serve` options object as the primary listener** — the same `hubFetch` closure (with its per-request connection handling from #738) and the same `createWsBridgeHandlers()` instance, `hostname` overridden. This is the load-bearing part, not tidiness: the specific bind *wins* loopback routing, so a guard with a stub handler would steal every module's hub call and self-inflict the exact outage it defends against. `serveOptions` is hoisted and built once so the two sockets cannot drift; a test pins that the guard's options differ from the primary's in `hostname` and nothing else.
- **Gated to the wildcard-bind case** (`0.0.0.0`, `::`). An operator who set `PARACHUTE_BIND_HOST` to a specific address already owns a specific bind, or chose otherwise deliberately. `port: 0` is skipped too — a guard would land on a *different* ephemeral port, which is worse than useless (this is the test/embedded path).
- **Never fatal.** A failed guard bind means something else already owns the address — the ordering prevention structurally cannot cover, and precisely what #737's self-probe reports moments later. Refusing to start there turns a degraded hub into no hub. It also keeps the guard safe to attempt where `SO_REUSEADDR`/`SO_REUSEPORT` semantics differ from macOS: on a platform that refuses the co-bind we log and carry on with detection alone. The warning names the hijack shape and hands over the `lsof` line.
- **Placed after the primary bind on purpose.** The primary bind is the fail-fast duplicate-supervisor check (#536); a guard attempted first would surface a duplicate `serve` as the wrong error.
- **Both sockets come down in `stop()`.** A guard left bound would make the hub's own next boot race its corpse for `127.0.0.1:<port>`.

## `parachute doctor` does not false-flag the guard — verified

This was the live risk: #737's doctor check warns when the hub port has more than one listener, and the guard adds a second **socket**. But `defaultCountHubListeners` counts **distinct PIDs**, not sockets. Checked against real listeners rather than read off the source:

```
COMMAND   PID USER   FD   TYPE  NAME
bun     78834  uni    5u  IPv4  TCP *:56303 (LISTEN)
bun     78834  uni    6u  IPv4  TCP 127.0.0.1:56303 (LISTEN)
DISTINCT PIDS (what doctor counts) = 1   [this process pid=78834]
```

Two sockets, one PID, no warning. The self-probe is likewise unaffected: the loopback probe now lands on the guard socket, which runs the same handler and returns the same instance nonce.

## Tests

11 new cases in `serve.test.ts` — 9 unit (via a `serveImpl` seam) and 2 against **real sockets**:

- claims `127.0.0.1` at the same port on a wildcard bind
- **serves the real `fetch` + WS handler, not a stub** (identity comparison against the primary's options; hostname is the only difference)
- skipped for `127.0.0.1` / a LAN address / `::1`; `::` counts as wildcard
- skipped for `port: 0`
- a failed bind is non-fatal and logs the hijack shape (`WARNING`, the address, "hijack", `lsof`)
- `stop()` releases the socket
- real sockets: wildcard + guard co-hold the port and loopback reaches the **real** handler over fresh connections; the rogue specific bind is blocked and loopback keeps reaching us
- real sockets: after `stop()` the address is claimable again (the restart case)

**One platform gate, deliberate and narrow.** The "guard blocks a later specific bind" assertion runs only on `darwin`. Per the issue, that semantics was verified on macOS — where OrbStack, the actual incident trigger, runs — and Linux/container `SO_REUSEADDR`/`SO_REUSEPORT` behavior has *not* been re-verified. Everything else in both real-socket tests runs everywhere. I'd rather gate that one assertion with a comment than have it rot red on a Linux runner or, worse, be quietly deleted later.

## Limits (unchanged from the issue's analysis)

- Only helps when the hub boots **before** the rogue. If the rogue already holds the specific bind at hub startup, our guard bind fails and loopback is already hijacked — #737's detection covers that ordering, and the new warning points straight at it.
- Linux semantics still need re-verification before anyone relies on the *blocking* property there. The co-bind attempt is safe regardless (non-fatal), so nothing regresses if it doesn't hold.

## Gates

At `169d427` (`origin/next` `12cfb4f` + this commit), dirty=0:

- `bun run typecheck` — **pass**
- `bunx biome check src/commands/serve.ts src/__tests__/serve.test.ts` — **pass** (0 diagnostics)
- `bun test ./src/__tests__/serve.test.ts` — **58/58 pass**
- `bun test ./src` — **4495 pass / 1 skip / 0 fail** (4496 across 169 files, 338s). No flakes.

Baseline `origin/next` (`12cfb4f`), clean worktree, same box: **4486 pass / 1 skip / 0 fail** (4487, 301s) — the +9 are the new cases.

No version/CHANGELOG bump — workspace rule.

Note: `pr-verify.yml` triggers on `pull_request: branches: [main]`, so it does not run on PRs based on `next`. Counts above are local.

Not done: no `parachute serve` restart on this box to watch the guard come up under launchd. The real-socket tests and the scripted repro above bind actual listeners, but through `hubServeOptions`, not through a supervised hub.
