### PR TITLE
feat(hub#833): Account SPA my-tokens + pubkey-link

### DIFF
--- a/src/__tests__/api-account-tokens.test.ts
+++ b/src/__tests__/api-account-tokens.test.ts
@@ -123,14 +123,67 @@ describe("GET /api/account/tokens", () => {
 
     const ownerList = await call("GET", "", owner.cookie);
     expect(ownerList.status).toBe(200);
-    const ownerBody = (await ownerList.json()) as { tokens: { user_id: string; jti: string }[] };
+    const ownerBody = (await ownerList.json()) as {
+      tokens: { user_id: string; jti: string }[];
+      next_cursor: string | null;
+    };
     expect(ownerBody.tokens.every((t) => t.user_id === owner.userId)).toBe(true);
     expect(ownerBody.tokens.length).toBeGreaterThan(0);
+    expect(ownerBody.next_cursor).toBeNull();
 
     const friendList = await call("GET", "", friend.cookie);
-    const friendBody = (await friendList.json()) as { tokens: { user_id: string }[] };
+    const friendBody = (await friendList.json()) as {
+      tokens: { user_id: string }[];
+      next_cursor: string | null;
+    };
     expect(friendBody.tokens.every((t) => t.user_id === friend.userId)).toBe(true);
     expect(friendBody.tokens.length).toBe(1);
+    expect(friendBody.next_cursor).toBeNull();
+  });
+
+  test("pages at 50 and returns next_cursor when more rows exist", async () => {
+    const { recordTokenMint } = await import("../jwt-sign.ts");
+    const owner = await userWithSession("owner");
+    const stamp = new Date("2026-08-25T12:00:00.000Z");
+    const user = db
+      .query<{ updated_at: string }, [string]>("SELECT updated_at FROM users WHERE id = ?")
+      .get(owner.userId);
+    if (!user) throw new Error("owner missing");
+    for (let i = 0; i < 51; i++) {
+      recordTokenMint(db, {
+        jti: `acct-page-${String(i).padStart(3, "0")}`,
+        createdVia: "cli_mint",
+        subject: "page",
+        userId: owner.userId,
+        userUpdatedAt: user.updated_at,
+        clientId: "parachute-account",
+        scopes: ["scribe:transcribe"],
+        expiresAt: "2030-01-01T00:00:00.000Z",
+        now: () => new Date(stamp.getTime() + i * 1000),
+      });
+    }
+    const first = await call("GET", "", owner.cookie);
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as {
+      tokens: { jti: string }[];
+      next_cursor: string | null;
+    };
+    expect(firstBody.tokens).toHaveLength(50);
+    expect(firstBody.next_cursor).toBeTruthy();
+    const second = await call(
+      "GET",
+      `?cursor=${encodeURIComponent(firstBody.next_cursor!)}`,
+      owner.cookie,
+    );
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as {
+      tokens: { jti: string }[];
+      next_cursor: string | null;
+    };
+    expect(secondBody.tokens.length).toBeGreaterThanOrEqual(1);
+    expect(secondBody.next_cursor).toBeNull();
+    const firstJtis = new Set(firstBody.tokens.map((t) => t.jti));
+    expect(secondBody.tokens.some((t) => firstJtis.has(t.jti))).toBe(false);
   });
 });
 

--- a/src/__tests__/operator-token-issuer-self-heal.test.ts
+++ b/src/__tests__/operator-token-issuer-self-heal.test.ts
@@ -22,6 +22,7 @@ import {
   OPERATOR_TOKEN_AUDIENCE,
   OPERATOR_TOKEN_CLIENT_ID,
   OPERATOR_TOKEN_FILENAME,
+  OPERATOR_TOKEN_SCOPE_SETS,
   OPERATOR_TOKEN_SCOPE_SET_CLAIM,
   issueOperatorToken,
   operatorTokenPath,
@@ -323,6 +324,40 @@ describe("selfHealOperatorTokenIssuer", () => {
         });
         expect(status.kind).toBe("skipped");
         if (status.kind === "skipped") expect(status.reason).toBe("no-sub");
+
+        const onDisk = await readOperatorTokenFile(h.dir);
+        expect(onDisk).toBe(signed.token);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("sub is not a users row (stale iss, aud=operator, valid scope-set) → skipped:sub-not-user, untouched", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        plantOperatorUsers(db);
+        const signed = await signAccessToken(db, {
+          sub: "operator",
+          scopes: [...OPERATOR_TOKEN_SCOPE_SETS.admin],
+          audience: OPERATOR_TOKEN_AUDIENCE,
+          clientId: OPERATOR_TOKEN_CLIENT_ID,
+          issuer: LOOPBACK_ISSUER,
+          extraClaims: { [OPERATOR_TOKEN_SCOPE_SET_CLAIM]: "admin" },
+        });
+        await writeOperatorTokenFile(signed.token, h.dir);
+
+        const status = await selfHealOperatorTokenIssuer(db, {
+          issuer: PUBLIC_ISSUER,
+          configDir: h.dir,
+        });
+        expect(status.kind).toBe("skipped");
+        if (status.kind === "skipped") expect(status.reason).toBe("sub-not-user");
 
         const onDisk = await readOperatorTokenFile(h.dir);
         expect(onDisk).toBe(signed.token);

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -459,6 +459,48 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
     }
   });
 
