### PR TITLE
fix(hub#859): reject duplicate linkage binding tags

### DIFF
--- a/src/__tests__/api-account-pubkeys.test.ts
+++ b/src/__tests__/api-account-pubkeys.test.ts
@@ -614,6 +614,29 @@ describe("POST /verify — rejections", () => {
     );
   });
 
+  test("duplicate binding tags are refused even when the first value is valid", async () => {
+    const alice = await userWithSession("alice");
+    for (const duplicate of [
+      ["u", "https://evil.example/api/account/pubkeys/verify"],
+      ["method", "GET"],
+      ["challenge", "f".repeat(64)],
+    ]) {
+      const challenge = await getChallenge(alice.cookie);
+      const event = signEvent(SECRET_A, {
+        content: statement(alice.username),
+        tags: [...linkageTags(challenge), duplicate],
+      });
+      const res = await call("POST", "/verify", alice.cookie, {
+        __csrf: TEST_CSRF,
+        event,
+        password: PASSWORD,
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toBe("invalid_event");
+    }
+    expect(listUserPubkeys(db, alice.userId)).toHaveLength(0);
+  });
+
   test("a tampered id is refused", async () => {
     const alice = await userWithSession("alice");
     const challenge = await getChallenge(alice.cookie);

--- a/src/api-account-pubkeys.ts
+++ b/src/api-account-pubkeys.ts
@@ -35,15 +35,16 @@
  *     type- and length-checked before any hashing or curve math)
  *   - `kind === 27235`
  *   - `created_at` within ±5 minutes of the hub's clock
- *   - the `u` tag naming an origin this hub answers on AND the verify path
- *   - the `method` tag exactly `POST`
+ *   - exactly one `u` tag, naming an origin this hub answers on AND the verify path
+ *   - exactly one `method` tag, with the value `POST`
  *   - `content` exactly the linkage statement for THIS session's account and
  *     that origin
  *   - a recomputed NIP-01 id matching the claimed `id`
  *   - a BIP-340 Schnorr signature over that id verifying against the claimed
  *     x-only pubkey
- *   - a challenge that exists, belongs to THIS user, is unconsumed, and is
- *     unexpired — consumed atomically with the link write
+ *   - exactly one `challenge` tag, naming a challenge that exists, belongs to
+ *     THIS user, is unconsumed, and is unexpired — consumed atomically with
+ *     the link write
  *
  * Four independent defenses stack here. Against REPLAY: the server-issued
  * single-use challenge (primary), the `created_at` window, and the `u`/`method`
@@ -373,7 +374,7 @@ function requestOrigin(req: Request): string {
  *   1. label validation (pure string check — reject before anything else so a
  *      bad label can't burn a challenge)
  *   2. event shape + bounds (`parseNostrEvent`; no hashing yet)
- *   3. kind / created_at / `u` / `method` / challenge-tag presence — all pure
+ *   3. kind / created_at / exactly-one `u` / `method` / `challenge` tags — all pure
  *   4. the legible statement in `content` (see `linkageStatement`), recomputed
  *      from the SESSION's user and the `u` tag's already-validated origin
  *   5. rate limit (before any curve math)
@@ -555,6 +556,24 @@ async function handleVerify(
  */
 type BindingResult = { ok: true; origin: string } | { ok: false; res: Response };
 
+type BindingTagName = "u" | "method" | "challenge";
+
+/**
+ * Return the first security-critical binding tag that appears more than once.
+ * `tagValue` is intentionally first-wins for general Nostr use, but a stored
+ * linkage proof must have one unambiguous interpretation for every verifier.
+ */
+function duplicateBindingTag(event: NostrEvent): BindingTagName | null {
+  const seen = new Set<BindingTagName>();
+  for (const tag of event.tags) {
+    const name = tag[0];
+    if (name !== "u" && name !== "method" && name !== "challenge") continue;
+    if (seen.has(name)) return name;
+    seen.add(name);
+  }
+  return null;
+}
+
 function checkBinding(
   event: NostrEvent,
   req: Request,
@@ -565,6 +584,11 @@ function checkBinding(
     ok: false,
     res: jsonError(400, "invalid_event", why),
   });
+
+  const duplicate = duplicateBindingTag(event);
+  if (duplicate !== null) {
+    return generic(`event must carry exactly one \`${duplicate}\` tag`);
+  }
 
   if (event.kind !== NOSTR_AUTH_KIND) {
     return generic(`event kind must be ${NOSTR_AUTH_KIND}`);


### PR DESCRIPTION
## Summary

- reject linkage proof events that carry duplicate `u`, `method`, or `challenge` tags before selecting any binding value
- preserve the general Nostr first-wins tag helper; enforce exact-one semantics only on this stored-proof boundary
- cover valid-first/malicious-second duplicates for all three binding tags

Closes #859

## Verification

- watched the new regression fail on the old behavior: duplicate `u` event returned 200 instead of 400
- affected surface at `b4f696e32994abc159aa9e1c0ffdc305d3ce8bab`: 43 pass / 0 fail
- `bun run typecheck`: pass
- Biome on both changed files: pass
- `git diff --check origin/next...HEAD`: pass

Not run: `bun test ./src`. Workspace verification forbids the full hub suite on this live box until launchctl-touching tests are fully stubbed, because its hardcoded label can boot out the deployed hub. All tests used a fresh isolated `PARACHUTE_HOME`.
