### PR TITLE
chore(ci): pin Bun 1.4 as the floor

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install bun (host — needed for HUB_SOURCE=local pack)
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4
 
       - name: Run Tier-1 E2E
         env:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,10 +2,12 @@ name: e2e
 
 # Tier-1 end-to-end harness: systemd-in-container fresh-install flow.
 #
-# Runs the REAL operator install path (curl bun.sh/install → bun add -g
-# @openparachute/hub → parachute init → wizard → MCP OAuth dance) against a
-# privileged Ubuntu+systemd container, replaying recent field-failure
-# scenarios as staged assertions. See e2e/README.md.
+# Runs the REAL operator install path (curl bun.sh/install bun-v1.4.0 →
+# bun add -g @openparachute/hub → parachute init → wizard → MCP OAuth dance)
+# against a privileged Ubuntu+systemd container, replaying recent
+# field-failure scenarios as staged assertions. See e2e/README.md.
+# The container's bun install is pinned to 1.4.0 in e2e/stages.sh — not
+# unversioned curl|bash — so a later bun.sh latest cannot drift the harness.
 #
 # Triggers:
 #   workflow_dispatch  — manual, with a hub_source input (default npm:rc).

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - name: install deps
         run: bun install --frozen-lockfile
       - name: build depcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           fetch-tags: true
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - id: hub
         run: bun scripts/release-plan.ts . @openparachute/hub ${{ github.ref_type == 'tag' && '--tag-push' || '' }}
       - id: scope_guard
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - name: install deps
         run: bun install --frozen-lockfile
       - name: build depcheck
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
@@ -260,7 +260,7 @@ jobs:
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -317,7 +317,7 @@ jobs:
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -375,7 +375,7 @@ jobs:
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -504,7 +504,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - name: tag published packages
         continue-on-error: true
         run: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@
 #                                       `--channel rc|latest` and `--tag`
 #                                       still override.
 
-ARG BUN_VERSION=1.3
+ARG BUN_VERSION=1.4
 FROM oven/bun:${BUN_VERSION}-alpine AS builder
 
 WORKDIR /app

--- a/e2e/Dockerfile.systemd
+++ b/e2e/Dockerfile.systemd
@@ -7,8 +7,8 @@
 # postinstall scripts assume it present on Linux).
 #
 # We DO NOT pre-install bun or @openparachute/hub — installing those is the
-# test (Stage 1 of e2e/stages.sh runs the real `curl bun.sh/install` +
-# `bun add -g @openparachute/hub` an operator runs). Baking them in would
+# test (Stage 1 of e2e/stages.sh runs `curl bun.sh/install` pinned to
+# bun-v1.4.0 + `bun add -g @openparachute/hub`). Baking them in would
 # defeat the whole point of the harness.
 #
 # systemd-as-PID-1 is the load-bearing choice: `parachute init` installs and

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,7 +2,7 @@
 
 This directory holds the **Tier 1** end-to-end harness for the hub: a
 systemd-in-container test that runs the **real fresh-Linux install flow** an
