### PR TITLE
release: hub 0.7.17-rc.1 — username chokepoint, attribution proofs, rc-before-stable gate

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -2,10 +2,12 @@ name: e2e
 
 # Tier-1 end-to-end harness: systemd-in-container fresh-install flow.
 #
-# Runs the REAL operator install path (curl bun.sh/install → bun add -g
-# @openparachute/hub → parachute init → wizard → MCP OAuth dance) against a
-# privileged Ubuntu+systemd container, replaying recent field-failure
-# scenarios as staged assertions. See e2e/README.md.
+# Runs the REAL operator install path (curl bun.sh/install bun-v1.4.0 →
+# bun add -g @openparachute/hub → parachute init → wizard → MCP OAuth dance)
+# against a privileged Ubuntu+systemd container, replaying recent
+# field-failure scenarios as staged assertions. See e2e/README.md.
+# The container's bun install is pinned to 1.4.0 in e2e/stages.sh — not
+# unversioned curl|bash — so a later bun.sh latest cannot drift the harness.
 #
 # Triggers:
 #   workflow_dispatch  — manual, with a hub_source input (default npm:rc).
@@ -40,7 +42,7 @@ jobs:
       - name: Install bun (host — needed for HUB_SOURCE=local pack)
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.4
 
       - name: Run Tier-1 E2E
         env:

--- a/.github/workflows/pr-verify.yml
+++ b/.github/workflows/pr-verify.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - name: install deps
         run: bun install --frozen-lockfile
       - name: build depcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
           fetch-tags: true
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - id: hub
         run: bun scripts/release-plan.ts . @openparachute/hub ${{ github.ref_type == 'tag' && '--tag-push' || '' }}
       - id: scope_guard
@@ -141,7 +141,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - name: install deps
         run: bun install --frozen-lockfile
       - name: build depcheck
@@ -190,7 +190,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           # Node 24 ships npm 11.5+ which has Trusted Publishing OIDC
@@ -260,7 +260,7 @@ jobs:
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -317,7 +317,7 @@ jobs:
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -375,7 +375,7 @@ jobs:
         # checkout has no working-directory option; runs from repo root.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - uses: actions/setup-node@v6
         with:
           node-version: '24'