+  test("skips auto-rotate when sub is not a users row (skipped: sub-not-user)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        plantOperatorUsers(db);
+        // Legacy sentinel principal: aud=operator + recognized scope-set +
+        // short TTL, but sub is the old "operator" label, not a users.id.
+        // mintOperatorToken would throw; auto-rotate must skip, not crash.
+        const signed = await signAccessToken(db, {
+          sub: "operator",
+          scopes: [...OPERATOR_TOKEN_SCOPE_SETS.admin],
+          audience: OPERATOR_TOKEN_AUDIENCE,
+          clientId: OPERATOR_TOKEN_CLIENT_ID,
+          issuer: TEST_ISSUER,
+          ttlSeconds: 3600,
+          extraClaims: { [OPERATOR_TOKEN_SCOPE_SET_CLAIM]: "admin" },
+        });
+        await writeOperatorTokenFile(signed.token, h.dir);
+
+        const used = await useOperatorTokenWithAutoRotate(db, {
+          configDir: h.dir,
+          issuer: TEST_ISSUER,
+        });
+        expect(used).not.toBeNull();
+        expect(used?.status.kind).toBe("skipped");
+        if (used?.status.kind === "skipped") {
+          expect(used.status.reason).toBe("sub-not-user");
+        }
+        expect(used?.rotated).toBeUndefined();
+        expect(used?.token).toBe(signed.token);
+        const onDisk = await readOperatorTokenFile(h.dir);
+        expect(onDisk).toBe(signed.token);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("returns null when no operator token file exists", async () => {
     const h = makeHarness();
     try {

--- a/src/api-account-2fa.ts
+++ b/src/api-account-2fa.ts
@@ -17,7 +17,8 @@
  *                                   → the hub#833 phase-1a linkage ceremony
  *                                     (implementation in
  *                                     `api-account-pubkeys.ts`)
- *   GET  /api/account/tokens       → this user's tokens (unrevoked default)
+ *   GET  /api/account/tokens       → this user's tokens (unrevoked default;
+ *                                     `?cursor=` pages 50; `next_cursor`)
  *   POST /api/account/tokens       → mint as the session user
  *   POST /api/account/tokens/:jti/revoke
  *                                   → revoke own jti only (hub#833)

--- a/src/api-account-tokens.ts
+++ b/src/api-account-tokens.ts
@@ -12,7 +12,8 @@
  * Routes (`subpath` is relative to `/api/account/tokens`):
  *
  *   GET  ""                 → this user's tokens (unrevoked default;
- *                             `?revoked=all|true|false`)
+ *                             `?revoked=all|true|false`; `?cursor=` pages;
+ *                             page size 50, `next_cursor` when more)
  *   POST ""                 → mint as the session user
  *   POST "/:jti/revoke"     → revoke own jti only; 404 if not yours
  *                             (no cross-account existence oracle)
@@ -123,7 +124,11 @@ function handleList(req: Request, user: User, deps: AccountTokensDeps): Response
   if (raw !== "true" && raw !== "false" && raw !== "all") {
     return jsonError(400, "invalid_request", "revoked must be true, false, or all");
   }
-  const page = listTokens(deps.db, { filter: { userId: user.id, revoked: raw } });
+  const cursor = url.searchParams.get("cursor");
+  const page = listTokens(deps.db, {
+    filter: { userId: user.id, revoked: raw },
+    ...(cursor ? { cursor } : {}),
+  });
   return json(200, {
     tokens: page.rows.map((row) => ({
       jti: row.jti,
@@ -137,6 +142,7 @@ function handleList(req: Request, user: User, deps: AccountTokensDeps): Response
       created_via: row.createdVia,
       subject_pubkey: row.subjectPubkey,
     })),
+    next_cursor: page.nextCursor,
   });
 }
 

--- a/src/commands/expose-supervisor.ts
+++ b/src/commands/expose-supervisor.ts
@@ -237,6 +237,11 @@ export async function restartHubDependentViaSupervisor(args: {
       });
       if (status.kind === "rotated") {
         log(`  refreshed operator.token issuer → ${hubOrigin} (was stale after exposure)`);
+      } else if (status.kind === "skipped") {
+        // Name the cause so a legacy `"operator"` sentinel / deleted-user
+        // sub is visible (`skipped: sub-not-user`) rather than a catch-all
+        // try-wrap. Other skip reasons (aud-mismatch, no-sub, …) too.
+        log(`  note: operator.token issuer self-heal skipped: ${status.reason}`);
       }
     } catch (err) {
       // A self-heal failure must never block the restart — degrade to a note.

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -107,7 +107,7 @@
  *   /api/account/pubkeys/challenge (POST)      → mint a single-use, user-bound linkage challenge + the event template to sign (cookie-gated; CSRF)
  *   /api/account/pubkeys/verify   (POST)       → present a signed NIP-01 (kind 27235) event; verify BIP-340 possession + consume the challenge → link (cookie-gated; CSRF)
  *   /api/account/pubkeys/unlink   (POST)       → drop one of the caller's own links (cookie-gated; CSRF; does NOT rewrite tokens.subject_pubkey history)
- *   /api/account/tokens           (GET)        → this user's tokens (cookie-gated; self-only; unrevoked default, ?revoked=all|true|false) — hub#833
+ *   /api/account/tokens           (GET)        → this user's tokens (cookie-gated; self-only; unrevoked default, ?revoked=all|true|false, ?cursor= pages 50, next_cursor) — hub#833
  *   /api/account/tokens           (POST)       → mint as session user (cookie-gated; CSRF; self-only; cannot mint parachute:host:*) — hub#833
  *   /api/account/tokens/:jti/revoke (POST)     → revoke own jti only (cookie-gated; CSRF; 404 if not yours) — hub#833
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -344,11 +344,20 @@ export interface UseOperatorTokenOpts {
  *       `issueOperatorToken`); a token without it is either a hand-crafted
  *       JWT (don't widen) or a pre-#213 legacy token (operator should
  *       explicitly `parachute auth rotate-operator` to recover).
+ *     - `sub-not-user`: `sub` is present but is not a `users` row (the old
+ *       `"operator"` sentinel, or a deleted user). `mintOperatorToken` is a
+ *       person-mint as of hub#833 and throws `TokenMintPrincipalGoneError`
+ *       for those; catching it here keeps auto-rotate fail-closed without
+ *       turning a legacy file into a CLI exception. Recover via explicit
+ *       `parachute auth rotate-operator` against a real users row.
  */
 export type RotationStatus =
   | { kind: "fresh" }
   | { kind: "rotated" }
-  | { kind: "skipped"; reason: "aud-mismatch" | "no-sub" | "no-scope-set" };
+  | {
+      kind: "skipped";
+      reason: "aud-mismatch" | "no-sub" | "no-scope-set" | "sub-not-user";
+    };
 
 export interface UsedOperatorToken {
   /** The operator token plaintext to present as bearer. After auto-rotation, this is the freshly-minted token. */
@@ -550,12 +559,24 @@ export async function useOperatorTokenWithAutoRotate(
     return { token, payload, status: { kind: "skipped", reason: "no-scope-set" } };
   }
   const scopeSet: OperatorScopeSet = claimedSet;
-  const issued = await issueOperatorToken(db, sub, {
-    dir,
-    issuer: opts.issuer,
-    scopeSet,
-    now: opts.now,
-  });
+  let issued: IssueOperatorTokenResult;
+  try {
+    issued = await issueOperatorToken(db, sub, {
+      dir,
+      issuer: opts.issuer,
+      scopeSet,
+      now: opts.now,
+    });
+  } catch (err) {
+    // Person-mint as of hub#833: a legacy `"operator"` sentinel or a
+    // deleted-user `sub` is not a users row. Skip rather than throw so
+    // callers (expose-supervisor, CLI try-wraps) can log `skipped:
+    // sub-not-user` instead of treating this as a crash.
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return { token, payload, status: { kind: "skipped", reason: "sub-not-user" } };
+    }
+    throw err;
+  }
   const reValidated = await validateAccessToken(db, issued.token, opts.issuer);
   return {
     token: issued.token,
@@ -605,6 +626,9 @@ export interface SelfHealOperatorTokenOpts {
  *     - `no-scope-set`: the token lacks (or has an unrecognized) `pa_scope_set`
  *       claim. Falling back to a default would widen scope (hub#224 hardening);
  *       refuse instead. Operator recovers via explicit rotate-operator.
+ *     - `sub-not-user`: `sub` is present but is not a `users` row. Same
+ *       person-mint fail-close as auto-rotate (`mintOperatorToken` throws
+ *       `TokenMintPrincipalGoneError`). The on-disk file is left untouched.
  *     - `issuer-loopback`: the TARGET issuer is loopback. Re-minting to a
  *       loopback `iss` would downgrade a good public token; never do it.
  */
@@ -614,7 +638,13 @@ export type OperatorIssuerHealStatus =
   | { kind: "rotated"; path: string; scopeSet: OperatorScopeSet; expiresAt: string }
   | {
       kind: "skipped";
-      reason: "unverifiable" | "aud-mismatch" | "no-sub" | "no-scope-set" | "issuer-loopback";
+      reason:
+        | "unverifiable"
+        | "aud-mismatch"
+        | "no-sub"
+        | "no-scope-set"
+        | "sub-not-user"
+        | "issuer-loopback";
     };
 
 /**
@@ -701,12 +731,20 @@ export async function selfHealOperatorTokenIssuer(
 
   // Re-mint preserving scope-set + sub. `issueOperatorToken` writes the new
   // token to disk atomically (mint → writeOperatorTokenFile).
-  const issued = await issueOperatorToken(db, sub, {
-    dir,
-    issuer: opts.issuer,
-    scopeSet: claimedSet,
-    ...(opts.now !== undefined ? { now: opts.now } : {}),
-  });
+  let issued: IssueOperatorTokenResult;
+  try {
+    issued = await issueOperatorToken(db, sub, {
+      dir,
+      issuer: opts.issuer,
+      scopeSet: claimedSet,
+      ...(opts.now !== undefined ? { now: opts.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return { kind: "skipped", reason: "sub-not-user" };
+    }
+    throw err;
+  }
   return {
     kind: "rotated",
     path: issued.path,

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -28,6 +28,8 @@ vi.mock("./lib/api.ts", async (orig) => {
     listVaults: vi.fn().mockResolvedValue({ vaults: [], moduleInstalled: false }),
     listGrants: vi.fn().mockResolvedValue([]),
     listTokens: vi.fn().mockResolvedValue({ tokens: [], next_cursor: null }),
+    listAccountTokens: vi.fn().mockResolvedValue({ tokens: [], next_cursor: null }),
+    listAccountPubkeys: vi.fn().mockResolvedValue([]),
     listModules: vi.fn().mockResolvedValue({ modules: [], supervisor_available: false }),
     // App's useEffect hits getMe() on mount. Default mock = signed-out so
     // the AuthIndicator renders the deterministic "Sign in" link rather

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -488,3 +488,80 @@ describe("resolveManagementUrl", () => {
     ).toBe("https://elsewhere.example/manage");
   });
 });
+
+describe("listAccountTokens / mintAccountToken", () => {
+  it("GETs /api/account/tokens with same-origin credentials and parses next_cursor", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { tokens: [], next_cursor: "abc" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const api = await import("./api.ts");
+    const page = await api.listAccountTokens({ cursor: "prev" });
+    expect(page.next_cursor).toBe("abc");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/account/tokens?cursor=prev",
+      expect.objectContaining({
+        method: "GET",
+        credentials: "same-origin",
+      }),
+    );
+  });
+
+  it("POSTs mint with CSRF + scope + label", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        jti: "j1",
+        token: "eyJ",
+        expires_at: "2030-01-01T00:00:00.000Z",
+        scope: "vault:work:read",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const api = await import("./api.ts");
+    const minted = await api.mintAccountToken("csrf-x", {
+      scope: "vault:work:read",
+      label: "laptop",
+    });
+    expect(minted.jti).toBe("j1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/account/tokens",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        body: JSON.stringify({
+          __csrf: "csrf-x",
+          scope: "vault:work:read",
+          label: "laptop",
+        }),
+      }),
+    );
+  });
+});
+
+describe("verifyPubkeyLink", () => {
+  it("surfaces first-link password_required instead of bouncing to login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(401, {
+          error: "password_required",
+          error_description:
+            "Re-enter your current password to link your first key to this account.",
+        }),
+      ),
+    );
+    const api = await import("./api.ts");
+    await expect(
+      api.verifyPubkeyLink("csrf-x", {
+        event: {
+          id: "a",
+          pubkey: "b",
+          created_at: 1,
+          kind: 27235,
+          tags: [],
+          content: "x",
+          sig: "c",
+        },
+      }),
+    ).rejects.toMatchObject({ status: 401, message: expect.stringMatching(/re-enter/i) });
+    expect(auth.redirectToLoginAndHang).not.toHaveBeenCalled();
+  });
+});

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -2041,3 +2041,185 @@ export async function changeAccountPassword(
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
 }
+
+// ---------------------------------------------------------------------------
+// Self-service account tokens + pubkey linkage (hub#833 (b))
+//
+// Same cookie + CSRF posture as password/2FA above. Operator `/admin/tokens`
+// stays the registry; these helpers are "my tokens" and "my keys" for the
+// signed-in user. Identity is always `session.userId`.
+// ---------------------------------------------------------------------------
+
+export interface AccountTokenListing {
+  jti: string;
+  user_id: string;
+  subject: string | null;
+  client_id: string;
+  scopes: string[];
+  expires_at: string;
+  revoked_at: string | null;
+  created_at: string;
+  created_via: string;
+  subject_pubkey: string | null;
+}
+
+export interface AccountTokensPage {
+  tokens: AccountTokenListing[];
+  next_cursor: string | null;
+}
+
+export interface MintAccountTokenInput {
+  scope: string;
+  expires_in?: number;
+  label?: string;
+}
+
+export interface MintedAccountToken {
+  jti: string;
+  token: string;
+  expires_at: string;
+  scope: string;
+}
+
+export interface AccountPubkey {
+  pubkey: string;
+  label: string | null;
+  proof_event_id: string;
+  linked_at: string;
+  last_verified_at: string;
+}
+
+export interface PubkeyChallenge {
+  challenge: string;
+  expires_at: string;
+  event_template: {
+    kind: number;
+    content: string;
+    tags: string[][];
+  };
+}
+
+export interface SignedNostrEvent {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+  sig: string;
+}
+
+export interface LinkedPubkeyResult extends AccountPubkey {
+  linked: true;
+  relinked: boolean;
+}
+
+async function getAccount(subpath: string): Promise<Response> {
+  return await fetch(`/api/account${subpath}`, {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+}
+
+/**
+ * GET /api/account/tokens — this user's tokens. Default is unrevoked.
+ * Cursor pagination: pass `cursor` from the previous page's `next_cursor`.
+ */
+export async function listAccountTokens(
+  opts: { revoked?: "true" | "false" | "all"; cursor?: string } = {},
+): Promise<AccountTokensPage> {
+  const params = new URLSearchParams();
+  if (opts.revoked) params.set("revoked", opts.revoked);
+  if (opts.cursor) params.set("cursor", opts.cursor);
+  const query = params.toString();
+  const res = await getAccount(query ? `/tokens?${query}` : "/tokens");
+  if (res.status === 401) return redirectToLoginAndHang<AccountTokensPage>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as AccountTokensPage;
+}
+
+/**
+ * POST /api/account/tokens — mint as the session user. JWT is shown once.
+ * Cannot mint `parachute:host:*` (that stays on the operator registry).
+ */
+export async function mintAccountToken(
+  csrf: string,
+  input: MintAccountTokenInput,
+): Promise<MintedAccountToken> {
+  const body: Record<string, unknown> = { scope: input.scope };
+  if (input.expires_in !== undefined) body.expires_in = input.expires_in;
+  if (input.label !== undefined) body.label = input.label;
+  const res = await postAccount("/tokens", csrf, body);
+  if (res.status === 401) return redirectToLoginAndHang<MintedAccountToken>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as MintedAccountToken;
+}
+
+/** POST /api/account/tokens/:jti/revoke — revoke own jti only. */
+export async function revokeAccountToken(csrf: string, jti: string): Promise<void> {
+  const res = await postAccount(`/tokens/${encodeURIComponent(jti)}/revoke`, csrf);
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/** GET /api/account/pubkeys — the caller's linked Nostr keys. */
+export async function listAccountPubkeys(): Promise<AccountPubkey[]> {
+  const res = await getAccount("/pubkeys");
+  if (res.status === 401) return redirectToLoginAndHang<AccountPubkey[]>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { pubkeys: AccountPubkey[] };
+  return body.pubkeys ?? [];
+}
+
+/** POST /api/account/pubkeys/challenge — mint a single-use event template. */
+export async function startPubkeyChallenge(csrf: string): Promise<PubkeyChallenge> {
+  const res = await postAccount("/pubkeys/challenge", csrf);
+  if (res.status === 401) return redirectToLoginAndHang<PubkeyChallenge>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as PubkeyChallenge;
+}
+
+/**
+ * POST /api/account/pubkeys/verify — present a signed NIP-01 event.
+ *
+ * First-link requires `password` (401 `password_required` if omitted). That
+ * 401 is NOT a gone session — surface it; only a message that isn't a
+ * step-up / proof failure bounces to login.
+ */
+export async function verifyPubkeyLink(
+  csrf: string,
+  opts: { event: SignedNostrEvent; label?: string; password?: string },
+): Promise<LinkedPubkeyResult> {
+  const body: Record<string, unknown> = { event: opts.event };
+  if (opts.label !== undefined) body.label = opts.label;
+  if (opts.password !== undefined) body.password = opts.password;
+  const res = await postAccount("/pubkeys/verify", csrf, body);
+  if (res.status === 401) {
+    const message = await readError(res);
+    const lower = message.toLowerCase();
+    if (
+      lower.includes("re-enter") ||
+      lower.includes("password") ||
+      lower.includes("signature") ||
+      lower.includes("incorrect")
+    ) {
+      throw new HttpError(401, message);
+    }
+    return redirectToLoginAndHang<LinkedPubkeyResult>();
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as LinkedPubkeyResult;
+}
+
+/** POST /api/account/pubkeys/unlink — drop one of the caller's own links. */
+export async function unlinkAccountPubkey(csrf: string, pubkey: string): Promise<boolean> {
+  const res = await postAccount("/pubkeys/unlink", csrf, { pubkey });
+  if (res.status === 401) return redirectToLoginAndHang<boolean>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { unlinked: boolean };
+  return body.unlinked;
+}

--- a/web/ui/src/routes/Account.test.tsx
+++ b/web/ui/src/routes/Account.test.tsx
@@ -20,11 +20,20 @@ vi.mock("../lib/api.ts", async (orig) => {
     startTwoFactor: vi.fn(),
     confirmTwoFactor: vi.fn(),
     disableTwoFactor: vi.fn(),
+    listAccountTokens: vi.fn(),
+    mintAccountToken: vi.fn(),
+    revokeAccountToken: vi.fn(),
+    listAccountPubkeys: vi.fn(),
+    startPubkeyChallenge: vi.fn(),
+    verifyPubkeyLink: vi.fn(),
+    unlinkAccountPubkey: vi.fn(),
   };
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(api.listAccountTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+  vi.mocked(api.listAccountPubkeys).mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -250,5 +259,214 @@ describe("Account — 2FA disable", () => {
       expect(screen.getByTestId("account-2fa-error")).toHaveTextContent(/current password/i),
     );
     expect(api.disableTwoFactor).not.toHaveBeenCalled();
+  });
+});
+
+describe("Account — API tokens", () => {
+  const tokenRow = (
+    jti: string,
+    overrides: Partial<api.AccountTokenListing> = {},
+  ): api.AccountTokenListing => ({
+    jti,
+    user_id: "u1",
+    subject: "laptop",
+    client_id: "parachute-account",
+    scopes: ["vault:work:read"],
+    expires_at: "2030-01-01T00:00:00.000Z",
+    revoked_at: null,
+    created_at: "2026-08-25T12:00:00.000Z",
+    created_via: "cli_mint",
+    subject_pubkey: null,
+    ...overrides,
+  });
+
+  it("renders the empty state when this account has no live tokens", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    expect(await screen.findByTestId("account-tokens-empty")).toBeInTheDocument();
+  });
+
+  it("lists a token row and mints, showing the JWT once", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.listAccountTokens)
+      .mockResolvedValueOnce({ tokens: [], next_cursor: null })
+      .mockResolvedValueOnce({
+        tokens: [tokenRow("aaaaaaaaXXXXXXXbbbb")],
+        next_cursor: null,
+      });
+    vi.mocked(api.mintAccountToken).mockResolvedValue({
+      jti: "aaaaaaaaXXXXXXXbbbb",
+      token: "eyJhbGciOi.test",
+      expires_at: "2030-01-01T00:00:00.000Z",
+      scope: "vault:work:read",
+    });
+    renderRoute();
+    await screen.findByTestId("account-token-mint-toggle");
+    fireEvent.click(screen.getByTestId("account-token-mint-toggle"));
+    fireEvent.change(screen.getByTestId("account-token-scope"), {
+      target: { value: "vault:work:read" },
+    });
+    fireEvent.change(screen.getByTestId("account-token-label"), { target: { value: "laptop" } });
+    fireEvent.click(screen.getByTestId("account-token-mint"));
+
+    await waitFor(() =>
+      expect(api.mintAccountToken).toHaveBeenCalledWith("csrf-abc", {
+        scope: "vault:work:read",
+        label: "laptop",
+      }),
+    );
+    expect(await screen.findByTestId("account-token-jwt")).toHaveTextContent("eyJhbGciOi.test");
+  });
+
+  it("revokes a live token after confirm", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.listAccountTokens)
+      .mockResolvedValueOnce({
+        tokens: [tokenRow("jti-live-0001")],
+        next_cursor: null,
+      })
+      .mockResolvedValueOnce({ tokens: [], next_cursor: null });
+    vi.mocked(api.revokeAccountToken).mockResolvedValue();
+    renderRoute();
+    await screen.findByTestId("account-token-revoke-jti-live-0001");
+    fireEvent.click(screen.getByTestId("account-token-revoke-jti-live-0001"));
+    fireEvent.click(screen.getByTestId("account-token-revoke-confirm-jti-live-0001"));
+    await waitFor(() =>
+      expect(api.revokeAccountToken).toHaveBeenCalledWith("csrf-abc", "jti-live-0001"),
+    );
+    await waitFor(() => expect(screen.getByTestId("account-tokens-empty")).toBeInTheDocument());
+  });
+
+  it("Load more appends the next page and is disabled while in flight", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    const listMock = vi.mocked(api.listAccountTokens);
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("page-one-aaaaaa")],
+      next_cursor: "cursor-2",
+    });
+    let resolveSecond: (page: api.AccountTokensPage) => void = () => {};
+    listMock.mockReturnValueOnce(
+      new Promise<api.AccountTokensPage>((resolve) => {
+        resolveSecond = resolve;
+      }),
+    );
+    renderRoute();
+    const more = await screen.findByTestId("account-tokens-load-more");
+    fireEvent.click(more);
+    await waitFor(() => expect(screen.getByTestId("account-tokens-load-more")).toBeDisabled());
+    fireEvent.click(screen.getByTestId("account-tokens-load-more"));
+    expect(listMock.mock.calls.filter((c) => c[0]?.cursor === "cursor-2")).toHaveLength(1);
+    resolveSecond({ tokens: [tokenRow("page-two-bbbbbb")], next_cursor: null });
+    expect(await screen.findByTestId("account-token-row-page-two-bbbbbb")).toBeInTheDocument();
+    expect(screen.getByTestId("account-token-row-page-one-aaaaaa")).toBeInTheDocument();
+    expect(screen.queryByTestId("account-tokens-load-more")).toBeNull();
+  });
+});
+
+describe("Account — Nostr keys", () => {
+  it("renders empty state and starts the challenge flow", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
+      challenge: "aa".repeat(32),
+      expires_at: "2026-08-25T12:05:00.000Z",
+      event_template: {
+        kind: 27235,
+        content: 'Link this key to account "aaron" on this hub.',
+        tags: [
+          ["u", "https://hub.example/api/account/pubkeys/verify"],
+          ["method", "POST"],
+          ["challenge", "aa".repeat(32)],
+        ],
+      },
+    });
+    renderRoute();
+    expect(await screen.findByTestId("account-pubkeys-empty")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("account-pubkey-link"));
+    await waitFor(() => expect(api.startPubkeyChallenge).toHaveBeenCalledWith("csrf-abc"));
+    expect(await screen.findByTestId("account-pubkey-statement")).toHaveTextContent(
+      /link this key/i,
+    );
+    expect(screen.getByTestId("account-pubkey-password")).toBeInTheDocument();
+  });
+
+  it("posts the pasted event + first-link password", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
+      challenge: "bb".repeat(32),
+      expires_at: "2026-08-25T12:05:00.000Z",
+      event_template: {
+        kind: 27235,
+        content: "statement",
+        tags: [["u", "https://hub.example/api/account/pubkeys/verify"]],
+      },
+    });
+    vi.mocked(api.verifyPubkeyLink).mockResolvedValue({
+      linked: true,
+      relinked: false,
+      pubkey: "aa".repeat(32),
+      label: "phone",
+      proof_event_id: "cc".repeat(32),
+      linked_at: "2026-08-25T12:00:00.000Z",
+      last_verified_at: "2026-08-25T12:00:00.000Z",
+    });
+    vi.mocked(api.listAccountPubkeys)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          pubkey: "aa".repeat(32),
+          label: "phone",
+          proof_event_id: "cc".repeat(32),
+          linked_at: "2026-08-25T12:00:00.000Z",
+          last_verified_at: "2026-08-25T12:00:00.000Z",
+        },
+      ]);
+    renderRoute();
+    await screen.findByTestId("account-pubkey-link");
+    fireEvent.click(screen.getByTestId("account-pubkey-link"));
+    await screen.findByTestId("account-pubkey-event");
+    const event = {
+      id: "dd".repeat(32),
+      pubkey: "aa".repeat(32),
+      created_at: 1,
+      kind: 27235,
+      tags: [] as string[][],
+      content: "statement",
+      sig: "ee".repeat(32),
+    };
+    fireEvent.change(screen.getByTestId("account-pubkey-event"), {
+      target: { value: JSON.stringify(event) },
+    });
+    fireEvent.change(screen.getByTestId("account-pubkey-label"), { target: { value: "phone" } });
+    fireEvent.change(screen.getByTestId("account-pubkey-password"), {
+      target: { value: "correct-horse-battery" },
+    });
+    fireEvent.click(screen.getByTestId("account-pubkey-verify"));
+    await waitFor(() =>
+      expect(api.verifyPubkeyLink).toHaveBeenCalledWith("csrf-abc", {
+        event,
+        label: "phone",
+        password: "correct-horse-battery",
+      }),
+    );
+    expect(await screen.findByTestId(`account-pubkey-row-${"aa".repeat(32)}`)).toBeInTheDocument();
+  });
+
+  it("rejects non-JSON event client-side (no POST)", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
+      challenge: "bb".repeat(32),
+      expires_at: "2026-08-25T12:05:00.000Z",
+      event_template: { kind: 27235, content: "statement", tags: [] },
+    });
+    renderRoute();
+    await screen.findByTestId("account-pubkey-link");
+    fireEvent.click(screen.getByTestId("account-pubkey-link"));
+    await screen.findByTestId("account-pubkey-event");
+    fireEvent.change(screen.getByTestId("account-pubkey-event"), { target: { value: "not-json" } });
+    fireEvent.click(screen.getByTestId("account-pubkey-verify"));
+    await waitFor(() =>
+      expect(screen.getByTestId("account-pubkeys-form-error")).toHaveTextContent(/not valid json/i),
+    );
+    expect(api.verifyPubkeyLink).not.toHaveBeenCalled();
   });
 });