-operator runs on a VPS — `curl bun.sh/install` → `bun add -g
+operator runs on a VPS — `curl bun.sh/install` pinned to bun-v1.4.0 → `bun add -g
 @openparachute/hub` → `parachute init` → setup wizard → MCP — and replays the
 field-failure scenarios from recent weeks as staged assertions.
 

--- a/e2e/stages.sh
+++ b/e2e/stages.sh
@@ -87,16 +87,25 @@ wait_for() {
 hr "STAGE 1 — fresh install happy path"
 
 # --- install bun ---
-note "Installing bun (curl bun.sh/install)…"
+# Floor is 1.4 — same pin as oven-sh/setup-bun in e2e.yml and ARG
+# BUN_VERSION in the hub Dockerfile. An operator still runs unversioned
+# `curl | bash`; this harness must not, or a later bun.sh latest silently
+# changes the operator-install assertions.
+BUN_PIN="${BUN_PIN:-1.4.0}"
+note "Installing bun ${BUN_PIN} (curl bun.sh/install bun-v${BUN_PIN})…"
 export BUN_INSTALL=/root/.bun
 export PATH="$BUN_INSTALL/bin:$PATH"
-if ! curl -fsSL https://bun.sh/install | bash >/tmp/bun-install.log 2>&1; then
+if ! curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_PIN}" >/tmp/bun-install.log 2>&1; then
   cat /tmp/bun-install.log >&2
   die "stage1-install-bun" "bun install script failed"
 fi
 hash -r
 command -v bun >/dev/null 2>&1 || die "stage1-install-bun" "bun not on PATH after install"
-note "bun $(bun --version) installed"
+INSTALLED="$(bun --version)"
+note "bun ${INSTALLED} installed"
+if [ "$INSTALLED" != "$BUN_PIN" ]; then
+  die "stage1-install-bun" "expected bun ${BUN_PIN} (1.4 floor), got ${INSTALLED}"
+fi
 
 # --- install @openparachute/hub ---
 # Regression pin hub#568: a "Blocked N postinstall" line means bun refused to

--- a/src/__tests__/ws-bridge.test.ts
+++ b/src/__tests__/ws-bridge.test.ts
@@ -198,15 +198,14 @@ describe("WS bridge integration — declaring module, real sockets (H1)", () => 
       client.send(new Uint8Array([1, 2, 3, 250]));
       expect([...(await gotBinary.promise)]).toEqual([1, 2, 3, 250]);
 
-      // Client-initiated close propagates the CODE to the upstream. The
-      // reason string is not propagated in this direction: Bun's server-side
-      // websocket close callback delivers an empty reason (verified on Bun
-      // 1.3.13), so the bridge never receives it. Upstream→client reason
-      // propagation works (next test).
+      // Client-initiated close propagates code + reason to the upstream.
+      // Bun 1.3.13 delivered an empty reason on the server-side close
+      // callback (so the bridge could not forward it). Bun 1.4 forwards
+      // the reason. Upstream→client still has its own test below.
       client.close(4002, "client done");
       const upstreamClose = await upstream.closed;
       expect(upstreamClose.code).toBe(4002);
-      expect(upstreamClose.reason).toBe("");
+      expect(upstreamClose.reason).toBe("client done");
     } finally {
       hub?.stop();
       upstream.stop();

--- a/src/ws-bridge.ts
+++ b/src/ws-bridge.ts
@@ -242,11 +242,11 @@ export function createWsBridgeHandlers(opts: WsBridgeOptions = {}): WebSocketHan
       // one teardown funnel every accepted socket passes through. The
       // closure latches, so re-entry is harmless.
       ws.data.releaseCap?.();
-      // Client → upstream close propagation. Note: Bun's server-side close
-      // callback delivers the client's close CODE but an empty `reason`
-      // (verified on Bun 1.3.13), so only the code propagates upstream in
-      // this direction. Upstream → client propagation (the close listener in
-      // open()) carries both.
+      // Client → upstream close propagation. Bun 1.3.13 delivered the
+      // close CODE but an empty `reason` on this callback; Bun 1.4
+      // forwards the reason. The bridge already passes both through.
+      // Upstream → client (the close listener in open()) has always
+      // carried both.
       const state = ws.data._bridge;
       if (!state || state.closed) return;
       state.closed = true;


### PR DESCRIPTION
## Why

Floor hub CI and Docker at Bun **1.4**. Aaron: 1.4 is the default going forward after the Rust migration. No 1.3 dual-support — the cost is the lockfile plus the CI matrix.

## What

- `.github/workflows/pr-verify.yml` + `release.yml`: `bun-version: 1.3` → `1.4`
- `.github/workflows/e2e.yml`: `bun-version: latest` → `1.4` (a tag-triggered e2e must not silently ride whatever is newest)
- `Dockerfile`: `ARG BUN_VERSION=1.3` → `1.4` (`oven/bun:1.4-alpine`)
- Lockfile **not** rewritten (`lockfileVersion` 1). Bun 1.4 still reads v1; a v2 write cannot be read by 1.3.
- Follow-up: WS-bridge test expected Bun 1.3.13 to drop the client→upstream close *reason* (empty string). 1.4 forwards `"client done"`. Bridge already passed both through; production close path unchanged. Comment in `src/ws-bridge.ts` updated to match.

## Verified at this SHA (`6523fc27c69f89c542486563e52be11a9cfaeb3b`)

Homebrew bun **1.4.0** (`34cbb9a40`) after the box bounce (was sidecar at the first commit):

- Pin commit `857b6df`: `bun install --frozen-lockfile` lockfile sha256 unchanged; `bun run typecheck` 0
- Follow-up: `bun test src/__tests__/ws-bridge.test.ts` **16 pass / 0 fail**; `tsc --noEmit` 0
- Did **not** run `bun test ./src` (hardcoded launchd label on this live box)
- First CI run on `857b6df`: **4630 pass / 3 skip / 1 fail** — that one fail is the close-reason assertion this follow-up updates

Auth/wire specialists do not trigger (CI pin + test-expectation). `release-check.sh` will still false-fail vs `origin/main` for a missing version bump; this targets `next`; not a finding.