### PR TITLE
fix(release): let the unpublished-drift advisory actually run (hub#830)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,21 @@ jobs:
       door_contract: ${{ steps.door_contract.outputs.should_publish }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          # The drift advisory in release-plan.ts asks git "what's on main that
+          # no published version contains?" — a `<tag>..HEAD` range. A bare
+          # checkout fetches `--depth=1 --no-tags`, where that range exits 128
+          # ("unknown revision") and the advisory reported nothing, forever
+          # (hub#830). Indistinguishable from "everything is shipped", which is
+          # the exact confusion it was added to end.
+          #
+          # Only this job needs history; every other job's checkout stays
+          # shallow.
+          fetch-depth: 0
+          # Redundant alongside fetch-depth: 0 today, deliberate anyway: it
+          # states the dependency, so narrowing the depth later can't silently
+          # take the tags away again.
+          fetch-tags: true
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -195,6 +195,50 @@ export function unpublishedDrift(commitSubjects: readonly string[]): {
   };
 }
 
+/**
+ * The git tag namespace a package's releases are recorded under.
+ *
+ * Not a detail — the drift advisory's revision range is a TAG, and hub's tags
+ * are bare (`v0.7.0`) while every sub-package's are namespaced
+ * (`door-contract-v0.7.0`). The advisory hardcoded `v`, so door-contract@0.7.0
+ * resolved against HUB's `v0.7.0` — a tag that exists, pointing at unrelated
+ * history — and would have reported ~137 hub commits as door-contract's
+ * unpublished work (hub#830). A wrong-but-resolving range is worse than a
+ * missing one.
+ *
+ * The mapping is the one `tag-record` uses at the bottom of release.yml, and
+ * the one `on: push: tags:` filters against: package dir basename + `-v`, or a
+ * bare `v` for the root package.
+ */
+export function tagPrefixFor(dir: string): string {
+  const name = dir.replace(/\/+$/, "").split("/").pop() ?? "";
+  if (name === "" || name === "." || name === "..") return "v";
+  return `${name}-v`;
+}
+
+/**
+ * The `git log` invocation behind the drift advisory.
+ *
+ * Split out from the CLI so the range and the pathspec are testable without a
+ * repo — both were wrong in ways that only showed up in a release run.
+ *
+ * The trailing pathspec scopes the listing to the package: without it,
+ * "commits not in any published version" for scope-guard would list every hub
+ * commit merged since scope-guard last shipped, which is noise dressed as a
+ * warning.
+ */
+export function driftLogArgs(dir: string, version: string): string[] {
+  return [
+    "git",
+    "log",
+    `${tagPrefixFor(dir)}${version}..HEAD`,
+    "--oneline",
+    "--no-merges",
+    "--",
+    dir.replace(/\/+$/, "") || ".",
+  ];
+}
+
 // --- CLI -------------------------------------------------------------------
 // Usage: bun scripts/release-plan.ts <package-dir> <npm-name> [--tag-push]
 // Emits GitHub Actions outputs; exits non-zero on refusal.
@@ -220,8 +264,17 @@ if (import.meta.main) {
   // in a row sat unpublished on main.
   if (!decision.publish && !rest.includes("--no-drift-check")) {
     try {
-      const proc = Bun.spawnSync(["git", "log", `v${version}..HEAD`, "--oneline", "--no-merges"]);
-      if (proc.exitCode === 0) {
+      const proc = Bun.spawnSync(driftLogArgs(dir, version));
+      if (proc.exitCode !== 0) {
+        // Say so. This is the whole of hub#830: the plan job used a bare
+        // `actions/checkout@v6` (`--depth=1 --no-tags`), git exited 128
+        // "unknown revision", and this branch stayed silent — so a CI run that
+        // COULDN'T check drift looked exactly like one that found none.
+        console.log(
+          `::notice::${npmName}: couldn't check for unpublished drift ` +
+            `(${tagPrefixFor(dir)}${version} not resolvable — shallow or tagless clone?)`,
+        );
+      } else {
         const drift = unpublishedDrift(new TextDecoder().decode(proc.stdout).split("\n"));
         if (drift.drifted) {
           console.log(`::warning::${npmName}: ${drift.summary}`);

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -14,8 +14,10 @@ import {
   compareVersions,
   decidePublish,
   distTagFor,
+  driftLogArgs,
   emitOutputs,
   readRegistry,
+  tagPrefixFor,
   unpublishedDrift,
 } from "../../scripts/release-plan.ts";
 
@@ -178,6 +180,113 @@ describe("unpublishedDrift", () => {
 
   test("blank lines from git's trailing newline don't inflate the count", () => {
     expect(unpublishedDrift(["abc one", ""]).count).toBe(1);
+  });
+});
+
+/**
+ * hub#830: the drift advisory has to be able to RUN.
+ *
+ * Two independent defects made it dead code in CI:
+ *
+ *   1. The `plan` job used a bare `actions/checkout@v6`, which fetches
+ *      `--depth=1 --no-tags`. `git log v0.7.14..HEAD` in that clone exits 128
+ *      ("unknown revision"), the `proc.exitCode === 0` guard skips, and the
+ *      advisory reports nothing — indistinguishable from "everything is
+ *      shipped", which is the exact confusion it was built to end.
+ *   2. The revision range hardcoded a `v` prefix. Sub-package tags are
+ *      namespaced (`door-contract-v0.7.0`), so door-contract@0.7.0 would have
+ *      been compared against HUB's `v0.7.0` tag — a real tag, pointing at
+ *      unrelated history, so the advisory would have listed nine months of hub
+ *      commits as "door-contract's unpublished work". Masked only by defect 1.
+ *
+ * The prefixes here are not invented: they're the ones `tag-record` pushes at
+ * the bottom of release.yml, and the ones the `on: push: tags:` filters match.
+ */
+describe("tagPrefixFor", () => {
+  test("the root package is hub, whose tags are bare `vX.Y.Z`", () => {
+    expect(tagPrefixFor(".")).toBe("v");
+    expect(tagPrefixFor("")).toBe("v");
+    expect(tagPrefixFor("./")).toBe("v");
+  });
+
+  test("sub-packages get their namespaced prefix — same strings tag-record pushes", () => {
+    expect(tagPrefixFor("packages/scope-guard")).toBe("scope-guard-v");
+    expect(tagPrefixFor("packages/depcheck")).toBe("depcheck-v");
+    expect(tagPrefixFor("packages/door-contract")).toBe("door-contract-v");
+    // Trailing slash is the same package.
+    expect(tagPrefixFor("packages/door-contract/")).toBe("door-contract-v");
+  });
+
+  test("the prefixes match what release.yml's tag-record actually pushes", () => {
+    const workflow = readFileSync(
+      join(import.meta.dir, "../../.github/workflows/release.yml"),
+      "utf8",
+    );
+    for (const [dir, prefix] of [
+      [".", "v"],
+      ["packages/scope-guard", "scope-guard-v"],
+      ["packages/depcheck", "depcheck-v"],
+      ["packages/door-contract", "door-contract-v"],
+    ] as const) {
+      expect(tagPrefixFor(dir)).toBe(prefix);
+      expect(workflow).toMatch(
+        new RegExp(`tag_if\\s+"${prefix}"\\s+"${dir === "." ? "\\." : dir}"`),
+      );
+    }
+  });
+});
+
+describe("driftLogArgs", () => {
+  test("hub compares against its own bare-v tag", () => {
+    expect(driftLogArgs(".", "0.7.14")).toEqual([
+      "git",
+      "log",
+      "v0.7.14..HEAD",
+      "--oneline",
+      "--no-merges",
+      "--",
+      ".",
+    ]);
+  });
+
+  test("door-contract compares against door-contract-v, NOT hub's v tag", () => {
+    const args = driftLogArgs("packages/door-contract", "0.7.0");
+    expect(args).toContain("door-contract-v0.7.0..HEAD");
+    // The bug: `v0.7.0` is a real HUB tag, so the wrong range would have
+    // resolved and listed hub's history as door-contract's drift.
+    expect(args).not.toContain("v0.7.0..HEAD");
+  });
+
+  test("the listing is scoped to the package — a hub commit isn't scope-guard drift", () => {
+    expect(driftLogArgs("packages/scope-guard", "0.5.1").slice(-2)).toEqual([
+      "--",
+      "packages/scope-guard",
+    ]);
+  });
+});
+
+describe("release.yml drift advisory can execute (hub#830)", () => {
+  const workflow = readFileSync(
+    join(import.meta.dir, "../../.github/workflows/release.yml"),
+    "utf8",
+  );
+  // Scope every assertion to the `plan` job — the other jobs' shallow
+  // checkouts are fine, only `plan` reads git history.
+  const planJob = workflow.match(/\n {2}plan:\n([\s\S]*?)\n {2}[a-z][\w-]*:\n/)?.[1];
+
+  test("the plan job is findable (guards the slicing above)", () => {
+    expect(planJob).toBeTruthy();
+    expect(planJob).toContain("bun scripts/release-plan.ts . @openparachute/hub");
+  });
+
+  test("the plan job's checkout fetches full history — depth=1 has no merge base", () => {
+    expect(planJob).toMatch(/actions\/checkout@v6\n\s*with:\n(?:\s*.+\n)*?\s*fetch-depth:\s*0/);
+  });
+
+  test("the plan job's checkout fetches tags — the advisory's range is a TAG", () => {
+    // Bare checkout passes `--no-tags`; without this the range never resolves
+    // and the advisory silently reports nothing, forever.
+    expect(planJob).toMatch(/fetch-tags:\s*true/);
   });
 });
 


### PR DESCRIPTION
Fixes #830 (items 1 + 2 — item 3, the `GITHUB_OUTPUT` truncation, was already fixed by #835).

## What was actually wrong

The unpublished-drift advisory has never fired. Two independent defects, either fatal alone:

**1. The `plan` job's checkout can't see the tag.** `- uses: actions/checkout@v6` with no `with:` fetches `--depth=1 --no-tags`. The advisory's range is a *tag* range. Reproduced locally against a `--depth=1 --no-tags` clone of this repo:

```
$ git log v0.7.14..HEAD --oneline --no-merges
fatal: ambiguous argument 'v0.7.14..HEAD': unknown revision or path not in the working tree.
exit=128
```

Worth a correction to the issue text: the error is **not** swallowed by the `catch`. `Bun.spawnSync` doesn't throw on a non-zero exit — it returns `exitCode: 128` with the fatal on stderr, and the `if (proc.exitCode === 0)` guard is what skipped in silence. Same outcome, different line, and it matters because the fix is to make that branch *speak*.

**2. The `v` prefix is hub's alone.** Sub-package tags are namespaced (`door-contract-v0.7.0`) — the same strings `tag-record` pushes at the bottom of `release.yml` and `on: push: tags:` filters against. So door-contract@0.7.0 was compared against **hub's** `v0.7.0`, a tag that exists and points at unrelated history. On this repo right now:

| range | commits listed |
|---|---|
| `v0.7.0..HEAD` (what the code did for door-contract) | **137** |
| `door-contract-v0.7.0..HEAD -- packages/door-contract` | **0** |

A wrong-but-resolving range is worse than a missing one. Defect 1 was the only thing hiding it.

## The fix

- `fetch-depth: 0` + `fetch-tags: true` on the **plan** job's checkout only — it's the one job that reads history; the rest stay shallow. `fetch-tags` is redundant next to depth 0 today, kept deliberately so narrowing the depth later can't silently take the tags away again.
- `tagPrefixFor(dir)` derives the prefix from the package dir (`.` → `v`, `packages/door-contract` → `door-contract-v`), and a test pins those four strings against what `tag-record` actually pushes — so the two can't drift apart.
- `driftLogArgs()` also scopes the listing to the package dir. Without the pathspec, "unpublished work" for scope-guard means every hub commit merged since scope-guard last shipped: noise dressed as a warning.
- A non-zero `git log` exit now emits `::notice:: couldn't check for unpublished drift (… shallow or tagless clone?)`. The silent-skip is the bug class; a future one should be visible.

## Verification

Not just asserted — run.

**Watch-fail.** The two workflow assertions are red against `next`'s `release.yml`:

```
(fail) release.yml drift advisory can execute (hub#830) > the plan job's checkout fetches full history — depth=1 has no merge base
(fail) release.yml drift advisory can execute (hub#830) > the plan job's checkout fetches tags — the advisory's range is a TAG
 36 pass  2 fail
```
Green with the workflow fix: `38 pass, 0 fail`. The `tagPrefixFor` / `driftLogArgs` tests fail on `next` at import (the exports don't exist).

**The advisory firing (control).** Pinning root `package.json` to the published `0.7.13` and running the real script:

```
::warning::@openparachute/hub: 21 commit(s) on main are NOT in any published version:
  - b72a0dd docs: top up 0.7.16 changelog entry with 6 additional PRs (#850-#856)
  - f1a6786 feat(serve): own an explicit 127.0.0.1 guard bind against loopback hijack (#856)
  …
```

**The notice firing.** Same script copied into the `--depth=1 --no-tags` clone:

```
::notice::@openparachute/door-contract: couldn't check for unpublished drift (door-contract-v0.7.0 not resolvable — shallow or tagless clone?)
```

**Correct quiet.** In a full clone, door-contract@0.7.0 and scope-guard@0.5.1 both take the skip path and report no drift — correct, and previously impossible to distinguish from the broken case.

## Gates

- `bunx biome check scripts/release-plan.ts src/__tests__/release-plan.test.ts` — clean for this diff. Two pre-existing `lint/style/useTemplate` findings remain at `release-plan.ts:129` and `:192`; both reproduce identically on unmodified `next` (unrelated lines, biome declines to auto-fix them), so they're baseline, not introduced.
- `bun run typecheck` — clean.
- `bun test ./src` — **4512 pass, 1 skip, 0 fail** (169 files, 417s). Hub-only count per CLAUDE.md's `./src` trap.

No version bump, no CHANGELOG (release PRs own those).

🤖 Generated with [Claude Code](https://claude.com/claude-code)