--- a/web/ui/src/routes/Account.tsx
+++ b/web/ui/src/routes/Account.tsx
@@ -1,32 +1,49 @@
 /**
- * /admin/account — "My account": self-service password + 2FA for the
- * signed-in user (hub#85). Aaron chose option B — native in the SPA rather
- * than a link out to the server-rendered `/account/`.
+ * /admin/account — "My account": self-service password, 2FA, my-tokens, and
+ * pubkey-link for the signed-in user (hub#85 + hub#833 (b)).
  *
  * The owner is NOT special here: `two_factor_enabled` comes from `/api/me`
  * (keyed off the session's own user), and every action POSTs to
  * `/api/account/*`, which act on `session.userId`. Same path for the first
  * admin and any friend user.
  *
- * Two sections:
+ * Four sections:
  *   - Password — current → new (+ confirm). 12-char floor mirrors the server
  *     validator; the server is authoritative (its 400/401 message surfaces).
  *   - Two-factor — status pill; when off, an enroll flow (QR + secret + verify
  *     a code → backup codes shown ONCE); when on, a password-gated disable.
+ *   - API tokens — list / mint / revoke THIS user's tokens. Operator registry
+ *     stays at `/admin/tokens`. JWT shown once. Cookie+CSRF, cannot mint
+ *     `parachute:host:*`.
+ *   - Nostr keys — list / link / unlink. A linked key is an attribution
+ *     label; it grants nothing. First-link is password-gated.
  *
  * The CSRF token + 2FA status are read from `/api/me` (the single who-am-I
  * read App.tsx already does). We refetch it after a 2FA change so the status
  * pill + section swap without a full reload.
  */
 import { type FormEvent, useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
+  type AccountPubkey,
+  type AccountTokenListing,
   type MeResponse,
+  type MintedAccountToken,
+  type PubkeyChallenge,
+  type SignedNostrEvent,
   type TwoFactorStart,
   changeAccountPassword,
   confirmTwoFactor,
   disableTwoFactor,
   getMe,
+  listAccountPubkeys,
+  listAccountTokens,
+  mintAccountToken,
+  revokeAccountToken,
+  startPubkeyChallenge,
   startTwoFactor,
+  unlinkAccountPubkey,
+  verifyPubkeyLink,
 } from "../lib/api.ts";
 
 type LoadState =
