### PR TITLE
release: hub 0.7.17-rc.1 — username chokepoint, attribution proofs, rc-before-stable gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.17-rc.1] - 2026-08-24
+
+**Username chokepoint, attribution that survives unlink, and an rc-before-stable
+publish gate.** Six PRs over 0.7.16 plus this hook. Soaks on `@rc`; stable later
+is a suffix-drop only.
+
+- **Every username write hits one validator (#865, closes hub#864).** Create
+  and rename both go through `[a-z0-9_-]` 2–32 and the reserved-word list
+  (`admin|root|system|setup|parachute|hub`). First-boot seed may still be
+  exactly `admin`; later `admin` creates are refused.
+
+- **Duplicate linkage binding tags are refused without naming the other
+  holder (#866, closes hub#859).** A ceremony that repeats a binding tag is
+  rejected; the 4xx does not leak who already holds the key.
+
+- **Attribution proofs survive unlink (#868, closes hub#860).**
+  `GET /api/auth/attribution` reads `attribution_proofs` (migration v18), not
+  the live `user_pubkeys` table. Unlink / account-delete cannot erase a proof
+  that already existed. A linked key still grants nothing (no login, no
+  scope) — it is an attribution label. **No account-page UI** — the ceremony
+  is API-only (`/api/account/pubkeys`).
+
+- **Test-suite `PARACHUTE_HOME` sandbox (#867, closes hub#840).** bunfig.toml
+  `[test]` preload replaces any inherited home with a fresh temp dir before
+  config.ts freezes paths. Does **not** make `bun test ./src` safe on a live
+  operator box (launchd-touching tests still ignore `PARACHUTE_HOME`).
+
+- **Unpublished-drift advisory actually runs (#857, closes hub#830).** The
+  `plan` job now fetches full history + tags, and the revision range uses each
+  package's own tag prefix, so a skip-path release can warn instead of looking
+  like "everything is shipped".
+
+- **CI/Docker Bun 1.4 floor (#869).** setup-bun, e2e systemd container, and
+  comments pin 1.4.0. Lockfiles stay `lockfileVersion: 1`.
+
+- **Stable cannot skip rc.** `release-plan.ts` refuses a stable publish unless
+  npm already has a matching `X.Y.Z-rc.*`, and refuses again unless `git diff`
+  from that rc tag only touches version/changelog/lockfile paths. Tag-push
+  still overrides. 0.7.13–0.7.16 skipped this; the gate starts here.
+
 ## [0.7.16] - 2026-08-21
 
 **Train CI + token de-escalation on both create doors: `next`-targeted PRs

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,14 +36,24 @@ Per [governance rule 2 (updated 2026-05-24)](https://github.com/ParachuteCompute
 
 ### Releasing hub
 
+Always cut an **rc** first. Stable is a suffix-drop from that rc, never a
+skip — `release-plan.ts` refuses a stable unless npm already has a matching
+`X.Y.Z-rc.*`, and refuses again unless the tree is a suffix-drop from that
+rc tag (version / changelog / lockfile only). `0.7.13`–`0.7.16` skipped this;
+the hook starts at `0.7.17-rc.1`. An explicit tag push still overrides.
+
+Feature work lands on `next`. The rc cut is a version bump on `next`, then
+`next` → `main`. That merge publishes `@rc`.
+
 ```sh
-git fetch && git checkout -b release/hub-X.Y.Z origin/main
-# Bump the version in ./package.json (rc.N or drop -rc for stable) + CHANGELOG.
-git commit -am "chore(release): hub X.Y.Z — <what shipped>"
-gh pr create
+git fetch && git checkout -b release/hub-X.Y.Z-rc.N origin/next
+# Bump ./package.json to X.Y.Z-rc.N + CHANGELOG.
+git commit -am "release: hub X.Y.Z-rc.N — <what shipped>"
+gh pr create --base next
+# After that merges: open next → main. That click publishes @rc.
 ```
 
-Merge it to `main`. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
+Merge the `next` → `main` PR. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
 - npm gets the new version with the appropriate dist-tag
 - ghcr gets a new image at `:vX.Y.Z` plus `:rc`, or `:stable` + `:latest`
 - a `vX.Y.Z` git tag is pushed as a record
@@ -56,7 +66,12 @@ Same shape: bump the version in `./packages/<name>/package.json` and merge. Each
 
 ### Promoting an rc chain to stable
 
-Open a release PR that drops the `-rc.N` suffix from the relevant `package.json` and merge it. CI publishes with `dist-tag=latest` (and, for hub, moves `:stable` + `:latest` on ghcr).
+**No new code.** Branch from the rc tag (or from `main` at that tag), drop
+the `-rc.N` suffix from `package.json`, update CHANGELOG, and PR to `main`.
+Do **not** merge `next` — anything landed on `next` after the rc waits for
+the next rc. CI publishes with `dist-tag=latest` (and, for hub, moves
+`:stable` + `:latest` on ghcr). A merge that isn't a suffix-drop from the
+latest matching rc tag is refused at publish time.
 
 ### Doc-only PRs
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.16",
+  "version": "0.7.17-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -23,6 +23,13 @@
  * installing `@rc` would silently DOWNGRADE. We refuse to move a dist-tag
  * backwards. (Re-publishing an older version deliberately is still possible
  * via an explicit tag push, which takes the tag branch below.)
+ *
+ * **Stable that skipped rc.** 0.7.13 through 0.7.16 shipped `@latest` with
+ * new code and no matching `X.Y.Z-rc.*`. Stable is a suffix-drop from an rc
+ * of the same X.Y.Z, never a skip: `decidePublish` refuses a stable unless
+ * npm already has that rc, and the CLI refuses again unless `git diff` from
+ * the latest matching rc tag only touches version/changelog/lockfile paths.
+ * An explicit tag push still overrides — a human saying "release this".
  */
 
 import { appendFileSync } from "node:fs";
@@ -62,6 +69,13 @@ export interface RegistryView {
   versionExists: boolean;
   /** Current version behind the dist-tag we'd move (`rc` or `latest`). */
   currentDistTagVersion?: string;
+  /**
+   * Every version currently on npm. Used to require an `X.Y.Z-rc.*` of the
+   * same core before a stable. Omitted is treated as empty — a stable then
+   * refuses unless this is a first-ever package (nothing on the dist-tag
+   * either). Forgetting to plumb the list must not silently skip the gate.
+   */
+  publishedVersions?: readonly string[];
 }
 
 /** `rc` for a prerelease, `latest` otherwise. */
@@ -95,6 +109,70 @@ export function compareVersions(a: string, b: string): number {
   }
   if (pa.preNum === pb.preNum) return 0;
   return pa.preNum < pb.preNum ? -1 : 1;
+}
+
+/** `0.7.17-rc.1` → `0.7.17`; a stable is returned unchanged. */
+export function coreVersion(version: string): string {
+  return version.split("-")[0] ?? version;
+}
+
+/**
+ * Published versions that are an `X.Y.Z-rc.N` of `version`'s core.
+ * `0.7.16-rc.1` does not match a `0.7.17` stable.
+ */
+export function matchingRcVersions(version: string, published: readonly string[]): string[] {
+  const core = coreVersion(version);
+  const escaped = core.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}-rc\\.\\d+$`);
+  return published.filter((v) => re.test(v)).sort(compareVersions);
+}
+
+/**
+ * Files a stable promotion may touch vs the latest matching rc tag.
+ * Anything else is "new code" and the publish is refused.
+ */
+export const STABLE_PROMOTION_ALLOWED_PATHS: readonly string[] = [
+  "package.json",
+  "CHANGELOG.md",
+  "RELEASING.md",
+  "bun.lock",
+  "packages/scope-guard/package.json",
+  "packages/scope-guard/CHANGELOG.md",
+  "packages/depcheck/package.json",
+  "packages/door-contract/package.json",
+  "packages/door-contract/CHANGELOG.md",
+];
+
+export function disallowedStablePromotionPaths(
+  changedPaths: readonly string[],
+  allowed: readonly string[] = STABLE_PROMOTION_ALLOWED_PATHS,
+): string[] {
+  const allow = new Set(allowed);
+  return changedPaths.filter((p) => p.length > 0 && !allow.has(p));
+}
+
+/** Highest `prefix+X.Y.Z-rc.N` tag for this version's core, or undefined. */
+export function latestMatchingRcTag(
+  tags: readonly string[],
+  version: string,
+  prefix: string,
+): string | undefined {
+  const core = coreVersion(version);
+  const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedCore = core.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escapedPrefix}${escapedCore}-rc\\.\\d+$`);
+  const matches = tags.filter((t) => re.test(t));
+  if (matches.length === 0) return undefined;
+  matches.sort((a, b) => compareVersions(a.slice(prefix.length), b.slice(prefix.length)));
+  return matches[matches.length - 1];
+}
+
+export function rcTagListArgs(dir: string, version: string): string[] {
+  return ["git", "tag", "-l", `${tagPrefixFor(dir)}${coreVersion(version)}-rc.*`];
+}
+
+export function stablePromotionDiffArgs(rcTag: string): string[] {
+  return ["git", "diff", "--name-only", `${rcTag}..HEAD`];
 }
 
 /**
@@ -131,6 +209,20 @@ export function decidePublish(
         "This usually means parallel PRs merged out of version order; bump and re-merge.",
     };
   }
+  if (distTagFor(version) === "latest") {
+    const published = registry.publishedVersions ?? [];
+    const firstEver = published.length === 0 && !current;
+    if (!firstEver) {
+      const rcs = matchingRcVersions(version, published);
+      if (rcs.length === 0) {
+        const core = coreVersion(version);
+        return {
+          refuse: true,
+          reason: `${version} is a stable release but npm has no ${core}-rc.* — stable is a suffix-drop from an rc, never a skip. Cut an rc first, soak, then drop the suffix.`,
+        };
+      }
+    }
+  }
   return { publish: true, reason: `${version} is not on npm` };
 }
 
@@ -145,7 +237,7 @@ export async function readRegistry(
     const res = await fetchImpl(`https://registry.npmjs.org/${encoded}`);
     if (res.status === 404) {
       // Package has never been published at all — first release.
-      return { versionExists: false };
+      return { versionExists: false, publishedVersions: [] };
     }
     if (!res.ok) return { ambiguous: true };
     const body = (await res.json()) as {
@@ -155,6 +247,7 @@ export async function readRegistry(
     return {
       versionExists: Boolean(body.versions?.[version]),
       currentDistTagVersion: body["dist-tags"]?.[distTagFor(version)],
+      publishedVersions: Object.keys(body.versions ?? {}),
     };
   } catch {
     return { ambiguous: true };
@@ -258,6 +351,51 @@ if (import.meta.main) {
   if ("refuse" in decision) {
     console.error(`::error::${npmName}@${version}: ${decision.reason}`);
     process.exit(1);
+  }
+  // Stable must be a suffix-drop from the latest matching rc tag.
+  // decidePublish already required that npm has an X.Y.Z-rc.*; this is the
+  // "no new code" half. First-ever packages have no rc to diff against and
+  // skip. Tag-push overrides, same as decidePublish.
+  if (
+    decision.publish &&
+    distTagFor(version) === "latest" &&
+    !rest.includes("--tag-push") &&
+    !("ambiguous" in registry) &&
+    matchingRcVersions(version, registry.publishedVersions ?? []).length > 0
+  ) {
+    const tagProc = Bun.spawnSync(rcTagListArgs(dir, version));
+    const tags = new TextDecoder()
+      .decode(tagProc.stdout)
+      .split("\n")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+    const rcTag = latestMatchingRcTag(tags, version, tagPrefixFor(dir));
+    if (!rcTag) {
+      const core = coreVersion(version);
+      console.error(
+        `::error::${npmName}@${version}: npm has ${core}-rc.* but no matching git tag (${tagPrefixFor(dir)}${core}-rc.*) — cannot verify this stable is a suffix-drop. Fetch tags, or pass --tag-push to override.`,
+      );
+      process.exit(1);
+    }
+    const diffProc = Bun.spawnSync(stablePromotionDiffArgs(rcTag));
+    if (diffProc.exitCode !== 0) {
+      console.error(
+        `::error::${npmName}@${version}: git diff ${rcTag}..HEAD failed — cannot verify suffix-drop.`,
+      );
+      process.exit(1);
+    }
+    const changed = new TextDecoder()
+      .decode(diffProc.stdout)
+      .split("\n")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+    const extra = disallowedStablePromotionPaths(changed);
+    if (extra.length > 0) {
+      console.error(
+        `::error::${npmName}@${version}: stable is not a suffix-drop from ${rcTag}. Extra paths vs the rc:\n${extra.map((p) => `  - ${p}`).join("\n")}\nPromote by branching from the rc tag and dropping -rc.N only. Do not merge next.`,
+      );
+      process.exit(1);
+    }
   }
   // On the skip path, say whether anything is stranded. A silent skip is
   // indistinguishable from "everything is shipped", which is how three fixes

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -12,11 +12,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   compareVersions,
+  coreVersion,
   decidePublish,
+  disallowedStablePromotionPaths,
   distTagFor,
   driftLogArgs,
   emitOutputs,
+  latestMatchingRcTag,
+  matchingRcVersions,
+  rcTagListArgs,
   readRegistry,
+  stablePromotionDiffArgs,
   tagPrefixFor,
   unpublishedDrift,
 } from "../../scripts/release-plan.ts";
@@ -117,6 +123,140 @@ describe("decidePublish", () => {
     const d = decidePublish("0.7.9", { ambiguous: true }, { isTagPush: true });
     expect(d).toMatchObject({ publish: true });
   });
+
+  test("a stable without a matching rc is refused — 0.7.13 through 0.7.16 skipped this", () => {
+    // Cutting @latest with new code and no rc of the same X.Y.Z is how
+    // 0.7.13–0.7.16 shipped. Stable is a suffix-drop, never a skip.
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+      publishedVersions: ["0.7.16", "0.7.12-rc.2"],
+    });
+    expect(d).toMatchObject({ refuse: true });
+    expect("refuse" in d && d.reason).toMatch(/0\.7\.17-rc/);
+    expect("refuse" in d && d.reason).toMatch(/suffix-drop|Cut an rc first/i);
+  });
+
+  test("a stable whose only published rcs are a different X.Y.Z is still refused", () => {
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+      publishedVersions: ["0.7.16", "0.7.16-rc.1"],
+    });
+    expect(d).toMatchObject({ refuse: true });
+  });
+
+  test("a stable with a matching rc publishes — suffix-drop is the only legal stable", () => {
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+      publishedVersions: ["0.7.16", "0.7.17-rc.1"],
+    });
+    expect(d).toMatchObject({ publish: true });
+  });
+
+  test("omitted publishedVersions still refuses a stable when latest already exists", () => {
+    // Callers that forget to plumb the version list must not silently skip
+    // the gate — that's how 0.7.13–0.7.16 would keep shipping.
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+    });
+    expect(d).toMatchObject({ refuse: true });
+  });
+
+  test("tag-push still overrides the rc-required check", () => {
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16"],
+      },
+      { isTagPush: true },
+    );
+    expect(d).toMatchObject({ publish: true });
+  });
+});
+
+describe("matchingRcVersions", () => {
+  test("matches only the same X.Y.Z rc chain", () => {
+    expect(
+      matchingRcVersions("0.7.17", ["0.7.16", "0.7.16-rc.1", "0.7.17-rc.1", "0.7.17-rc.2"]),
+    ).toEqual(["0.7.17-rc.1", "0.7.17-rc.2"]);
+  });
+
+  test("a prerelease still matches siblings of its core", () => {
+    expect(matchingRcVersions("0.7.17-rc.3", ["0.7.17-rc.1", "0.7.16-rc.1"])).toEqual([
+      "0.7.17-rc.1",
+    ]);
+  });
+});
+
+describe("coreVersion", () => {
+  test("strips the rc suffix and leaves a stable alone", () => {
+    expect(coreVersion("0.7.17-rc.1")).toBe("0.7.17");
+    expect(coreVersion("0.7.17")).toBe("0.7.17");
+  });
+});
+
+describe("latestMatchingRcTag", () => {
+  test("picks the highest N for hub's bare-v tags", () => {
+    expect(
+      latestMatchingRcTag(
+        ["v0.7.16-rc.1", "v0.7.17-rc.1", "v0.7.17-rc.2", "v0.7.17"],
+        "0.7.17",
+        "v",
+      ),
+    ).toBe("v0.7.17-rc.2");
+  });
+
+  test("namespaces sub-package tags — a hub v tag is not door-contract's", () => {
+    expect(
+      latestMatchingRcTag(
+        ["v0.7.0-rc.9", "door-contract-v0.7.0-rc.1", "door-contract-v0.7.0-rc.2"],
+        "0.7.0",
+        "door-contract-v",
+      ),
+    ).toBe("door-contract-v0.7.0-rc.2");
+  });
+
+  test("undefined when the chain has no rc tag", () => {
+    expect(latestMatchingRcTag(["v0.7.16"], "0.7.17", "v")).toBeUndefined();
+  });
+});
+
+describe("disallowedStablePromotionPaths", () => {
+  test("version/changelog/lockfile-only is a suffix-drop", () => {
+    expect(disallowedStablePromotionPaths(["package.json", "CHANGELOG.md", "bun.lock"])).toEqual(
+      [],
+    );
+  });
+
+  test("a source file is new code — the 0.7.13–0.7.16 skip-rc shape", () => {
+    expect(disallowedStablePromotionPaths(["package.json", "src/users.ts"])).toEqual([
+      "src/users.ts",
+    ]);
+  });
+});
+
+describe("rcTagListArgs / stablePromotionDiffArgs", () => {
+  test("hub lists its own bare-v rc tags", () => {
+    expect(rcTagListArgs(".", "0.7.17")).toEqual(["git", "tag", "-l", "v0.7.17-rc.*"]);
+  });
+
+  test("door-contract lists door-contract-v, not hub's v", () => {
+    expect(rcTagListArgs("packages/door-contract", "0.7.0")[3]).toBe("door-contract-v0.7.0-rc.*");
+  });
+
+  test("the suffix-drop diff is name-only from the rc tag to HEAD", () => {
+    expect(stablePromotionDiffArgs("v0.7.17-rc.1")).toEqual([
+      "git",
+      "diff",
+      "--name-only",
+      "v0.7.17-rc.1..HEAD",
+    ]);
+  });
 });
 
 describe("readRegistry", () => {
@@ -129,7 +269,11 @@ describe("readRegistry", () => {
         versions: { "0.7.9-rc.1": {}, "0.7.9-rc.2": {} },
         "dist-tags": { rc: "0.7.9-rc.2", latest: "0.7.8" },
       })) as unknown as typeof fetch);
-    expect(v).toMatchObject({ versionExists: true, currentDistTagVersion: "0.7.9-rc.2" });
+    expect(v).toMatchObject({
+      versionExists: true,
+      currentDistTagVersion: "0.7.9-rc.2",
+      publishedVersions: ["0.7.9-rc.1", "0.7.9-rc.2"],
+    });
   });
 
   test("picks the dist-tag matching the version's channel", async () => {


### PR DESCRIPTION
release: hub 0.7.17-rc.1 — username chokepoint, attribution proofs, rc-before-stable gate

Cuts `@openparachute/hub` **0.7.17-rc.1** on `next`. Merging this does **not** publish. The follow-up `next` → `main` click publishes `@rc`.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What is in this rc (over 0.7.16)

Already on `next`, listed in CHANGELOG:

- #857 unpublished-drift advisory actually runs
- #865 username validator chokepoint
- #866 duplicate linkage binding tags refused
- #867 PARACHUTE_HOME test sandbox
- #868 attribution proofs survive unlink
- #869 Bun 1.4 CI pin

New in this PR:

- **rc-before-stable publish hook.** `decidePublish` refuses a stable unless npm already has a matching `X.Y.Z-rc.*`. The CLI refuses again unless `git diff` from the latest matching rc tag only touches version/changelog/lockfile paths. Tag-push still overrides. 0.7.13–0.7.16 skipped this; the gate starts here.
- `package.json` 0.7.16 → 0.7.17-rc.1 + CHANGELOG + RELEASING.md (rc first, stable = suffix-drop from the rc tag, never merge `next` for a stable).

Stable later is suffix-drop only. No new code on that PR.

## Verification at `4ea99d1`

- `bun run typecheck` — 0 errors
- `bun test ./src/__tests__/release-plan.test.ts` — **54 pass / 0 fail** (88 expects)
- Watch-fail: the three new refuse tests published `0.7.17` as `"not on npm"` against unpatched `decidePublish`, then went green after the hook
- `release-check.sh` vs `origin/main` — PASS (`0.7.16` → `0.7.17-rc.1`); WARN on lockfile is version-only (deps untouched; `bun.lock` does not embed hub's own version)
- **Did not** run `bun test ./src` on this live operator box — launchd-touching tests still ignore `PARACHUTE_HOME` (hub#867). Full suite is CI.

## After merge to `next`

Open `next` → `main` for the owner click. That merge publishes `@rc`. Then `parachute upgrade hub --channel rc` can replace the bun-linked worktree on this box.


