### PR TITLE
fix(hub#840): sandbox PARACHUTE_HOME for the test suite

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ bun run typecheck                # tsc --noEmit
 
 **Test-count trap:** `bun test src` (no `./`) picks up *both* `src/` and `packages/scope-guard/src/` in one inflated, cross-interfering run. Use `bun test ./src`; cite hub-only counts by default, and pair with a separate scope-guard count only when scope-guard is load-bearing in the PR.
 
+- **Test state isolation is unconditional (hub#840).** `bunfig.toml` `[test] preload` replaces any inherited `PARACHUTE_HOME` with a fresh empty temp dir *before* `config.ts` computes `CONFIG_DIR` / `SERVICES_MANIFEST_PATH` (those are import-time constants). Do not weaken this to "only when unset": an inherited value commonly names the live install, and handler tests fall back to `SERVICES_MANIFEST_PATH`. `NODE_ENV=test` also refuses a live `~/.parachute` `CONFIG_DIR` if the cwd-sensitive preload is missed. This does **not** make `bun test ./src` safe on a live operator box: launchd-touching tests still ignore `PARACHUTE_HOME`.
+
 For end-to-end against a real install, `bun link` this repo — the linked `parachute` binary follows the checked-out branch.
 
 ## Naming

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,11 @@
+# Bun config. Test-only so far.
+
+[test]
+# Sandbox PARACHUTE_HOME before anything imports `config.ts`, whose CONFIG_DIR
+# / SERVICES_MANIFEST_PATH are computed at import time and can't be moved
+# afterwards. Without this the suite reads — and writes — the operator's live
+# `~/.parachute` (hub#840). See the preload file for the measurements.
+#
+# Here rather than in package.json's `test` script because CI and everyone's
+# muscle memory run `bun test ./src` directly, not `bun run test`.
+preload = ["./src/__tests__/preload-isolate-home.ts"]

--- a/src/__tests__/home-isolation.test.ts
+++ b/src/__tests__/home-isolation.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The suite must not be able to see, let alone touch, the operator's live
+ * `~/.parachute` (hub#840).
+ *
+ * This is a guard on the harness itself, not on a feature. It exists because
+ * the leak it covers is invisible in the place people look: CI runners have no
+ * `~/.parachute`, so the suite has always been green while quietly reading the
+ * live manifest 116 times per run on a developer box — and creating
+ * `operator.token` and `well-known/parachute.json` in it. #840 records a test
+ * run registering a dead `parachute-app` row at port 1942 into the real
+ * manifest, which is live supervisor state.
+ *
+ * The isolation is a `bunfig.toml` `[test] preload`; these assertions are what
+ * notices if that wiring is dropped, renamed, or defeated.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH, configDir } from "../config.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "../..");
+const realConfigDir = join(homedir(), ".parachute");
+
+describe("test-run home isolation (hub#840)", () => {
+  test("PARACHUTE_HOME is set, and points inside the temp dir", () => {
+    const home = process.env.PARACHUTE_HOME;
+    expect(home).toBeTruthy();
+    // `resolve` both sides: macOS hands out /var/folders/... paths that are a
+    // symlink to /private/var/folders/..., and tmpdir() picks one spelling.
+    expect(resolve(home as string).startsWith(resolve(tmpdir()))).toBe(true);
+  });
+
+  test("the sandbox is a REAL directory — a bad path would send writes anywhere", () => {
+    expect(existsSync(process.env.PARACHUTE_HOME as string)).toBe(true);
+  });
+
+  test("CONFIG_DIR resolved to the sandbox, not the operator's ~/.parachute", () => {
+    // The load-bearing one. CONFIG_DIR is frozen at import time, so this can
+    // only be true if the override landed BEFORE the first `config.ts` import
+    // — i.e. from a preload, not a beforeEach.
+    expect(CONFIG_DIR).toBe(process.env.PARACHUTE_HOME as string);
+    expect(resolve(CONFIG_DIR)).not.toBe(resolve(realConfigDir));
+  });
+
+  test("SERVICES_MANIFEST_PATH — the actual leak — is not the live manifest", () => {
+    // Every `deps.manifestPath ?? SERVICES_MANIFEST_PATH` fallback in the
+    // server resolves through this constant.
+    expect(SERVICES_MANIFEST_PATH).toBe(
+      join(process.env.PARACHUTE_HOME as string, "services.json"),
+    );
+    expect(resolve(SERVICES_MANIFEST_PATH)).not.toBe(resolve(join(realConfigDir, "services.json")));
+  });
+
+  test("inherited hub token is blanked", () => {
+    expect(process.env.PARACHUTE_HUB_TOKEN).toBe("");
+  });
+
+  test("the mechanism still works: configDir honours PARACHUTE_HOME", () => {
+    // Control. If this ever failed, the assertions above would be vacuous —
+    // they'd be describing a variable nothing reads.
+    expect(configDir({ PARACHUTE_HOME: "/tmp/some-other-root" })).toBe("/tmp/some-other-root");
+    expect(configDir({})).toBe(realConfigDir);
+  });
+
+  test("the preload overrides an inherited live-looking home in a child suite", async () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "hub-home-isolation-"));
+    try {
+      const inherited = join(sandbox, ".parachute");
+      const probe = join(sandbox, "probe.test.ts");
+      await Bun.write(
+        probe,
+        [
+          `import { test } from "bun:test";`,
+          `import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from ${JSON.stringify(resolve(REPO_ROOT, "src/config.ts"))};`,
+          `test("default config constants", () => {`,
+          `  console.log("CONFIG_DIR=" + CONFIG_DIR);`,
+          `  console.log("MANIFEST=" + SERVICES_MANIFEST_PATH);`,
+          `  console.log("HUB_TOKEN=" + process.env.PARACHUTE_HUB_TOKEN);`,
+          "});",
+        ].join("\n"),
+      );
+
+      const proc = Bun.spawn(["bun", "test", probe], {
+        cwd: REPO_ROOT,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          HOME: sandbox,
+          PARACHUTE_HOME: inherited,
+          PARACHUTE_HUB_TOKEN: "live-looking-token",
+        },
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      const output = stdout + stderr;
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain("CONFIG_DIR=");
+      expect(output).toContain("HUB_TOKEN=\n");
+      expect(output).not.toContain("HUB_TOKEN=live-looking-token");
+      expect(output).not.toContain(`CONFIG_DIR=${inherited}`);
+      expect(output).not.toContain(`MANIFEST=${join(inherited, "services.json")}`);
+      expect(existsSync(inherited)).toBe(false);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("a test process without the preload refuses the real fallback", async () => {
+    const probe = [
+      "delete process.env.PARACHUTE_HOME;",
+      'process.env.NODE_ENV = "test";',
+      `const { CONFIG_DIR } = await import(${JSON.stringify(resolve(REPO_ROOT, "src/config.ts"))});`,
+      "console.log(CONFIG_DIR);",
+    ].join("\n");
+    const proc = Bun.spawn(["bun", "-e", probe], {
+      cwd: tmpdir(),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, PARACHUTE_HOME: undefined, HOME: homedir(), NODE_ENV: "test" },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout + stderr).toContain("refusing to resolve test state inside the live install");
+  });
+});

--- a/src/__tests__/preload-isolate-home.ts
+++ b/src/__tests__/preload-isolate-home.ts
@@ -1,0 +1,70 @@
+/**
+ * Sandbox `PARACHUTE_HOME` for the whole test run. Wired as `[test] preload`
+ * in `bunfig.toml`, so it applies to `bun test` however it's invoked — not
+ * only through `bun run test`, which is not how CI runs the suite.
+ *
+ * ## Why a preload and not a `beforeEach`
+ *
+ * `config.ts` computes the config root ONCE, at import time:
+ *
+ *     export const CONFIG_DIR = configDir();
+ *     export const SERVICES_MANIFEST_PATH = join(CONFIG_DIR, "services.json");
+ *
+ * Every `deps.manifestPath ?? SERVICES_MANIFEST_PATH` fallback in the server
+ * (hub-server, api-users, api-vault-caps, account-api, admin-vaults, …) reads
+ * that frozen value. By the time a `beforeEach` runs, the constant is already
+ * bound to the operator's real `~/.parachute`. Only something that runs BEFORE
+ * the first import can move it — hence a preload.
+ *
+ * ## What was leaking (hub#840)
+ *
+ * The suite has plenty of per-test temp dirs; the leak is in the handler tests
+ * that build a hub server without threading `manifestPath` through `deps`.
+ * Measured on `next` by pointing `HOME` at a sentinel and running `bun test
+ * ./src`: **116 reads of the live `services.json`** — 84 from
+ * `oauth-handlers.test.ts`, 17 from `migrate.test.ts`, 13 from
+ * `hub-server.test.ts`, one each from `setup-gate.test.ts` and
+ * `admin-lock.test.ts`. Not read-only, either: the same run CREATED
+ * `operator.token` (mode 0600) and `well-known/parachute.json` inside the live
+ * config dir.
+ *
+ * On a CI runner that is harmless — there is no `~/.parachute` there, which is
+ * why this has never turned CI red. On an operator box it is live supervisor
+ * state, and #840 records a test run registering a dead `parachute-app` row at
+ * port 1942 into the real manifest.
+ *
+ * ## Why an EMPTY dir specifically
+ *
+ * The sandbox reproduces the CI shape: a config root with nothing in it. That
+ * matters — seeding it instead is what makes tests fail. The same sentinel run
+ * above went 38 red, and every one of those failures was a test reading the
+ * sentinel's contents (the `expose` plan tests read the manifest to build their
+ * plan). Under an empty root they pass, exactly as they do on CI. Isolation
+ * here means "no ambient state", not "different ambient state".
+ *
+ * Deliberately unconditional: an exported `PARACHUTE_HOME` pointing at the real
+ * config root is precisely the case this has to defend against, so honouring a
+ * pre-set value would hand the footgun back. An inherited bearer would bypass
+ * on-disk isolation the same way; blank it. Tests that need a token inject one
+ * explicitly.
+ *
+ * Bun test does not reliably dispatch process exit hooks, so do not promise
+ * cleanup that will not run. The OS reaps these small temp directories.
+ */
+
+import { mkdtempSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, sep } from "node:path";
+
+const realHome = join(homedir(), ".parachute");
+const sandbox = mkdtempSync(join(tmpdir(), "phub-test-home-"));
+
+if (sandbox === realHome || sandbox.startsWith(`${realHome}${sep}`)) {
+  throw new Error(
+    `[hub test preload] refusing to run: temporary test home ${sandbox} is inside ` +
+      `the live install at ${realHome}; check TMPDIR`,
+  );
+}
+
+process.env.PARACHUTE_HOME = sandbox;
+process.env.PARACHUTE_HUB_TOKEN = "";

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 /**
  * Root config directory. Honors `$PARACHUTE_HOME` to match the convention
@@ -14,3 +14,15 @@ export function configDir(env: NodeJS.ProcessEnv = process.env): string {
 
 export const CONFIG_DIR = configDir();
 export const SERVICES_MANIFEST_PATH = join(CONFIG_DIR, "services.json");
+
+// bunfig.toml's preload is cwd-sensitive. If a test process imports this
+// module without it, fail here instead of freezing CONFIG_DIR onto the live
+// install (hub#840). Production (`NODE_ENV` unset / not `test`) is unchanged.
+if (process.env.NODE_ENV === "test") {
+  const realHome = join(homedir(), ".parachute");
+  if (CONFIG_DIR === realHome || CONFIG_DIR.startsWith(`${realHome}${sep}`)) {
+    throw new Error(
+      `[parachute-hub] refusing to resolve test state inside the live install at ${realHome}; set PARACHUTE_HOME to a temporary directory (the bunfig.toml [test] preload does this automatically)`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- sandbox `PARACHUTE_HOME` for every `bun test` invocation via `bunfig.toml` `[test] preload` (not `bun run test` only)
- blank inherited `PARACHUTE_HUB_TOKEN`
- `NODE_ENV=test` tripwire refuses `CONFIG_DIR` resolving inside the live `~/.parachute` if the cwd-sensitive preload is missed
- regression tests cover inherited live-looking home+token in a child suite, and the no-preload fallback

Closes #840

Production path resolution is unchanged (`NODE_ENV` unset / not `test`). This does **not** make `bun test ./src` safe on a live operator box: launchd-touching tests still ignore `PARACHUTE_HOME`.

## Verification

- watched the new isolation tests fail on `origin/next` (`fe37a2b`) with only the test file overlaid: **1 pass / 7 fail**; `CONFIG_DIR` resolved to `/Users/uni/.parachute`
- isolation tests at this tree: **8 pass / 0 fail** (preload overrides an inherited live `PARACHUTE_HOME`)
- leak-source sentinel: `oauth-handlers.test.ts` **277 pass / 0 fail** with inherited `PARACHUTE_HOME=$HOME/.parachute`; live `~/.parachute/services.json` SHA unchanged (`c9afca0b5396ab298080e8e56f7db753e06b28a06d03ec02392ea8658fbc6098`)
- `bun run typecheck`: pass
- Biome on the changed TS files: pass

Not run: `bun test ./src`. Workspace verification forbids the full hub suite on this live box until launchctl-touching tests are fully stubbed.