@@ -71,7 +88,8 @@ export function Account() {
     <section className="settings" data-testid="account-page">
       <h1>My account</h1>
       <p className="muted">
-        Manage your own sign-in credentials. Changes here apply to your account only.
+        Manage your own sign-in credentials, API tokens, and linked Nostr keys. Changes here apply
+        to your account only. The operator token registry is a separate page.
       </p>
 
       <PasswordSection csrf={state.csrf} />
@@ -80,6 +98,8 @@ export function Account() {
         enabled={state.twoFactorEnabled}
         onChanged={() => void refresh()}
       />
+      <TokensSection csrf={state.csrf} />
+      <PubkeysSection csrf={state.csrf} />
     </section>
   );
 }
@@ -419,4 +439,717 @@ function TwoFactorSection({
       )}
     </section>
   );
+}
+
+// ---------------------------------------------------------------------------
+// API tokens (self-service)
+// ---------------------------------------------------------------------------
+
+type TokenListState =
+  | { kind: "loading" }
+  | { kind: "ok"; tokens: AccountTokenListing[]; nextCursor: string | null }
+  | { kind: "error"; message: string };
+
+type TokenMintState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "minted"; token: MintedAccountToken }
+  | { kind: "error"; message: string };
+
+type TokenRevokeState =
+  | { kind: "idle" }
+  | { kind: "confirming"; jti: string }
+  | { kind: "revoking"; jti: string }
+  | { kind: "error"; jti: string; message: string };
+
+function TokensSection({ csrf }: { csrf: string }) {
+  const [list, setList] = useState<TokenListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [mint, setMint] = useState<TokenMintState>({ kind: "idle" });
+  const [revoke, setRevoke] = useState<TokenRevokeState>({ kind: "idle" });
+  const [showForm, setShowForm] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [scope, setScope] = useState("");
+  const [label, setLabel] = useState("");
+  const [expiresIn, setExpiresIn] = useState("");
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setList({ kind: "loading" });
+    listAccountTokens()
+      .then((page) => {
+        if (cancelled) return;
+        setList({ kind: "ok", tokens: page.tokens, nextCursor: page.next_cursor });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setList({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  async function loadMore(): Promise<void> {
+    if (list.kind !== "ok" || !list.nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const page = await listAccountTokens({ cursor: list.nextCursor });
+      setList({
+        kind: "ok",
+        tokens: [...list.tokens, ...page.tokens],
+        nextCursor: page.next_cursor,
+      });
+    } catch (err) {
+      setList({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  async function onSubmitMint(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const trimmed = scope.trim();
+    if (trimmed.length === 0) {
+      setMint({ kind: "error", message: "scope is required" });
+      return;
+    }
+    let ttl: number | undefined;
+    if (expiresIn.trim().length > 0) {
+      const n = Number(expiresIn);
+      if (!Number.isInteger(n) || n <= 0) {
+        setMint({ kind: "error", message: "expires_in must be a positive integer (seconds)" });
+        return;
+      }
+      ttl = n;
+    }
+    setMint({ kind: "submitting" });
+    try {
+      const minted = await mintAccountToken(csrf, {
+        scope: trimmed,
+        ...(ttl !== undefined ? { expires_in: ttl } : {}),
+        ...(label.trim() ? { label: label.trim() } : {}),
+      });
+      setMint({ kind: "minted", token: minted });
+      setScope("");
+      setLabel("");
+      setExpiresIn("");
+      setShowForm(false);
+      setReload((n) => n + 1);
+    } catch (err) {
+      setMint({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function onConfirmRevoke(jti: string): Promise<void> {
+    setRevoke({ kind: "revoking", jti });
+    try {
+      await revokeAccountToken(csrf, jti);
+      setRevoke({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRevoke({
+        kind: "error",
+        jti,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  function copyToken(token: string): void {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      void navigator.clipboard.writeText(token);
+    }
+  }
+
+  return (
+    <section
+      className="settings-block"
+      aria-labelledby="account-tokens-heading"
+      data-testid="account-tokens"
+    >
+      <h2 id="account-tokens-heading">API tokens</h2>
+      <p className="muted">
+        Tokens minted as you. A friend can mint a subset of their own authority (assigned vaults);
+        nobody mints <code>parachute:host:*</code> here. The operator registry — every CLI / OAuth /
+        operator-mint on this hub — stays on <Link to="/tokens">Tokens</Link>.
+      </p>
+
+      {mint.kind === "minted" ? (
+        <div className="mint-banner" data-testid="account-token-minted">
+          <h3>Minted</h3>
+          <p>
+            Your new access token (jti: <code>{mint.token.jti}</code>):
+          </p>
+          <div className="token-box">
+            <code data-testid="account-token-jwt">{mint.token.token}</code>
+          </div>
+          <p className="warn">This is the only time the JWT is shown. Copy it now.</p>
+          <div className="actions">
+            <button type="button" onClick={() => copyToken(mint.token.token)}>
+              Copy
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setMint({ kind: "idle" })}
+              data-testid="account-token-minted-dismiss"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="actions" style={{ marginBottom: "0.75rem" }}>
+        <button
+          type="button"
+          onClick={() => setShowForm((s) => !s)}
+          data-testid="account-token-mint-toggle"
+        >
+          {showForm ? "Hide form" : "Mint a token"}
+        </button>
+      </div>
+
+      {showForm ? (
+        <form onSubmit={(e) => void onSubmitMint(e)} className="settings-form">
+          <label>
+            Scope (space-separated)
+            <input
+              type="text"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              placeholder="e.g. vault:work:read"
+              data-testid="account-token-scope"
+            />
+          </label>
+          <label>
+            Label (optional)
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="laptop, backup, …"
+              data-testid="account-token-label"
+            />
+          </label>
+          <label>
+            Expires in (seconds, optional)
+            <input
+              type="text"
+              inputMode="numeric"
+              value={expiresIn}
+              onChange={(e) => setExpiresIn(e.target.value)}
+              placeholder="default 90d"
+              data-testid="account-token-expires"
+            />
+          </label>
+          {mint.kind === "error" ? (
+            <div className="error" data-testid="account-token-mint-error">
+              {mint.message}
+            </div>
+          ) : null}
+          <div className="actions">
+            <button
+              type="submit"
+              disabled={mint.kind === "submitting"}
+              data-testid="account-token-mint"
+            >
+              {mint.kind === "submitting" ? "Minting…" : "Mint"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => {
+                setShowForm(false);
+                setMint({ kind: "idle" });
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {list.kind === "loading" ? (
+        <p className="muted">Loading tokens…</p>
+      ) : list.kind === "error" ? (
+        <div className="error" data-testid="account-tokens-error">
+          {list.message}
+        </div>
+      ) : list.tokens.length === 0 ? (
+        <p className="muted" data-testid="account-tokens-empty">
+          No live tokens on this account yet.
+        </p>
+      ) : (
+        <div data-testid="account-tokens-list">
+          {list.tokens.map((t) => {
+            const isConfirming = revoke.kind === "confirming" && revoke.jti === t.jti;
+            const isRevoking = revoke.kind === "revoking" && revoke.jti === t.jti;
+            const rowError = revoke.kind === "error" && revoke.jti === t.jti ? revoke : null;
+            const live = !t.revoked_at;
+            return (
+              <div key={t.jti} className="vault-row" data-testid={`account-token-row-${t.jti}`}>
+                <div className="body">
+                  <div className="name">
+                    <code title={t.jti}>{truncateJti(t.jti)}</code>
+                    <span className={`tag${live ? "" : " muted"}`}>
+                      {live ? "live" : "revoked"}
+                    </span>
+                    {t.subject ? (
+                      <span className="tag muted" title="label">
+                        {t.subject}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="dim" style={{ marginTop: "0.25rem" }}>
+                    <span className="muted">scope: </span>
+                    {t.scopes.map((s, i) => (
+                      <span key={s}>
+                        <code>{s}</code>
+                        {i < t.scopes.length - 1 ? " " : null}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="dim" style={{ marginTop: "0.25rem", fontSize: "0.82rem" }}>
+                    <span className="muted">expires </span>
+                    <code>{formatDate(t.expires_at)}</code>
+                  </div>
+                  {rowError ? (
+                    <div className="error" style={{ marginTop: "0.5rem" }}>
+                      {rowError.message}
+                    </div>
+                  ) : null}
+                  {isConfirming ? (
+                    <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+                      <p>
+                        Revoke <code>{truncateJti(t.jti)}</code>? This cannot be undone.
+                      </p>
+                      <div className="actions">
+                        <button
+                          type="button"
+                          onClick={() => void onConfirmRevoke(t.jti)}
+                          disabled={isRevoking}
+                          data-testid={`account-token-revoke-confirm-${t.jti}`}
+                        >
+                          {isRevoking ? "Revoking…" : "Revoke"}
+                        </button>
+                        <button
+                          type="button"
+                          className="secondary"
+                          onClick={() => setRevoke({ kind: "idle" })}
+                          disabled={isRevoking}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+                {!isConfirming && live ? (
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={() => setRevoke({ kind: "confirming", jti: t.jti })}
+                    data-testid={`account-token-revoke-${t.jti}`}
+                  >
+                    Revoke
+                  </button>
+                ) : null}
+              </div>
+            );
+          })}
+          {list.nextCursor ? (
+            <div style={{ marginTop: "1rem" }}>
+              <button
+                type="button"
+                className="secondary"
+                disabled={loadingMore}
+                onClick={() => void loadMore()}
+                data-testid="account-tokens-load-more"
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function truncateJti(jti: string): string {
+  if (jti.length <= 14) return jti;
+  return `${jti.slice(0, 8)}…${jti.slice(-4)}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+// ---------------------------------------------------------------------------
+// Linked Nostr keys
+// ---------------------------------------------------------------------------
+
+type PubkeyListState =
+  | { kind: "loading" }
+  | { kind: "ok"; pubkeys: AccountPubkey[] }
+  | { kind: "error"; message: string };
+
+type LinkView = { kind: "idle" } | { kind: "challenging"; challenge: PubkeyChallenge };
+
+type Nip07 = {
+  signEvent: (event: {
+    kind: number;
+    created_at: number;
+    tags: string[][];
+    content: string;
+  }) => Promise<SignedNostrEvent>;
+};
+
+function hasNip07(): Nip07 | null {
+  if (typeof window === "undefined") return null;
+  const nostr = (window as unknown as { nostr?: Nip07 }).nostr;
+  return nostr && typeof nostr.signEvent === "function" ? nostr : null;
+}
+
+function PubkeysSection({ csrf }: { csrf: string }) {
+  const [list, setList] = useState<PubkeyListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [view, setView] = useState<LinkView>({ kind: "idle" });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [eventJson, setEventJson] = useState("");
+  const [label, setLabel] = useState("");
+  const [password, setPassword] = useState("");
+  const [unlink, setUnlink] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setList({ kind: "loading" });
+    listAccountPubkeys()
+      .then((pubkeys) => {
+        if (cancelled) return;
+        setList({ kind: "ok", pubkeys });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setList({ kind: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  // Password step-up is required on the FIRST link. Show the field unless we
+  // already know this account holds a key; a failed list still shows it
+  // (server ignores the extra password on a subsequent link).
+  const firstLink = list.kind !== "ok" || list.pubkeys.length === 0;
+
+  async function onStartLink(): Promise<void> {
+    if (busy) return;
+    setErr(null);
+    setNotice(null);
+    setBusy(true);
+    try {
+      const challenge = await startPubkeyChallenge(csrf);
+      setView({ kind: "challenging", challenge });
+      setEventJson("");
+      setLabel("");
+      setPassword("");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onSignWithExtension(): Promise<void> {
+    if (view.kind !== "challenging") return;
+    const nostr = hasNip07();
+    if (!nostr) {
+      setErr("No NIP-07 signer is available in this browser.");
+      return;
+    }
+    setErr(null);
+    setBusy(true);
+    try {
+      const tpl = view.challenge.event_template;
+      const signed = await nostr.signEvent({
+        kind: tpl.kind,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: tpl.tags,
+        content: tpl.content,
+      });
+      setEventJson(JSON.stringify(signed, null, 2));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onVerify(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    if (busy) return;
+    setErr(null);
+    setNotice(null);
+    let event: SignedNostrEvent;
+    try {
+      const parsed = JSON.parse(eventJson) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        setErr("Paste a signed NIP-01 event object.");
+        return;
+      }
+      event = parsed as SignedNostrEvent;
+    } catch {
+      setErr("Signed event is not valid JSON.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await verifyPubkeyLink(csrf, {
+        event,
+        ...(label.trim() ? { label: label.trim() } : {}),
+        ...(password ? { password } : {}),
+      });
+      setView({ kind: "idle" });
+      setEventJson("");
+      setLabel("");
+      setPassword("");
+      setNotice(
+        result.relinked
+          ? `Re-verified ${truncatePubkey(result.pubkey)}.`
+          : `Linked ${truncatePubkey(result.pubkey)}. A linked key grants nothing — it is an attribution label.`,
+      );
+      setReload((n) => n + 1);
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onUnlink(pubkey: string): Promise<void> {
+    if (busy) return;
+    setErr(null);
+    setBusy(true);
+    try {
+      await unlinkAccountPubkey(csrf, pubkey);
+      setUnlink(null);
+      setReload((n) => n + 1);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const nip07 = hasNip07();
+
+  return (
+    <section
+      className="settings-block"
+      aria-labelledby="account-pubkeys-heading"
+      data-testid="account-pubkeys"
+    >
+      <h2 id="account-pubkeys-heading">Nostr keys</h2>
+      <p className="muted">
+        A linked key is an attribution label. It does not log you in, mint a token, or widen a
+        scope. Unlink does not revoke tokens.
+      </p>
+
+      {notice ? (
+        <p className="muted" data-testid="account-pubkeys-notice">
+          {notice}
+        </p>
+      ) : null}
+
+      {view.kind === "challenging" ? (
+        <form onSubmit={(e) => void onVerify(e)} className="settings-form">
+          <p>
+            Sign this statement with a Nostr key you hold, then paste the signed event. A signer
+            that shows you the content will show you this sentence:
+          </p>
+          <pre
+            className="token-box"
+            data-testid="account-pubkey-statement"
+            style={{ whiteSpace: "pre-wrap" }}
+          >
+            <code>{view.challenge.event_template.content}</code>
+          </pre>
+          {nip07 ? (
+            <div className="actions">
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void onSignWithExtension()}
+                data-testid="account-pubkey-nip07"
+              >
+                {busy ? "Waiting for signer…" : "Sign with browser extension"}
+              </button>
+            </div>
+          ) : (
+            <p className="muted">
+              No NIP-07 extension detected. Sign the event template elsewhere and paste the JSON
+              below.
+            </p>
+          )}
+          <label>
+            Signed event (JSON)
+            <textarea
+              value={eventJson}
+              onChange={(e) => setEventJson(e.target.value)}
+              rows={8}
+              style={{ width: "100%", fontFamily: "monospace", fontSize: "0.85rem" }}
+              data-testid="account-pubkey-event"
+            />
+          </label>
+          <label>
+            Label (optional)
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="phone, signing device, …"
+              data-testid="account-pubkey-label"
+            />
+          </label>
+          {firstLink ? (
+            <label>
+              Current password (required to link your first key)
+              <input
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                data-testid="account-pubkey-password"
+              />
+            </label>
+          ) : null}
+          <div className="actions">
+            <button type="submit" disabled={busy} data-testid="account-pubkey-verify">
+              {busy ? "Verifying…" : "Link key"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              disabled={busy}
+              onClick={() => {
+                setView({ kind: "idle" });
+                setErr(null);
+              }}
+              data-testid="account-pubkey-cancel"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="actions">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void onStartLink()}
+            data-testid="account-pubkey-link"
+          >
+            {busy ? "Starting…" : "Link a Nostr key"}
+          </button>
+        </div>
+      )}
+
+      {list.kind === "loading" ? (
+        <p className="muted">Loading keys…</p>
+      ) : list.kind === "error" ? (
+        <div className="error" data-testid="account-pubkeys-error">
+          {list.message}
+        </div>
+      ) : list.pubkeys.length === 0 ? (
+        <p className="muted" data-testid="account-pubkeys-empty">
+          No keys linked to this account.
+        </p>
+      ) : (
+        <div data-testid="account-pubkeys-list">
+          {list.pubkeys.map((k) => (
+            <div
+              key={k.pubkey}
+              className="vault-row"
+              data-testid={`account-pubkey-row-${k.pubkey}`}
+            >
+              <div className="body">
+                <div className="name">
+                  <code title={k.pubkey}>{truncatePubkey(k.pubkey)}</code>
+                  {k.label ? <span className="tag muted">{k.label}</span> : null}
+                </div>
+                <div className="dim" style={{ marginTop: "0.25rem", fontSize: "0.82rem" }}>
+                  <span className="muted">linked </span>
+                  <code>{formatDate(k.linked_at)}</code>
+                </div>
+                {unlink === k.pubkey ? (
+                  <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+                    <p>
+                      Unlink <code>{truncatePubkey(k.pubkey)}</code>? Attribution proofs already
+                      written stay; tokens are not revoked.
+                    </p>
+                    <div className="actions">
+                      <button
+                        type="button"
+                        onClick={() => void onUnlink(k.pubkey)}
+                        disabled={busy}
+                        data-testid={`account-pubkey-unlink-confirm-${k.pubkey}`}
+                      >
+                        {busy ? "Unlinking…" : "Unlink"}
+                      </button>
+                      <button
+                        type="button"
+                        className="secondary"
+                        onClick={() => setUnlink(null)}
+                        disabled={busy}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+              {unlink !== k.pubkey ? (
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => setUnlink(k.pubkey)}
+                  data-testid={`account-pubkey-unlink-${k.pubkey}`}
+                >
+                  Unlink
+                </button>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {err && (
+        <div className="error" data-testid="account-pubkeys-form-error">
+          {err}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function truncatePubkey(pubkey: string): string {
+  if (pubkey.length <= 16) return pubkey;
+  return `${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`;
 }


### PR DESCRIPTION
Towards #833 — slice (b) only. Does **not** close the issue: (c) NIP-98 login is still later.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

Walkthrough (real SPA bundle, mock API on :18765 — not live :1939): mint / revoke / first-link password on `/admin/account`.

## What changed

`/admin/account` gains **my tokens** and **linked Nostr keys**. Operator `/admin/tokens` stays the registry (IA call unchanged).

### Self-service tokens UI

Cookie+CSRF helpers against `GET/POST /api/account/tokens` and `POST .../:jti/revoke`. List / mint / revoke this user's tokens. JWT shown once. Cannot mint `parachute:host:*` (server still denies). "Load more" cursor pagination matches the operator Tokens page (loadingMore + disabled + early return).

### Pubkey-link UI

List / challenge / paste-a-signed-event / unlink. NIP-07 `window.nostr` when present; otherwise paste JSON. First-link password field (server 401 `password_required` is surfaced, not treated as a gone session). Copy: a linked key is an attribution label and grants nothing.

### API nits folded from (a)

- `GET /api/account/tokens` now returns `next_cursor` (page size 50), same helper as the operator registry. Dropped in #872; the SPA needs it.
- ClaudeJi note 1 from the (a) SHIP: `mintOperatorToken` throws when `sub` is not a users row. Auto-rotate and issuer self-heal now return `skipped: sub-not-user` instead of throwing. `expose-supervisor` logs the skip reason.

## Out of this PR

- Operator Tokens page (unchanged).
- Fail-closed missing-row bypass in `validateAccessToken`.
- Unlink-as-logout / (c) NIP-98.
- `skipped: sub-not-user` does not revive a legacy sentinel token; recover via explicit `rotate-operator`.

## Verify

- `bun run typecheck` (hub) 0; `web/ui` typecheck 0.
- SPA `vitest run` **338 pass / 0 fail**.
- Targeted hub: `api-account-tokens` + `operator-token` + `operator-token-issuer-self-heal` **52 pass / 0 fail** (includes the 51-row `next_cursor` page and both `sub-not-user` skip tests).
- Full `bun test ./src` **not** run on this box (hub#840). CI is the full suite.
- Video: Playwright against a throwaway mock hub on `:18765` driving the built SPA. Did not bun-link, did not `parachute upgrade`, did not touch live `:1939` / `:1940`.