@@ -504,7 +504,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3
+          bun-version: 1.4
       - name: tag published packages
         continue-on-error: true
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,21 @@ jobs:
       door_contract: ${{ steps.door_contract.outputs.should_publish }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          # The drift advisory in release-plan.ts asks git "what's on main that
+          # no published version contains?" — a `<tag>..HEAD` range. A bare
+          # checkout fetches `--depth=1 --no-tags`, where that range exits 128
+          # ("unknown revision") and the advisory reported nothing, forever
+          # (hub#830). Indistinguishable from "everything is shipped", which is
+          # the exact confusion it was added to end.
+          #
+          # Only this job needs history; every other job's checkout stays
+          # shallow.
+          fetch-depth: 0
+          # Redundant alongside fetch-depth: 0 today, deliberate anyway: it
+          # states the dependency, so narrowing the depth later can't silently
+          # take the tags away again.
+          fetch-tags: true
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,46 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.17-rc.1] - 2026-08-24
+
+**Username chokepoint, attribution that survives unlink, and an rc-before-stable
+publish gate.** Six PRs over 0.7.16 plus this hook. Soaks on `@rc`; stable later
+is a suffix-drop only.
+
+- **Every username write hits one validator (#865, closes hub#864).** Create
+  and rename both go through `[a-z0-9_-]` 2–32 and the reserved-word list
+  (`admin|root|system|setup|parachute|hub`). First-boot seed may still be
+  exactly `admin`; later `admin` creates are refused.
+
+- **Duplicate linkage binding tags are refused without naming the other
+  holder (#866, closes hub#859).** A ceremony that repeats a binding tag is
+  rejected; the 4xx does not leak who already holds the key.
+
+- **Attribution proofs survive unlink (#868, closes hub#860).**
+  `GET /api/auth/attribution` reads `attribution_proofs` (migration v18), not
+  the live `user_pubkeys` table. Unlink / account-delete cannot erase a proof
+  that already existed. A linked key still grants nothing (no login, no
+  scope) — it is an attribution label. **No account-page UI** — the ceremony
+  is API-only (`/api/account/pubkeys`).
+
+- **Test-suite `PARACHUTE_HOME` sandbox (#867, closes hub#840).** bunfig.toml
+  `[test]` preload replaces any inherited home with a fresh temp dir before
+  config.ts freezes paths. Does **not** make `bun test ./src` safe on a live
+  operator box (launchd-touching tests still ignore `PARACHUTE_HOME`).
+
+- **Unpublished-drift advisory actually runs (#857, closes hub#830).** The
+  `plan` job now fetches full history + tags, and the revision range uses each
+  package's own tag prefix, so a skip-path release can warn instead of looking
+  like "everything is shipped".
+
+- **CI/Docker Bun 1.4 floor (#869).** setup-bun, e2e systemd container, and
+  comments pin 1.4.0. Lockfiles stay `lockfileVersion: 1`.
+
+- **Stable cannot skip rc.** `release-plan.ts` refuses a stable publish unless
+  npm already has a matching `X.Y.Z-rc.*`, and refuses again unless `git diff`
+  from that rc tag only touches version/changelog/lockfile paths. Tag-push
+  still overrides. 0.7.13–0.7.16 skipped this; the gate starts here.
+
 ## [0.7.16] - 2026-08-21
 
 **Train CI + token de-escalation on both create doors: `next`-targeted PRs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ bun run typecheck                # tsc --noEmit
 
 **Test-count trap:** `bun test src` (no `./`) picks up *both* `src/` and `packages/scope-guard/src/` in one inflated, cross-interfering run. Use `bun test ./src`; cite hub-only counts by default, and pair with a separate scope-guard count only when scope-guard is load-bearing in the PR.
 
+- **Test state isolation is unconditional (hub#840).** `bunfig.toml` `[test] preload` replaces any inherited `PARACHUTE_HOME` with a fresh empty temp dir *before* `config.ts` computes `CONFIG_DIR` / `SERVICES_MANIFEST_PATH` (those are import-time constants). Do not weaken this to "only when unset": an inherited value commonly names the live install, and handler tests fall back to `SERVICES_MANIFEST_PATH`. `NODE_ENV=test` also refuses a live `~/.parachute` `CONFIG_DIR` if the cwd-sensitive preload is missed. This does **not** make `bun test ./src` safe on a live operator box: launchd-touching tests still ignore `PARACHUTE_HOME`.
+
 For end-to-end against a real install, `bun link` this repo — the linked `parachute` binary follows the checked-out branch.
 
 ## Naming

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@
 #                                       `--channel rc|latest` and `--tag`
 #                                       still override.
 
-ARG BUN_VERSION=1.3
+ARG BUN_VERSION=1.4
 FROM oven/bun:${BUN_VERSION}-alpine AS builder
 
 WORKDIR /app

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -36,14 +36,24 @@ Per [governance rule 2 (updated 2026-05-24)](https://github.com/ParachuteCompute
 
 ### Releasing hub
 
+Always cut an **rc** first. Stable is a suffix-drop from that rc, never a
+skip — `release-plan.ts` refuses a stable unless npm already has a matching
+`X.Y.Z-rc.*`, and refuses again unless the tree is a suffix-drop from that
+rc tag (version / changelog / lockfile only). `0.7.13`–`0.7.16` skipped this;
+the hook starts at `0.7.17-rc.1`. An explicit tag push still overrides.
+
+Feature work lands on `next`. The rc cut is a version bump on `next`, then
+`next` → `main`. That merge publishes `@rc`.
+
 ```sh
-git fetch && git checkout -b release/hub-X.Y.Z origin/main
-# Bump the version in ./package.json (rc.N or drop -rc for stable) + CHANGELOG.
-git commit -am "chore(release): hub X.Y.Z — <what shipped>"
-gh pr create
+git fetch && git checkout -b release/hub-X.Y.Z-rc.N origin/next
+# Bump ./package.json to X.Y.Z-rc.N + CHANGELOG.
+git commit -am "release: hub X.Y.Z-rc.N — <what shipped>"
+gh pr create --base next
+# After that merges: open next → main. That click publishes @rc.
 ```
 
-Merge it to `main`. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
+Merge the `next` → `main` PR. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
 - npm gets the new version with the appropriate dist-tag
 - ghcr gets a new image at `:vX.Y.Z` plus `:rc`, or `:stable` + `:latest`
 - a `vX.Y.Z` git tag is pushed as a record
@@ -56,7 +66,12 @@ Same shape: bump the version in `./packages/<name>/package.json` and merge. Each
 
 ### Promoting an rc chain to stable
 
-Open a release PR that drops the `-rc.N` suffix from the relevant `package.json` and merge it. CI publishes with `dist-tag=latest` (and, for hub, moves `:stable` + `:latest` on ghcr).
+**No new code.** Branch from the rc tag (or from `main` at that tag), drop
+the `-rc.N` suffix from `package.json`, update CHANGELOG, and PR to `main`.
+Do **not** merge `next` — anything landed on `next` after the rc waits for
+the next rc. CI publishes with `dist-tag=latest` (and, for hub, moves
+`:stable` + `:latest` on ghcr). A merge that isn't a suffix-drop from the
+latest matching rc tag is refused at publish time.
 
 ### Doc-only PRs
 

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -1,0 +1,11 @@
+# Bun config. Test-only so far.
+
+[test]
+# Sandbox PARACHUTE_HOME before anything imports `config.ts`, whose CONFIG_DIR
+# / SERVICES_MANIFEST_PATH are computed at import time and can't be moved
+# afterwards. Without this the suite reads — and writes — the operator's live
+# `~/.parachute` (hub#840). See the preload file for the measurements.
+#
+# Here rather than in package.json's `test` script because CI and everyone's
+# muscle memory run `bun test ./src` directly, not `bun run test`.
+preload = ["./src/__tests__/preload-isolate-home.ts"]

--- a/e2e/Dockerfile.systemd
+++ b/e2e/Dockerfile.systemd
@@ -7,8 +7,8 @@
 # postinstall scripts assume it present on Linux).
 #
 # We DO NOT pre-install bun or @openparachute/hub — installing those is the
-# test (Stage 1 of e2e/stages.sh runs the real `curl bun.sh/install` +
-# `bun add -g @openparachute/hub` an operator runs). Baking them in would
+# test (Stage 1 of e2e/stages.sh runs `curl bun.sh/install` pinned to
+# bun-v1.4.0 + `bun add -g @openparachute/hub`). Baking them in would
 # defeat the whole point of the harness.
 #
 # systemd-as-PID-1 is the load-bearing choice: `parachute init` installs and

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,7 +2,7 @@
 
 This directory holds the **Tier 1** end-to-end harness for the hub: a
 systemd-in-container test that runs the **real fresh-Linux install flow** an
-operator runs on a VPS — `curl bun.sh/install` → `bun add -g
+operator runs on a VPS — `curl bun.sh/install` pinned to bun-v1.4.0 → `bun add -g
 @openparachute/hub` → `parachute init` → setup wizard → MCP — and replays the
 field-failure scenarios from recent weeks as staged assertions.
 

--- a/e2e/stages.sh
+++ b/e2e/stages.sh
@@ -87,16 +87,25 @@ wait_for() {
 hr "STAGE 1 — fresh install happy path"
 
 # --- install bun ---
-note "Installing bun (curl bun.sh/install)…"
+# Floor is 1.4 — same pin as oven-sh/setup-bun in e2e.yml and ARG
+# BUN_VERSION in the hub Dockerfile. An operator still runs unversioned
+# `curl | bash`; this harness must not, or a later bun.sh latest silently
+# changes the operator-install assertions.
+BUN_PIN="${BUN_PIN:-1.4.0}"
+note "Installing bun ${BUN_PIN} (curl bun.sh/install bun-v${BUN_PIN})…"
 export BUN_INSTALL=/root/.bun
 export PATH="$BUN_INSTALL/bin:$PATH"
-if ! curl -fsSL https://bun.sh/install | bash >/tmp/bun-install.log 2>&1; then
+if ! curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_PIN}" >/tmp/bun-install.log 2>&1; then
   cat /tmp/bun-install.log >&2
   die "stage1-install-bun" "bun install script failed"
 fi
 hash -r
 command -v bun >/dev/null 2>&1 || die "stage1-install-bun" "bun not on PATH after install"
-note "bun $(bun --version) installed"
+INSTALLED="$(bun --version)"
+note "bun ${INSTALLED} installed"
+if [ "$INSTALLED" != "$BUN_PIN" ]; then
+  die "stage1-install-bun" "expected bun ${BUN_PIN} (1.4 floor), got ${INSTALLED}"
+fi
 
 # --- install @openparachute/hub ---
 # Regression pin hub#568: a "Blocked N postinstall" line means bun refused to

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.16",
+  "version": "0.7.17-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -195,6 +195,50 @@ export function unpublishedDrift(commitSubjects: readonly string[]): {
   };
 }
 
+/**
+ * The git tag namespace a package's releases are recorded under.
+ *
+ * Not a detail — the drift advisory's revision range is a TAG, and hub's tags
+ * are bare (`v0.7.0`) while every sub-package's are namespaced
+ * (`door-contract-v0.7.0`). The advisory hardcoded `v`, so door-contract@0.7.0
+ * resolved against HUB's `v0.7.0` — a tag that exists, pointing at unrelated
+ * history — and would have reported ~137 hub commits as door-contract's
+ * unpublished work (hub#830). A wrong-but-resolving range is worse than a
+ * missing one.
+ *
+ * The mapping is the one `tag-record` uses at the bottom of release.yml, and
+ * the one `on: push: tags:` filters against: package dir basename + `-v`, or a
+ * bare `v` for the root package.
+ */
+export function tagPrefixFor(dir: string): string {
+  const name = dir.replace(/\/+$/, "").split("/").pop() ?? "";
+  if (name === "" || name === "." || name === "..") return "v";
+  return `${name}-v`;
+}
+
+/**
+ * The `git log` invocation behind the drift advisory.
+ *
+ * Split out from the CLI so the range and the pathspec are testable without a
+ * repo — both were wrong in ways that only showed up in a release run.
+ *
+ * The trailing pathspec scopes the listing to the package: without it,
+ * "commits not in any published version" for scope-guard would list every hub
+ * commit merged since scope-guard last shipped, which is noise dressed as a
+ * warning.
+ */
+export function driftLogArgs(dir: string, version: string): string[] {
+  return [
+    "git",
+    "log",
+    `${tagPrefixFor(dir)}${version}..HEAD`,
+    "--oneline",
+    "--no-merges",
+    "--",
+    dir.replace(/\/+$/, "") || ".",
+  ];
+}
+
 // --- CLI -------------------------------------------------------------------
 // Usage: bun scripts/release-plan.ts <package-dir> <npm-name> [--tag-push]
 // Emits GitHub Actions outputs; exits non-zero on refusal.
@@ -220,8 +264,17 @@ if (import.meta.main) {
   // in a row sat unpublished on main.
   if (!decision.publish && !rest.includes("--no-drift-check")) {
     try {
-      const proc = Bun.spawnSync(["git", "log", `v${version}..HEAD`, "--oneline", "--no-merges"]);
-      if (proc.exitCode === 0) {
+      const proc = Bun.spawnSync(driftLogArgs(dir, version));
+      if (proc.exitCode !== 0) {
+        // Say so. This is the whole of hub#830: the plan job used a bare
+        // `actions/checkout@v6` (`--depth=1 --no-tags`), git exited 128
+        // "unknown revision", and this branch stayed silent — so a CI run that
+        // COULDN'T check drift looked exactly like one that found none.
+        console.log(
+          `::notice::${npmName}: couldn't check for unpublished drift ` +
+            `(${tagPrefixFor(dir)}${version} not resolvable — shallow or tagless clone?)`,
+        );
+      } else {
         const drift = unpublishedDrift(new TextDecoder().decode(proc.stdout).split("\n"));
         if (drift.drifted) {
           console.log(`::warning::${npmName}: ${drift.summary}`);

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -23,6 +23,13 @@
  * installing `@rc` would silently DOWNGRADE. We refuse to move a dist-tag
  * backwards. (Re-publishing an older version deliberately is still possible
  * via an explicit tag push, which takes the tag branch below.)
+ *
+ * **Stable that skipped rc.** 0.7.13 through 0.7.16 shipped `@latest` with
+ * new code and no matching `X.Y.Z-rc.*`. Stable is a suffix-drop from an rc
+ * of the same X.Y.Z, never a skip: `decidePublish` refuses a stable unless
+ * npm already has that rc, and the CLI refuses again unless `git diff` from
+ * the latest matching rc tag only touches version/changelog/lockfile paths.
+ * An explicit tag push still overrides — a human saying "release this".
  */
 
 import { appendFileSync } from "node:fs";
@@ -62,6 +69,13 @@ export interface RegistryView {
   versionExists: boolean;
   /** Current version behind the dist-tag we'd move (`rc` or `latest`). */
   currentDistTagVersion?: string;
+  /**
+   * Every version currently on npm. Used to require an `X.Y.Z-rc.*` of the
+   * same core before a stable. Omitted is treated as empty — a stable then
+   * refuses unless this is a first-ever package (nothing on the dist-tag
+   * either). Forgetting to plumb the list must not silently skip the gate.
+   */
+  publishedVersions?: readonly string[];
 }
 
 /** `rc` for a prerelease, `latest` otherwise. */
@@ -95,6 +109,70 @@ export function compareVersions(a: string, b: string): number {
   }
   if (pa.preNum === pb.preNum) return 0;
   return pa.preNum < pb.preNum ? -1 : 1;
+}
+
+/** `0.7.17-rc.1` → `0.7.17`; a stable is returned unchanged. */
+export function coreVersion(version: string): string {
+  return version.split("-")[0] ?? version;
+}
+
+/**
+ * Published versions that are an `X.Y.Z-rc.N` of `version`'s core.
+ * `0.7.16-rc.1` does not match a `0.7.17` stable.
+ */
+export function matchingRcVersions(version: string, published: readonly string[]): string[] {
+  const core = coreVersion(version);
+  const escaped = core.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escaped}-rc\\.\\d+$`);
+  return published.filter((v) => re.test(v)).sort(compareVersions);
+}
+
+/**
+ * Files a stable promotion may touch vs the latest matching rc tag.
+ * Anything else is "new code" and the publish is refused.
+ */
+export const STABLE_PROMOTION_ALLOWED_PATHS: readonly string[] = [
+  "package.json",
+  "CHANGELOG.md",
+  "RELEASING.md",
+  "bun.lock",
+  "packages/scope-guard/package.json",
+  "packages/scope-guard/CHANGELOG.md",
+  "packages/depcheck/package.json",
+  "packages/door-contract/package.json",
+  "packages/door-contract/CHANGELOG.md",
+];
+
+export function disallowedStablePromotionPaths(
+  changedPaths: readonly string[],
+  allowed: readonly string[] = STABLE_PROMOTION_ALLOWED_PATHS,
+): string[] {
+  const allow = new Set(allowed);
+  return changedPaths.filter((p) => p.length > 0 && !allow.has(p));
+}
+
+/** Highest `prefix+X.Y.Z-rc.N` tag for this version's core, or undefined. */
+export function latestMatchingRcTag(
+  tags: readonly string[],
+  version: string,
+  prefix: string,
+): string | undefined {
+  const core = coreVersion(version);
+  const escapedPrefix = prefix.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escapedCore = core.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const re = new RegExp(`^${escapedPrefix}${escapedCore}-rc\\.\\d+$`);
+  const matches = tags.filter((t) => re.test(t));
+  if (matches.length === 0) return undefined;
+  matches.sort((a, b) => compareVersions(a.slice(prefix.length), b.slice(prefix.length)));
+  return matches[matches.length - 1];
+}
+
+export function rcTagListArgs(dir: string, version: string): string[] {
+  return ["git", "tag", "-l", `${tagPrefixFor(dir)}${coreVersion(version)}-rc.*`];
+}
+
+export function stablePromotionDiffArgs(rcTag: string): string[] {
+  return ["git", "diff", "--name-only", `${rcTag}..HEAD`];
 }
 
 /**
@@ -131,6 +209,20 @@ export function decidePublish(
         "This usually means parallel PRs merged out of version order; bump and re-merge.",
     };
   }
+  if (distTagFor(version) === "latest") {
+    const published = registry.publishedVersions ?? [];
+    const firstEver = published.length === 0 && !current;
+    if (!firstEver) {
+      const rcs = matchingRcVersions(version, published);
+      if (rcs.length === 0) {
+        const core = coreVersion(version);
+        return {
+          refuse: true,
+          reason: `${version} is a stable release but npm has no ${core}-rc.* — stable is a suffix-drop from an rc, never a skip. Cut an rc first, soak, then drop the suffix.`,
+        };
+      }
+    }
+  }
   return { publish: true, reason: `${version} is not on npm` };
 }
 
@@ -145,7 +237,7 @@ export async function readRegistry(
     const res = await fetchImpl(`https://registry.npmjs.org/${encoded}`);
     if (res.status === 404) {
       // Package has never been published at all — first release.
-      return { versionExists: false };
+      return { versionExists: false, publishedVersions: [] };
     }
     if (!res.ok) return { ambiguous: true };
     const body = (await res.json()) as {
@@ -155,6 +247,7 @@ export async function readRegistry(
     return {
       versionExists: Boolean(body.versions?.[version]),
       currentDistTagVersion: body["dist-tags"]?.[distTagFor(version)],
+      publishedVersions: Object.keys(body.versions ?? {}),
     };
   } catch {
     return { ambiguous: true };
@@ -258,6 +351,51 @@ if (import.meta.main) {
   if ("refuse" in decision) {
     console.error(`::error::${npmName}@${version}: ${decision.reason}`);
     process.exit(1);
+  }
+  // Stable must be a suffix-drop from the latest matching rc tag.
+  // decidePublish already required that npm has an X.Y.Z-rc.*; this is the
+  // "no new code" half. First-ever packages have no rc to diff against and
+  // skip. Tag-push overrides, same as decidePublish.
+  if (
+    decision.publish &&
+    distTagFor(version) === "latest" &&
+    !rest.includes("--tag-push") &&
+    !("ambiguous" in registry) &&
+    matchingRcVersions(version, registry.publishedVersions ?? []).length > 0
+  ) {
+    const tagProc = Bun.spawnSync(rcTagListArgs(dir, version));
+    const tags = new TextDecoder()
+      .decode(tagProc.stdout)
+      .split("\n")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+    const rcTag = latestMatchingRcTag(tags, version, tagPrefixFor(dir));
+    if (!rcTag) {
+      const core = coreVersion(version);
+      console.error(
+        `::error::${npmName}@${version}: npm has ${core}-rc.* but no matching git tag (${tagPrefixFor(dir)}${core}-rc.*) — cannot verify this stable is a suffix-drop. Fetch tags, or pass --tag-push to override.`,
+      );
+      process.exit(1);
+    }
+    const diffProc = Bun.spawnSync(stablePromotionDiffArgs(rcTag));
+    if (diffProc.exitCode !== 0) {
+      console.error(
+        `::error::${npmName}@${version}: git diff ${rcTag}..HEAD failed — cannot verify suffix-drop.`,
+      );
+      process.exit(1);
+    }
+    const changed = new TextDecoder()
+      .decode(diffProc.stdout)
+      .split("\n")
+      .map((p) => p.trim())
+      .filter((p) => p.length > 0);
+    const extra = disallowedStablePromotionPaths(changed);
+    if (extra.length > 0) {
+      console.error(
+        `::error::${npmName}@${version}: stable is not a suffix-drop from ${rcTag}. Extra paths vs the rc:\n${extra.map((p) => `  - ${p}`).join("\n")}\nPromote by branching from the rc tag and dropping -rc.N only. Do not merge next.`,
+      );
+      process.exit(1);
+    }
   }
   // On the skip path, say whether anything is stranded. A silent skip is
   // indistinguishable from "everything is shipped", which is how three fixes

--- a/src/__tests__/api-account-pubkeys.test.ts
+++ b/src/__tests__/api-account-pubkeys.test.ts
@@ -614,6 +614,29 @@ describe("POST /verify — rejections", () => {
     );
   });
 
+  test("duplicate binding tags are refused even when the first value is valid", async () => {
+    const alice = await userWithSession("alice");
+    for (const duplicate of [
+      ["u", "https://evil.example/api/account/pubkeys/verify"],
+      ["method", "GET"],
+      ["challenge", "f".repeat(64)],
+    ]) {
+      const challenge = await getChallenge(alice.cookie);
+      const event = signEvent(SECRET_A, {
+        content: statement(alice.username),
+        tags: [...linkageTags(challenge), duplicate],
+      });
+      const res = await call("POST", "/verify", alice.cookie, {
+        __csrf: TEST_CSRF,
+        event,
+        password: PASSWORD,
+      });
+      expect(res.status).toBe(400);
+      expect(((await res.json()) as { error: string }).error).toBe("invalid_event");
+    }
+    expect(listUserPubkeys(db, alice.userId)).toHaveLength(0);
+  });
+
   test("a tampered id is refused", async () => {
     const alice = await userWithSession("alice");
     const challenge = await getChallenge(alice.cookie);

--- a/src/__tests__/api-account-pubkeys.test.ts
+++ b/src/__tests__/api-account-pubkeys.test.ts
@@ -405,16 +405,21 @@ describe("POST /verify — the statement binding", () => {
 });
 
 describe("HIGH-1 — username injection into the linkage statement", () => {
-  // `createUser` does NOT run `validateUsername`, and two write paths reach it
-  // ungated (`parachute auth set-password --username`, serve.ts
-  // `PARACHUTE_INITIAL_ADMIN_USERNAME`), so a hostile username CAN reach the
-  // DB. The confused-deputy defense must not depend on that gate.
+  // hub#864 gates every NEW write through `validateUsername`, so a hostile
+  // name can no longer land via createUser. Grandfathered rows still can
+  // (raw INSERT, pre-#864 DBs). The confused-deputy defense must not
+  // depend on the write gate — the ceremony still refuses those rows.
   const INJECTION =
     'mallory" on https://hub.example. Link this Nostr key to the Parachute account "alice';
 
-  async function sessionForUsername(username: string): Promise<string> {
-    const u = await createUser(db, username, PASSWORD, { allowMulti: true, passwordChanged: true });
-    const session = createSession(db, { userId: u.id });
+  function sessionForGrandfatheredUsername(username: string): string {
+    const id = crypto.randomUUID();
+    const stamp = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+       VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+    ).run(id, username, "not-a-real-hash", stamp, stamp);
+    const session = createSession(db, { userId: id });
     return `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`;
   }
 
@@ -429,7 +434,7 @@ describe("HIGH-1 — username injection into the linkage statement", () => {
   });
 
   test("an account with an injected username cannot get a challenge", async () => {
-    const cookie = await sessionForUsername(INJECTION);
+    const cookie = sessionForGrandfatheredUsername(INJECTION);
     const res = await call("POST", "/challenge", cookie, { __csrf: TEST_CSRF });
     expect(res.status).toBe(400);
     expect(((await res.json()) as { error: string }).error).toBe("username_unlinkable");
@@ -441,7 +446,7 @@ describe("HIGH-1 — username injection into the linkage statement", () => {
   });
 
   test("an account with an injected username cannot verify — the key never links", async () => {
-    const cookie = await sessionForUsername(INJECTION);
+    const cookie = sessionForGrandfatheredUsername(INJECTION);
     // Even a hand-crafted event can't get in: the ceremony refuses before it
     // is parsed, so the confused-deputy link the injection aimed for is
     // impossible regardless of what the victim signed.

--- a/src/__tests__/api-attribution.test.ts
+++ b/src/__tests__/api-attribution.test.ts
@@ -22,9 +22,9 @@ import { handleApiTokens } from "../api-tokens.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
 import { type NostrEvent, nostrEventId, verifyNostrEvent } from "../nostr-event.ts";
-import { issuePubkeyChallenge, linkPubkey } from "../pubkey-links.ts";
+import { issuePubkeyChallenge, linkPubkey, unlinkPubkey } from "../pubkey-links.ts";
 import { getActiveSigningKey } from "../signing-keys.ts";
-import { createUser } from "../users.ts";
+import { createUser, deleteUser } from "../users.ts";
 
 const ISSUER = "https://hub.example";
 
@@ -192,6 +192,52 @@ describe("resolution", () => {
     const dump = JSON.stringify(await res.json());
     expect(dump).not.toContain(PUBKEY);
     expect(dump).not.toContain(alice);
+  });
+
+  test("keeps a registry-attributed proof resolvable after unlink", async () => {
+    const userId = await linkedUser("alice");
+    recordTokenMint(db, {
+      jti: "jti-unlinked-proof",
+      createdVia: "cli_mint",
+      subject: userId,
+      userId,
+      clientId: "parachute-hub",
+      scopes: ["vault:work:read"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(unlinkPubkey(db, userId, PUBKEY)).toBe(true);
+
+    const res = await get(
+      `/api/auth/attribution?subject=${userId}`,
+      await bearer(["parachute:host:auth"]),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pubkeys: { proof_event: NostrEvent }[] };
+    expect(body.pubkeys).toHaveLength(1);
+    expect(verifyNostrEvent(body.pubkeys[0]!.proof_event)).toEqual({ ok: true });
+  });
+
+  test("keeps a registry-attributed proof resolvable after account deletion", async () => {
+    const userId = await linkedUser("alice");
+    recordTokenMint(db, {
+      jti: "jti-deleted-user-proof",
+      createdVia: "cli_mint",
+      subject: userId,
+      userId,
+      clientId: "parachute-hub",
+      scopes: ["vault:work:read"],
+      expiresAt: new Date(Date.now() + 60_000).toISOString(),
+    });
+    expect(deleteUser(db, userId)).toBe(true);
+
+    const res = await get(
+      `/api/auth/attribution?subject=${userId}`,
+      await bearer(["parachute:host:auth"]),
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { pubkeys: { proof_event: NostrEvent }[] };
+    expect(body.pubkeys).toHaveLength(1);
+    expect(verifyNostrEvent(body.pubkeys[0]!.proof_event)).toEqual({ ok: true });
   });
 });
 

--- a/src/__tests__/home-isolation.test.ts
+++ b/src/__tests__/home-isolation.test.ts
@@ -1,0 +1,137 @@
+/**
+ * The suite must not be able to see, let alone touch, the operator's live
+ * `~/.parachute` (hub#840).
+ *
+ * This is a guard on the harness itself, not on a feature. It exists because
+ * the leak it covers is invisible in the place people look: CI runners have no
+ * `~/.parachute`, so the suite has always been green while quietly reading the
+ * live manifest 116 times per run on a developer box — and creating
+ * `operator.token` and `well-known/parachute.json` in it. #840 records a test
+ * run registering a dead `parachute-app` row at port 1942 into the real
+ * manifest, which is live supervisor state.
+ *
+ * The isolation is a `bunfig.toml` `[test] preload`; these assertions are what
+ * notices if that wiring is dropped, renamed, or defeated.
+ */
+
+import { describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { CONFIG_DIR, SERVICES_MANIFEST_PATH, configDir } from "../config.ts";
+
+const REPO_ROOT = resolve(import.meta.dir, "../..");
+const realConfigDir = join(homedir(), ".parachute");
+
+describe("test-run home isolation (hub#840)", () => {
+  test("PARACHUTE_HOME is set, and points inside the temp dir", () => {
+    const home = process.env.PARACHUTE_HOME;
+    expect(home).toBeTruthy();
+    // `resolve` both sides: macOS hands out /var/folders/... paths that are a
+    // symlink to /private/var/folders/..., and tmpdir() picks one spelling.
+    expect(resolve(home as string).startsWith(resolve(tmpdir()))).toBe(true);
+  });
+
+  test("the sandbox is a REAL directory — a bad path would send writes anywhere", () => {
+    expect(existsSync(process.env.PARACHUTE_HOME as string)).toBe(true);
+  });
+
+  test("CONFIG_DIR resolved to the sandbox, not the operator's ~/.parachute", () => {
+    // The load-bearing one. CONFIG_DIR is frozen at import time, so this can
+    // only be true if the override landed BEFORE the first `config.ts` import
+    // — i.e. from a preload, not a beforeEach.
+    expect(CONFIG_DIR).toBe(process.env.PARACHUTE_HOME as string);
+    expect(resolve(CONFIG_DIR)).not.toBe(resolve(realConfigDir));
+  });
+
+  test("SERVICES_MANIFEST_PATH — the actual leak — is not the live manifest", () => {
+    // Every `deps.manifestPath ?? SERVICES_MANIFEST_PATH` fallback in the
+    // server resolves through this constant.
+    expect(SERVICES_MANIFEST_PATH).toBe(
+      join(process.env.PARACHUTE_HOME as string, "services.json"),
+    );
+    expect(resolve(SERVICES_MANIFEST_PATH)).not.toBe(resolve(join(realConfigDir, "services.json")));
+  });
+
+  test("inherited hub token is blanked", () => {
+    expect(process.env.PARACHUTE_HUB_TOKEN).toBe("");
+  });
+
+  test("the mechanism still works: configDir honours PARACHUTE_HOME", () => {
+    // Control. If this ever failed, the assertions above would be vacuous —
+    // they'd be describing a variable nothing reads.
+    expect(configDir({ PARACHUTE_HOME: "/tmp/some-other-root" })).toBe("/tmp/some-other-root");
+    expect(configDir({})).toBe(realConfigDir);
+  });
+
+  test("the preload overrides an inherited live-looking home in a child suite", async () => {
+    const sandbox = mkdtempSync(join(tmpdir(), "hub-home-isolation-"));
+    try {
+      const inherited = join(sandbox, ".parachute");
+      const probe = join(sandbox, "probe.test.ts");
+      await Bun.write(
+        probe,
+        [
+          `import { test } from "bun:test";`,
+          `import { CONFIG_DIR, SERVICES_MANIFEST_PATH } from ${JSON.stringify(resolve(REPO_ROOT, "src/config.ts"))};`,
+          `test("default config constants", () => {`,
+          `  console.log("CONFIG_DIR=" + CONFIG_DIR);`,
+          `  console.log("MANIFEST=" + SERVICES_MANIFEST_PATH);`,
+          `  console.log("HUB_TOKEN=" + process.env.PARACHUTE_HUB_TOKEN);`,
+          "});",
+        ].join("\n"),
+      );
+
+      const proc = Bun.spawn(["bun", "test", probe], {
+        cwd: REPO_ROOT,
+        stdout: "pipe",
+        stderr: "pipe",
+        env: {
+          ...process.env,
+          HOME: sandbox,
+          PARACHUTE_HOME: inherited,
+          PARACHUTE_HUB_TOKEN: "live-looking-token",
+        },
+      });
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+      const output = stdout + stderr;
+
+      expect(exitCode).toBe(0);
+      expect(output).toContain("CONFIG_DIR=");
+      expect(output).toContain("HUB_TOKEN=\n");
+      expect(output).not.toContain("HUB_TOKEN=live-looking-token");
+      expect(output).not.toContain(`CONFIG_DIR=${inherited}`);
+      expect(output).not.toContain(`MANIFEST=${join(inherited, "services.json")}`);
+      expect(existsSync(inherited)).toBe(false);
+    } finally {
+      rmSync(sandbox, { recursive: true, force: true });
+    }
+  });
+
+  test("a test process without the preload refuses the real fallback", async () => {
+    const probe = [
+      "delete process.env.PARACHUTE_HOME;",
+      'process.env.NODE_ENV = "test";',
+      `const { CONFIG_DIR } = await import(${JSON.stringify(resolve(REPO_ROOT, "src/config.ts"))});`,
+      "console.log(CONFIG_DIR);",
+    ].join("\n");
+    const proc = Bun.spawn(["bun", "-e", probe], {
+      cwd: tmpdir(),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, PARACHUTE_HOME: undefined, HOME: homedir(), NODE_ENV: "test" },
+    });
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+
+    expect(exitCode).not.toBe(0);
+    expect(stdout + stderr).toContain("refusing to resolve test state inside the live install");
+  });
+});

--- a/src/__tests__/preload-isolate-home.ts
+++ b/src/__tests__/preload-isolate-home.ts
@@ -1,0 +1,70 @@
+/**
+ * Sandbox `PARACHUTE_HOME` for the whole test run. Wired as `[test] preload`
+ * in `bunfig.toml`, so it applies to `bun test` however it's invoked — not
+ * only through `bun run test`, which is not how CI runs the suite.
+ *
+ * ## Why a preload and not a `beforeEach`
+ *
+ * `config.ts` computes the config root ONCE, at import time:
+ *
+ *     export const CONFIG_DIR = configDir();
+ *     export const SERVICES_MANIFEST_PATH = join(CONFIG_DIR, "services.json");
+ *
+ * Every `deps.manifestPath ?? SERVICES_MANIFEST_PATH` fallback in the server
+ * (hub-server, api-users, api-vault-caps, account-api, admin-vaults, …) reads
+ * that frozen value. By the time a `beforeEach` runs, the constant is already
+ * bound to the operator's real `~/.parachute`. Only something that runs BEFORE
+ * the first import can move it — hence a preload.
+ *
+ * ## What was leaking (hub#840)
+ *
+ * The suite has plenty of per-test temp dirs; the leak is in the handler tests
+ * that build a hub server without threading `manifestPath` through `deps`.
+ * Measured on `next` by pointing `HOME` at a sentinel and running `bun test
+ * ./src`: **116 reads of the live `services.json`** — 84 from
+ * `oauth-handlers.test.ts`, 17 from `migrate.test.ts`, 13 from
+ * `hub-server.test.ts`, one each from `setup-gate.test.ts` and
+ * `admin-lock.test.ts`. Not read-only, either: the same run CREATED
+ * `operator.token` (mode 0600) and `well-known/parachute.json` inside the live
+ * config dir.
+ *
+ * On a CI runner that is harmless — there is no `~/.parachute` there, which is
+ * why this has never turned CI red. On an operator box it is live supervisor
+ * state, and #840 records a test run registering a dead `parachute-app` row at
+ * port 1942 into the real manifest.
+ *
+ * ## Why an EMPTY dir specifically
+ *
+ * The sandbox reproduces the CI shape: a config root with nothing in it. That
+ * matters — seeding it instead is what makes tests fail. The same sentinel run
+ * above went 38 red, and every one of those failures was a test reading the
+ * sentinel's contents (the `expose` plan tests read the manifest to build their
+ * plan). Under an empty root they pass, exactly as they do on CI. Isolation
+ * here means "no ambient state", not "different ambient state".
+ *
+ * Deliberately unconditional: an exported `PARACHUTE_HOME` pointing at the real
+ * config root is precisely the case this has to defend against, so honouring a
+ * pre-set value would hand the footgun back. An inherited bearer would bypass
+ * on-disk isolation the same way; blank it. Tests that need a token inject one
+ * explicitly.
+ *
+ * Bun test does not reliably dispatch process exit hooks, so do not promise
+ * cleanup that will not run. The OS reaps these small temp directories.
+ */
+
+import { mkdtempSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { join, sep } from "node:path";
+
+const realHome = join(homedir(), ".parachute");
+const sandbox = mkdtempSync(join(tmpdir(), "phub-test-home-"));
+
+if (sandbox === realHome || sandbox.startsWith(`${realHome}${sep}`)) {
+  throw new Error(
+    `[hub test preload] refusing to run: temporary test home ${sandbox} is inside ` +
+      `the live install at ${realHome}; check TMPDIR`,
+  );
+}
+
+process.env.PARACHUTE_HOME = sandbox;
+process.env.PARACHUTE_HUB_TOKEN = "";

--- a/src/__tests__/pubkey-links.test.ts
+++ b/src/__tests__/pubkey-links.test.ts
@@ -3,8 +3,8 @@
  * attribution snapshot on `tokens` rows (phase 1b).
  *
  * Coverage:
- *   - migration v17 lands `user_pubkeys`, `pubkey_challenges`, and the
- *     additive `tokens.subject_pubkey` column
+ *   - migrations v17/v18 land live linkage, registry attribution, and the
+ *     durable proof archive
  *   - challenges: issued hashed (raw value is NOT recoverable from the DB),
  *     single-use, TTL-bounded, user-bound
  *   - link: happy path; replay of a consumed challenge; expired challenge;
@@ -20,11 +20,12 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { hubDbPath, migrate, openHubDb } from "../hub-db.ts";
 import { findTokenRowByJti, recordTokenMint, signRefreshToken } from "../jwt-sign.ts";
 import {
   MAX_PUBKEYS_PER_USER,
   PUBKEY_CHALLENGE_TTL_MS,
+  attributionProofsForSubject,
   attributionPubkey,
   issuePubkeyChallenge,
   linkPubkey,
@@ -70,14 +71,15 @@ async function user(name: string): Promise<string> {
   return u.id;
 }
 
-describe("migration v17", () => {
-  test("creates the linkage tables and the additive tokens column", () => {
+describe("migrations v17/v18", () => {
+  test("creates the linkage and proof tables plus the additive tokens column", () => {
     const tables = db
       .query<{ name: string }, []>("SELECT name FROM sqlite_master WHERE type = 'table'")
       .all()
       .map((r) => r.name);
     expect(tables).toContain("user_pubkeys");
     expect(tables).toContain("pubkey_challenges");
+    expect(tables).toContain("attribution_proofs");
 
     const cols = db.query<{ name: string; notnull: number }, []>("PRAGMA table_info(tokens)").all();
     const subjectPubkey = cols.find((c) => c.name === "subject_pubkey");
@@ -110,6 +112,39 @@ describe("migration v17", () => {
         now,
       }),
     ).toEqual({ ok: false, reason: "pubkey_taken" });
+  });
+
+  test("v18 backfills proofs from links that existed at migration time", async () => {
+    const alice = await user("alice");
+    const now = new Date(1_700_000_000_000);
+    const { challenge } = issuePubkeyChallenge(db, alice, now);
+    const signedProof = proof(PK_A, challenge);
+    expect(
+      linkPubkey(db, {
+        userId: alice,
+        pubkey: PK_A,
+        challenge,
+        proofEvent: signedProof,
+        proofEventId: "proof-before-v18",
+        now,
+      }).ok,
+    ).toBe(true);
+
+    // Recreate the exact pre-v18 schema state while retaining its live link.
+    db.exec("DROP TABLE attribution_proofs; DELETE FROM schema_version WHERE version = 18");
+    migrate(db);
+
+    expect(attributionProofsForSubject(db, alice)).toEqual([
+      {
+        pubkey: PK_A,
+        userId: alice,
+        label: null,
+        proofEvent: signedProof,
+        proofEventId: "proof-before-v18",
+        linkedAt: now.toISOString(),
+        lastVerifiedAt: now.toISOString(),
+      },
+    ]);
   });
 });
 
@@ -154,6 +189,45 @@ describe("linkPubkey", () => {
     expect(res.link.label).toBe("laptop");
     expect(res.link.linkedAt).toBe(now.toISOString());
     expect(proofEventFor(db, PK_A)).toBe(proof(PK_A, challenge));
+    expect(attributionProofsForSubject(db, alice)).toEqual([
+      expect.objectContaining({
+        pubkey: PK_A,
+        userId: alice,
+        proofEvent: proof(PK_A, challenge),
+      }),
+    ]);
+  });
+
+  test("keeps each subject's proof when an unlinked key is linked to someone else", async () => {
+    const alice = await user("alice");
+    const bob = await user("bob");
+    const first = issuePubkeyChallenge(db, alice, new Date(1_700_000_000_000));
+    expect(
+      linkPubkey(db, {
+        userId: alice,
+        pubkey: PK_A,
+        challenge: first.challenge,
+        proofEvent: proof(PK_A, first.challenge),
+        now: new Date(1_700_000_000_000),
+      }).ok,
+    ).toBe(true);
+    expect(unlinkPubkey(db, alice, PK_A)).toBe(true);
+
+    const second = issuePubkeyChallenge(db, bob, new Date(1_700_000_001_000));
+    expect(
+      linkPubkey(db, {
+        userId: bob,
+        pubkey: PK_A,
+        challenge: second.challenge,
+        proofEvent: proof(PK_A, second.challenge),
+        now: new Date(1_700_000_001_000),
+      }).ok,
+    ).toBe(true);
+
+    expect(attributionProofsForSubject(db, alice)[0]?.proofEvent).toBe(
+      proof(PK_A, first.challenge),
+    );
+    expect(attributionProofsForSubject(db, bob)[0]?.proofEvent).toBe(proof(PK_A, second.challenge));
   });
 
   test("a challenge is single-use — replay is refused", async () => {

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -14,8 +14,10 @@ import {
   compareVersions,
   decidePublish,
   distTagFor,
+  driftLogArgs,
   emitOutputs,
   readRegistry,
+  tagPrefixFor,
   unpublishedDrift,
 } from "../../scripts/release-plan.ts";
 
@@ -178,6 +180,113 @@ describe("unpublishedDrift", () => {
 
   test("blank lines from git's trailing newline don't inflate the count", () => {
     expect(unpublishedDrift(["abc one", ""]).count).toBe(1);
+  });
+});
+
+/**
+ * hub#830: the drift advisory has to be able to RUN.
+ *
+ * Two independent defects made it dead code in CI:
+ *
+ *   1. The `plan` job used a bare `actions/checkout@v6`, which fetches
+ *      `--depth=1 --no-tags`. `git log v0.7.14..HEAD` in that clone exits 128
+ *      ("unknown revision"), the `proc.exitCode === 0` guard skips, and the
+ *      advisory reports nothing — indistinguishable from "everything is
+ *      shipped", which is the exact confusion it was built to end.
+ *   2. The revision range hardcoded a `v` prefix. Sub-package tags are
+ *      namespaced (`door-contract-v0.7.0`), so door-contract@0.7.0 would have
+ *      been compared against HUB's `v0.7.0` tag — a real tag, pointing at
+ *      unrelated history, so the advisory would have listed nine months of hub
+ *      commits as "door-contract's unpublished work". Masked only by defect 1.
+ *
+ * The prefixes here are not invented: they're the ones `tag-record` pushes at
+ * the bottom of release.yml, and the ones the `on: push: tags:` filters match.
+ */
+describe("tagPrefixFor", () => {
+  test("the root package is hub, whose tags are bare `vX.Y.Z`", () => {
+    expect(tagPrefixFor(".")).toBe("v");
+    expect(tagPrefixFor("")).toBe("v");
+    expect(tagPrefixFor("./")).toBe("v");
+  });
+
+  test("sub-packages get their namespaced prefix — same strings tag-record pushes", () => {
+    expect(tagPrefixFor("packages/scope-guard")).toBe("scope-guard-v");
+    expect(tagPrefixFor("packages/depcheck")).toBe("depcheck-v");
+    expect(tagPrefixFor("packages/door-contract")).toBe("door-contract-v");
+    // Trailing slash is the same package.
+    expect(tagPrefixFor("packages/door-contract/")).toBe("door-contract-v");
+  });
+
+  test("the prefixes match what release.yml's tag-record actually pushes", () => {
+    const workflow = readFileSync(
+      join(import.meta.dir, "../../.github/workflows/release.yml"),
+      "utf8",
+    );
+    for (const [dir, prefix] of [
+      [".", "v"],
+      ["packages/scope-guard", "scope-guard-v"],
+      ["packages/depcheck", "depcheck-v"],
+      ["packages/door-contract", "door-contract-v"],
+    ] as const) {
+      expect(tagPrefixFor(dir)).toBe(prefix);
+      expect(workflow).toMatch(
+        new RegExp(`tag_if\\s+"${prefix}"\\s+"${dir === "." ? "\\." : dir}"`),
+      );
+    }
+  });
+});
+
+describe("driftLogArgs", () => {
+  test("hub compares against its own bare-v tag", () => {
+    expect(driftLogArgs(".", "0.7.14")).toEqual([
+      "git",
+      "log",
+      "v0.7.14..HEAD",
+      "--oneline",
+      "--no-merges",
+      "--",
+      ".",
+    ]);
+  });
+
+  test("door-contract compares against door-contract-v, NOT hub's v tag", () => {
+    const args = driftLogArgs("packages/door-contract", "0.7.0");
+    expect(args).toContain("door-contract-v0.7.0..HEAD");
+    // The bug: `v0.7.0` is a real HUB tag, so the wrong range would have
+    // resolved and listed hub's history as door-contract's drift.
+    expect(args).not.toContain("v0.7.0..HEAD");
+  });
+
+  test("the listing is scoped to the package — a hub commit isn't scope-guard drift", () => {
+    expect(driftLogArgs("packages/scope-guard", "0.5.1").slice(-2)).toEqual([
+      "--",
+      "packages/scope-guard",
+    ]);
+  });
+});
+
+describe("release.yml drift advisory can execute (hub#830)", () => {
+  const workflow = readFileSync(
+    join(import.meta.dir, "../../.github/workflows/release.yml"),
+    "utf8",
+  );
+  // Scope every assertion to the `plan` job — the other jobs' shallow
+  // checkouts are fine, only `plan` reads git history.
+  const planJob = workflow.match(/\n {2}plan:\n([\s\S]*?)\n {2}[a-z][\w-]*:\n/)?.[1];
+
+  test("the plan job is findable (guards the slicing above)", () => {
+    expect(planJob).toBeTruthy();
+    expect(planJob).toContain("bun scripts/release-plan.ts . @openparachute/hub");
+  });
+
+  test("the plan job's checkout fetches full history — depth=1 has no merge base", () => {
+    expect(planJob).toMatch(/actions\/checkout@v6\n\s*with:\n(?:\s*.+\n)*?\s*fetch-depth:\s*0/);
+  });
+
+  test("the plan job's checkout fetches tags — the advisory's range is a TAG", () => {
+    // Bare checkout passes `--no-tags`; without this the range never resolves
+    // and the advisory silently reports nothing, forever.
+    expect(planJob).toMatch(/fetch-tags:\s*true/);
   });
 });
 

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -12,11 +12,17 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   compareVersions,
+  coreVersion,
   decidePublish,
+  disallowedStablePromotionPaths,
   distTagFor,
   driftLogArgs,
   emitOutputs,
+  latestMatchingRcTag,
+  matchingRcVersions,
+  rcTagListArgs,
   readRegistry,
+  stablePromotionDiffArgs,
   tagPrefixFor,
   unpublishedDrift,
 } from "../../scripts/release-plan.ts";
@@ -117,6 +123,140 @@ describe("decidePublish", () => {
     const d = decidePublish("0.7.9", { ambiguous: true }, { isTagPush: true });
     expect(d).toMatchObject({ publish: true });
   });
+
+  test("a stable without a matching rc is refused — 0.7.13 through 0.7.16 skipped this", () => {
+    // Cutting @latest with new code and no rc of the same X.Y.Z is how
+    // 0.7.13–0.7.16 shipped. Stable is a suffix-drop, never a skip.
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+      publishedVersions: ["0.7.16", "0.7.12-rc.2"],
+    });
+    expect(d).toMatchObject({ refuse: true });
+    expect("refuse" in d && d.reason).toMatch(/0\.7\.17-rc/);
+    expect("refuse" in d && d.reason).toMatch(/suffix-drop|Cut an rc first/i);
+  });
+
+  test("a stable whose only published rcs are a different X.Y.Z is still refused", () => {
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+      publishedVersions: ["0.7.16", "0.7.16-rc.1"],
+    });
+    expect(d).toMatchObject({ refuse: true });
+  });
+
+  test("a stable with a matching rc publishes — suffix-drop is the only legal stable", () => {
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+      publishedVersions: ["0.7.16", "0.7.17-rc.1"],
+    });
+    expect(d).toMatchObject({ publish: true });
+  });
+
+  test("omitted publishedVersions still refuses a stable when latest already exists", () => {
+    // Callers that forget to plumb the version list must not silently skip
+    // the gate — that's how 0.7.13–0.7.16 would keep shipping.
+    const d = decidePublish("0.7.17", {
+      versionExists: false,
+      currentDistTagVersion: "0.7.16",
+    });
+    expect(d).toMatchObject({ refuse: true });
+  });
+
+  test("tag-push still overrides the rc-required check", () => {
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16"],
+      },
+      { isTagPush: true },
+    );
+    expect(d).toMatchObject({ publish: true });
+  });
+});
+
+describe("matchingRcVersions", () => {
+  test("matches only the same X.Y.Z rc chain", () => {
+    expect(
+      matchingRcVersions("0.7.17", ["0.7.16", "0.7.16-rc.1", "0.7.17-rc.1", "0.7.17-rc.2"]),
+    ).toEqual(["0.7.17-rc.1", "0.7.17-rc.2"]);
+  });
+
+  test("a prerelease still matches siblings of its core", () => {
+    expect(matchingRcVersions("0.7.17-rc.3", ["0.7.17-rc.1", "0.7.16-rc.1"])).toEqual([
+      "0.7.17-rc.1",
+    ]);
+  });
+});
+
+describe("coreVersion", () => {
+  test("strips the rc suffix and leaves a stable alone", () => {
+    expect(coreVersion("0.7.17-rc.1")).toBe("0.7.17");
+    expect(coreVersion("0.7.17")).toBe("0.7.17");
+  });
+});
+
+describe("latestMatchingRcTag", () => {
+  test("picks the highest N for hub's bare-v tags", () => {
+    expect(
+      latestMatchingRcTag(
+        ["v0.7.16-rc.1", "v0.7.17-rc.1", "v0.7.17-rc.2", "v0.7.17"],
+        "0.7.17",
+        "v",
+      ),
+    ).toBe("v0.7.17-rc.2");
+  });
+
+  test("namespaces sub-package tags — a hub v tag is not door-contract's", () => {
+    expect(
+      latestMatchingRcTag(
+        ["v0.7.0-rc.9", "door-contract-v0.7.0-rc.1", "door-contract-v0.7.0-rc.2"],
+        "0.7.0",
+        "door-contract-v",
+      ),
+    ).toBe("door-contract-v0.7.0-rc.2");
+  });
+
+  test("undefined when the chain has no rc tag", () => {
+    expect(latestMatchingRcTag(["v0.7.16"], "0.7.17", "v")).toBeUndefined();
+  });
+});
+
+describe("disallowedStablePromotionPaths", () => {
+  test("version/changelog/lockfile-only is a suffix-drop", () => {
+    expect(disallowedStablePromotionPaths(["package.json", "CHANGELOG.md", "bun.lock"])).toEqual(
+      [],
+    );
+  });
+
+  test("a source file is new code — the 0.7.13–0.7.16 skip-rc shape", () => {
+    expect(disallowedStablePromotionPaths(["package.json", "src/users.ts"])).toEqual([
+      "src/users.ts",
+    ]);
+  });
+});
+
+describe("rcTagListArgs / stablePromotionDiffArgs", () => {
+  test("hub lists its own bare-v rc tags", () => {
+    expect(rcTagListArgs(".", "0.7.17")).toEqual(["git", "tag", "-l", "v0.7.17-rc.*"]);
+  });
+
+  test("door-contract lists door-contract-v, not hub's v", () => {
+    expect(rcTagListArgs("packages/door-contract", "0.7.0")[3]).toBe("door-contract-v0.7.0-rc.*");
+  });
+
+  test("the suffix-drop diff is name-only from the rc tag to HEAD", () => {
+    expect(stablePromotionDiffArgs("v0.7.17-rc.1")).toEqual([
+      "git",
+      "diff",
+      "--name-only",
+      "v0.7.17-rc.1..HEAD",
+    ]);
+  });
 });
 
 describe("readRegistry", () => {
@@ -129,7 +269,11 @@ describe("readRegistry", () => {
         versions: { "0.7.9-rc.1": {}, "0.7.9-rc.2": {} },
         "dist-tags": { rc: "0.7.9-rc.2", latest: "0.7.8" },
       })) as unknown as typeof fetch);
-    expect(v).toMatchObject({ versionExists: true, currentDistTagVersion: "0.7.9-rc.2" });
+    expect(v).toMatchObject({
+      versionExists: true,
+      currentDistTagVersion: "0.7.9-rc.2",
+      publishedVersions: ["0.7.9-rc.1", "0.7.9-rc.2"],
+    });
   });
 
   test("picks the dist-tag matching the version's channel", async () => {

--- a/src/__tests__/serve.test.ts
+++ b/src/__tests__/serve.test.ts
@@ -16,7 +16,7 @@ import {
   seedInitialAdminIfNeeded,
 } from "../commands/serve.ts";
 import { openHubDb } from "../hub-db.ts";
-import { getUserByUsername, userCount } from "../users.ts";
+import { InvalidUsernameError, getUserByUsername, userCount } from "../users.ts";
 
 describe("hubServeOptions — the production listener wires the WS bridge", () => {
   // Regression guard: the WS bridge handler was wired into hub-server.ts's
@@ -392,6 +392,132 @@ describe("seedInitialAdminIfNeeded", () => {
     );
     expect(result).toBe("needs-setup");
     expect(userCount(db)).toBe(0);
+  });
+
+  test("hub#864 — first-boot reserved `admin` seeds, then warns it cannot link", async () => {
+    const db = openHubDb(dbPath);
+    const log = mock<(line: string) => void>(() => {});
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "admin",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "correct horse battery staple",
+      },
+      log,
+    );
+    expect(result).toBe("seeded");
+    expect(userCount(db)).toBe(1);
+    const joined = log.mock.calls.map((c) => c[0] ?? "").join("\n");
+    expect(joined).toContain("seeded initial admin");
+    expect(joined).toContain("cannot run the pubkey-linkage ceremony");
+    expect(joined).toContain('"admin" (reserved)');
+  });
+
+  test("hub#864 — invalid env username is refused and nothing is seeded", async () => {
+    const db = openHubDb(dbPath);
+    const log = mock<(line: string) => void>(() => {});
+    await expect(
+      seedInitialAdminIfNeeded(
+        db,
+        {
+          PARACHUTE_INITIAL_ADMIN_USERNAME: "Alice",
+          PARACHUTE_INITIAL_ADMIN_PASSWORD: "correct horse battery staple",
+        },
+        log,
+      ),
+    ).rejects.toThrow(InvalidUsernameError);
+    expect(userCount(db)).toBe(0);
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("PARACHUTE_INITIAL_ADMIN_USERNAME");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("invalid (format)");
+  });
+
+  test("hub#864 — existing grandfathered row logs the unlinkable warning", async () => {
+    const db = openHubDb(dbPath);
+    await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "first-pw",
+      },
+      () => {},
+    );
+    const stamp = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+       VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+    ).run("legacy-1", "Alice", "not-a-real-hash", stamp, stamp);
+    const log = mock<(line: string) => void>(() => {});
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "ignored",
+      },
+      log,
+    );
+    expect(result).toBe("exists");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain("cannot run the pubkey-linkage ceremony");
+    expect(log.mock.calls[0]?.[0] ?? "").toContain('"Alice" (format)');
+  });
+
+  test("hub#864 — grandfathered username with a newline cannot forge extra log lines", async () => {
+    const db = openHubDb(dbPath);
+    await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "first-pw",
+      },
+      () => {},
+    );
+    // Pre-#864 rows could contain control chars; a raw interpolation would
+    // split the boot warning into extra operator-log lines.
+    const forged = "Alice\nFORGED extra operator line";
+    const stamp = new Date().toISOString();
+    db.prepare(
+      `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+       VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+    ).run("legacy-nl", forged, "not-a-real-hash", stamp, stamp);
+    const log = mock<(line: string) => void>(() => {});
+    const result = await seedInitialAdminIfNeeded(
+      db,
+      {
+        PARACHUTE_INITIAL_ADMIN_USERNAME: "ops",
+        PARACHUTE_INITIAL_ADMIN_PASSWORD: "ignored",
+      },
+      log,
+    );
+    expect(result).toBe("exists");
+    expect(log.mock.calls).toHaveLength(1);
+    const line = log.mock.calls[0]?.[0] ?? "";
+    expect(line).not.toContain("\n");
+    expect(line).not.toContain("\r");
+    expect(line).toContain(JSON.stringify(forged));
+    expect(line).toContain("cannot run the pubkey-linkage ceremony");
+  });
+
+  test("hub#864 — invalid env username with a newline cannot forge extra log lines", async () => {
+    const db = openHubDb(dbPath);
+    const forged = "Alice\nFORGED extra operator line";
+    const log = mock<(line: string) => void>(() => {});
+    await expect(
+      seedInitialAdminIfNeeded(
+        db,
+        {
+          PARACHUTE_INITIAL_ADMIN_USERNAME: forged,
+          PARACHUTE_INITIAL_ADMIN_PASSWORD: "correct horse battery staple",
+        },
+        log,
+      ),
+    ).rejects.toThrow(InvalidUsernameError);
+    expect(userCount(db)).toBe(0);
+    expect(log.mock.calls).toHaveLength(1);
+    const line = log.mock.calls[0]?.[0] ?? "";
+    expect(line).not.toContain("\n");
+    expect(line).not.toContain("\r");
+    expect(line).toContain(JSON.stringify(forged));
+    expect(line).toContain("PARACHUTE_INITIAL_ADMIN_USERNAME");
+    expect(line).toContain("invalid (format)");
   });
 });
 

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -6,6 +6,7 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { recordTokenMint, signAccessToken } from "../jwt-sign.ts";
 import { createSession, findSession } from "../sessions.ts";
 import {
+  InvalidUsernameError,
   PASSWORD_MIN_LEN,
   SingleUserModeError,
   USERNAME_RESERVED,
@@ -18,6 +19,8 @@ import {
   getUserByUsername,
   getUserByUsernameCI,
   isFirstAdmin,
+  isSeedAdminUsername,
+  listUnlinkableUsernames,
   listUsers,
   resetUserPassword,
   setPassword,
@@ -177,6 +180,37 @@ describe("createUser", () => {
       cleanup();
     }
   });
+
+  test("hub#864 chokepoint — rejects format/length/reserved on every write", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await expect(createUser(db, "Alice", "pw1")).rejects.toThrow(InvalidUsernameError);
+      await expect(createUser(db, "user.name", "pw1")).rejects.toThrow(InvalidUsernameError);
+      await expect(createUser(db, "a", "pw1")).rejects.toThrow(InvalidUsernameError);
+      await expect(createUser(db, "root", "pw1")).rejects.toThrow(InvalidUsernameError);
+      expect(userCount(db)).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("hub#864 — first-user reserved `admin` is allowed; a later `admin` is not", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const first = await createUser(db, "admin", "pw1");
+      expect(first.username).toBe("admin");
+      await expect(createUser(db, "admin", "pw2", { allowMulti: true })).rejects.toThrow(
+        InvalidUsernameError,
+      );
+      // A second reserved word never gets the seed exemption.
+      await expect(createUser(db, "root", "pw2", { allowMulti: true })).rejects.toThrow(
+        InvalidUsernameError,
+      );
+      expect(userCount(db)).toBe(1);
+    } finally {
+      cleanup();
+    }
+  });
 });
 
 describe("verifyPassword", () => {
@@ -228,8 +262,8 @@ describe("listUsers / getUserByUsername", () => {
   test("listUsers returns rows in created_at order", async () => {
     const { db, cleanup } = makeDb();
     try {
-      const a = await createUser(db, "a", "pw", { now: () => new Date(1000) });
-      const b = await createUser(db, "b", "pw", {
+      const a = await createUser(db, "aa", "pw", { now: () => new Date(1000) });
+      const b = await createUser(db, "bb", "pw", {
         allowMulti: true,
         now: () => new Date(2000),
       });
@@ -400,6 +434,50 @@ describe("validateUsername", () => {
     expect(validateUsername("user-2").valid).toBe(true);
     expect(validateUsername("123").valid).toBe(true);
     expect(validateUsername("_-_").valid).toBe(true);
+  });
+});
+
+describe("isSeedAdminUsername", () => {
+  test("only the exact lowercase first-user `admin`", () => {
+    expect(isSeedAdminUsername("admin", 0)).toBe(true);
+    expect(isSeedAdminUsername("admin", 1)).toBe(false);
+    expect(isSeedAdminUsername("Admin", 0)).toBe(false);
+    expect(isSeedAdminUsername("root", 0)).toBe(false);
+    expect(isSeedAdminUsername("ops", 0)).toBe(false);
+  });
+});
+
+describe("listUnlinkableUsernames", () => {
+  test("empty when every row is valid", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "ops", "pw1");
+      expect(listUnlinkableUsernames(db)).toEqual([]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("reports a seeded `admin` and a grandfathered out-of-charset row", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      await createUser(db, "admin", "pw1");
+      const stamp = new Date().toISOString();
+      db.prepare(
+        `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed, email)
+         VALUES (?, ?, ?, ?, ?, 1, NULL)`,
+      ).run("legacy-1", "Alice", "not-a-real-hash", stamp, stamp);
+      const listed = listUnlinkableUsernames(db);
+      expect(listed).toEqual(
+        expect.arrayContaining([
+          { username: "admin", reason: "reserved" },
+          { username: "Alice", reason: "format" },
+        ]),
+      );
+      expect(listed).toHaveLength(2);
+    } finally {
+      cleanup();
+    }
   });
 });
 

--- a/src/__tests__/ws-bridge.test.ts
+++ b/src/__tests__/ws-bridge.test.ts
@@ -198,15 +198,14 @@ describe("WS bridge integration — declaring module, real sockets (H1)", () => 
       client.send(new Uint8Array([1, 2, 3, 250]));
       expect([...(await gotBinary.promise)]).toEqual([1, 2, 3, 250]);
 
-      // Client-initiated close propagates the CODE to the upstream. The
-      // reason string is not propagated in this direction: Bun's server-side
-      // websocket close callback delivers an empty reason (verified on Bun
-      // 1.3.13), so the bridge never receives it. Upstream→client reason
-      // propagation works (next test).
+      // Client-initiated close propagates code + reason to the upstream.
+      // Bun 1.3.13 delivered an empty reason on the server-side close
+      // callback (so the bridge could not forward it). Bun 1.4 forwards
+      // the reason. Upstream→client still has its own test below.
       client.close(4002, "client done");
       const upstreamClose = await upstream.closed;
       expect(upstreamClose.code).toBe(4002);
-      expect(upstreamClose.reason).toBe("");
+      expect(upstreamClose.reason).toBe("client done");
     } finally {
       hub?.stop();
       upstream.stop();

--- a/src/api-account-pubkeys.ts
+++ b/src/api-account-pubkeys.ts
@@ -150,17 +150,12 @@ export const MAX_PUBKEY_LABEL_LEN = 64;
  *     signer pane that truncates cannot hide the `Account:` prefix and leave a
  *     forged tail behind.
  *   - We REFUSE to build the statement at all when `validateUsername` rejects
- *     the name. `createUser` does not run the validator, and two write paths
- *     reach it ungated — `parachute auth set-password --username` (auth.ts) and
- *     `PARACHUTE_INITIAL_ADMIN_USERNAME` (serve.ts) — so a hostile username CAN
- *     reach the DB. The ceremony must not trust that it didn't: an account
- *     whose username the validator rejects simply cannot run the ceremony
- *     (`username_unlinkable`). (The two username validators still diverge —
- *     `setup-wizard.ts` accepts a looser `[A-Za-z0-9_.-]` superset; reconciling
- *     them onto `validateUsername` touches a shipped-door setup path and
- *     `admin`-as-reserved / period / length compat, so it is filed as a
- *     follow-up rather than folded here. This refusal closes the exploit
- *     independent of that reconciliation.)
+ *     the name. `createUser` now runs the validator (hub#864), so new writes
+ *     cannot land a hostile username. Existing rows (and a seeded first-user
+ *     `admin`) are grandfathered and still cannot run the ceremony
+ *     (`username_unlinkable`) until renamed. The ceremony must not trust that
+ *     the row was gated: an account whose username the validator rejects
+ *     simply cannot run it.
  *
  * @throws if `validateUsername(username)` fails — callers on this surface guard
  * with the same check first and return `username_unlinkable`, so this throw is
@@ -174,9 +169,9 @@ export function linkageStatement(origin: string, username: string): string {
     );
   }
   // EIP-4361 / SIWE shape: one legible sentence, the bound account isolated on
-  // its own line, its value JSON-encoded. `validateUsername` has already pinned
-  // the charset to [a-z0-9_-], so the encoding can never actually need to
-  // escape anything — it is defense-in-depth for the ungated-write paths above.
+  // its own line, its value JSON-encoded. `validateUsername` (and createUser)
+  // pin the charset to [a-z0-9_-] for new writes; the encoding is still
+  // defense-in-depth for grandfathered rows that reached the DB before #864.
   return [
     `${origin} asks you to link a Nostr key to a Parachute account.`,
     "",

--- a/src/api-account-pubkeys.ts
+++ b/src/api-account-pubkeys.ts
@@ -17,7 +17,8 @@
  *   GET  ""           → the caller's own linked keys
  *   POST "/challenge" → mint a single-use challenge + the event template
  *   POST "/verify"    → present a signed NIP-01 event; link on success
- *   POST "/unlink"    → drop one of the caller's own links
+ *   POST "/unlink"    → drop one of the caller's own live links; retain its
+ *                        proof for historical registry attribution
  *
  * ## The ceremony
  *
@@ -64,7 +65,7 @@
  *
  * Nothing. No scope, no claim, no authentication path. A linked key is an
  * attribution label; `sub` remains the only principal the hub authorizes on.
- * See `pubkey-links.ts` and migration v17.
+ * See `pubkey-links.ts` and migrations v17/v18.
  */
 import type { Database } from "bun:sqlite";
 import {

--- a/src/api-account-pubkeys.ts
+++ b/src/api-account-pubkeys.ts
@@ -35,15 +35,16 @@
  *     type- and length-checked before any hashing or curve math)
  *   - `kind === 27235`
  *   - `created_at` within ±5 minutes of the hub's clock
- *   - the `u` tag naming an origin this hub answers on AND the verify path
- *   - the `method` tag exactly `POST`
+ *   - exactly one `u` tag, naming an origin this hub answers on AND the verify path
+ *   - exactly one `method` tag, with the value `POST`
  *   - `content` exactly the linkage statement for THIS session's account and
  *     that origin
  *   - a recomputed NIP-01 id matching the claimed `id`
  *   - a BIP-340 Schnorr signature over that id verifying against the claimed
  *     x-only pubkey
- *   - a challenge that exists, belongs to THIS user, is unconsumed, and is
- *     unexpired — consumed atomically with the link write
+ *   - exactly one `challenge` tag, naming a challenge that exists, belongs to
+ *     THIS user, is unconsumed, and is unexpired — consumed atomically with
+ *     the link write
  *
  * Four independent defenses stack here. Against REPLAY: the server-issued
  * single-use challenge (primary), the `created_at` window, and the `u`/`method`
@@ -373,7 +374,7 @@ function requestOrigin(req: Request): string {
  *   1. label validation (pure string check — reject before anything else so a
  *      bad label can't burn a challenge)
  *   2. event shape + bounds (`parseNostrEvent`; no hashing yet)
- *   3. kind / created_at / `u` / `method` / challenge-tag presence — all pure
+ *   3. kind / created_at / exactly-one `u` / `method` / `challenge` tags — all pure
  *   4. the legible statement in `content` (see `linkageStatement`), recomputed
  *      from the SESSION's user and the `u` tag's already-validated origin
  *   5. rate limit (before any curve math)
@@ -555,6 +556,24 @@ async function handleVerify(
  */
 type BindingResult = { ok: true; origin: string } | { ok: false; res: Response };
 
+type BindingTagName = "u" | "method" | "challenge";
+
+/**
+ * Return the first security-critical binding tag that appears more than once.
+ * `tagValue` is intentionally first-wins for general Nostr use, but a stored
+ * linkage proof must have one unambiguous interpretation for every verifier.
+ */
+function duplicateBindingTag(event: NostrEvent): BindingTagName | null {
+  const seen = new Set<BindingTagName>();
+  for (const tag of event.tags) {
+    const name = tag[0];
+    if (name !== "u" && name !== "method" && name !== "challenge") continue;
+    if (seen.has(name)) return name;
+    seen.add(name);
+  }
+  return null;
+}
+
 function checkBinding(
   event: NostrEvent,
   req: Request,
@@ -565,6 +584,11 @@ function checkBinding(
     ok: false,
     res: jsonError(400, "invalid_event", why),
   });
+
+  const duplicate = duplicateBindingTag(event);
+  if (duplicate !== null) {
+    return generic(`event must carry exactly one \`${duplicate}\` tag`);
+  }
 
   if (event.kind !== NOSTR_AUTH_KIND) {
     return generic(`event kind must be ${NOSTR_AUTH_KIND}`);

--- a/src/api-attribution.ts
+++ b/src/api-attribution.ts
@@ -13,9 +13,10 @@
  * and that no third party can check.
  *
  * Phase 1b does NOT change that column. It adds a resolution step a reader can
- * take at display time: `sub` → linked pubkey(s) → a portable, checkable
- * identity. The stored value stays opaque and stable; the identity becomes
- * verifiable. This endpoint is the hub's half of that step.
+ * take at display time: `sub` → historically proved pubkey(s) → a portable,
+ * checkable identity. The stored value stays opaque and stable; the identity
+ * remains verifiable even if the live account link is later removed. This
+ * endpoint is the hub's half of that step.
  *
  * ## What "verifiable" means here, precisely
  *
@@ -33,8 +34,9 @@
  * ## Auth + disclosure posture
  *
  * Bearer-gated on `parachute:host:auth`, matching the rest of `/api/auth/*`
- * (`mint-token`, `revoke-token`, `tokens`). This is a **directory of who holds
- * which key**, so it is operator-level on purpose.
+ * (`mint-token`, `revoke-token`, `tokens`). This is a **directory of who has
+ * proved possession of which key**, including historical proofs rather than a
+ * claim about who holds the key now, so it is operator-level on purpose.
  *
  * That is also an acknowledged SEAM, not an oversight: the natural consumer of
  * phase-1b resolution is a resource server (the vault, rendering `created_by`),
@@ -43,12 +45,12 @@
  * — squarely an ACL question (design doc seam S1/S1b, Jon's), so phase 1 leaves
  * it at the operator level rather than guessing.
  *
- * An unknown subject and a subject with no linked key return the SAME body
- * shape with an empty list. There is no user-existence oracle here.
+ * An unknown subject and a subject that never proved a key return the SAME
+ * body shape with an empty list. There is no user-existence oracle here.
  */
 import type { Database } from "bun:sqlite";
 import { validateAccessToken } from "./jwt-sign.ts";
-import { listUserPubkeys, proofEventFor } from "./pubkey-links.ts";
+import { attributionProofsForSubject } from "./pubkey-links.ts";
 
 /** Scope required on the bearer. Same gate as `GET /api/auth/tokens`. */
 export const API_ATTRIBUTION_REQUIRED_SCOPE = "parachute:host:auth";
@@ -133,9 +135,12 @@ export async function handleApiAttribution(
     );
   }
 
-  // 5. Resolve. An unknown subject simply has no rows — same body as a known
-  //    subject with no linked key.
-  const pubkeys = listUserPubkeys(deps.db, subject).map((link) => ({
+  // 5. Resolve from the durable proof archive. An unknown subject simply
+  //    has no rows — same body as a subject that never established a proof.
+  //    Deliberately include historical proofs whose live account link was
+  //    removed: downstream attribution snapshots must stay independently
+  //    verifiable after unlink or account deletion.
+  const pubkeys = attributionProofsForSubject(deps.db, subject).map((link) => ({
     pubkey: link.pubkey,
     label: link.label,
     linked_at: link.linkedAt,
@@ -145,7 +150,7 @@ export async function handleApiAttribution(
     // native shape it would sign. Malformed JSON (impossible via the ceremony —
     // we store `JSON.stringify` of a parsed event — but defense in depth)
     // surfaces as null rather than crashing the response.
-    proof_event: parseProof(proofEventFor(deps.db, link.pubkey)),
+    proof_event: parseProof(link.proofEvent),
   }));
 
   return new Response(JSON.stringify({ subject, pubkeys }), {

--- a/src/api-users.ts
+++ b/src/api-users.ts
@@ -48,10 +48,12 @@ import { type AdminAuthError, adminAuthErrorResponse, requireScope } from "./adm
 import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
 import { SERVICES_MANIFEST_PATH } from "./config.ts";
 import {
+  InvalidUsernameError,
   PASSWORD_MAX_LEN,
   type User,
   UsernameTakenError,
   createUser,
+  describeUsernameReason,
   deleteUser,
   getFirstAdminId,
   getUserById,
@@ -342,6 +344,9 @@ export async function handleCreateUser(req: Request, deps: ApiUsersDeps): Promis
     // INSERT and snagged the username. Surface as the same 409.
     if (err instanceof UsernameTakenError) {
       return jsonError(409, "username_taken", err.message);
+    }
+    if (err instanceof InvalidUsernameError) {
+      return jsonError(400, "invalid_username", describeUsernameReason(err.reason));
     }
     const msg = err instanceof Error ? err.message : String(err);
     return jsonError(500, "server_error", `failed to create user: ${msg}`);
@@ -830,15 +835,4 @@ export async function handleResetUserPassword(
       headers: { "content-type": "application/json", "cache-control": "no-store" },
     },
   );
-}
-
-function describeUsernameReason(reason: "format" | "length" | "reserved"): string {
-  switch (reason) {
-    case "length":
-      return "username must be 2-32 characters long";
-    case "format":
-      return "username must contain only lowercase letters, digits, hyphens, and underscores ([a-z0-9_-])";
-    case "reserved":
-      return "username is reserved (admin, root, system, setup, parachute, hub)";
-  }
 }

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -65,6 +65,7 @@ import {
   persistEnrollment,
 } from "../two-factor-store.ts";
 import {
+  InvalidUsernameError,
   SingleUserModeError,
   UsernameTakenError,
   createUser,
@@ -508,6 +509,10 @@ async function runSetPassword(args: readonly string[], deps: AuthDeps): Promise<
         return 1;
       }
       if (err instanceof UsernameTakenError) {
+        console.error(err.message);
+        return 1;
+      }
+      if (err instanceof InvalidUsernameError) {
         console.error(err.message);
         return 1;
       }

--- a/src/commands/serve.ts
+++ b/src/commands/serve.ts
@@ -49,7 +49,13 @@ import { getHubOrigin } from "../hub-settings.ts";
 import { writeHubFile } from "../hub.ts";
 import { enrichedPath } from "../spawn-path.ts";
 import { Supervisor } from "../supervisor.ts";
-import { createUser, userCount } from "../users.ts";
+import {
+  InvalidUsernameError,
+  createUser,
+  describeUsernameReason,
+  listUnlinkableUsernames,
+  userCount,
+} from "../users.ts";
 import { sanitizePublicOrigin } from "../vault-hub-origin-env.ts";
 import { WELL_KNOWN_DIR } from "../well-known.ts";
 import { createWsBridgeHandlers } from "../ws-bridge.ts";
@@ -441,7 +447,10 @@ export async function seedInitialAdminIfNeeded(
   env: NodeJS.ProcessEnv,
   log: (line: string) => void = () => {},
 ): Promise<"seeded" | "exists" | "needs-setup"> {
-  if (userCount(db) > 0) return "exists";
+  if (userCount(db) > 0) {
+    logUnlinkableUsernamesWarning(db, log);
+    return "exists";
+  }
   const username = env.PARACHUTE_INITIAL_ADMIN_USERNAME?.trim();
   const password = env.PARACHUTE_INITIAL_ADMIN_PASSWORD;
   if (!username || !password) return "needs-setup";
@@ -449,9 +458,32 @@ export async function seedInitialAdminIfNeeded(
   // multi-user-Phase-1 force-change-password redirect by landing
   // `password_changed=true`. Same treatment as the wizard's first admin.
   // `assignedVault` stays null — admin posture (no per-vault restriction).
-  await createUser(db, username, password, { passwordChanged: true });
+  try {
+    await createUser(db, username, password, { passwordChanged: true });
+  } catch (err) {
+    if (err instanceof InvalidUsernameError) {
+      log(
+        `parachute serve: PARACHUTE_INITIAL_ADMIN_USERNAME ${JSON.stringify(username)} is invalid (${err.reason}); ${describeUsernameReason(err.reason)}. First-boot seed may use "admin"; other reserved words, uppercase, periods, and names outside 2–32 chars are rejected.`,
+      );
+    }
+    throw err;
+  }
   log(`parachute serve: seeded initial admin "${username}" from PARACHUTE_INITIAL_ADMIN_*`);
+  logUnlinkableUsernamesWarning(db, log);
   return "seeded";
+}
+
+function logUnlinkableUsernamesWarning(
+  db: ReturnType<typeof openHubDb>,
+  log: (line: string) => void,
+): void {
+  const bad = listUnlinkableUsernames(db);
+  if (bad.length === 0) return;
+  log(
+    `parachute serve: ${bad.length} existing username(s) cannot run the pubkey-linkage ceremony until renamed: ${bad
+      .map((b) => `${JSON.stringify(b.username)} (${b.reason})`)
+      .join(", ")}`,
+  );
 }
 
 /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,5 +1,5 @@
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { join, sep } from "node:path";
 
 /**
  * Root config directory. Honors `$PARACHUTE_HOME` to match the convention
@@ -14,3 +14,15 @@ export function configDir(env: NodeJS.ProcessEnv = process.env): string {
 
 export const CONFIG_DIR = configDir();
 export const SERVICES_MANIFEST_PATH = join(CONFIG_DIR, "services.json");
+
+// bunfig.toml's preload is cwd-sensitive. If a test process imports this
+// module without it, fail here instead of freezing CONFIG_DIR onto the live
+// install (hub#840). Production (`NODE_ENV` unset / not `test`) is unchanged.
+if (process.env.NODE_ENV === "test") {
+  const realHome = join(homedir(), ".parachute");
+  if (CONFIG_DIR === realHome || CONFIG_DIR.startsWith(`${realHome}${sep}`)) {
+    throw new Error(
+      `[parachute-hub] refusing to resolve test state inside the live install at ${realHome}; set PARACHUTE_HOME to a temporary directory (the bunfig.toml [test] preload does this automatically)`,
+    );
+  }
+}

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -9,7 +9,7 @@
  * multi-use public-signup links + email-as-username + the `vault_caps`
  * per-vault storage-cap table), and Nostr-pubkey ↔ user linkage plus the
  * additive `tokens.subject_pubkey` attribution snapshot (v17, hub#833
- * phase 1).
+ * phase 1), and the durable attribution proof archive (v18, hub#860).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -660,6 +660,37 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE tokens ADD COLUMN subject_pubkey TEXT;
       CREATE INDEX tokens_subject_pubkey ON tokens (subject_pubkey)
         WHERE subject_pubkey IS NOT NULL;
+    `,
+  },
+  {
+    version: 18,
+    sql: `
+      -- Preserve the signed possession proof independently of the LIVE
+      -- user_pubkeys link (hub#860). Unlinking a key or deleting its user must
+      -- not make an already-written tokens.subject_pubkey snapshot impossible
+      -- to verify later. No FK to users/user_pubkeys on purpose: this is an
+      -- durable audit store, keyed by the stable subject string that JWTs
+      -- and downstream attribution rows already carry plus the pubkey.
+      CREATE TABLE attribution_proofs (
+        subject TEXT NOT NULL,
+        pubkey TEXT NOT NULL,
+        label TEXT,
+        proof_event TEXT NOT NULL,
+        proof_event_id TEXT NOT NULL,
+        linked_at TEXT NOT NULL,
+        last_verified_at TEXT NOT NULL,
+        PRIMARY KEY (subject, pubkey)
+      );
+      CREATE INDEX attribution_proofs_pubkey ON attribution_proofs (pubkey);
+
+      -- Every proof that is still live at migration time is already verified;
+      -- preserve it before any later unlink/account-delete can cascade the
+      -- source row away. Historical proofs deleted before v18 cannot be
+      -- reconstructed and are intentionally not fabricated.
+      INSERT INTO attribution_proofs
+        (subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at)
+      SELECT user_id, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at
+      FROM user_pubkeys;
     `,
   },
 ];

--- a/src/pubkey-links.ts
+++ b/src/pubkey-links.ts
@@ -13,6 +13,10 @@
  * A hub user may hold **zero or more** linked keys; a key names **at most one**
  * user hub-wide (`user_pubkeys.pubkey` is the PRIMARY KEY — see migration v17
  * for why that is a security property rather than a convenience).
+ * Successful ceremonies are also copied into `attribution_proofs`, keyed by
+ * `(subject, pubkey)` without a user foreign key. That durable audit row is
+ * intentionally not deleted with the live link or account: registry snapshots
+ * naming the subject and key must remain independently verifiable.
  *
  * No new principal entity is introduced. `users.id` is already what every
  * minted token's `sub` claim carries, so linkage hangs off the row that
@@ -67,10 +71,26 @@ export interface LinkedPubkey {
   lastVerifiedAt: string;
 }
 
+/** A subject→pubkey possession proof retained independently of the live link. */
+export interface AttributionProof extends LinkedPubkey {
+  /** Verbatim signed NIP-01 event; callers can re-verify it independently. */
+  proofEvent: string;
+}
+
 interface LinkRow {
   pubkey: string;
   user_id: string;
   label: string | null;
+  proof_event_id: string;
+  linked_at: string;
+  last_verified_at: string;
+}
+
+interface AttributionProofRow {
+  subject: string;
+  pubkey: string;
+  label: string | null;
+  proof_event: string;
   proof_event_id: string;
   linked_at: string;
   last_verified_at: string;
@@ -85,6 +105,50 @@ function rowToLink(r: LinkRow): LinkedPubkey {
     linkedAt: r.linked_at,
     lastVerifiedAt: r.last_verified_at,
   };
+}
+
+function rowToAttributionProof(r: AttributionProofRow): AttributionProof {
+  return {
+    pubkey: r.pubkey,
+    userId: r.subject,
+    label: r.label,
+    proofEvent: r.proof_event,
+    proofEventId: r.proof_event_id,
+    linkedAt: r.linked_at,
+    lastVerifiedAt: r.last_verified_at,
+  };
+}
+
+function retainAttributionProof(
+  db: Database,
+  proof: {
+    subject: string;
+    pubkey: string;
+    label: string | null;
+    proofEvent: string;
+    proofEventId: string;
+    linkedAt: string;
+    lastVerifiedAt: string;
+  },
+): void {
+  db.prepare(
+    `INSERT INTO attribution_proofs
+       (subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(subject, pubkey) DO UPDATE SET
+       label = excluded.label,
+       proof_event = excluded.proof_event,
+       proof_event_id = excluded.proof_event_id,
+       last_verified_at = excluded.last_verified_at`,
+  ).run(
+    proof.subject,
+    proof.pubkey,
+    proof.label,
+    proof.proofEvent,
+    proof.proofEventId,
+    proof.linkedAt,
+    proof.lastVerifiedAt,
+  );
 }
 
 /**
@@ -216,6 +280,15 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
            (pubkey, user_id, label, proof_event, proof_event_id, linked_at, last_verified_at)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
       ).run(opts.pubkey, opts.userId, label, opts.proofEvent, proofEventId, stamp, stamp);
+      retainAttributionProof(db, {
+        subject: opts.userId,
+        pubkey: opts.pubkey,
+        label,
+        proofEvent: opts.proofEvent,
+        proofEventId,
+        linkedAt: stamp,
+        lastVerifiedAt: stamp,
+      });
       return {
         ok: true,
         relinked: false,
@@ -235,6 +308,15 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
          SET label = ?, proof_event = ?, proof_event_id = ?, last_verified_at = ?
        WHERE pubkey = ? AND user_id = ?`,
     ).run(label, opts.proofEvent, proofEventId, stamp, opts.pubkey, opts.userId);
+    retainAttributionProof(db, {
+      subject: opts.userId,
+      pubkey: opts.pubkey,
+      label,
+      proofEvent: opts.proofEvent,
+      proofEventId,
+      linkedAt: existing.linked_at,
+      lastVerifiedAt: stamp,
+    });
     return {
       ok: true,
       relinked: true,
@@ -283,6 +365,23 @@ export function proofEventFor(db: Database, pubkey: string): string | null {
   return row?.proof_event ?? null;
 }
 
+/**
+ * Every possession proof a subject has established, including proofs whose
+ * live link was later removed. This durable archive is the audit counterpart
+ * to `listUserPubkeys`, which answers only what the account holds now.
+ */
+export function attributionProofsForSubject(db: Database, subject: string): AttributionProof[] {
+  return db
+    .query<AttributionProofRow, [string]>(
+      `SELECT subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at
+       FROM attribution_proofs
+       WHERE subject = ?
+       ORDER BY linked_at ASC, pubkey ASC`,
+    )
+    .all(subject)
+    .map(rowToAttributionProof);
+}
+
 /** Phase-1b resolution: a subject's linked keys, in deterministic order. */
 export function pubkeysForUser(db: Database, userId: string): string[] {
   return listUserPubkeys(db, userId).map((l) => l.pubkey);
@@ -303,7 +402,10 @@ export function primaryPubkeyForUser(db: Database, userId: string): string | nul
   return row?.pubkey ?? null;
 }
 
-/** Remove a link. Self-only: the `user_id` predicate is not optional. */
+/**
+ * Remove a LIVE link. Self-only: the `user_id` predicate is not optional.
+ * The independently stored attribution proof is deliberately retained.
+ */
 export function unlinkPubkey(db: Database, userId: string, pubkey: string): boolean {
   const res = db
     .prepare("DELETE FROM user_pubkeys WHERE pubkey = ? AND user_id = ?")

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -86,7 +86,7 @@ import {
   findActiveSession,
 } from "./sessions.ts";
 import type { Supervisor } from "./supervisor.ts";
-import { createUser, userCount } from "./users.ts";
+import { createUser, isSeedAdminUsername, userCount, validateUsername } from "./users.ts";
 import { sanitizePublicOrigin } from "./vault-hub-origin-env.ts";
 import { DEFAULT_VAULT_NAME, validateVaultName } from "./vault-name.ts";
 
@@ -684,10 +684,10 @@ export function renderAccountStep(props: RenderAccountStepProps): string {
         <label class="field">
           <span class="field-label">Username</span>
           <input type="text" name="username" autocomplete="username"${usernameAutofocus}
-            required minlength="2" maxlength="64"
-            pattern="[A-Za-z0-9_.-]+" title="letters, digits, _ . - (2–64 chars)"
+            required minlength="2" maxlength="32"
+            pattern="[a-z0-9_-]+" title="lowercase letters, digits, hyphens, underscores (2–32 chars). First account may be named admin."
             ${usernameAttr} />
-          <span class="field-hint">letters, digits, <code>_</code>, <code>.</code>, <code>-</code></span>
+          <span class="field-hint">lowercase letters, digits, <code>_</code>, <code>-</code>; 2–32 chars. First account may be <code>admin</code>.</span>
         </label>
         <label class="field">
           <span class="field-label">Password</span>
@@ -2771,11 +2771,19 @@ function validateAccountFields(input: {
   password: string;
   confirm: string;
 }): string | undefined {
-  if (input.username.length < 2 || input.username.length > 64) {
-    return "Username must be 2–64 characters.";
-  }
-  if (!/^[A-Za-z0-9_.-]+$/.test(input.username)) {
-    return "Username may use letters, digits, underscore, period, hyphen.";
+  // Same vocabulary as createUser (hub#864). The wizard is always the
+  // first-user path, so reserved `admin` is allowed; other reserved
+  // words, uppercase, periods, and names outside 2–32 are not.
+  const u = validateUsername(input.username);
+  if (!u.valid && !isSeedAdminUsername(input.username, 0)) {
+    switch (u.reason) {
+      case "length":
+        return "Username must be 2–32 characters.";
+      case "format":
+        return "Username may use lowercase letters, digits, underscore, hyphen.";
+      case "reserved":
+        return "Username is reserved (admin is allowed for this first account; root, system, setup, parachute, hub are not).";
+    }
   }
   if (input.password.length < 8) {
     return "Password must be at least 8 characters.";

--- a/src/users.ts
+++ b/src/users.ts
@@ -658,6 +658,9 @@ export async function resetUserPassword(
  *   - `user_vaults.user_id` has `ON DELETE CASCADE` (migration v10), so
  *     vault assignments are dropped automatically when the parent row
  *     goes. No explicit cleanup needed.
+ *   - `attribution_proofs` deliberately has no user FK (migration v18), so a
+ *     deleted subject's signed key-possession proof remains available for
+ *     historical registry rows whose `subject` and `subject_pubkey` survive.
  *
  * Returns false when no user matches the id (idempotent — the API
  * layer translates that to 404). Returns true on a successful delete.
@@ -692,7 +695,7 @@ export function deleteUser(db: Database, userId: string): boolean {
     db.prepare("DELETE FROM sessions WHERE user_id = ?").run(userId);
     db.prepare("DELETE FROM grants WHERE user_id = ?").run(userId);
     db.prepare("DELETE FROM auth_codes WHERE user_id = ?").run(userId);
-    // 3. Drop the user row itself.
+    // 3. Drop the user row itself. The no-FK attribution proof archive remains.
     db.prepare("DELETE FROM users WHERE id = ?").run(userId);
   })();
   return true;

--- a/src/users.ts
+++ b/src/users.ts
@@ -76,6 +76,15 @@ export class UsernameTakenError extends Error {
   }
 }
 
+export class InvalidUsernameError extends Error {
+  readonly reason: "format" | "length" | "reserved";
+  constructor(username: string, reason: "format" | "length" | "reserved") {
+    super(`username "${username}" is invalid (${reason})`);
+    this.name = "InvalidUsernameError";
+    this.reason = reason;
+  }
+}
+
 export class UserNotFoundError extends Error {
   constructor(ref: string) {
     super(`user "${ref}" not found`);
@@ -283,6 +292,14 @@ export async function createUser(
   const count = (db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM users").get() ?? { n: 0 })
     .n;
   if (count > 0 && !opts.allowMulti) throw new SingleUserModeError();
+
+  // Chokepoint (hub#864): every users.username write is gated here so the
+  // wizard / env-seed / `auth set-password` paths cannot land a name the
+  // linkage ceremony will refuse. Existing rows are not rewritten.
+  const check = validateUsername(username);
+  if (!check.valid && !isSeedAdminUsername(username, count)) {
+    throw new InvalidUsernameError(username, check.reason);
+  }
 
   const id = randomUUID();
   const passwordHash = await argonHash(password);
@@ -706,8 +723,8 @@ export function deleteUser(db: Database, userId: string): boolean {
 export const USERNAME_RESERVED = ["admin", "root", "system", "setup", "parachute", "hub"] as const;
 
 const USERNAME_REGEX = /^[a-z0-9_-]+$/;
-const USERNAME_MIN_LEN = 2;
-const USERNAME_MAX_LEN = 32;
+export const USERNAME_MIN_LEN = 2;
+export const USERNAME_MAX_LEN = 32;
 
 export type ValidateUsernameResult =
   | { valid: true; name: string }
@@ -734,6 +751,46 @@ export function validateUsername(name: string): ValidateUsernameResult {
     return { valid: false, reason: "reserved" };
   }
   return { valid: true, name };
+}
+
+/**
+ * First-user seed paths (`PARACHUTE_INITIAL_ADMIN_USERNAME`, the wizard's
+ * first admin, `parachute auth set-password` with no existing user) may
+ * use the reserved word `admin` — it IS the admin. Charset + length still
+ * apply via `validateUsername` (this helper only waives the reserved-word
+ * reason, and only for the exact lowercase spelling). Other reserved
+ * words, and `admin` on any subsequent create, stay rejected.
+ */
+export function isSeedAdminUsername(name: string, existingUserCount: number): boolean {
+  return existingUserCount === 0 && name === "admin";
+}
+
+export function describeUsernameReason(reason: "format" | "length" | "reserved"): string {
+  switch (reason) {
+    case "length":
+      return "username must be 2-32 characters long";
+    case "format":
+      return "username must contain only lowercase letters, digits, hyphens, and underscores ([a-z0-9_-])";
+    case "reserved":
+      return "username is reserved (admin, root, system, setup, parachute, hub)";
+  }
+}
+
+/**
+ * Existing rows whose username `validateUsername` rejects — including a
+ * seeded `admin`. They stay in the DB (grandfathered) but cannot run the
+ * pubkey-linkage ceremony until renamed. Callers (serve boot) surface
+ * this as an operator warning.
+ */
+export function listUnlinkableUsernames(
+  db: Database,
+): Array<{ username: string; reason: "format" | "length" | "reserved" }> {
+  const out: Array<{ username: string; reason: "format" | "length" | "reserved" }> = [];
+  for (const u of listUsers(db)) {
+    const r = validateUsername(u.username);
+    if (!r.valid) out.push({ username: u.username, reason: r.reason });
+  }
+  return out;
 }
 
 /**

--- a/src/ws-bridge.ts
+++ b/src/ws-bridge.ts
@@ -242,11 +242,11 @@ export function createWsBridgeHandlers(opts: WsBridgeOptions = {}): WebSocketHan
       // one teardown funnel every accepted socket passes through. The
       // closure latches, so re-entry is harmless.
       ws.data.releaseCap?.();
-      // Client → upstream close propagation. Note: Bun's server-side close
-      // callback delivers the client's close CODE but an empty `reason`
-      // (verified on Bun 1.3.13), so only the code propagates upstream in
-      // this direction. Upstream → client propagation (the close listener in
-      // open()) carries both.
+      // Client → upstream close propagation. Bun 1.3.13 delivered the
+      // close CODE but an empty `reason` on this callback; Bun 1.4
+      // forwards the reason. The bridge already passes both through.
+      // Upstream → client (the close listener in open()) has always
+      // carried both.
       const state = ws.data._bridge;
       if (!state || state.closed) return;
       state.closed = true;


### PR DESCRIPTION
release: hub 0.7.17-rc.1 — username chokepoint, attribution proofs, rc-before-stable gate

Merging this publishes `@openparachute/hub@0.7.17-rc.1` to npm `@rc` (and ghcr `:rc`). It is an **rc**, not stable. Stable later is a suffix-drop from this tag — no new code on that PR.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What ships (over 0.7.16)

- #857 unpublished-drift advisory actually runs
- #865 username validator chokepoint
- #866 duplicate linkage binding tags refused
- #867 PARACHUTE_HOME test sandbox
- #868 attribution proofs survive unlink (v18)
- #869 Bun 1.4 CI pin
- #870 rc-before-stable publish hook + this version bump

On-box soak already happened via bun-link of `origin/next` at `429db5d` (v18 applied). This published rc lets the box leave that worktree (`parachute upgrade hub --channel rc`).

## Process (Aaron 2026-08-24)

Always cut rc before stable. Stable is suffix-drop only. The hook in this rc refuses a later stable unless npm already has `0.7.17-rc.*` and the tree is a suffix-drop from that rc tag. Tag-push still overrides.

**Do not merge `next` for the 0.7.17 stable.** Branch from `v0.7.17-rc.1`.

## Verification

- #870 CI `typecheck + unit tests` SUCCESS at `4ea99d1` (3m10s); squash landed as `ccb219c` on `next`
- Independent generalist **SHIP** (nits: CLI suffix-drop composition untested — follow-up)
- `bun test ./src/__tests__/release-plan.test.ts` **54/0** at `4ea99d1` locally; full hub suite not run on this live operator box (launchd-touching tests still ignore PARACHUTE_HOME)

Click merge when ready. I will upgrade the box off bun-link after npm shows 0.7.17-rc.1.

