### PR TITLE
feat(hub#833): per-account mint rooted at users.id

### DIFF
--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -1009,7 +1009,8 @@ describe("handleAccountMintVaultToken", () => {
   test("mints a vault token with aud=vault.<name> and default read+write scope", async () => {
     const h = makeHarness(["field-notes"]);
     try {
-      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const u = await createUser(h.db, "owner", "pw");
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE], u.id);
       const res = await handleAccountMintVaultToken(
         withBearer("/account/vaults/field-notes/token", token, { method: "POST" }),
         "field-notes",
@@ -1038,7 +1039,8 @@ describe("handleAccountMintVaultToken", () => {
   test("honors an explicit scopes list", async () => {
     const h = makeHarness(["field-notes"]);
     try {
-      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const u = await createUser(h.db, "owner", "pw");
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE], u.id);
       const res = await handleAccountMintVaultToken(
         jsonReq("/account/vaults/field-notes/token", token, "POST", {
           scopes: ["vault:field-notes:read"],
@@ -1050,6 +1052,30 @@ describe("handleAccountMintVaultToken", () => {
       const body = (await res.json()) as { vault_token: string };
       const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
       expect(validated.payload.scope).toBe("vault:field-notes:read");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("non-user bearer sub fails closed instead of minting with user_id NULL", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE], "not-a-user");
+      const res = await handleAccountMintVaultToken(
+        withBearer("/account/vaults/field-notes/token", token, { method: "POST" }),
+        "field-notes",
+        deps(h),
+      );
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("invalid_subject");
+      const n =
+        h.db
+          .query<{ n: number }, []>(
+            "SELECT COUNT(*) AS n FROM tokens WHERE created_via = 'cli_mint'",
+          )
+          .get()?.n ?? 0;
+      expect(n).toBe(0);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/api-account-tokens.test.ts
+++ b/src/__tests__/api-account-tokens.test.ts
@@ -1,0 +1,230 @@
+/**
+ * `/api/account/tokens*` — self-service list/mint/revoke (hub#833).
+ *
+ * Coverage:
+ *   - cookie + CSRF posture (401 / 403), self-only
+ *   - mint as session user_id; JWT sub is users.id
+ *   - friend cannot mint parachute:host:*
+ *   - friend with assigned vaults can mint vault:<assigned>:<verb>
+ *   - revoke 404 for someone else's jti (no existence oracle)
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleApiAccount } from "../api-account-2fa.ts";
+import { CSRF_COOKIE_NAME } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { mintOperatorToken } from "../operator-token.ts";
+import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const TEST_CSRF = "csrf-account-tokens";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
+const ORIGIN = "https://hub.example";
+const ISSUER = "http://127.0.0.1:1939";
+const PASSWORD = "correct-horse-battery";
+
+let db: Database;
+let configDir: string;
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), "phub-api-acct-tokens-"));
+  db = openHubDb(hubDbPath(configDir));
+  rotateSigningKey(db);
+  resetRateLimit();
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(configDir, { recursive: true, force: true });
+});
+
+interface TestUser {
+  userId: string;
+  username: string;
+  cookie: string;
+}
+
+async function userWithSession(
+  username: string,
+  extra: { assignedVaults?: string[]; allowMulti?: boolean } = {},
+): Promise<TestUser> {
+  const u = await createUser(db, username, PASSWORD, {
+    allowMulti: extra.allowMulti ?? username !== "owner",
+    passwordChanged: true,
+    ...(extra.assignedVaults ? { assignedVaults: extra.assignedVaults } : {}),
+  });
+  const session = createSession(db, { userId: u.id });
+  return {
+    userId: u.id,
+    username: u.username,
+    cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+  };
+}
+
+function call(
+  method: string,
+  subpath: string,
+  cookie: string | null,
+  body?: Record<string, unknown>,
+): Promise<Response> {
+  const url = `${ORIGIN}/api/account/tokens${subpath}`;
+  const req = new Request(url, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      origin: ORIGIN,
+      ...(cookie ? { cookie } : {}),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  return handleApiAccount(req, `/tokens${subpath.split("?")[0]}`, {
+    db,
+    issuer: ISSUER,
+  });
+}
+
+describe("auth posture", () => {
+  test("every route needs a session", async () => {
+    for (const [method, path, body] of [
+      ["GET", "", undefined],
+      ["POST", "", { __csrf: TEST_CSRF, scope: "vault:work:read" }],
+      ["POST", "/no-such/revoke", { __csrf: TEST_CSRF }],
+    ] as const) {
+      const res = await call(method, path, null, body as Record<string, unknown> | undefined);
+      expect(res.status).toBe(401);
+    }
+  });
+
+  test("every mutation needs a valid CSRF token", async () => {
+    const owner = await userWithSession("owner");
+    const mint = await call("POST", "", owner.cookie, { scope: "scribe:transcribe" });
+    expect(mint.status).toBe(403);
+    const revoke = await call("POST", "/abc/revoke", owner.cookie, {});
+    expect(revoke.status).toBe(403);
+  });
+});
+
+describe("GET /api/account/tokens", () => {
+  test("lists only this user's tokens; unrevoked default", async () => {
+    const owner = await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    await mintOperatorToken(db, owner.userId, { issuer: ISSUER });
+    const minted = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "vault:work:read",
+    });
+    expect(minted.status).toBe(200);
+
+    const ownerList = await call("GET", "", owner.cookie);
+    expect(ownerList.status).toBe(200);
+    const ownerBody = (await ownerList.json()) as { tokens: { user_id: string; jti: string }[] };
+    expect(ownerBody.tokens.every((t) => t.user_id === owner.userId)).toBe(true);
+    expect(ownerBody.tokens.length).toBeGreaterThan(0);
+
+    const friendList = await call("GET", "", friend.cookie);
+    const friendBody = (await friendList.json()) as { tokens: { user_id: string }[] };
+    expect(friendBody.tokens.every((t) => t.user_id === friend.userId)).toBe(true);
+    expect(friendBody.tokens.length).toBe(1);
+  });
+});
+
+describe("POST /api/account/tokens", () => {
+  test("mints as the session user_id; JWT sub is users.id", async () => {
+    const owner = await userWithSession("owner");
+    const res = await call("POST", "", owner.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "scribe:transcribe",
+      label: "laptop",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { jti: string; token: string; scope: string };
+    expect(body.scope).toBe("scribe:transcribe");
+    const validated = await validateAccessToken(db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(owner.userId);
+    const row = db
+      .query<{ user_id: string; subject: string }, [string]>(
+        "SELECT user_id, subject FROM tokens WHERE jti = ?",
+      )
+      .get(body.jti);
+    expect(row?.user_id).toBe(owner.userId);
+    expect(row?.subject).toBe("laptop");
+  });
+
+  test("friend cannot mint parachute:host:*", async () => {
+    await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const res = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "parachute:host:admin",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_scope");
+    expect(body.error_description).toContain("parachute:host:admin");
+  });
+
+  test("friend with assigned vaults can mint vault:<assigned>:<verb>", async () => {
+    await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const res = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "vault:work:read",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    const validated = await validateAccessToken(db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(friend.userId);
+    expect(validated.payload.scope).toBe("vault:work:read");
+  });
+
+  test("friend cannot mint a vault they are not assigned", async () => {
+    await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const res = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "vault:other:read",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_scope");
+  });
+});
+
+describe("POST /api/account/tokens/:jti/revoke", () => {
+  test("404 for someone else's jti (no existence oracle)", async () => {
+    const owner = await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const minted = await call("POST", "", owner.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "scribe:transcribe",
+    });
+    expect(minted.status).toBe(200);
+    const { jti } = (await minted.json()) as { jti: string };
+
+    const asFriend = await call("POST", `/${jti}/revoke`, friend.cookie, { __csrf: TEST_CSRF });
+    expect(asFriend.status).toBe(404);
+    const missing = await call("POST", "/no-such-jti/revoke", friend.cookie, { __csrf: TEST_CSRF });
+    expect(missing.status).toBe(404);
+    expect(await asFriend.text()).toBe(await missing.clone().text());
+  });
+
+  test("owner can revoke their own jti", async () => {
+    const owner = await userWithSession("owner");
+    const minted = await call("POST", "", owner.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "scribe:transcribe",
+    });
+    const { jti } = (await minted.json()) as { jti: string };
+    const res = await call("POST", `/${jti}/revoke`, owner.cookie, { __csrf: TEST_CSRF });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { revoked: boolean; jti: string };
+    expect(body.revoked).toBe(true);
+    expect(body.jti).toBe(jti);
+  });
+});

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -4,10 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleApiMintToken } from "../api-mint-token.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { signAccessToken, validateAccessToken } from "../jwt-sign.ts";
+import { findTokenRowByJti, signAccessToken, validateAccessToken } from "../jwt-sign.ts";
 import { mintOperatorToken } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
-import { createUser } from "../users.ts";
+import { createUser, deleteUser, resetUserPassword } from "../users.ts";
 
 interface Harness {
   dir: string;
@@ -895,10 +895,36 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     });
 
     // Item A (subject-pin) — audit-attribution forgery. A non-operator
-    // (vault-admin-only) bearer may NOT override the minted token's `sub`:
-    // forging a foreign subject would mis-attribute the registry + revocation
-    // rows. It may still mint under its OWN sub (subject omitted / equal).
-    test("subject override by non-operator bearer → 403 (forgery blocked)", async () => {
+    // (vault-admin-only) bearer may NOT mint as another account via `user`.
+    // A deprecated `subject` that does not match a hub account is a label,
+    // not a principal override.
+    test("user override by non-operator bearer → 403 (forgery blocked)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const other = await createUser(db, "friend", "pw", { allowMulti: true });
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", user: other.id },
+              { authorization: `Bearer ${bearer}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(403);
+          const body = (await resp.json()) as { error: string; error_description: string };
+          expect(body.error).toBe("insufficient_scope");
+          expect(body.error_description).toContain("non-operator");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("deprecated subject that is not a hub account is a label, JWT sub stays own", async () => {
       const h = makeHarness();
       try {
         const { db, userId } = await bootstrap(h.dir);
@@ -911,10 +937,18 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
             ),
             { db, issuer: ISSUER },
           );
-          expect(resp.status).toBe(403);
-          const body = (await resp.json()) as { error: string; error_description: string };
-          expect(body.error).toBe("insufficient_scope");
-          expect(body.error_description).toContain("non-operator");
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string; warnings?: string[] };
+          expect(body.warnings?.some((w) => w.includes("deprecated"))).toBe(true);
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(userId);
+          const row = db
+            .query<{ subject: string; user_id: string }, [string]>(
+              "SELECT subject, user_id FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.subject).toBe("someone-else");
+          expect(row?.user_id).toBe(userId);
         } finally {
           db.close();
         }
@@ -951,12 +985,160 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     });
   });
 
-  // Item A (subject-pin) — the operator carve-out: a host operator
-  // (parachute:host:auth / parachute:host:admin) MAY override `sub` to stamp a
-  // service-account subject. This is the documented service-account override
-  // that the non-operator pin above must NOT break.
-  describe("subject override — operator carve-out (item A)", () => {
-    test("host:auth operator overrides subject → 200, registry row carries override", async () => {
+  // hub#833 — `subject` is a deprecated label; `service` is the remaining
+  // non-account principal; `user` mints as that account.
+  describe("principal is users.id (hub#833)", () => {
+    test("person-mint writes user_id and JWT sub is users.id", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "scribe:transcribe" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(userId);
+          const row = db
+            .query<{ user_id: string; subject: string }, [string]>(
+              "SELECT user_id, subject FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.user_id).toBe(userId);
+          expect(row?.subject).toBe(userId);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("label sets tokens.subject; JWT sub stays the account id", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "scribe:transcribe", label: "laptop" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(userId);
+          const row = db
+            .query<{ user_id: string; subject: string }, [string]>(
+              "SELECT user_id, subject FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.user_id).toBe(userId);
+          expect(row?.subject).toBe("laptop");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("operator user field mints as that account", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", user: "friend" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(friend.id);
+          const row = db
+            .query<{ user_id: string }, [string]>("SELECT user_id FROM tokens WHERE jti = ?")
+            .get(body.jti);
+          expect(row?.user_id).toBe(friend.id);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("operator service field mints with user_id NULL and JWT sub = service name", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", service: "svc-account" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe("svc-account");
+          const row = db
+            .query<{ user_id: string | null; subject: string }, [string]>(
+              "SELECT user_id, subject FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.user_id).toBeNull();
+          expect(row?.subject).toBe("svc-account");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("deprecated subject matching a username is treated as user", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", subject: "friend" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string; warnings?: string[] };
+          expect(body.warnings?.some((w) => w.includes("treating as `user`"))).toBe(true);
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(friend.id);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("host:auth operator deprecated subject that is not an account is a label", async () => {
       const h = makeHarness();
       try {
         const { db, userId } = await bootstrap(h.dir);
@@ -972,36 +1154,14 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
           expect(resp.status).toBe(200);
           const body = (await resp.json()) as { jti: string; token: string };
           const validated = await validateAccessToken(db, body.token, ISSUER);
-          expect(validated.payload.sub).toBe("svc-account");
+          expect(validated.payload.sub).toBe(userId);
           const row = db
-            .query<{ subject: string }, [string]>("SELECT subject FROM tokens WHERE jti = ?")
+            .query<{ subject: string; user_id: string }, [string]>(
+              "SELECT subject, user_id FROM tokens WHERE jti = ?",
+            )
             .get(body.jti);
           expect(row?.subject).toBe("svc-account");
-        } finally {
-          db.close();
-        }
-      } finally {
-        h.cleanup();
-      }
-    });
-
-    test("host:admin operator overrides subject → 200", async () => {
-      const h = makeHarness();
-      try {
-        const { db, userId } = await bootstrap(h.dir);
-        try {
-          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
-          const resp = await handleApiMintToken(
-            jsonRequest(
-              { scope: "vault:work:admin", subject: "svc-account" },
-              { authorization: `Bearer ${op.token}` },
-            ),
-            { db, issuer: ISSUER },
-          );
-          expect(resp.status).toBe(200);
-          const body = (await resp.json()) as { token: string };
-          const validated = await validateAccessToken(db, body.token, ISSUER);
-          expect(validated.payload.sub).toBe("svc-account");
+          expect(row?.user_id).toBe(userId);
         } finally {
           db.close();
         }
@@ -1408,6 +1568,149 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
         const req = new Request("http://localhost/api/auth/mint-token", { method: "GET" });
         const resp = await handleApiMintToken(req, { db, issuer: ISSUER });
         expect(resp.status).toBe(405);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// hub#833 fold 2 — CAS insert after the crypto await. `afterSign` is the
+// test seam: it runs after `signAccessToken` and before `recordTokenMint`,
+// so the race is deterministic (no wall-clock). Watched failing before the
+// CAS existed (plain insert landed a live unrevoked row + returned the JWT).
+describe("CAS after crypto await (hub#833)", () => {
+  test("deleteUser during afterSign → 409, no token in body, no live unrevoked row", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        let signedJti: string | undefined;
+        let signedToken: string | undefined;
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          {
+            db,
+            issuer: ISSUER,
+            afterSign: ({ token, jti }) => {
+              signedToken = token;
+              signedJti = jti;
+              deleteUser(db, userId);
+            },
+          },
+        );
+        expect(resp.status).toBe(409);
+        const body = (await resp.json()) as { error?: string; token?: string };
+        expect(body.token).toBeUndefined();
+        expect(body.error).toBe("conflict");
+        expect(signedJti).toBeDefined();
+        const row = findTokenRowByJti(db, signedJti!);
+        expect(row === null || row.revokedAt !== null).toBe(true);
+        // The signed JWT was never returned. Missing-row bypass in
+        // validateAccessToken is out of this PR (historical pre-v6 tokens);
+        // fail-closed for NEW mints is the insert gate + not emitting the JWT.
+        expect(signedToken).toBeDefined();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unlink racing mint does not leave a dangling user_id (INSERT-time snapshot)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const { issuePubkeyChallenge, linkPubkey, unlinkPubkey } = await import(
+          "../pubkey-links.ts"
+        );
+        const now = new Date();
+        const { challenge } = issuePubkeyChallenge(db, userId, now);
+        const pubkey = "a".repeat(64);
+        const linked = linkPubkey(db, {
+          userId,
+          pubkey,
+          challenge,
+          proofEvent: JSON.stringify({
+            id: "0".repeat(64),
+            pubkey,
+            kind: 27235,
+            tags: [["challenge", challenge]],
+          }),
+          now,
+        });
+        expect(linked.ok).toBe(true);
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          {
+            db,
+            issuer: ISSUER,
+            afterSign: () => {
+              expect(unlinkPubkey(db, userId, pubkey)).toBe(true);
+            },
+          },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { jti: string; token: string };
+        const row = db
+          .query<{ user_id: string | null; subject_pubkey: string | null }, [string]>(
+            "SELECT user_id, subject_pubkey FROM tokens WHERE jti = ?",
+          )
+          .get(body.jti);
+        expect(row?.user_id).toBe(userId);
+        // Snapshot is taken at INSERT, after the unlink, so it is NULL. The
+        // user row is still there — unlink is not logout (v17 snapshot).
+        expect(row?.subject_pubkey).toBeNull();
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.sub).toBe(userId);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("resetUserPassword during afterSign → 409, no token in body, no live unrevoked row", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        let signedJti: string | undefined;
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          {
+            db,
+            issuer: ISSUER,
+            afterSign: async ({ jti }) => {
+              signedJti = jti;
+              await resetUserPassword(db, userId, "new-password-after-reset");
+            },
+          },
+        );
+        expect(resp.status).toBe(409);
+        const body = (await resp.json()) as { error?: string; token?: string };
+        expect(body.token).toBeUndefined();
+        expect(body.error).toBe("conflict");
+        expect(signedJti).toBeDefined();
+        const row = findTokenRowByJti(db, signedJti!);
+        expect(row === null || row.revokedAt !== null).toBe(true);
       } finally {
         db.close();
       }

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -15,7 +15,7 @@ import {
   readOperatorTokenFile,
   writeOperatorTokenFile,
 } from "../operator-token.ts";
-import { createUser, listUsers, verifyPassword } from "../users.ts";
+import { createUser, deleteUser, listUsers, verifyPassword } from "../users.ts";
 
 function makeRunner(result: number | (() => Promise<number>) = 0): {
   runner: Runner;
@@ -1799,7 +1799,43 @@ describe("parachute auth mint-token", () => {
     }
   });
 
-  test("--sub override emits the JWT with that subject", async () => {
+  test("--sub that is not a hub account is a label; JWT sub stays the account id", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe", "--sub", "agent:scribe-runner"], deps),
+      );
+      expect(code).toBe(0);
+      expect(stderr).toContain("--sub is deprecated");
+      expect(stderr).toContain("treating as --label");
+      const token = stdout.trim();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token);
+        const users = listUsers(db);
+        expect(validated.payload.sub).toBe(users[0]!.id);
+        const row = db
+          .query<{ subject: string; user_id: string }, [string]>(
+            "SELECT subject, user_id FROM tokens WHERE jti = ?",
+          )
+          .get(validated.payload.jti as string);
+        expect(row?.subject).toBe("agent:scribe-runner");
+        expect(row?.user_id).toBe(users[0]!.id);
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--label sets tokens.subject; JWT sub stays the account id", async () => {
     const tmp = makeTmp();
     try {
       const deps: AuthDeps = {
@@ -1809,17 +1845,84 @@ describe("parachute auth mint-token", () => {
       };
       await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
       const { code, stdout } = await captureOutput(() =>
-        auth(["mint-token", "--scope", "scribe:transcribe", "--sub", "agent:scribe-runner"], deps),
+        auth(["mint-token", "--scope", "scribe:transcribe", "--label", "laptop"], deps),
       );
       expect(code).toBe(0);
       const token = stdout.trim();
       const db = openHubDb(tmp.dbPath);
       try {
         const validated = await validateAccessToken(db, token);
-        expect(validated.payload.sub).toBe("agent:scribe-runner");
+        const users = listUsers(db);
+        expect(validated.payload.sub).toBe(users[0]!.id);
+        const row = db
+          .query<{ subject: string }, [string]>("SELECT subject FROM tokens WHERE jti = ?")
+          .get(validated.payload.jti as string);
+        expect(row?.subject).toBe("laptop");
       } finally {
         db.close();
       }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--service mints a non-account principal (user_id NULL, JWT sub = name)", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe", "--service", "surface:notes"], deps),
+      );
+      expect(code).toBe(0);
+      const token = stdout.trim();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token);
+        expect(validated.payload.sub).toBe("surface:notes");
+        const row = db
+          .query<{ user_id: string | null; subject: string }, [string]>(
+            "SELECT user_id, subject FROM tokens WHERE jti = ?",
+          )
+          .get(validated.payload.jti as string);
+        expect(row?.user_id).toBeNull();
+        expect(row?.subject).toBe("surface:notes");
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("CAS: deleteUser during afterSign fails closed and does not print the JWT", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+        afterSign: ({ userId }) => {
+          if (!userId) return;
+          const db = openHubDb(tmp.dbPath);
+          try {
+            deleteUser(db, userId);
+          } finally {
+            db.close();
+          }
+        },
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stdout.trim()).toBe("");
+      expect(stderr).toContain("no longer exists");
     } finally {
       tmp.cleanup();
     }

--- a/src/__tests__/hub-db.test.ts
+++ b/src/__tests__/hub-db.test.ts
@@ -416,6 +416,42 @@ describe("openHubDb + migrate", () => {
     }
   });
 
+  test("v19 backfills tokens.user_id where subject equals a users.id; leaves the rest", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        const stamp = new Date().toISOString();
+        db.prepare(
+          `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+           VALUES (?, ?, 'x', ?, ?, 1)`,
+        ).run("user-backfill", "owner", stamp, stamp);
+        db.prepare(
+          `INSERT INTO tokens (jti, user_id, client_id, scopes, expires_at, created_at, created_via, subject)
+           VALUES (?, NULL, 'c', 'vault:read', ?, ?, 'cli_mint', ?)`,
+        ).run("t-account", stamp, stamp, "user-backfill");
+        db.prepare(
+          `INSERT INTO tokens (jti, user_id, client_id, scopes, expires_at, created_at, created_via, subject)
+           VALUES (?, NULL, 'c', 'vault:read', ?, ?, 'operator_mint', 'operator')`,
+        ).run("t-operator", stamp, stamp);
+        db.exec("DELETE FROM schema_version WHERE version = 19");
+        migrate(db);
+        const account = db
+          .query<{ user_id: string | null }, [string]>("SELECT user_id FROM tokens WHERE jti = ?")
+          .get("t-account");
+        const operator = db
+          .query<{ user_id: string | null }, [string]>("SELECT user_id FROM tokens WHERE jti = ?")
+          .get("t-operator");
+        expect(account?.user_id).toBe("user-backfill");
+        expect(operator?.user_id).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("v10 FK cascade: deleting a user drops their user_vaults rows", () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -8,6 +8,7 @@ import {
   ACCESS_TOKEN_TTL_SECONDS,
   REFRESH_TOKEN_TTL_MS,
   RefreshTokenInsertError,
+  TokenMintPrincipalGoneError,
   findRefreshToken,
   findTokenRowByJti,
   linkRotation,
@@ -480,6 +481,52 @@ describe("token registry (hub#212 Phase 1)", () => {
       expect(byName.has("subject")).toBe(true);
       // created_via has the back-compat default for pre-v6 rows.
       expect(byName.get("created_via")?.dflt_value).toMatch(/oauth_refresh/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("person-mint CAS misses when the user is gone", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "owner", "pw");
+      const expiresAt = new Date(Date.now() + 86400_000).toISOString();
+      db.prepare("DELETE FROM users WHERE id = ?").run(u.id);
+      expect(() =>
+        recordTokenMint(db, {
+          jti: "jti-cas-gone",
+          createdVia: "cli_mint",
+          subject: u.id,
+          userId: u.id,
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt,
+        }),
+      ).toThrow(TokenMintPrincipalGoneError);
+      expect(findTokenRowByJti(db, "jti-cas-gone")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("person-mint CAS misses when updated_at no longer matches (reset pin)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "owner", "pw");
+      const expiresAt = new Date(Date.now() + 86400_000).toISOString();
+      expect(() =>
+        recordTokenMint(db, {
+          jti: "jti-cas-reset",
+          createdVia: "cli_mint",
+          subject: u.id,
+          userId: u.id,
+          userUpdatedAt: "1999-01-01T00:00:00.000Z",
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt,
+        }),
+      ).toThrow(TokenMintPrincipalGoneError);
+      expect(findTokenRowByJti(db, "jti-cas-reset")).toBeNull();
     } finally {
       cleanup();
     }

--- a/src/__tests__/operator-token-issuer-self-heal.test.ts
+++ b/src/__tests__/operator-token-issuer-self-heal.test.ts
@@ -31,6 +31,16 @@ import {
 } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
+function plantOperatorUsers(db: ReturnType<typeof openHubDb>): void {
+  const stamp = new Date().toISOString();
+  const insert = db.prepare(
+    `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+     VALUES (?, ?, 'x', ?, ?, 1)`,
+  );
+  insert.run("user-abc", "owner", stamp, stamp);
+  insert.run("user-xyz", "other", stamp, stamp);
+}
+
 interface Harness {
   dir: string;
   cleanup: () => void;
@@ -51,6 +61,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint at loopback issuer with a non-default scope-set ("start").
         await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
@@ -90,6 +101,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: PUBLIC_ISSUER,
@@ -119,6 +131,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const status = await selfHealOperatorTokenIssuer(db, {
           issuer: PUBLIC_ISSUER,
           configDir: h.dir,
@@ -138,6 +151,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint a real token at loopback, then corrupt its signature segment so
         // it no longer verifies against the hub's keys.
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -184,6 +198,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint a token that expired in the past — jose's exp check throws on
         // validate, so the self-heal must classify it unverifiable.
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -217,6 +232,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // A hub-signed token with the WRONG audience must not be re-minted as
         // an operator token (privilege guard).
         const signed = await signAccessToken(db, {
@@ -252,6 +268,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // aud=operator + stale iss + NO pa_scope_set claim. Falling back to a
         // default scope-set would silently widen to admin (hub#224); refuse.
         const signed = await signAccessToken(db, {
@@ -287,6 +304,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // aud=operator + recognized scope-set + stale iss but NO sub — we can't
         // re-mint a token we can't attribute.
         const signed = await signAccessToken(db, {
@@ -322,6 +340,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // A good PUBLIC-issuer token; calling self-heal with a loopback target
         // must never downgrade it.
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -356,6 +375,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         await issueOperatorToken(db, "user-xyz", {
           dir: h.dir,
           issuer: LOOPBACK_ISSUER,
@@ -388,6 +408,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: LOOPBACK_ISSUER,

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -26,6 +26,18 @@ import {
 } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
+/** Operator mint is a person-mint (hub#833): the user row must exist. */
+function plantOperatorUsers(db: ReturnType<typeof openHubDb>): void {
+  const stamp = new Date().toISOString();
+  const insert = db.prepare(
+    `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+     VALUES (?, ?, 'x', ?, ?, 1)`,
+  );
+  insert.run("user-abc", "owner", stamp, stamp);
+  insert.run("user-xyz", "other", stamp, stamp);
+  insert.run("u", "shortn", stamp, stamp);
+}
+
 interface Harness {
   dir: string;
   cleanup: () => void;
@@ -45,6 +57,7 @@ describe("mintOperatorToken", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint at the real clock (no pinned `now`): `validateAccessToken` below
         // enforces `exp` against jose's real clock, which has no override, so a
         // pinned past mint date would eventually push `exp` into the past and
@@ -140,6 +153,7 @@ describe("issueOperatorToken", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const issued = await issueOperatorToken(db, "user-xyz", {
           dir: h.dir,
           issuer: TEST_ISSUER,
@@ -176,6 +190,7 @@ describe("mintOperatorToken scope-sets (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "user-abc", { issuer: TEST_ISSUER });
         expect(minted.scopeSet).toBe("admin");
         const validated = await validateAccessToken(db, minted.token, TEST_ISSUER);
@@ -195,6 +210,7 @@ describe("mintOperatorToken scope-sets (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "user-abc", {
           issuer: TEST_ISSUER,
           scopeSet: "start",
@@ -217,6 +233,7 @@ describe("mintOperatorToken scope-sets (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "u", {
           issuer: TEST_ISSUER,
           scopeSet: "install",
@@ -293,6 +310,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const issued = await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: TEST_ISSUER,
@@ -320,6 +338,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint with a 1-day TTL — well below the 7d threshold.
         const original = await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
@@ -358,6 +377,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Hand-sign a narrow JWT with aud=scribe (not "operator") and a
         // 1-hour TTL. Even though it's within the rotation window, the
         // helper must not silently upgrade it to a full operator token.
@@ -403,6 +423,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // aud=operator + 1h TTL + NO pa_scope_set claim. Pre-#224 this would
         // fall back to OPERATOR_TOKEN_DEFAULT_SCOPE_SET (admin) on rotation
         // — a silent widening of a token of unknown provenance.
@@ -444,6 +465,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const used = await useOperatorTokenWithAutoRotate(db, {
           configDir: h.dir,
           issuer: TEST_ISSUER,
@@ -463,6 +485,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint a token that's already expired.
         const expiredAt = new Date("2026-01-01T00:00:00Z");
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -542,6 +565,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // Mint the operator token under the hub's PUBLIC origin — what
           // happens on an exposed box (selfHealOperatorTokenIssuer re-mints to
           // the public iss).
@@ -577,6 +601,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           const issued = await issueOperatorToken(db, "user-abc", {
             dir: h.dir,
             issuer: TEST_ISSUER,
@@ -605,6 +630,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // Hub-SIGNED (so the signature gate passes) but stamped with an iss
           // that's neither loopback nor in expose-state nor env. Must reject.
           const issued = await issueOperatorToken(db, "user-abc", {
@@ -640,7 +666,9 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const foreignDb = openHubDb(hubDbPath(foreign.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           rotateSigningKey(foreignDb);
+          plantOperatorUsers(foreignDb);
           const foreignToken = await mintOperatorToken(foreignDb, "user-abc", {
             issuer: PUBLIC_ISSUER,
           });
@@ -670,6 +698,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // A loopback-iss token is accepted (loopback alias is always in the set).
           const loopbackTok = await issueOperatorToken(db, "user-abc", {
             dir: h.dir,
@@ -708,6 +737,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // Public-iss + 1-day TTL (below the 7d threshold). Validates via the
           // known set (expose-state public origin), then auto-rotates.
           const original = await issueOperatorToken(db, "user-abc", {
@@ -762,12 +792,13 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
 // registry so they show up in the revocation list and admin UI alongside
 // OAuth refresh tokens and CLI mints.
 describe("mintOperatorToken registry write (#212)", () => {
-  test("writes a tokens row with created_via='operator_mint', subject='operator', user_id NULL", async () => {
+  test("writes a tokens row with created_via='operator_mint', subject='operator', user_id set", async () => {
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "user-abc", {
           issuer: TEST_ISSUER,
           scopeSet: "start",
@@ -788,7 +819,7 @@ describe("mintOperatorToken registry write (#212)", () => {
           )
           .get(minted.jti);
         expect(row).not.toBeNull();
-        expect(row?.user_id).toBeNull();
+        expect(row?.user_id).toBe("user-abc");
         expect(row?.subject).toBe("operator");
         expect(row?.created_via).toBe("operator_mint");
         expect(row?.scopes).toBe("parachute:host:start");
@@ -807,6 +838,7 @@ describe("mintOperatorToken registry write (#212)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const original = await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: TEST_ISSUER,

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -59,6 +59,7 @@ import { activePublicSignupPath } from "./invites.ts";
 import { inferAudience } from "./jwt-audience.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
+  TokenMintPrincipalGoneError,
   recordTokenMint,
   signAccessToken,
   validateAccessToken,
@@ -738,8 +739,19 @@ export async function handleAccountMintVaultToken(
 
   const scopes = parsed.scopes;
   const audience = inferAudience(scopes); // → vault.<name>
+  // Person-mint (hub#833): JWT sub must resolve to a users row. Operator
+  // tokens now carry user_id, so a missing user is fail-closed rather than
+  // minting with user_id NULL. Check before signing so a signed JWT is
+  // never minted for a non-user principal.
+  const subjectUser = getUserById(deps.db, ctx.sub);
+  if (!subjectUser) {
+    return json(403, {
+      error: "invalid_subject",
+      message: "bearer subject is not a hub user",
+    });
+  }
   const minted = await signAccessToken(deps.db, {
-    sub: ctx.sub,
+    sub: subjectUser.id,
     scopes,
     audience,
     clientId: ACCOUNT_API_CLIENT_ID,
@@ -748,21 +760,24 @@ export async function handleAccountMintVaultToken(
     vaultScope: [vaultName],
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-  // Registry row so the operator token registry + revocation list attribute it.
-  // Anchor to the subject's user_id only when it names a real user row (an
-  // operator token's `sub` may be the "operator" sentinel, which is not a
-  // `users` row — pass it as `subject` but omit `user_id` to avoid a dangling FK).
-  const subjectIsUser = getUserById(deps.db, ctx.sub) !== null;
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject: ctx.sub,
-    ...(subjectIsUser ? { userId: ctx.sub } : {}),
-    clientId: ACCOUNT_API_CLIENT_ID,
-    scopes,
-    expiresAt: minted.expiresAt,
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: subjectUser.id,
+      userId: subjectUser.id,
+      userUpdatedAt: subjectUser.updatedAt,
+      clientId: ACCOUNT_API_CLIENT_ID,
+      scopes,
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return json(409, { error: "conflict", message: err.message });
+    }
+    throw err;
+  }
 
   return json(200, {
     vault_token: minted.token,

--- a/src/api-account-2fa.ts
+++ b/src/api-account-2fa.ts
@@ -17,6 +17,10 @@
  *                                   → the hub#833 phase-1a linkage ceremony
  *                                     (implementation in
  *                                     `api-account-pubkeys.ts`)
+ *   GET  /api/account/tokens       → this user's tokens (unrevoked default)
+ *   POST /api/account/tokens       → mint as the session user
+ *   POST /api/account/tokens/:jti/revoke
+ *                                   → revoke own jti only (hub#833)
  *
  * Auth posture: every endpoint is **self-service** — it acts on the
  * SIGNED-IN user's OWN account (`session.userId`), never a client-supplied
@@ -45,6 +49,7 @@ import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import QRCode from "qrcode";
 import { handleAccountPubkeys } from "./api-account-pubkeys.ts";
+import { handleAccountTokens } from "./api-account-tokens.ts";
 import { verifyCsrfToken } from "./csrf.ts";
 import { changePasswordRateLimiter, totpEnrollConfirmRateLimiter } from "./rate-limit.ts";
 import { findActiveSession } from "./sessions.ts";
@@ -72,6 +77,11 @@ export interface ApiAccount2faDeps {
    * event's `u` tag to one of them. See `AccountPubkeysDeps.hubBoundOrigins`.
    */
   hubBoundOrigins?: readonly string[];
+  /**
+   * Hub origin — `iss` of tokens minted on `POST /api/account/tokens`.
+   * Production always passes it; tests that don't mint may omit it.
+   */
+  issuer?: string;
   /** Test seam — defaults to the real clock. */
   now?: () => Date;
 }
@@ -154,10 +164,10 @@ function passwordRateLimit(userId: string, now: () => Date): Response | null {
  *
  * The 2FA + password routes are POST-only (all state-changing); the read-side
  * 2FA status the SPA renders comes from `/api/me`'s `two_factor_enabled`
- * field. The `/pubkeys` sub-surface (hub#833) is the one exception — it has a
- * read route — so it is dispatched BEFORE the POST-only gate and owns its own
- * method handling. The gate is left in place verbatim for the pre-existing
- * routes so their "405 before the session check" behavior is unchanged.
+ * field. `/pubkeys` and `/tokens` (hub#833) have GET routes, so they are
+ * dispatched BEFORE the POST-only gate and own their own method handling.
+ * The gate is left in place verbatim for the pre-existing routes so their
+ * "405 before the session check" behavior is unchanged.
  */
 export async function handleApiAccount(
   req: Request,
@@ -181,6 +191,24 @@ export async function handleApiAccount(
       subpath.slice("/pubkeys".length),
       { id: pubkeyGate.user.id, username: pubkeyGate.user.username },
       pubkeyBody,
+      deps,
+    );
+  }
+
+  // Self-service tokens (hub#833). Same session + CSRF posture as /pubkeys;
+  // GET is the list, so this is dispatched BEFORE the POST-only gate.
+  if (subpath === "/tokens" || subpath.startsWith("/tokens/")) {
+    const tokensGate = requireUser(deps.db, req);
+    if (!tokensGate.ok) return tokensGate.res;
+    const tokensBody = req.method === "GET" ? {} : await readJsonBody(req);
+    if (req.method !== "GET" && !checkCsrf(req, tokensBody)) {
+      return jsonError(403, "csrf_failed", "missing or invalid CSRF token");
+    }
+    return handleAccountTokens(
+      req,
+      subpath.slice("/tokens".length),
+      tokensGate.user,
+      tokensBody,
       deps,
     );
   }

--- a/src/api-account-tokens.ts
+++ b/src/api-account-tokens.ts
@@ -1,0 +1,280 @@
+/**
+ * `/api/account/tokens*` — self-service token list / mint / revoke (hub#833).
+ *
+ * Mounted under `/api/account/*` (`api-account-2fa.ts` routes here), so it
+ * inherits that surface's posture:
+ *
+ *   1. session cookie (else 401) — identity from `session.userId`, never a
+ *      client-supplied user id.
+ *   2. CSRF double-submit `__csrf` on every mutation (else 403).
+ *   3. same-origin belt, applied by the hub-server dispatcher before we run.
+ *
+ * Routes (`subpath` is relative to `/api/account/tokens`):
+ *
+ *   GET  ""                 → this user's tokens (unrevoked default;
+ *                             `?revoked=all|true|false`)
+ *   POST ""                 → mint as the session user
+ *   POST "/:jti/revoke"     → revoke own jti only; 404 if not yours
+ *                             (no cross-account existence oracle)
+ *
+ * Operator `/api/auth/tokens` and `/admin/tokens` stay the operator
+ * registry. This surface is how a non-operator actually mints without
+ * the operator bearer. Attenuation is a subset of THEIR authority
+ * (assigned-vault verbs; first-admin requestable scopes). Nobody can
+ * mint `parachute:host:*` here.
+ *
+ * Reuses `signAccessToken` + `recordTokenMint` + assigned-vault
+ * authority. No second mint stack.
+ */
+import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULT_TOKEN_TTL_SECONDS } from "./account-home-ui.ts";
+import { inferAudience } from "./jwt-audience.ts";
+import {
+  TokenMintPrincipalGoneError,
+  findTokenRowByJti,
+  listTokens,
+  recordTokenMint,
+  revokeTokenByJti,
+  signAccessToken,
+} from "./jwt-sign.ts";
+import { vaultTokenMintRateLimiter } from "./rate-limit.ts";
+import {
+  isNonRequestableScope,
+  isWellFormedOrNonVaultScope,
+  vaultScopeName,
+} from "./scope-explanations.ts";
+import { type User, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
+
+export interface AccountTokensDeps {
+  db: Database;
+  /** Hub origin — `iss` of minted tokens. Required on POST mint. */
+  issuer?: string;
+  now?: () => Date;
+}
+
+const ACCOUNT_TOKENS_CLIENT_ID = "parachute-account";
+const MAX_TTL_SECONDS = 365 * 24 * 60 * 60;
+const REVOKE_PATH = /^\/([^/]+)\/revoke$/;
+
+function json(status: number, body: unknown, extra: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store", ...extra },
+  });
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return json(status, { error, error_description: description });
+}
+
+/**
+ * Can this session user mint `requestedScope` on the self-service surface?
+ * First admin: any requestable scope except `parachute:host:*`. Friend:
+ * `vault:<assigned>:<verb>` they hold. Nobody mints host operator scopes
+ * here — those stay on `/api/auth/mint-token`.
+ */
+export function canAccountSelfMint(db: Database, user: User, scope: string): boolean {
+  if (scope.toLowerCase().startsWith("parachute:host:")) return false;
+  if (isFirstAdmin(db, user.id)) return !isNonRequestableScope(scope);
+  const name = vaultScopeName(scope);
+  if (name === null) return false;
+  const verb = scope.split(":")[2];
+  if (!verb) return false;
+  const held = vaultVerbsForUserVault(db, user.id, name);
+  return held !== null && (held as readonly string[]).includes(verb);
+}
+
+function hasAccountMintAuthority(db: Database, user: User): boolean {
+  if (isFirstAdmin(db, user.id)) return true;
+  return user.assignedVaults.some((name) => {
+    const held = vaultVerbsForUserVault(db, user.id, name);
+    return held !== null && held.length > 0;
+  });
+}
+
+/**
+ * Router. `subpath` is relative to `/api/account/tokens` ("" for the
+ * collection). The caller (`handleApiAccount`) has already established the
+ * session and, for POSTs, the CSRF token.
+ */
+export async function handleAccountTokens(
+  req: Request,
+  subpath: string,
+  user: User,
+  body: Record<string, unknown>,
+  deps: AccountTokensDeps,
+): Promise<Response> {
+  if (req.method === "GET") {
+    if (subpath !== "") return jsonError(404, "not_found", "no account route at that path");
+    return handleList(req, user, deps);
+  }
+  if (req.method !== "POST") {
+    return jsonError(405, "method_not_allowed", "use GET or POST");
+  }
+  if (subpath === "") return handleMint(req, user, body, deps);
+  const revoke = REVOKE_PATH.exec(subpath);
+  if (revoke) return handleRevoke(user, revoke[1]!, deps);
+  return jsonError(404, "not_found", `no account route at /api/account/tokens${subpath}`);
+}
+
+function handleList(req: Request, user: User, deps: AccountTokensDeps): Response {
+  const url = new URL(req.url);
+  const raw = url.searchParams.get("revoked") ?? "false";
+  if (raw !== "true" && raw !== "false" && raw !== "all") {
+    return jsonError(400, "invalid_request", "revoked must be true, false, or all");
+  }
+  const page = listTokens(deps.db, { filter: { userId: user.id, revoked: raw } });
+  return json(200, {
+    tokens: page.rows.map((row) => ({
+      jti: row.jti,
+      user_id: row.userId,
+      subject: row.subject,
+      client_id: row.clientId,
+      scopes: row.scopes,
+      expires_at: row.expiresAt,
+      revoked_at: row.revokedAt,
+      created_at: row.createdAt,
+      created_via: row.createdVia,
+      subject_pubkey: row.subjectPubkey,
+    })),
+  });
+}
+
+async function handleMint(
+  _req: Request,
+  user: User,
+  body: Record<string, unknown>,
+  deps: AccountTokensDeps,
+): Promise<Response> {
+  if (!deps.issuer) {
+    return jsonError(500, "server_error", "hub issuer is not configured");
+  }
+  if (!user.passwordChanged) {
+    return jsonError(
+      403,
+      "password_change_required",
+      "change your password before minting a token",
+    );
+  }
+  if (!hasAccountMintAuthority(deps.db, user)) {
+    return jsonError(
+      403,
+      "insufficient_scope",
+      "this account holds no minting authority (no assigned vaults)",
+    );
+  }
+  if (typeof body.scope !== "string" || body.scope.trim().length === 0) {
+    return jsonError(400, "invalid_request", "scope is required and must be a non-empty string");
+  }
+  const scopes = body.scope.split(/\s+/).filter((s) => s.length > 0);
+  if (scopes.length === 0) {
+    return jsonError(400, "invalid_request", "scope must contain at least one scope");
+  }
+  const malformed = scopes.filter((s) => !isWellFormedOrNonVaultScope(s));
+  if (malformed.length > 0) {
+    return jsonError(
+      400,
+      "invalid_scope",
+      `malformed vault scope ${malformed.join(", ")}; expected vault:<name>:<read|write|admin>`,
+    );
+  }
+  const blocked = scopes.filter((s) => !canAccountSelfMint(deps.db, user, s));
+  if (blocked.length > 0) {
+    return jsonError(
+      400,
+      "invalid_scope",
+      `scope ${blocked.join(", ")} is not grantable by this account`,
+    );
+  }
+
+  let ttlSeconds = ACCOUNT_VAULT_TOKEN_TTL_SECONDS;
+  if (body.expires_in !== undefined) {
+    if (
+      typeof body.expires_in !== "number" ||
+      !Number.isInteger(body.expires_in) ||
+      body.expires_in <= 0
+    ) {
+      return jsonError(400, "invalid_request", "expires_in must be a positive integer (seconds)");
+    }
+    if (body.expires_in > MAX_TTL_SECONDS) {
+      return jsonError(
+        400,
+        "invalid_request",
+        `expires_in exceeds 365d cap (${MAX_TTL_SECONDS} seconds)`,
+      );
+    }
+    ttlSeconds = body.expires_in;
+  }
+
+  let label: string = user.id;
+  if (body.label !== undefined) {
+    if (typeof body.label !== "string" || body.label.length === 0) {
+      return jsonError(400, "invalid_request", "label must be a non-empty string when present");
+    }
+    label = body.label;
+  }
+
+  const now = deps.now ?? (() => new Date());
+  const gate = vaultTokenMintRateLimiter.checkAndRecord(user.id, now());
+  if (!gate.allowed) {
+    const retryAfter = gate.retryAfterSeconds ?? 1;
+    return json(
+      429,
+      {
+        error: "too_many_attempts",
+        error_description: `Too many token-mint attempts. Try again in ${retryAfter} seconds.`,
+      },
+      { "retry-after": String(retryAfter) },
+    );
+  }
+
+  const vaultScopePin = [
+    ...new Set(scopes.map((s) => vaultScopeName(s)).filter((n): n is string => n !== null)),
+  ];
+  const minted = await signAccessToken(deps.db, {
+    sub: user.id,
+    scopes,
+    audience: inferAudience(scopes),
+    clientId: ACCOUNT_TOKENS_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds,
+    vaultScope: vaultScopePin,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: label,
+      userId: user.id,
+      userUpdatedAt: user.updatedAt,
+      clientId: ACCOUNT_TOKENS_CLIENT_ID,
+      scopes,
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return jsonError(409, "conflict", err.message);
+    }
+    throw err;
+  }
+
+  return json(200, {
+    jti: minted.jti,
+    token: minted.token,
+    expires_at: minted.expiresAt,
+    scope: scopes.join(" "),
+  });
+}
+
+function handleRevoke(user: User, jti: string, deps: AccountTokensDeps): Response {
+  const row = findTokenRowByJti(deps.db, jti);
+  // Same 404 for "not yours" and "does not exist" — no cross-account oracle.
+  if (!row || row.userId !== user.id) {
+    return jsonError(404, "not_found", "no token with that jti");
+  }
+  const now = deps.now?.() ?? new Date();
+  if (!row.revokedAt) revokeTokenByJti(deps.db, jti, now);
+  return json(200, { revoked: true, jti });
+}

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -46,7 +46,12 @@
  */
 import type { Database } from "bun:sqlite";
 import { inferAudience } from "./jwt-audience.ts";
-import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import {
+  TokenMintPrincipalGoneError,
+  recordTokenMint,
+  signAccessToken,
+  validateAccessToken,
+} from "./jwt-sign.ts";
 import {
   MINT_HOST_ADMIN_SCOPE,
   MINT_HOST_AUTH_SCOPE,
@@ -59,6 +64,7 @@ import {
   isWellFormedOrNonVaultScope,
   vaultScopeName,
 } from "./scope-explanations.ts";
+import { getUserById, resolveUser } from "./users.ts";
 
 // Re-export `canGrant` so existing importers (and the symmetric revoke path)
 // have a single name to reach for; the implementation lives in the shared
@@ -115,13 +121,25 @@ export interface ApiMintTokenDeps {
   knownVaultNames?: ReadonlySet<string>;
   /** Test seam for time. */
   now?: () => Date;
+  /**
+   * Test seam (hub#833): runs after `signAccessToken` and before
+   * `recordTokenMint`. The CAS insert is what keeps a signed JWT from
+   * leaking when the target account vanishes during the crypto await;
+   * this hook is how the race test deletes / resets the user in that
+   * window. Production callers omit it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 interface MintTokenRequest {
   scope?: unknown;
   audience?: unknown;
   expires_in?: unknown;
+  /** @deprecated Use `label` (display) or `user` (account principal). */
   subject?: unknown;
+  label?: unknown;
+  user?: unknown;
+  service?: unknown;
   permissions?: unknown;
 }
 
@@ -313,28 +331,111 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     ttlSeconds = body.expires_in;
   }
 
-  let subject: string;
-  if (body.subject === undefined) {
-    subject = bearerSub;
-  } else if (typeof body.subject === "string" && body.subject.length > 0) {
-    // Subject override is an OPERATOR-only capability (audit-attribution
-    // forgery otherwise). A host operator (`parachute:host:auth` /
-    // `parachute:host:admin`) may stamp a service-account `sub` other than its
-    // own — the documented service-account override. A merely vault-scoped
-    // bearer (`vault:<N>:admin` only, no host authority) has no business
-    // forging the minted token's subject: it would let a vault admin mint a
-    // token the registry + revocation list attribute to a foreign subject. So
-    // a non-operator bearer may only mint tokens carrying its OWN `sub`.
-    if (!isOperatorBearer(bearerScopes) && body.subject !== bearerSub) {
+  // Identity (hub#833): person-mint JWT `sub` is always `users.id`.
+  // `tokens.subject` is a display label. `subject` (body) is a deprecated
+  // alias of `label`, unless the value matches a hub account — then it is
+  // treated as `user` (one-release back-compat). Never silently mint a
+  // fake principal.
+  const warnings: string[] = [];
+  const asNonEmpty = (v: unknown): string | null =>
+    typeof v === "string" && v.length > 0 ? v : null;
+
+  const readOptional = (
+    value: unknown,
+    present: boolean,
+    field: string,
+  ): { ok: true; value: string | null } | { ok: false; res: Response } => {
+    if (!present) return { ok: true, value: null };
+    const parsed = asNonEmpty(value);
+    if (parsed === null) {
+      return {
+        ok: false,
+        res: jsonError(400, "invalid_request", `${field} must be a non-empty string when present`),
+      };
+    }
+    return { ok: true, value: parsed };
+  };
+  const labelField = readOptional(body.label, body.label !== undefined, "label");
+  if (!labelField.ok) return labelField.res;
+  const userField = readOptional(body.user, body.user !== undefined, "user");
+  if (!userField.ok) return userField.res;
+  const serviceField = readOptional(body.service, body.service !== undefined, "service");
+  if (!serviceField.ok) return serviceField.res;
+  const subjectField = readOptional(body.subject, body.subject !== undefined, "subject");
+  if (!subjectField.ok) return subjectField.res;
+
+  if (userField.value && serviceField.value) {
+    return jsonError(400, "invalid_request", "pass user OR service, not both");
+  }
+
+  let asUser = userField.value;
+  const asService = serviceField.value;
+  let asLabel = labelField.value;
+  if (subjectField.value !== null) {
+    if (asUser || asService || asLabel) {
+      return jsonError(
+        400,
+        "invalid_request",
+        "`subject` is deprecated; pass `user`, `label`, or `service` instead (not together with `subject`)",
+      );
+    }
+    const matched = resolveUser(deps.db, subjectField.value);
+    if (matched) {
+      warnings.push(
+        "`subject` is deprecated; treating as `user` because it matches a hub account. JWT sub is the account id.",
+      );
+      asUser = matched.id;
+    } else {
+      warnings.push(
+        "`subject` is deprecated; treating as `label`. JWT sub stays the bearer account id.",
+      );
+      asLabel = subjectField.value;
+    }
+  }
+
+  let jwtSub: string;
+  let mintUserId: string | null = null;
+  let mintUserUpdatedAt: string | undefined;
+  let subjectLabel: string;
+  if (asService) {
+    if (!isOperatorBearer(bearerScopes)) {
       return jsonError(
         403,
         "insufficient_scope",
-        "non-operator bearers may not override subject; omit `subject` to mint under your own identity",
+        "non-operator bearers may not mint a service principal; omit `service` to mint under your own account",
       );
     }
-    subject = body.subject;
+    jwtSub = asService;
+    subjectLabel = asLabel ?? asService;
+  } else if (asUser) {
+    const target = resolveUser(deps.db, asUser);
+    if (!target) {
+      return jsonError(400, "invalid_request", `no hub account matching user "${asUser}"`);
+    }
+    if (!isOperatorBearer(bearerScopes) && target.id !== bearerSub) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        "non-operator bearers may not mint as another account; omit `user` to mint under your own identity",
+      );
+    }
+    jwtSub = target.id;
+    mintUserId = target.id;
+    mintUserUpdatedAt = target.updatedAt;
+    subjectLabel = asLabel ?? target.id;
   } else {
-    return jsonError(400, "invalid_request", "subject must be a non-empty string when present");
+    const bearerUser = getUserById(deps.db, bearerSub);
+    if (!bearerUser) {
+      return jsonError(
+        401,
+        "unauthenticated",
+        "bearer subject is not a hub user; person-mint requires a users.id principal",
+      );
+    }
+    jwtSub = bearerUser.id;
+    mintUserId = bearerUser.id;
+    mintUserUpdatedAt = bearerUser.updatedAt;
+    subjectLabel = asLabel ?? bearerUser.id;
   }
 
   let permissionsClaim: Record<string, unknown> | undefined;
@@ -385,9 +486,12 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   }
   const vaultScopePin = [...vaultScopePinSet];
 
-  // 6. Mint + register.
+  // 6. Mint + register. Person-mint JWT sub is users.id; service mint uses
+  // the service name. Registry insert for person-mints is a CAS against the
+  // users row (hub#833) so a delete/reset racing the crypto await cannot
+  // land a live unregistered JWT.
   const minted = await signAccessToken(deps.db, {
-    sub: subject,
+    sub: jwtSub,
     scopes,
     audience,
     clientId: API_MINT_TOKEN_CLIENT_ID,
@@ -406,20 +510,30 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
 
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject,
-    // user_id intentionally omitted — CLI-mint rows store subject only,
-    // matching the CLI path's shape (so HTTP and CLI mints look identical
-    // in the registry). The bearer's user identity is implicit via the
-    // bearer's own user_id (which is in its own tokens row).
-    clientId: API_MINT_TOKEN_CLIENT_ID,
-    scopes,
-    expiresAt: minted.expiresAt,
-    ...(permissionsCanonical !== undefined ? { permissions: permissionsCanonical } : {}),
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  if (deps.afterSign) {
+    await deps.afterSign({ token: minted.token, jti: minted.jti, userId: mintUserId });
+  }
+
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: subjectLabel,
+      ...(mintUserId
+        ? { userId: mintUserId, ...(mintUserUpdatedAt ? { userUpdatedAt: mintUserUpdatedAt } : {}) }
+        : {}),
+      clientId: API_MINT_TOKEN_CLIENT_ID,
+      scopes,
+      expiresAt: minted.expiresAt,
+      ...(permissionsCanonical !== undefined ? { permissions: permissionsCanonical } : {}),
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return jsonError(409, "conflict", err.message);
+    }
+    throw err;
+  }
 
   return new Response(
     JSON.stringify({
@@ -428,6 +542,7 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
       expires_at: minted.expiresAt,
       scope: scopes.join(" "),
       ...(permissionsClaim !== undefined ? { permissions: permissionsClaim } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
     }),
     {
       status: 200,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -40,6 +40,7 @@ import { openHubDb } from "../hub-db.ts";
 import { resolveHubIssuer } from "../hub-issuer.ts";
 import { inferAudience } from "../jwt-audience.ts";
 import {
+  TokenMintPrincipalGoneError,
   findTokenRowByJti,
   recordTokenMint,
   revokeTokenByJti,
@@ -69,8 +70,10 @@ import {
   SingleUserModeError,
   UsernameTakenError,
   createUser,
+  getUserById,
   getUserByUsername,
   listUsers,
+  resolveUser,
   setPassword,
   userCount,
 } from "../users.ts";
@@ -131,13 +134,19 @@ Usage:
                                        default admin)
   parachute auth mint-token --scope <scope> [--aud <aud>]
                                             [--ephemeral | --expires-in <seconds>]
-                                            [--sub <sub>] [--permissions <json>]
-                                       Mint a scope-narrow JWT against the
-                                       operator's identity (stdout = JWT).
-                                       --ephemeral = short-lived (1h), ideal for
-                                       scripting; default lifetime is 90d.
-                                       --ttl <duration> is the deprecated
-                                       alias (use --expires-in seconds).
+                                            [--label <label>] [--user <username|id>]
+                                            [--service <name>] [--permissions <json>]
+                                       Mint a scope-narrow JWT. Person-mint
+                                       JWT sub is the hub account id (stdout =
+                                       JWT). --label is the display label
+                                       (tokens.subject). --user (operator)
+                                       mints as that account. --service mints
+                                       a non-account principal. --sub is the
+                                       deprecated alias of --label (or --user
+                                       when the value matches an account).
+                                       --ephemeral = short-lived (1h); default
+                                       lifetime is 90d. --ttl is the deprecated
+                                       lifetime alias.
   parachute auth revoke-token <jti>    Mark a registry-row token revoked
                                        by jti. Idempotent: a re-revoke
                                        prints the existing revoked_at and
@@ -302,6 +311,11 @@ export interface AuthDeps {
    * for `PARACHUTE_HUB_ORIGIN` so the token's iss matches what services see.
    */
   hubOrigin?: string;
+  /**
+   * Test seam (hub#833): runs after `signAccessToken` and before
+   * `recordTokenMint` on `mint-token`. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 function defaultRotateKey(): { kid: string; createdAt: string } {
@@ -978,7 +992,11 @@ interface MintTokenFlags {
   aud?: string;
   ttl?: string;
   expiresIn?: string;
+  /** @deprecated Use --label or --user. */
   sub?: string;
+  label?: string;
+  user?: string;
+  service?: string;
   permissions?: string;
   /** True when --ttl was used (deprecated alias). Triggers a one-line stderr warning. */
   ttlDeprecationSeen?: boolean;
@@ -993,6 +1011,9 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
   let ttl: string | undefined;
   let expiresIn: string | undefined;
   let sub: string | undefined;
+  let label: string | undefined;
+  let user: string | undefined;
+  let service: string | undefined;
   let permissions: string | undefined;
   let ttlDeprecationSeen = false;
   let ephemeral = false;
@@ -1035,6 +1056,27 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
     } else if (a?.startsWith("--sub=")) {
       sub = a.slice("--sub=".length);
       if (!sub) return { error: "--sub requires a value" };
+    } else if (a === "--label") {
+      const v = args[++i];
+      if (!v) return { error: "--label requires a value" };
+      label = v;
+    } else if (a?.startsWith("--label=")) {
+      label = a.slice("--label=".length);
+      if (!label) return { error: "--label requires a value" };
+    } else if (a === "--user") {
+      const v = args[++i];
+      if (!v) return { error: "--user requires a value" };
+      user = v;
+    } else if (a?.startsWith("--user=")) {
+      user = a.slice("--user=".length);
+      if (!user) return { error: "--user requires a value" };
+    } else if (a === "--service") {
+      const v = args[++i];
+      if (!v) return { error: "--service requires a value" };
+      service = v;
+    } else if (a?.startsWith("--service=")) {
+      service = a.slice("--service=".length);
+      if (!service) return { error: "--service requires a value" };
     } else if (a === "--permissions") {
       const v = args[++i];
       if (!v) return { error: "--permissions requires a value" };
@@ -1056,7 +1098,28 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
       error: "pass --ephemeral OR an explicit lifetime (--expires-in/--ttl), not both",
     };
   }
-  return { scope, aud, ttl, expiresIn, sub, permissions, ttlDeprecationSeen, ephemeral };
+  if (user !== undefined && service !== undefined) {
+    return { error: "pass --user OR --service, not both" };
+  }
+  if (sub !== undefined && (label !== undefined || user !== undefined || service !== undefined)) {
+    return {
+      error:
+        "--sub is deprecated; pass --user, --label, or --service instead (not together with --sub)",
+    };
+  }
+  return {
+    scope,
+    aud,
+    ttl,
+    expiresIn,
+    sub,
+    label,
+    user,
+    service,
+    permissions,
+    ttlDeprecationSeen,
+    ephemeral,
+  };
 }
 
 const MINT_TOKEN_TTL_DEFAULT_SECONDS = 90 * 24 * 60 * 60;
@@ -1119,7 +1182,7 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
   if (!flags.scope) {
     console.error("parachute auth mint-token: --scope is required");
     console.error(
-      "usage: parachute auth mint-token --scope <scope> [--aud <aud>] [--ephemeral | --expires-in <seconds>] [--sub <sub>] [--permissions <json>]",
+      "usage: parachute auth mint-token --scope <scope> [--aud <aud>] [--ephemeral | --expires-in <seconds>] [--label <label>] [--user <username|id>] [--service <name>] [--permissions <json>]",
     );
     return 1;
   }
@@ -1257,11 +1320,59 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
     }
 
     const audience = flags.aud ?? inferAudience(scopes);
-    const subjectForMint = flags.sub ?? operatorSub;
     const permissionsClaim = permissions !== undefined ? JSON.parse(permissions) : undefined;
 
+    let asUser = flags.user;
+    const asService = flags.service;
+    let asLabel = flags.label;
+    if (flags.sub) {
+      const matched = resolveUser(db, flags.sub);
+      if (matched) {
+        console.error(
+          "parachute auth mint-token: --sub is deprecated; treating as --user because it matches a hub account. JWT sub is the account id.",
+        );
+        asUser = matched.id;
+      } else {
+        console.error(
+          "parachute auth mint-token: --sub is deprecated; treating as --label. JWT sub stays the bearer account id.",
+        );
+        asLabel = flags.sub;
+      }
+    }
+
+    let jwtSub: string;
+    let mintUserId: string | null = null;
+    let mintUserUpdatedAt: string | undefined;
+    let subjectLabel: string;
+    if (asService) {
+      jwtSub = asService;
+      subjectLabel = asLabel ?? asService;
+    } else if (asUser) {
+      const target = resolveUser(db, asUser);
+      if (!target) {
+        console.error(`parachute auth mint-token: no hub account matching --user "${asUser}"`);
+        return 1;
+      }
+      jwtSub = target.id;
+      mintUserId = target.id;
+      mintUserUpdatedAt = target.updatedAt;
+      subjectLabel = asLabel ?? target.id;
+    } else {
+      const bearerUser = getUserById(db, operatorSub);
+      if (!bearerUser) {
+        console.error(
+          "parachute auth mint-token: operator token sub is not a hub user; person-mint requires a users.id principal",
+        );
+        return 1;
+      }
+      jwtSub = bearerUser.id;
+      mintUserId = bearerUser.id;
+      mintUserUpdatedAt = bearerUser.updatedAt;
+      subjectLabel = asLabel ?? bearerUser.id;
+    }
+
     const minted = await signAccessToken(db, {
-      sub: subjectForMint,
+      sub: jwtSub,
       scopes,
       audience,
       clientId: OPERATOR_TOKEN_CLIENT_ID,
@@ -1271,20 +1382,37 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
       ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     });
 
-    // Write a registry row (hub#212 Phase 1). Powers the revocation list
-    // endpoint and admin UI introspection. Per design: CLI-mint rows have
-    // user_id NULL; the subject column carries the chosen mint subject
-    // (--sub overrides operator-sub). The JWT is its own access token,
-    // not a refresh token, so refresh_token_hash + family_id stay NULL.
-    recordTokenMint(db, {
-      jti: minted.jti,
-      createdVia: "cli_mint",
-      subject: subjectForMint,
-      clientId: OPERATOR_TOKEN_CLIENT_ID,
-      scopes,
-      expiresAt: minted.expiresAt,
-      ...(permissions !== undefined ? { permissions } : {}),
-    });
+    if (deps.afterSign) {
+      await deps.afterSign({ token: minted.token, jti: minted.jti, userId: mintUserId });
+    }
+
+    // Write a registry row (hub#212 Phase 1 / hub#833). Person-mint JWT
+    // sub is users.id and user_id is set; tokens.subject is the display
+    // label. Service mints leave user_id NULL. The JWT is its own access
+    // token, so refresh_token_hash + family_id stay NULL.
+    try {
+      recordTokenMint(db, {
+        jti: minted.jti,
+        createdVia: "cli_mint",
+        subject: subjectLabel,
+        ...(mintUserId
+          ? {
+              userId: mintUserId,
+              ...(mintUserUpdatedAt ? { userUpdatedAt: mintUserUpdatedAt } : {}),
+            }
+          : {}),
+        clientId: OPERATOR_TOKEN_CLIENT_ID,
+        scopes,
+        expiresAt: minted.expiresAt,
+        ...(permissions !== undefined ? { permissions } : {}),
+      });
+    } catch (err) {
+      if (err instanceof TokenMintPrincipalGoneError) {
+        console.error(`parachute auth mint-token: ${err.message}`);
+        return 1;
+      }
+      throw err;
+    }
 
     console.log(minted.token);
     return 0;

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -9,7 +9,9 @@
  * multi-use public-signup links + email-as-username + the `vault_caps`
  * per-vault storage-cap table), and Nostr-pubkey ↔ user linkage plus the
  * additive `tokens.subject_pubkey` attribution snapshot (v17, hub#833
- * phase 1), and the durable attribution proof archive (v18, hub#860).
+ * phase 1), the durable attribution proof archive (v18, hub#860), and a
+ * live `tokens.user_id` backfill where `subject` already equals a
+ * `users.id` (v19, hub#833 per-account mint).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -691,6 +693,21 @@ const MIGRATIONS: readonly Migration[] = [
         (subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at)
       SELECT user_id, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at
       FROM user_pubkeys;
+    `,
+  },
+  {
+    version: 19,
+    sql: `
+      -- Backfill tokens.user_id where subject already is a users.id (hub#833).
+      -- Person-mints going forward always set user_id; this recovers live
+      -- rows whose subject was the account id. Leave the rest grandfathered
+      -- (operator/service labels, friend-named strings). Do not rewrite
+      -- already-issued JWTs — they expire / rotate.
+      UPDATE tokens
+         SET user_id = subject
+       WHERE user_id IS NULL
+         AND subject IS NOT NULL
+         AND EXISTS (SELECT 1 FROM users WHERE id = tokens.subject);
     `,
   },
 ];

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -107,6 +107,9 @@
  *   /api/account/pubkeys/challenge (POST)      → mint a single-use, user-bound linkage challenge + the event template to sign (cookie-gated; CSRF)
  *   /api/account/pubkeys/verify   (POST)       → present a signed NIP-01 (kind 27235) event; verify BIP-340 possession + consume the challenge → link (cookie-gated; CSRF)
  *   /api/account/pubkeys/unlink   (POST)       → drop one of the caller's own links (cookie-gated; CSRF; does NOT rewrite tokens.subject_pubkey history)
+ *   /api/account/tokens           (GET)        → this user's tokens (cookie-gated; self-only; unrevoked default, ?revoked=all|true|false) — hub#833
+ *   /api/account/tokens           (POST)       → mint as session user (cookie-gated; CSRF; self-only; cannot mint parachute:host:*) — hub#833
+ *   /api/account/tokens/:jti/revoke (POST)     → revoke own jti only (cookie-gated; CSRF; 404 if not yours) — hub#833
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
  *   /api/hub/upgrade/status       (GET)        → poll the on-disk hub-upgrade status (host:admin)
@@ -3480,6 +3483,7 @@ export function hubFetch(
         const subpath = pathname.slice("/api/account".length);
         return handleApiAccount(req, subpath, {
           db: getDb(),
+          issuer: oauthDeps(req).issuer,
           // Only the /pubkeys sub-surface reads this — the hub#833 linkage
           // ceremony binds the signed event's `u` tag to an origin this hub
           // actually answers on, so a NIP-98 signature harvested for another

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -227,6 +227,17 @@ export class RefreshTokenInsertError extends Error {
   }
 }
 
+/**
+ * Person-mint CAS miss (hub#833): `INSERT ... SELECT ... FROM users WHERE id = ?`
+ * matched zero rows, so the target account was deleted (or password-reset,
+ * when `userUpdatedAt` is pinned) during the crypto await. The mint handler
+ * must NOT return the signed JWT — a signed-but-unregistered token leaks
+ * because `validateAccessToken` still treats a missing registry row as valid.
+ */
+export class TokenMintPrincipalGoneError extends Error {
+  override name = "TokenMintPrincipalGoneError";
+}
+
 export function signRefreshToken(db: Database, opts: SignRefreshTokenOpts): SignedRefreshToken {
   const token = randomBytes(32).toString("base64url");
   const refreshTokenHash = createHash("sha256").update(token).digest("hex");
@@ -293,6 +304,15 @@ export interface RecordTokenMintOpts {
    */
   subjectPubkey?: string | null;
   now?: () => Date;
+  /**
+   * Person-mint CAS pin (hub#833). When set with `userId`, the insert is
+   * `INSERT ... SELECT ... FROM users WHERE id = ? AND updated_at = ?`.
+   * Zero rows — account deleted, or `resetUserPassword` racing the crypto
+   * await (it bumps `updated_at`) — throws `TokenMintPrincipalGoneError`.
+   * Omit on service mints (`userId` unset) and on callers that only need
+   * the existence check.
+   */
+  userUpdatedAt?: string;
 }
 
 /**
@@ -318,7 +338,48 @@ export function recordTokenMint(db: Database, opts: RecordTokenMintOpts): void {
     opts.subjectPubkey !== undefined
       ? opts.subjectPubkey
       : attributionPubkey(db, { userId: opts.userId, subject: opts.subject });
+  const createdAt = now.toISOString();
+  const scopes = opts.scopes.join(" ");
   try {
+    if (opts.userId) {
+      // Person-mint CAS (hub#833): the user row must still exist at INSERT.
+      // Pin `updated_at` when the caller snapshotted it before `signAccessToken`
+      // so a password-reset racing the crypto await also misses.
+      const pinUpdatedAt = opts.userUpdatedAt !== undefined;
+      const sql = pinUpdatedAt
+        ? `INSERT INTO tokens (
+             jti, user_id, client_id, scopes, expires_at, created_at,
+             permissions, created_via, subject, subject_pubkey
+           )
+           SELECT ?, u.id, ?, ?, ?, ?, ?, ?, ?, ?
+           FROM users u WHERE u.id = ? AND u.updated_at = ?`
+        : `INSERT INTO tokens (
+             jti, user_id, client_id, scopes, expires_at, created_at,
+             permissions, created_via, subject, subject_pubkey
+           )
+           SELECT ?, u.id, ?, ?, ?, ?, ?, ?, ?, ?
+           FROM users u WHERE u.id = ?`;
+      const args: (string | null)[] = [
+        opts.jti,
+        opts.clientId,
+        scopes,
+        opts.expiresAt,
+        createdAt,
+        opts.permissions ?? null,
+        opts.createdVia,
+        opts.subject,
+        subjectPubkey,
+        opts.userId,
+      ];
+      if (pinUpdatedAt) args.push(opts.userUpdatedAt ?? null);
+      const result = db.prepare(sql).run(...args);
+      if (Number(result.changes) === 0) {
+        throw new TokenMintPrincipalGoneError(
+          `account ${opts.userId} no longer exists (or was reset) at mint insert; refusing to register jti=${opts.jti}`,
+        );
+      }
+      return;
+    }
     db.prepare(
       `INSERT INTO tokens (
         jti, user_id, client_id, scopes, expires_at, created_at,
@@ -326,17 +387,18 @@ export function recordTokenMint(db: Database, opts: RecordTokenMintOpts): void {
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       opts.jti,
-      opts.userId ?? null,
+      null,
       opts.clientId,
-      opts.scopes.join(" "),
+      scopes,
       opts.expiresAt,
-      now.toISOString(),
+      createdAt,
       opts.permissions ?? null,
       opts.createdVia,
       opts.subject,
       subjectPubkey,
     );
   } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) throw err;
     throw new RefreshTokenInsertError(
       `failed to insert token registry row (jti=${opts.jti}, created_via=${opts.createdVia}): ${err instanceof Error ? err.message : String(err)}`,
       err,
@@ -415,6 +477,8 @@ export interface ListTokensFilter {
   revoked?: "true" | "false" | "all";
   subject?: string;
   createdVia?: TokenCreatedVia;
+  /** Exact match on `tokens.user_id`. Self-service account list uses this. */
+  userId?: string;
 }
 
 /**
@@ -483,6 +547,10 @@ export function listTokens(
   if (typeof filter.subject === "string" && filter.subject.length > 0) {
     wheres.push("(user_id = ? OR subject = ?)");
     params.push(filter.subject, filter.subject);
+  }
+  if (typeof filter.userId === "string" && filter.userId.length > 0) {
+    wheres.push("user_id = ?");
+    params.push(filter.userId);
   }
   if (filter.createdVia) {
     wheres.push("created_via = ?");

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -34,8 +34,14 @@ import { EXPOSE_STATE_PATH, readExposeState } from "./expose-state.ts";
 import { validateHostAdminToken } from "./host-admin-token-validation.ts";
 import { readHubPort } from "./hub-control.ts";
 import { HUB_UNIT_DEFAULT_PORT } from "./hub-unit.ts";
-import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import {
+  TokenMintPrincipalGoneError,
+  recordTokenMint,
+  signAccessToken,
+  validateAccessToken,
+} from "./jwt-sign.ts";
 import { buildHubBoundOrigins } from "./origin-check.ts";
+import { getUserById } from "./users.ts";
 import { isLoopbackOrigin } from "./vault-hub-origin-env.ts";
 
 export const OPERATOR_TOKEN_FILENAME = "operator.token";
@@ -156,10 +162,16 @@ export async function mintOperatorToken(
   userId: string,
   opts: MintOperatorTokenOpts,
 ): Promise<{ token: string; jti: string; expiresAt: string; scopeSet: OperatorScopeSet }> {
+  const user = getUserById(db, userId);
+  if (!user) {
+    throw new TokenMintPrincipalGoneError(
+      `mintOperatorToken: no hub user ${userId}; operator mint is a person-mint`,
+    );
+  }
   const scopeSet = opts.scopeSet ?? OPERATOR_TOKEN_DEFAULT_SCOPE_SET;
   const scopes = [...OPERATOR_TOKEN_SCOPE_SETS[scopeSet]];
   const minted = await signAccessToken(db, {
-    sub: userId,
+    sub: user.id,
     scopes,
     audience: opts.audience ?? OPERATOR_TOKEN_AUDIENCE,
     clientId: OPERATOR_TOKEN_CLIENT_ID,
@@ -174,16 +186,15 @@ export async function mintOperatorToken(
     ...(opts.now !== undefined ? { now: opts.now } : {}),
   });
   // Register every operator-mint with the unified token registry (hub#212
-  // Phase 1). Per design: operator-mint rows have user_id NULL; the
-  // subject column carries the canonical "operator" identity string.
-  // (Storing user_id here would require an FK-valid users row, which the
-  // operator-mint path doesn't always have access to in test fixtures —
-  // and conceptually the operator is a role, not a hub user.) Powers the
-  // revocation list endpoint.
+  // Phase 1 / hub#833). JWT sub is the hub user id; user_id is set so
+  // account delete / password-reset revoke this row. subject stays the
+  // "operator" display label.
   recordTokenMint(db, {
     jti: minted.jti,
     createdVia: "operator_mint",
     subject: "operator",
+    userId: user.id,
+    userUpdatedAt: user.updatedAt,
     clientId: OPERATOR_TOKEN_CLIENT_ID,
     scopes,
     expiresAt: minted.expiresAt,

--- a/src/users.ts
+++ b/src/users.ts
@@ -384,6 +384,16 @@ export function getUserById(db: Database, id: string): User | null {
   return row ? rowToUser(row, readVaultsForUser(db, row.id)) : null;
 }
 
+/**
+ * Resolve a hub user by id, else username (case-insensitive). Used by the
+ * mint `--user` / body `user` flags (hub#833) so operators can name an
+ * account either way.
+ */
+export function resolveUser(db: Database, ident: string): User | null {
+  if (ident.length === 0) return null;
+  return getUserById(db, ident) ?? getUserByUsernameCI(db, ident);
+}
+
 export function listUsers(db: Database): User[] {
   const rows = db.query<Row, []>("SELECT * FROM users ORDER BY created_at ASC").all();
   if (rows.length === 0) return [];


### PR DESCRIPTION
Towards #833 — slice (a) only. Does **not** close the issue: (b) SPA Account.tsx UI and (c) NIP-98 login are follow-ups.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What changed

Grounded in the (a) spec folds.

### Fold 1 — principal is `users.id`

Person-mint JWT `sub` is always `users.id`. `tokens.user_id` is set on every person-mint (operator mint, CLI/HTTP mint against an account, account-door vault token). `tokens.subject` is a **label**, not the principal.

- CLI `parachute auth mint-token`: `--label` (display), `--user <username|id>` (operator, mint as that account), `--service <name>` (non-account principal, `user_id` NULL). `--sub` is deprecated: if the value matches a `users.id` or username, warn and treat as `--user`; otherwise warn and treat as `--label`. Never silently mints a fake principal.
- HTTP `POST /api/auth/mint-token`: same with body fields `label` / `user` / `service` / deprecated `subject`. Default JWT `sub` is the bearer's account id; bearer.sub must resolve to a users row for person-mint.
- `mintOperatorToken` keeps JWT `sub` = userId and now **also** sets `userId` on `recordTokenMint` (`subject` stays `"operator"`).
- `handleAccountMintVaultToken` fail-closes if `ctx.sub` is not a user (operator tokens now have `user_id`).
- Migration v19 backfills live `tokens.user_id` where `subject` equals a `users.id`. Leaves the rest grandfathered. Does not rewrite already-issued JWTs.

### Fold 2 — CAS after crypto await

`recordTokenMint` for person-mints is a CAS insert:

```sql
INSERT INTO tokens (...)
SELECT ... FROM users WHERE id = ? [AND updated_at = ?]
```

Zero rows → `TokenMintPrincipalGoneError`; the mint handler does **not** return the JWT (409 on HTTP). The `updated_at` pin is how a `resetUserPassword` racing the crypto await also misses (reset bumps `updated_at`; delete removes the row).

Injectable `afterSign` hook on `handleApiMintToken` and the CLI mint path (test seam).

**The race tests were watched failing before the CAS existed.** With `afterSign` calling `deleteUser` / `resetUserPassword` after sign and before insert, the handler returned **200** and a live token (`Expected: 409, Received: 200`). After the CAS they return 409, no `token` in the JSON body, no live unrevoked row for that jti.

Pubkey unlink does **not** revoke (v17 snapshot). A test documents INSERT-time snapshot: unlink racing mint does not leave a dangling `user_id`. No unlink-as-logout.

### Self-service API

Cookie+CSRF, self-only, same posture as `/api/account/pubkeys`. Identity from `session.userId`. Dispatched in `handleApiAccount` **before** the POST-only gate (GET exists). Hub-server route table updated.

| Method | Path | Does |
|---|---|---|
| GET | `/api/account/tokens` | this user's tokens (unrevoked default; `?revoked=all\|true\|false`) |
| POST | `/api/account/tokens` | mint as session user; body `{scope, expires_in?, label?, __csrf}` |
| POST | `/api/account/tokens/:jti/revoke` | revoke own jti only; 404 if not yours (no cross-account oracle) |

Attenuation: subset of **their** authority. Friends mint `vault:<assigned>:<verb>` they hold. Nobody mints `parachute:host:*` here. Operator `/api/auth/tokens` and `/admin/tokens` stay the operator registry.

Reuses `signAccessToken` + `recordTokenMint` + assigned-vault authority. No second mint stack.

## Verify

Same shell as HEAD:

- `bun run typecheck` — pass (`tsc --noEmit`)
- Targeted: **298 pass / 0 fail** across 8 files (`api-mint-token`, `api-account-tokens`, `operator-token`, `operator-token-issuer-self-heal`, `auth`, `account-api`, `jwt-sign`, `hub-db`)
- HEAD: `695ec326570a3536784760a1b6bd6c55fc71eebd`

**Full `bun test ./src` was NOT run on this box.** launchd-touching tests ignore `PARACHUTE_HOME` (hub#840) and can bootout the live hub. CI is the full suite.

## Out of this PR

- (b) SPA Account.tsx UI (next PR, wants a video)
- (c) NIP-98 login
- Requiring a live registry row for historical JWTs (missing-row bypass in `validateAccessToken`) — only fail-closed for **new** mints via the insert gate
- Admin IA cleanup
- Changelog version bump
- Cloud