### PR TITLE
fix(hub#864): gate every username write through validateUsername

### DIFF
--- a/src/__tests__/api-account-pubkeys.test.ts
+++ b/src/__tests__/api-account-pubkeys.test.ts
@@ -405,16 +405,21 @@ describe("POST /verify — the statement binding", () => {
 });
 
 describe("HIGH-1 — username injection into the linkage statement", () => {
-  // `createUser` does NOT run `validateUsername`, and two write paths reach it
-  // ungated (`parachute auth set-password --username`, serve.ts
-  // `PARACHUTE_INITIAL_ADMIN_USERNAME`), so a hostile username CAN reach the
-  // DB. The confused-deputy defense must not depend on that gate.
+  // hub#864 gates every NEW write through `validateUsername`, so a hostile
+  // name can no longer land via createUser. Grandfathered rows still can
+  // (raw INSERT, pre-#864 DBs). The confused-deputy defense must not
+  // depend on the write gate — the ceremony still refuses those rows.
   const INJECTION =
     'mallory" on https://hub.example. Link this Nostr key to the Parachute account "alice';
 
-  async function sessionForUsername(username: string): Promise<string> {
-    const u = await createUser(db, username, PASSWORD, { allowMulti: true, passwordChanged: true });
-    const session = createSession(db, { userId: u.id });
+  function sessionForGrandfatheredUsername(username: string): string {
+    const id = crypto.randomUUID();
+    const stamp = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+       VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+    ).run(id, username, "not-a-real-hash", stamp, stamp);
+    const session = createSession(db, { userId: id });
     return `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
   }
 
@@ -429,7 +434,7 @@ describe("HIGH-1 — username injection into the linkage statement", () => {
   });
 
   test("an account with an injected username cannot get a challenge", async () => {
-    const cookie = await sessionForUsername(INJECTION);
+    const cookie = sessionForGrandfatheredUsername(INJECTION);
     const res = await call("POST", "/challenge", cookie, { __csrf: TEST_CSRF });
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error: string }).error).toBe("username_unlinkable");
@@ -441,7 +446,7 @@ describe("HIGH-1 — username injection into the linkage statement", () => {
   });
 
   test("an account with an injected username cannot verify — the key never links", async () => {
-    const cookie = await sessionForUsername(INJECTION);
+    const cookie = sessionForGrandfatheredUsername(INJECTION);
     // Even a hand-crafted event can't get in: the ceremony refuses before it
     // is parsed, so the confused-deputy link the injection aimed for is
     // impossible regardless of what the victim signed.

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -459,6 +459,66 @@ describe("seedInitialAdminIfNeeded", () => {
     expect(log.mock.calls[0]?.[0] ?? "").toContain("cannot run the pubkey-linkage ceremony");
     expect(log.mock.calls[0]?.[0] ?? "").toContain('"Alice" (format)');
   });
+
+  test("hub#864 — grandfathered username with a newline cannot forge extra log lines", async () => {
+    const db = openHubDb(dbPath);
+    await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "first-pw",
+      },
+      () => {},
+    );
+    // Pre-#864 rows could contain control chars; a raw interpolation would
+    // split the boot warning into extra operator-log lines.
+    const forged = "Alice\nFORGED extra operator line";
+    const stamp = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+       VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+    ).run("legacy-nl", forged, "not-a-real-hash", stamp, stamp);
+    const log = mock<(line: string) => void>(() => {});
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "ignored",
+      },
+      log,
+    );
+    expect(result).toBe("exists");
+    expect(log.mock.calls).toHaveLength(1);
+    const line = log.mock.calls[0]?.[0] ?? "";
+    expect(line).not.toContain("\n");
+    expect(line).not.toContain("\r");
+    expect(line).toContain(JSON.stringify(forged));
+    expect(line).toContain("cannot run the pubkey-linkage ceremony");
+  });
+
+  test("hub#864 — invalid env username with a newline cannot forge extra log lines", async () => {
+    const db = openHubDb(dbPath);
+    const forged = "Alice\nFORGED extra operator line";
+    const log = mock<(line: string) => void>(() => {});
+    await expect(
+      seedInitialAdminIfNeeded(
+        db,
+        {
+          PARACHUTE_INITIAL_ADMIN_USERNAME: forged,
+          PARACHUTE_INITIAL_ADMIN_PASSWORD: "correct horse battery staple",
+        },
+        log,
+      ),
+    ).rejects.toThrow(InvalidUsernameError);
+    expect(userCount(db)).toBe(0);
+    expect(log.mock.calls).toHaveLength(1);
+    const line = log.mock.calls[0]?.[0] ?? "";
+    expect(line).not.toContain("\n");
+    expect(line).not.toContain("\r");
+    expect(line).toContain(JSON.stringify(forged));
+    expect(line).toContain("PARACHUTE_INITIAL_ADMIN_USERNAME");
+    expect(line).toContain("invalid (format)");
+  });
 });
 
 describe("formatListeningBanner", () => {

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -16,7 +16,7 @@ import {
   seedInitialAdminIfNeeded,
 } from "../commands/serve.ts";
 import { openHubDb } from "../hub-db.ts";
-import { getUserByUsername, userCount } from "../users.ts";
+import { InvalidUsernameError, getUserByUsername, userCount } from "../users.ts";
 
 describe("hubServeOptions — the production listener wires the WS bridge", () => {
   // Regression guard: the WS bridge handler was wired into hub-server.ts's
@@ -392,6 +392,72 @@ describe("seedInitialAdminIfNeeded", () => {
     );
     expect(result).toBe("needs-setup");
     expect(userCount(db)).toBe(0);
+  });
+
+  test("hub#864 — first-boot reserved `admin` seeds, then warns it cannot link", async () => {
+    const db = openHubDb(dbPath);
+    const log = mock<(line: string) => void>(() => {});
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "admin",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "correct horse battery staple",
+      },
+      log,
+    );
+    expect(result).toBe("seeded");
+    expect(userCount(db)).toBe(1);
+    const joined = log.mock.calls.map((c) => c[0] ?? "").join("\n");
+    expect(joined).toContain("seeded initial admin");
+    expect(joined).toContain("cannot run the pubkey-linkage ceremony");
+    expect(joined).toContain('"admin" (reserved)');
+  });
+
+  test("hub#864 — invalid env username is refused and nothing is seeded", async () => {
+    const db = openHubDb(dbPath);
+    const log = mock<(line: string) => void>(() => {});
+    await expect(
+      seedInitialAdminIfNeeded(
+        db,
+        {
+          PARACHUTE_INITIAL_ADMIN_USERNAME: "Alice",
+          PARACHUTE_INITIAL_ADMIN_PASSWORD: "correct horse battery staple",
+        },
+        log,
+      ),
+    ).rejects.toThrow(InvalidUsernameError);
+    expect(userCount(db)).toBe(0);
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("PARACHUTE_INITIAL_ADMIN_USERNAME");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("invalid (format)");
+  });
+
+  test("hub#864 — existing grandfathered row logs the unlinkable warning", async () => {
+    const db = openHubDb(dbPath);
+    await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "first-pw",
+      },
+      () => {},
+    );
+    const stamp = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+       VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+    ).run("legacy-1", "Alice", "not-a-real-hash", stamp, stamp);
+    const log = mock<(line: string) => void>(() => {});
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "ignored",
+      },
+      log,
+    );
+    expect(result).toBe("exists");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("cannot run the pubkey-linkage ceremony");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain('"Alice" (format)');
   });
 });
 

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -6,6 +6,7 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
 import { createSession, findSession } from "../sessions.ts";
 import {
+  InvalidUsernameError,
   PASSWORD_MIN_LEN,
   SingleUserModeError,
   USERNAME_RESERVED,
@@ -18,6 +19,8 @@ import {
   getUserByUsername,
   getUserByUsernameCI,
   isFirstAdmin,
+  isSeedAdminUsername,
+  listUnlinkableUsernames,
   listUsers,
   resetUserPassword,
   setPassword,
@@ -177,6 +180,37 @@ describe("createUser", () => {
       cleanup();
     }
   });
+
+  test("hub#864 chokepoint — rejects format/length/reserved on every write", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await expect(createUser(db, "Alice", "pw1")).rejects.toThrow(InvalidUsernameError);
+      await expect(createUser(db, "user.name", "pw1")).rejects.toThrow(InvalidUsernameError);
+      await expect(createUser(db, "a", "pw1")).rejects.toThrow(InvalidUsernameError);
+      await expect(createUser(db, "root", "pw1")).rejects.toThrow(InvalidUsernameError);
+      expect(userCount(db)).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("hub#864 — first-user reserved `admin` is allowed; a later `admin` is not", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const first = await createUser(db, "admin", "pw1");
+      expect(first.username).toBe("admin");
+      await expect(createUser(db, "admin", "pw2", { allowMulti: true })).rejects.toThrow(
+        InvalidUsernameError,
+      );
+      // A second reserved word never gets the seed exemption.
+      await expect(createUser(db, "root", "pw2", { allowMulti: true })).rejects.toThrow(
+        InvalidUsernameError,
+      );
+      expect(userCount(db)).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("verifyPassword", () => {
@@ -228,8 +262,8 @@ describe("listUsers / getUserByUsername", () => {
   test("listUsers returns rows in created_at order", async () => {
     const { db, cleanup } = makeDb();
     try {
-      const a = await createUser(db, "a", "pw", { now: () => new Date(1000) });
-      const b = await createUser(db, "b", "pw", {
+      const a = await createUser(db, "aa", "pw", { now: () => new Date(1000) });
+      const b = await createUser(db, "bb", "pw", {
         allowMulti: true,
         now: () => new Date(2000),
       });
@@ -400,6 +434,50 @@ describe("validateUsername", () => {
     expect(validateUsername("user-2").valid).toBe(true);
     expect(validateUsername("123").valid).toBe(true);
     expect(validateUsername("_-_").valid).toBe(true);
+  });
+});
+
+describe("isSeedAdminUsername", () => {
+  test("only the exact lowercase first-user `admin`", () => {
+    expect(isSeedAdminUsername("admin", 0)).toBe(true);
+    expect(isSeedAdminUsername("admin", 1)).toBe(false);
+    expect(isSeedAdminUsername("Admin", 0)).toBe(false);
+    expect(isSeedAdminUsername("root", 0)).toBe(false);
+    expect(isSeedAdminUsername("ops", 0)).toBe(false);
+  });
+});
+
+describe("listUnlinkableUsernames", () => {
+  test("empty when every row is valid", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "ops", "pw1");
+      expect(listUnlinkableUsernames(db)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reports a seeded `admin` and a grandfathered out-of-charset row", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "admin", "pw1");
+      const stamp = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+         VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+      ).run("legacy-1", "Alice", "not-a-real-hash", stamp, stamp);
+      const listed = listUnlinkableUsernames(db);
+      expect(listed).toEqual(
+        expect.arrayContaining([
+          { username: "admin", reason: "reserved" },
+          { username: "Alice", reason: "format" },
+        ]),
+      );
+      expect(listed).toHaveLength(2);
+    } finally {
+      cleanup();
+    }
   });
 });
 

--- a/src/api-account-pubkeys.ts
+++ b/src/api-account-pubkeys.ts
@@ -150,17 +150,12 @@ export const MAX_PUBKEY_LABEL_LEN = 64;
  *     signer pane that truncates cannot hide the `Account:` prefix and leave a
  *     forged tail behind.
  *   - We REFUSE to build the statement at all when `validateUsername` rejects
- *     the name. `createUser` does not run the validator, and two write paths
- *     reach it ungated — `parachute auth set-password --username` (auth.ts) and
- *     `PARACHUTE_INITIAL_ADMIN_USERNAME` (serve.ts) — so a hostile username CAN
- *     reach the DB. The ceremony must not trust that it didn't: an account
- *     whose username the validator rejects simply cannot run the ceremony
- *     (`username_unlinkable`). (The two username validators still diverge —
- *     `setup-wizard.ts` accepts a looser `[A-Za-z0-9_.-]` superset; reconciling
- *     them onto `validateUsername` touches a shipped-door setup path and
- *     `admin`-as-reserved / period / length compat, so it is filed as a
- *     follow-up rather than folded here. This refusal closes the exploit
- *     independent of that reconciliation.)
+ *     the name. `createUser` now runs the validator (hub#864), so new writes
+ *     cannot land a hostile username. Existing rows (and a seeded first-user
+ *     `admin`) are grandfathered and still cannot run the ceremony
+ *     (`username_unlinkable`) until renamed. The ceremony must not trust that
+ *     the row was gated: an account whose username the validator rejects
+ *     simply cannot run it.
  *
  * @throws if `validateUsername(username)` fails — callers on this surface guard
  * with the same check first and return `username_unlinkable`, so this throw is
@@ -174,9 +169,9 @@ export function linkageStatement(origin: string, username: string): string {
     );
   }
   // EIP-4361 / SIWE shape: one legible sentence, the bound account isolated on
-  // its own line, its value JSON-encoded. `validateUsername` has already pinned
-  // the charset to [a-z0-9_-], so the encoding can never actually need to
-  // escape anything — it is defense-in-depth for the ungated-write paths above.
+  // its own line, its value JSON-encoded. `validateUsername` (and createUser)
+  // pin the charset to [a-z0-9_-] for new writes; the encoding is still
+  // defense-in-depth for grandfathered rows that reached the DB before #864.
   return [
     `${origin} asks you to link a Nostr key to a Parachute account.`,
     "",

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -48,10 +48,12 @@ import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./adm
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import {
+  InvalidUsernameError,
   PASSWORD_MAX_LEN,
   type User,
   UsernameTakenError,
   createUser,
+  describeUsernameReason,
   deleteUser,
   getFirstAdminId,
   getUserById,
@@ -342,6 +344,9 @@ export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promis
     // INSERT and snagged the username. Surface as the same 409.
     if (err instanceof UsernameTakenError) {
       return jsonError(409, "username_taken", err.message);
+    }
+    if (err instanceof InvalidUsernameError) {
+      return jsonError(400, "invalid_username", describeUsernameReason(err.reason));
     }
     const msg = err instanceof Error ? err.message : String(err);
     return jsonError(500, "server_error", `failed to create user: ${msg}`);
@@ -832,13 +837,4 @@ export async function handleResetUserPassword(
   );
 }
 
-function describeUsernameReason(reason: "format" | "length" | "reserved"): string {
-  switch (reason) {
-    case "length":
-      return "username must be 2-32 characters long";
-    case "format":
-      return "username must contain only lowercase letters, digits, hyphens, and underscores ([a-z0-9_-])";
-    case "reserved":
-      return "username is reserved (admin, root, system, setup, parachute, hub)";
-  }
-}
+

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -836,5 +836,3 @@ export async function handleResetUserPassword(
     },
   );
 }
-
-

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -65,6 +65,7 @@ import {
   persistEnrollment,
 } from "../two-factor-store.ts";
 import {
+  InvalidUsernameError,
   SingleUserModeError,
   UsernameTakenError,
   createUser,
@@ -508,6 +509,10 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
         return 1;
       }
       if (err instanceof UsernameTakenError) {
+        console.error(err.message);
+        return 1;
+      }
+      if (err instanceof InvalidUsernameError) {
         console.error(err.message);
         return 1;
       }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -463,7 +463,7 @@ export async function seedInitialAdminIfNeeded(
   } catch (err) {
     if (err instanceof InvalidUsernameError) {
       log(
-        `parachute serve: PARACHUTE_INITIAL_ADMIN_USERNAME "${username}" is invalid (${err.reason}); ${describeUsernameReason(err.reason)}. First-boot seed may use "admin"; other reserved words, uppercase, periods, and names outside 2–32 chars are rejected.`,
+        `parachute serve: PARACHUTE_INITIAL_ADMIN_USERNAME ${JSON.stringify(username)} is invalid (${err.reason}); ${describeUsernameReason(err.reason)}. First-boot seed may use "admin"; other reserved words, uppercase, periods, and names outside 2–32 chars are rejected.`,
       );
     }
     throw err;
@@ -481,7 +481,7 @@ function logUnlinkableUsernamesWarning(
   if (bad.length === 0) return;
   log(
     `parachute serve: ${bad.length} existing username(s) cannot run the pubkey-linkage ceremony until renamed: ${bad
-      .map((b) => `"${b.username}" (${b.reason})`)
+      .map((b) => `${JSON.stringify(b.username)} (${b.reason})`)
       .join(", ")}`,
   );
 }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -49,7 +49,13 @@ import { getHubOrigin } from "../hub-settings.ts";
 import { writeHubFile } from "../hub.ts";
 import { enrichedPath } from "../spawn-path.ts";
 import { Supervisor } from "../supervisor.ts";
-import { createUser, userCount } from "../users.ts";
+import {
+  InvalidUsernameError,
+  createUser,
+  describeUsernameReason,
+  listUnlinkableUsernames,
+  userCount,
+} from "../users.ts";
 import { sanitizePublicOrigin } from "../vault-hub-origin-env.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { createWsBridgeHandlers } from "../ws-bridge.ts";
@@ -441,7 +447,10 @@ export async function seedInitialAdminIfNeeded(
   env: NodeJS.ProcessEnv,
   log: (line: string) => void = () => {},
 ): Promise<"seeded" | "exists" | "needs-setup"> {
-  if (userCount(db) > 0) return "exists";
+  if (userCount(db) > 0) {
+    logUnlinkableUsernamesWarning(db, log);
+    return "exists";
+  }
   const username = env.PARACHUTE_INITIAL_ADMIN_USERNAME?.trim();
   const password = env.PARACHUTE_INITIAL_ADMIN_PASSWORD;
   if (!username || !password) return "needs-setup";
@@ -449,9 +458,32 @@ export async function seedInitialAdminIfNeeded(
   // multi-user-Phase-1 force-change-password redirect by landing
   // `password_changed=true`. Same treatment as the wizard's first admin.
   // `assignedVault` stays null — admin posture (no per-vault restriction).
-  await createUser(db, username, password, { passwordChanged: true });
+  try {
+    await createUser(db, username, password, { passwordChanged: true });
+  } catch (err) {
+    if (err instanceof InvalidUsernameError) {
+      log(
+        `parachute serve: PARACHUTE_INITIAL_ADMIN_USERNAME "${username}" is invalid (${err.reason}); ${describeUsernameReason(err.reason)}. First-boot seed may use "admin"; other reserved words, uppercase, periods, and names outside 2–32 chars are rejected.`,
+      );
+    }
+    throw err;
+  }
   log(`parachute serve: seeded initial admin "${username}" from PARACHUTE_INITIAL_ADMIN_*`);
+  logUnlinkableUsernamesWarning(db, log);
   return "seeded";
+}
+
+function logUnlinkableUsernamesWarning(
+  db: ReturnType<typeof openHubDb>,
+  log: (line: string) => void,
+): void {
+  const bad = listUnlinkableUsernames(db);
+  if (bad.length === 0) return;
+  log(
+    `parachute serve: ${bad.length} existing username(s) cannot run the pubkey-linkage ceremony until renamed: ${bad
+      .map((b) => `"${b.username}" (${b.reason})`)
+      .join(", ")}`,
+  );
 }
 
 /**

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -86,7 +86,7 @@ import {
   findActiveSession,
 } from "./sessions.ts";
 import type { Supervisor } from "./supervisor.ts";
-import { createUser, userCount } from "./users.ts";
+import { createUser, isSeedAdminUsername, userCount, validateUsername } from "./users.ts";
 import { sanitizePublicOrigin } from "./vault-hub-origin-env.ts";
 import { DEFAULT_VAULT_NAME, validateVaultName } from "./vault-name.ts";
 
@@ -684,10 +684,10 @@ export function renderAccountStep(props: RenderAccountStepProps): string {
         <label class="field">
           <span class="field-label">Username</span>
           <input type="text" name="username" autocomplete="username"${usernameAutofocus}
-            required minlength="2" maxlength="64"
-            pattern="[A-Za-z0-9_.-]+" title="letters, digits, _ . - (2–64 chars)"
+            required minlength="2" maxlength="32"
+            pattern="[a-z0-9_-]+" title="lowercase letters, digits, hyphens, underscores (2–32 chars). First account may be named admin."
             ${usernameAttr} />
-          <span class="field-hint">letters, digits, <code>_</code>, <code>.</code>, <code>-</code></span>
+          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code>; 2–32 chars. First account may be <code>admin</code>.</span>
         </label>
         <label class="field">
           <span class="field-label">Password</span>
@@ -2771,11 +2771,19 @@ function validateAccountFields(input: {
   password: string;
   confirm: string;
 }): string | undefined {
-  if (input.username.length < 2 || input.username.length > 64) {
-    return "Username must be 2–64 characters.";
-  }
-  if (!/^[A-Za-z0-9_.-]+$/.test(input.username)) {
-    return "Username may use letters, digits, underscore, period, hyphen.";
+  // Same vocabulary as createUser (hub#864). The wizard is always the
+  // first-user path, so reserved `admin` is allowed; other reserved
+  // words, uppercase, periods, and names outside 2–32 are not.
+  const u = validateUsername(input.username);
+  if (!u.valid && !isSeedAdminUsername(input.username, 0)) {
+    switch (u.reason) {
+      case "length":
+        return "Username must be 2–32 characters.";
+      case "format":
+        return "Username may use lowercase letters, digits, underscore, hyphen.";
+      case "reserved":
+        return "Username is reserved (admin is allowed for this first account; root, system, setup, parachute, hub are not).";
+    }
   }
   if (input.password.length < 8) {
     return "Password must be at least 8 characters.";

--- a/src/users.ts
+++ b/src/users.ts
@@ -76,6 +76,15 @@ export class UsernameTakenError extends Error {
   }
 }
 
+export class InvalidUsernameError extends Error {
+  readonly reason: "format" | "length" | "reserved";
+  constructor(username: string, reason: "format" | "length" | "reserved") {
+    super(`username "${username}" is invalid (${reason})`);
+    this.name = "InvalidUsernameError";
+    this.reason = reason;
+  }
+}
+
 export class UserNotFoundError extends Error {
   constructor(ref: string) {
     super(`user "${ref}" not found`);
@@ -283,6 +292,14 @@ export async function createUser(
   const count = (db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM users").get() ?? { n: 0 })
     .n;
   if (count > 0 && !opts.allowMulti) throw new SingleUserModeError();
+
+  // Chokepoint (hub#864): every users.username write is gated here so the
+  // wizard / env-seed / `auth set-password` paths cannot land a name the
+  // linkage ceremony will refuse. Existing rows are not rewritten.
+  const check = validateUsername(username);
+  if (!check.valid && !isSeedAdminUsername(username, count)) {
+    throw new InvalidUsernameError(username, check.reason);
+  }
 
   const id = randomUUID();
   const passwordHash = await argonHash(password);
@@ -706,8 +723,8 @@ export function deleteUser(db: Database, userId: string): boolean {
 export const USERNAME_RESERVED = ["admin", "root", "system", "setup", "parachute", "hub"] as const;
 
 const USERNAME_REGEX = /^[a-z0-9_-]+$/;
-const USERNAME_MIN_LEN = 2;
-const USERNAME_MAX_LEN = 32;
+export const USERNAME_MIN_LEN = 2;
+export const USERNAME_MAX_LEN = 32;
 
 export type ValidateUsernameResult =
   | { valid: true; name: string }
@@ -734,6 +751,46 @@ export function validateUsername(name: string): ValidateUsernameResult {
     return { valid: false, reason: "reserved" };
   }
   return { valid: true, name };
+}
+
+/**
+ * First-user seed paths (`PARACHUTE_INITIAL_ADMIN_USERNAME`, the wizard's
+ * first admin, `parachute auth set-password` with no existing user) may
+ * use the reserved word `admin` — it IS the admin. Charset + length still
+ * apply via `validateUsername` (this helper only waives the reserved-word
+ * reason, and only for the exact lowercase spelling). Other reserved
+ * words, and `admin` on any subsequent create, stay rejected.
+ */
+export function isSeedAdminUsername(name: string, existingUserCount: number): boolean {
+  return existingUserCount === 0 && name === "admin";
+}
+
+export function describeUsernameReason(reason: "format" | "length" | "reserved"): string {
+  switch (reason) {
+    case "length":
+      return "username must be 2-32 characters long";
+    case "format":
+      return "username must contain only lowercase letters, digits, hyphens, and underscores ([a-z0-9_-])";
+    case "reserved":
+      return "username is reserved (admin, root, system, setup, parachute, hub)";
+  }
+}
+
+/**
+ * Existing rows whose username `validateUsername` rejects — including a
+ * seeded `admin`. They stay in the DB (grandfathered) but cannot run the
+ * pubkey-linkage ceremony until renamed. Callers (serve boot) surface
+ * this as an operator warning.
+ */
+export function listUnlinkableUsernames(
+  db: Database,
+): Array<{ username: string; reason: "format" | "length" | "reserved" }> {
+  const out: Array<{ username: string; reason: "format" | "length" | "reserved" }> = [];
+  for (const u of listUsers(db)) {
+    const r = validateUsername(u.username);
+    if (!r.valid) out.push({ username: u.username, reason: r.reason });
+  }
+  return out;
 }
 
 /**


### PR DESCRIPTION
Closes [hub#864](https://github.com/ParachuteComputer/parachute-hub/issues/864).

`createUser` is now the username chokepoint, so wizard / env-seed / `auth set-password` / `POST /api/users` cannot land a name the pubkey-linkage ceremony will refuse.

## Behavior

- Strict `validateUsername`: `[a-z0-9_-]`, 2–32, reserved words (`admin`, `root`, `system`, `setup`, `parachute`, `hub`).
- First-user seed exemption: exact lowercase `admin` is allowed (charset + length still apply). Later `admin` creates, and any other reserved word, are refused.
- Existing rows are not rewritten. `listUnlinkableUsernames` + serve boot log an operator warning; the ceremony still returns `username_unlinkable` until they rename.
- Wizard HTML `pattern`/copy and `validateAccountFields` use the same vocabulary.

## Verification at `6863bf00f89aa0d2e9fb3d3b0956a1527ae7da99`

Isolated `PARACHUTE_HOME` (not the live `~/.parachute`):

- `bun test ./src/__tests__/users.test.ts ./src/__tests__/serve.test.ts ./src/__tests__/api-users.test.ts ./src/__tests__/api-account-pubkeys.test.ts` → **213 pass / 0 fail**
- `bun test ./src/__tests__/setup-wizard.test.ts ./src/__tests__/setup-gate.test.ts ./src/__tests__/account-setup.test.ts ./src/__tests__/auth.test.ts` → **260 pass / 1 skip / 0 fail**
- `bun run typecheck` (`tsc --noEmit`) → **0**

Did **not** run `bun test ./src` on this live box. Workspace verify skill: the hub suite can bootout the real launchd hub if a lifecycle test is unstubbed. Targeted files above are the write paths this PR changes.

Not smoke-tested: a live wizard POST in a browser, a live `PARACHUTE_INITIAL_ADMIN_USERNAME=admin` boot against a throwaway home.

## Out of scope

No version bump (feature PR). No `next`→`main`. No wire/OAuth/module contract change.
