### PR TITLE
fix: retain attribution proofs after unlink

### DIFF
--- a/src/__tests__/api-attribution.test.ts
+++ b/src/__tests__/api-attribution.test.ts
@@ -22,9 +22,9 @@ import { handleApiTokens } from "../api-tokens.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
 import { type NostrEvent, nostrEventId, verifyNostrEvent } from "../nostr-event.ts";
-import { issuePubkeyChallenge, linkPubkey } from "../pubkey-links.ts";
+import { issuePubkeyChallenge, linkPubkey, unlinkPubkey } from "../pubkey-links.ts";
 import { getActiveSigningKey } from "../signing-keys.ts";
-import { createUser } from "../users.ts";
+import { createUser, deleteUser } from "../users.ts";
 
 const ISSUER = "https://hub.example";
 
@@ -192,6 +192,52 @@ describe("resolution", () => {
     const dump = JSON.stringify(await res.json());
     expect(dump).not.toContain(PUBKEY);
     expect(dump).not.toContain(alice);
+  });
+
+  test("keeps a registry-attributed proof resolvable after unlink", async () => {
+    const userId = await linkedUser("alice");
+    recordTokenMint(db, {
+      jti: "jti-unlinked-proof",
+      createdVia: "cli_mint",
+      subject: userId,
+      userId,
+      clientId: "parachute-hub",
+      scopes: ["vault:work:read"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(unlinkPubkey(db, userId, PUBKEY)).toBe(true);
+
+    const res = await get(
+      `/api/auth/attribution?subject=${userId}`,
+      await bearer(["parachute:host:auth"]),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pubkeys: { proof_event: NostrEvent }[] };
+    expect(body.pubkeys).toHaveLength(1);
+    expect(verifyNostrEvent(body.pubkeys[0]!.proof_event)).toEqual({ ok: true });
+  });
+
+  test("keeps a registry-attributed proof resolvable after account deletion", async () => {
+    const userId = await linkedUser("alice");
+    recordTokenMint(db, {
+      jti: "jti-deleted-user-proof",
+      createdVia: "cli_mint",
+      subject: userId,
+      userId,
+      clientId: "parachute-hub",
+      scopes: ["vault:work:read"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(deleteUser(db, userId)).toBe(true);
+
+    const res = await get(
+      `/api/auth/attribution?subject=${userId}`,
+      await bearer(["parachute:host:auth"]),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pubkeys: { proof_event: NostrEvent }[] };
+    expect(body.pubkeys).toHaveLength(1);
+    expect(verifyNostrEvent(body.pubkeys[0]!.proof_event)).toEqual({ ok: true });
   });
 });
 

--- a/src/__tests__/pubkey-links.test.ts
+++ b/src/__tests__/pubkey-links.test.ts
@@ -3,8 +3,8 @@
  * attribution snapshot on `tokens` rows (phase 1b).
  *
  * Coverage:
- *   - migration v17 lands `user_pubkeys`, `pubkey_challenges`, and the
- *     additive `tokens.subject_pubkey` column
+ *   - migrations v17/v18 land live linkage, registry attribution, and the
+ *     durable proof archive
  *   - challenges: issued hashed (raw value is NOT recoverable from the DB),
  *     single-use, TTL-bounded, user-bound
  *   - link: happy path; replay of a consumed challenge; expired challenge;
@@ -20,11 +20,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { hubDbPath, migrate, openHubDb } from "../hub-db.ts";
 import { findTokenRowByJti, recordTokenMint, signRefreshToken } from "../jwt-sign.ts";
 import {
   MAX_PUBKEYS_PER_USER,
   PUBKEY_CHALLENGE_TTL_MS,
+  attributionProofsForSubject,
   attributionPubkey,
   issuePubkeyChallenge,
   linkPubkey,
@@ -70,14 +71,15 @@ async function user(name: string): Promise<string> {
   return u.id;
 }
 
-describe("migration v17", () => {
-  test("creates the linkage tables and the additive tokens column", () => {
+describe("migrations v17/v18", () => {
+  test("creates the linkage and proof tables plus the additive tokens column", () => {
     const tables = db
       .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type = 'table'")
       .all()
       .map((r) => r.name);
     expect(tables).toContain("user_pubkeys");
     expect(tables).toContain("pubkey_challenges");
+    expect(tables).toContain("attribution_proofs");
 
     const cols = db.query<{ name: string; notnull: number }, []>("PRAGMA table_info(tokens)").all();
     const subjectPubkey = cols.find((c) => c.name === "subject_pubkey");
@@ -110,6 +112,39 @@ describe("migration v17", () => {
         now,
       }),
     ).toEqual({ ok: false, reason: "pubkey_taken" });
+  });
+
+  test("v18 backfills proofs from links that existed at migration time", async () => {
+    const alice = await user("alice");
+    const now = new Date(1_700_000_000_000);
+    const { challenge } = issuePubkeyChallenge(db, alice, now);
+    const signedProof = proof(PK_A, challenge);
+    expect(
+      linkPubkey(db, {
+        userId: alice,
+        pubkey: PK_A,
+        challenge,
+        proofEvent: signedProof,
+        proofEventId: "proof-before-v18",
+        now,
+      }).ok,
+    ).toBe(true);
+
+    // Recreate the exact pre-v18 schema state while retaining its live link.
+    db.exec("DROP TABLE attribution_proofs; DELETE FROM schema_version WHERE version = 18");
+    migrate(db);
+
+    expect(attributionProofsForSubject(db, alice)).toEqual([
+      {
+        pubkey: PK_A,
+        userId: alice,
+        label: null,
+        proofEvent: signedProof,
+        proofEventId: "proof-before-v18",
+        linkedAt: now.toISOString(),
+        lastVerifiedAt: now.toISOString(),
+      },
+    ]);
   });
 });
 
@@ -154,6 +189,45 @@ describe("linkPubkey", () => {
     expect(res.link.label).toBe("laptop");
     expect(res.link.linkedAt).toBe(now.toISOString());
     expect(proofEventFor(db, PK_A)).toBe(proof(PK_A, challenge));
+    expect(attributionProofsForSubject(db, alice)).toEqual([
+      expect.objectContaining({
+        pubkey: PK_A,
+        userId: alice,
+        proofEvent: proof(PK_A, challenge),
+      }),
+    ]);
+  });
+
+  test("keeps each subject's proof when an unlinked key is linked to someone else", async () => {
+    const alice = await user("alice");
+    const bob = await user("bob");
+    const first = issuePubkeyChallenge(db, alice, new Date(1_700_000_000_000));
+    expect(
+      linkPubkey(db, {
+        userId: alice,
+        pubkey: PK_A,
+        challenge: first.challenge,
+        proofEvent: proof(PK_A, first.challenge),
+        now: new Date(1_700_000_000_000),
+      }).ok,
+    ).toBe(true);
+    expect(unlinkPubkey(db, alice, PK_A)).toBe(true);
+
+    const second = issuePubkeyChallenge(db, bob, new Date(1_700_000_001_000));
+    expect(
+      linkPubkey(db, {
+        userId: bob,
+        pubkey: PK_A,
+        challenge: second.challenge,
+        proofEvent: proof(PK_A, second.challenge),
+        now: new Date(1_700_000_001_000),
+      }).ok,
+    ).toBe(true);
+
+    expect(attributionProofsForSubject(db, alice)[0]?.proofEvent).toBe(
+      proof(PK_A, first.challenge),
+    );
+    expect(attributionProofsForSubject(db, bob)[0]?.proofEvent).toBe(proof(PK_A, second.challenge));
   });
 
   test("a challenge is single-use — replay is refused", async () => {

--- a/src/api-account-pubkeys.ts
+++ b/src/api-account-pubkeys.ts
@@ -17,7 +17,8 @@
  *   GET  ""           → the caller's own linked keys
  *   POST "/challenge" → mint a single-use challenge + the event template
  *   POST "/verify"    → present a signed NIP-01 event; link on success
- *   POST "/unlink"    → drop one of the caller's own links
+ *   POST "/unlink"    → drop one of the caller's own live links; retain its
+ *                        proof for historical registry attribution
  *
  * ## The ceremony
  *
@@ -64,7 +65,7 @@
  *
  * Nothing. No scope, no claim, no authentication path. A linked key is an
  * attribution label; `sub` remains the only principal the hub authorizes on.
- * See `pubkey-links.ts` and migration v17.
+ * See `pubkey-links.ts` and migrations v17/v18.
  */
 import type { Database } from "bun:sqlite";
 import {

--- a/src/api-attribution.ts
+++ b/src/api-attribution.ts
@@ -13,9 +13,10 @@
  * and that no third party can check.
  *
  * Phase 1b does NOT change that column. It adds a resolution step a reader can
- * take at display time: `sub` → linked pubkey(s) → a portable, checkable
- * identity. The stored value stays opaque and stable; the identity becomes
- * verifiable. This endpoint is the hub's half of that step.
+ * take at display time: `sub` → historically proved pubkey(s) → a portable,
+ * checkable identity. The stored value stays opaque and stable; the identity
+ * remains verifiable even if the live account link is later removed. This
+ * endpoint is the hub's half of that step.
  *
  * ## What "verifiable" means here, precisely
  *
@@ -33,8 +34,9 @@
  * ## Auth + disclosure posture
  *
  * Bearer-gated on `parachute:host:auth`, matching the rest of `/api/auth/*`
- * (`mint-token`, `revoke-token`, `tokens`). This is a **directory of who holds
- * which key**, so it is operator-level on purpose.
+ * (`mint-token`, `revoke-token`, `tokens`). This is a **directory of who has
+ * proved possession of which key**, including historical proofs rather than a
+ * claim about who holds the key now, so it is operator-level on purpose.
  *
  * That is also an acknowledged SEAM, not an oversight: the natural consumer of
  * phase-1b resolution is a resource server (the vault, rendering `created_by`),
@@ -43,12 +45,12 @@
  * — squarely an ACL question (design doc seam S1/S1b, Jon's), so phase 1 leaves
  * it at the operator level rather than guessing.
  *
- * An unknown subject and a subject with no linked key return the SAME body
- * shape with an empty list. There is no user-existence oracle here.
+ * An unknown subject and a subject that never proved a key return the SAME
+ * body shape with an empty list. There is no user-existence oracle here.
  */
 import type { Database } from "bun:sqlite";
 import { validateAccessToken } from "./jwt-sign.ts";
-import { listUserPubkeys, proofEventFor } from "./pubkey-links.ts";
+import { attributionProofsForSubject } from "./pubkey-links.ts";
 
 /** Scope required on the bearer. Same gate as `GET /api/auth/tokens`. */
 export const API_ATTRIBUTION_REQUIRED_SCOPE = "parachute:host:auth";
@@ -133,9 +135,12 @@ export async function handleApiAttribution(
     );
   }
 
-  // 5. Resolve. An unknown subject simply has no rows — same body as a known
-  //    subject with no linked key.
-  const pubkeys = listUserPubkeys(deps.db, subject).map((link) => ({
+  // 5. Resolve from the durable proof archive. An unknown subject simply
+  //    has no rows — same body as a subject that never established a proof.
+  //    Deliberately include historical proofs whose live account link was
+  //    removed: downstream attribution snapshots must stay independently
+  //    verifiable after unlink or account deletion.
+  const pubkeys = attributionProofsForSubject(deps.db, subject).map((link) => ({
     pubkey: link.pubkey,
     label: link.label,
     linked_at: link.linkedAt,
@@ -145,7 +150,7 @@ export async function handleApiAttribution(
     // native shape it would sign. Malformed JSON (impossible via the ceremony —
     // we store `JSON.stringify` of a parsed event — but defense in depth)
     // surfaces as null rather than crashing the response.
-    proof_event: parseProof(proofEventFor(deps.db, link.pubkey)),
+    proof_event: parseProof(link.proofEvent),
   }));
 
   return new Response(JSON.stringify({ subject, pubkeys }), {

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -9,7 +9,7 @@
  * multi-use public-signup links + email-as-username + the `vault_caps`
  * per-vault storage-cap table), and Nostr-pubkey ↔ user linkage plus the
  * additive `tokens.subject_pubkey` attribution snapshot (v17, hub#833
- * phase 1).
+ * phase 1), and the durable attribution proof archive (v18, hub#860).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -660,6 +660,37 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE tokens ADD COLUMN subject_pubkey TEXT;
       CREATE INDEX tokens_subject_pubkey ON tokens (subject_pubkey)
         WHERE subject_pubkey IS NOT NULL;
+    `,
+  },
+  {
+    version: 18,
+    sql: `
+      -- Preserve the signed possession proof independently of the LIVE
+      -- user_pubkeys link (hub#860). Unlinking a key or deleting its user must
+      -- not make an already-written tokens.subject_pubkey snapshot impossible
+      -- to verify later. No FK to users/user_pubkeys on purpose: this is an
+      -- durable audit store, keyed by the stable subject string that JWTs
+      -- and downstream attribution rows already carry plus the pubkey.
+      CREATE TABLE attribution_proofs (
+        subject TEXT NOT NULL,
+        pubkey TEXT NOT NULL,
+        label TEXT,
+        proof_event TEXT NOT NULL,
+        proof_event_id TEXT NOT NULL,
+        linked_at TEXT NOT NULL,
+        last_verified_at TEXT NOT NULL,
+        PRIMARY KEY (subject, pubkey)
+      );
+      CREATE INDEX attribution_proofs_pubkey ON attribution_proofs (pubkey);
+
+      -- Every proof that is still live at migration time is already verified;
+      -- preserve it before any later unlink/account-delete can cascade the
+      -- source row away. Historical proofs deleted before v18 cannot be
+      -- reconstructed and are intentionally not fabricated.
+      INSERT INTO attribution_proofs
+        (subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at)
+      SELECT user_id, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at
+      FROM user_pubkeys;
     `,
   },
 ];

--- a/src/pubkey-links.ts
+++ b/src/pubkey-links.ts
@@ -13,6 +13,10 @@
  * A hub user may hold **zero or more** linked keys; a key names **at most one**
  * user hub-wide (`user_pubkeys.pubkey` is the PRIMARY KEY — see migration v17
  * for why that is a security property rather than a convenience).
+ * Successful ceremonies are also copied into `attribution_proofs`, keyed by
+ * `(subject, pubkey)` without a user foreign key. That durable audit row is
+ * intentionally not deleted with the live link or account: registry snapshots
+ * naming the subject and key must remain independently verifiable.
  *
  * No new principal entity is introduced. `users.id` is already what every
  * minted token's `sub` claim carries, so linkage hangs off the row that
@@ -67,10 +71,26 @@ export interface LinkedPubkey {
   lastVerifiedAt: string;
 }
 
+/** A subject→pubkey possession proof retained independently of the live link. */
+export interface AttributionProof extends LinkedPubkey {
+  /** Verbatim signed NIP-01 event; callers can re-verify it independently. */
+  proofEvent: string;
+}
+
 interface LinkRow {
   pubkey: string;
   user_id: string;
   label: string | null;
+  proof_event_id: string;
+  linked_at: string;
+  last_verified_at: string;
+}
+
+interface AttributionProofRow {
+  subject: string;
+  pubkey: string;
+  label: string | null;
+  proof_event: string;
   proof_event_id: string;
   linked_at: string;
   last_verified_at: string;
@@ -85,6 +105,50 @@ function rowToLink(r: LinkRow): LinkedPubkey {
     linkedAt: r.linked_at,
     lastVerifiedAt: r.last_verified_at,
   };
+}
+
+function rowToAttributionProof(r: AttributionProofRow): AttributionProof {
+  return {
+    pubkey: r.pubkey,
+    userId: r.subject,
+    label: r.label,
+    proofEvent: r.proof_event,
+    proofEventId: r.proof_event_id,
+    linkedAt: r.linked_at,
+    lastVerifiedAt: r.last_verified_at,
+  };
+}
+
+function retainAttributionProof(
+  db: Database,
+  proof: {
+    subject: string;
+    pubkey: string;
+    label: string | null;
+    proofEvent: string;
+    proofEventId: string;
+    linkedAt: string;
+    lastVerifiedAt: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO attribution_proofs
+       (subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(subject, pubkey) DO UPDATE SET
+       label = excluded.label,
+       proof_event = excluded.proof_event,
+       proof_event_id = excluded.proof_event_id,
+       last_verified_at = excluded.last_verified_at`,
+  ).run(
+    proof.subject,
+    proof.pubkey,
+    proof.label,
+    proof.proofEvent,
+    proof.proofEventId,
+    proof.linkedAt,
+    proof.lastVerifiedAt,
+  );
 }
 
 /**
@@ -216,6 +280,15 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
            (pubkey, user_id, label, proof_event, proof_event_id, linked_at, last_verified_at)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
       ).run(opts.pubkey, opts.userId, label, opts.proofEvent, proofEventId, stamp, stamp);
+      retainAttributionProof(db, {
+        subject: opts.userId,
+        pubkey: opts.pubkey,
+        label,
+        proofEvent: opts.proofEvent,
+        proofEventId,
+        linkedAt: stamp,
+        lastVerifiedAt: stamp,
+      });
       return {
         ok: true,
         relinked: false,
@@ -235,6 +308,15 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
          SET label = ?, proof_event = ?, proof_event_id = ?, last_verified_at = ?
        WHERE pubkey = ? AND user_id = ?`,
     ).run(label, opts.proofEvent, proofEventId, stamp, opts.pubkey, opts.userId);
+    retainAttributionProof(db, {
+      subject: opts.userId,
+      pubkey: opts.pubkey,
+      label,
+      proofEvent: opts.proofEvent,
+      proofEventId,
+      linkedAt: existing.linked_at,
+      lastVerifiedAt: stamp,
+    });
     return {
       ok: true,
       relinked: true,
@@ -283,6 +365,23 @@ export function proofEventFor(db: Database, pubkey: string): string | null {
   return row?.proof_event ?? null;
 }
 
+/**
+ * Every possession proof a subject has established, including proofs whose
+ * live link was later removed. This durable archive is the audit counterpart
+ * to `listUserPubkeys`, which answers only what the account holds now.
+ */
+export function attributionProofsForSubject(db: Database, subject: string): AttributionProof[] {
+  return db
+    .query<AttributionProofRow, [string]>(
+      `SELECT subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at
+       FROM attribution_proofs
+       WHERE subject = ?
+       ORDER BY linked_at ASC, pubkey ASC`,
+    )
+    .all(subject)
+    .map(rowToAttributionProof);
+}
+
 /** Phase-1b resolution: a subject's linked keys, in deterministic order. */
 export function pubkeysForUser(db: Database, userId: string): string[] {
   return listUserPubkeys(db, userId).map((l) => l.pubkey);
@@ -303,7 +402,10 @@ export function primaryPubkeyForUser(db: Database, userId: string): string | nul
   return row?.pubkey ?? null;
 }
 
-/** Remove a link. Self-only: the `user_id` predicate is not optional. */
+/**
+ * Remove a LIVE link. Self-only: the `user_id` predicate is not optional.
+ * The independently stored attribution proof is deliberately retained.
+ */
 export function unlinkPubkey(db: Database, userId: string, pubkey: string): boolean {
   const res = db
     .prepare("DELETE FROM user_pubkeys WHERE pubkey = ? AND user_id = ?")

--- a/src/users.ts
+++ b/src/users.ts
@@ -658,6 +658,9 @@ export async function resetUserPassword(
  *   - `user_vaults.user_id` has `ON DELETE CASCADE` (migration v10), so
  *     vault assignments are dropped automatically when the parent row
  *     goes. No explicit cleanup needed.
+ *   - `attribution_proofs` deliberately has no user FK (migration v18), so a
+ *     deleted subject's signed key-possession proof remains available for
+ *     historical registry rows whose `subject` and `subject_pubkey` survive.
  *
  * Returns false when no user matches the id (idempotent — the API
  * layer translates that to 404). Returns true on a successful delete.
@@ -692,7 +695,7 @@ export function deleteUser(db: Database, userId: string): boolean {
     db.prepare("DELETE FROM sessions WHERE user_id = ?").run(userId);
     db.prepare("DELETE FROM grants WHERE user_id = ?").run(userId);
     db.prepare("DELETE FROM auth_codes WHERE user_id = ?").run(userId);
-    // 3. Drop the user row itself.
+    // 3. Drop the user row itself. The no-FK attribution proof archive remains.
     db.prepare("DELETE FROM users WHERE id = ?").run(userId);
   })();
   return true;


### PR DESCRIPTION
## Summary

- add a durable `(subject, pubkey)` proof archive, backfilled from all live v17 links
- retain/update the archive atomically with successful linkage ceremonies
- resolve `/api/auth/attribution` from the archive so unlink and account deletion cannot erase historical verification
- keep live account-link APIs unchanged; document historical-possession semantics

## Verification

- watched the new unlink/account-delete regressions fail on the base before implementation
- isolated affected suites: 148 pass / 0 fail
- includes v17→v18 backfill and cross-subject relink coverage
- `tsc --noEmit`
- Biome on all changed files
- `git diff --check origin/next...HEAD`

Closes #860
