### PR TITLE
fix(hub#873): CAS pin leftover person-mint doors; first-link 401 code

### DIFF
--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -31,7 +31,7 @@ import {
 } from "../jwt-sign.ts";
 import { upsertService } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
-import { createUser } from "../users.ts";
+import { createUser, resetUserPassword } from "../users.ts";
 import { getVaultCap } from "../vault-caps.ts";
 
 const ISSUER = "http://127.0.0.1:1939";
@@ -95,7 +95,10 @@ function makeHarness(vaultNames: string[] = ["beta", "personal"]): Harness {
 
 function deps(
   h: Harness,
-  extra: Partial<{ runCommand: (cmd: readonly string[]) => Promise<RunResult> }> = {},
+  extra: Partial<{
+    runCommand: (cmd: readonly string[]) => Promise<RunResult>;
+    afterSign: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
+  }> = {},
 ) {
   return { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath, ...extra };
 }
@@ -736,6 +739,47 @@ describe("handleAccountCreateVault", () => {
       expect(body.message).toContain("WAS created");
       // And it must NOT leak the CLI bootstrap admin token as a consolation.
       expect(JSON.stringify(body)).not.toContain("hubjwt.work.admin");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("resetUserPassword during afterSign → vault exists, no JWT returned, no live unrevoked row (hub#873)", async () => {
+    const h = makeHarness(["default"]);
+    try {
+      const user = await createUser(h.db, "owner", "owner-password-123");
+      const token = await bearer(h, [ACCOUNT_WRITE_SCOPE], user.id);
+      let signedJti: string | undefined;
+      const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work", "hubjwt.work.access"), stderr: "" };
+      };
+      const res = await handleAccountCreateVault(
+        jsonReq("/account/vaults", token, "POST", { name: "work" }),
+        deps(h, {
+          runCommand,
+          afterSign: async ({ jti }) => {
+            signedJti = jti;
+            await resetUserPassword(h.db, user.id, "new-password-after-reset");
+          },
+        }),
+      );
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: string; vault_token?: string };
+      expect(body.error).toBe("vault_created_token_mint_failed");
+      expect(body.vault_token).toBeUndefined();
+      expect(signedJti).toBeDefined();
+      const row = findTokenRowByJti(h.db, signedJti!);
+      expect(row === null || row.revokedAt !== null).toBe(true);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-vault-admin-token.test.ts
+++ b/src/__tests__/account-vault-admin-token.test.ts
@@ -27,9 +27,10 @@ import { handleAccountVaultAdminTokenPost } from "../account-vault-admin-token.t
 import { VAULT_ADMIN_TOKEN_TTL_SECONDS } from "../admin-vault-admin-token.ts";
 import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { validateAccessToken } from "../jwt-sign.ts";
+import { findTokenRowByJti, validateAccessToken } from "../jwt-sign.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
-import { createUser } from "../users.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser, resetUserPassword } from "../users.ts";
 
 const ISSUER = "https://hub.test";
 
@@ -329,5 +330,29 @@ describe("handleAccountVaultAdminTokenPost — CSRF + method", () => {
       deps(),
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("handleAccountVaultAdminTokenPost — CAS after crypto await (hub#873)", () => {
+  test("resetUserPassword during afterSign → 409, no Location token, no live unrevoked row", async () => {
+    rotateSigningKey(harness.db);
+    const { friendId, cookie, csrfToken } = await seedFriend(["work"]);
+    let signedJti: string | undefined;
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken }),
+      "work",
+      {
+        ...deps(),
+        afterSign: async ({ jti }) => {
+          signedJti = jti;
+          await resetUserPassword(harness.db, friendId, "new-password-after-reset");
+        },
+      },
+    );
+    expect(res.status).toBe(409);
+    expect(res.headers.get("location")).toBeNull();
+    expect(signedJti).toBeDefined();
+    const row = findTokenRowByJti(harness.db, signedJti!);
+    expect(row === null || row.revokedAt !== null).toBe(true);
   });
 });

--- a/src/__tests__/account-vault-token.test.ts
+++ b/src/__tests__/account-vault-token.test.ts
@@ -28,10 +28,11 @@ import { ACCOUNT_VAULT_TOKEN_TTL_SECONDS } from "../account-home-ui.ts";
 import { handleAccountVaultTokenPost } from "../account-vault-token.ts";
 import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { validateAccessToken } from "../jwt-sign.ts";
+import { findTokenRowByJti, validateAccessToken } from "../jwt-sign.ts";
 import { __resetForTests } from "../rate-limit.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
-import { createUser } from "../users.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser, resetUserPassword } from "../users.ts";
 
 const ISSUER = "https://hub.test";
 
@@ -406,5 +407,30 @@ describe("handleAccountVaultTokenPost — CSRF + method + rate limit", () => {
       deps(),
     );
     expect(ok.status).toBe(200);
+  });
+});
+
+describe("handleAccountVaultTokenPost — CAS after crypto await (hub#873)", () => {
+  test("resetUserPassword during afterSign → 409, no minted banner, no live unrevoked row", async () => {
+    rotateSigningKey(harness.db);
+    const { friendId, cookie, csrfToken } = await seedFriend(["work"]);
+    let signedJti: string | undefined;
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "read" }),
+      "work",
+      {
+        ...deps(),
+        afterSign: async ({ jti }) => {
+          signedJti = jti;
+          await resetUserPassword(harness.db, friendId, "new-password-after-reset");
+        },
+      },
+    );
+    expect(res.status).toBe(409);
+    const html = await res.text();
+    expect(html).not.toContain('data-testid="minted-token-banner"');
+    expect(signedJti).toBeDefined();
+    const row = findTokenRowByJti(harness.db, signedJti!);
+    expect(row === null || row.revokedAt !== null).toBe(true);
   });
 });

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -167,6 +167,11 @@ export interface AccountApiDeps {
   manifestPath?: string;
   /** Test seam for the clock (mint + registry row). */
   now?: () => Date;
+  /**
+   * Test seam (hub#873): runs after `signAccessToken` and before
+   * `recordTokenMint` on the create-vault handoff. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
   /** Test seam threaded into `provisionVault` so create can be exercised
    * without spawning the real `parachute-vault create` binary. */
   runCommand?: (cmd: readonly string[]) => Promise<{
@@ -591,6 +596,10 @@ export async function handleAccountCreateVault(
     // below tells caller and operator exactly what state the box is in: the
     // vault EXISTS, only the handoff failed.
     try {
+      // Snapshot the users row BEFORE the crypto await (hub#873). A
+      // reset/delete racing sign used to re-fetch after sign and mint with
+      // user_id NULL — a live JWT the account-delete revoke set misses.
+      const subjectUser = getUserById(deps.db, auth.sub);
       const minted = await signAccessToken(deps.db, {
         sub: auth.sub,
         scopes,
@@ -601,7 +610,13 @@ export async function handleAccountCreateVault(
         vaultScope: [entry.name],
         ...(deps.now !== undefined ? { now: deps.now } : {}),
       });
-      const subjectIsUser = getUserById(deps.db, auth.sub) !== null;
+      if (deps.afterSign) {
+        await deps.afterSign({
+          token: minted.token,
+          jti: minted.jti,
+          userId: subjectUser?.id ?? null,
+        });
+      }
       recordTokenMint(deps.db, {
         jti: minted.jti,
         // hub#848: distinct from `cli_mint` — this row is a hub-signed
@@ -609,7 +624,7 @@ export async function handleAccountCreateVault(
         // door stamps, so registry forensics can find both.
         createdVia: "vault_create_handoff",
         subject: auth.sub,
-        ...(subjectIsUser ? { userId: auth.sub } : {}),
+        ...(subjectUser ? { userId: subjectUser.id, userUpdatedAt: subjectUser.updatedAt } : {}),
         clientId,
         scopes,
         expiresAt: minted.expiresAt,

--- a/src/account-vault-admin-token.ts
+++ b/src/account-vault-admin-token.ts
@@ -61,7 +61,7 @@ import type { Database } from "bun:sqlite";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { VAULT_ADMIN_TOKEN_TTL_SECONDS } from "./admin-vault-admin-token.ts";
 import { CSRF_FIELD_NAME, verifyCsrfToken } from "./csrf.ts";
-import { recordTokenMint, signAccessToken } from "./jwt-sign.ts";
+import { TokenMintPrincipalGoneError, recordTokenMint, signAccessToken } from "./jwt-sign.ts";
 import { findActiveSession } from "./sessions.ts";
 import { getUserById, vaultVerbsForUserVault } from "./users.ts";
 import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
@@ -87,6 +87,11 @@ export interface AccountVaultAdminTokenDeps {
   managementUrl?: string;
   /** Test seam for the clock (mint). */
   now?: () => Date;
+  /**
+   * Test seam (hub#873): runs after `signAccessToken` and before
+   * `recordTokenMint`. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
@@ -238,19 +243,37 @@ export async function handleAccountVaultAdminTokenPost(
     vaultScope: [vaultName],
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject: user.id,
-    // Anchor the registry row to the user's id so the operator's token registry
-    // + the revocation list attribute it correctly.
-    userId: user.id,
-    clientId: ACCOUNT_VAULT_ADMIN_CLIENT_ID,
-    scopes: [scope],
-    expiresAt: minted.expiresAt,
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  if (deps.afterSign) {
+    await deps.afterSign({ token: minted.token, jti: minted.jti, userId: user.id });
+  }
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: user.id,
+      // Anchor the registry row to the user's id so the operator's token registry
+      // + the revocation list attribute it correctly. Pin updated_at so a
+      // resetUserPassword racing the crypto await cannot land a live row
+      // (hub#873).
+      userId: user.id,
+      userUpdatedAt: user.updatedAt,
+      clientId: ACCOUNT_VAULT_ADMIN_CLIENT_ID,
+      scopes: [scope],
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return htmlResponse(
+        renderAdminError({
+          title: "Could not mint a token",
+          message: err.message,
+        }),
+        409,
+      );
+    }
+    throw err;
+  }
 
   // Build the redirect target: <vault-url>/<managementUrl>#token=<jwt>. The
   // vault URL is the hub-mounted path (`<hubOrigin>/vault/<name>`); the

--- a/src/account-vault-token.ts
+++ b/src/account-vault-token.ts
@@ -71,7 +71,7 @@ import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import { userHasExternalAiGrant } from "./grants.ts";
 import { inferAudience } from "./jwt-audience.ts";
-import { recordTokenMint, signAccessToken } from "./jwt-sign.ts";
+import { TokenMintPrincipalGoneError, recordTokenMint, signAccessToken } from "./jwt-sign.ts";
 import { vaultTokenMintRateLimiter } from "./rate-limit.ts";
 import { findActiveSession } from "./sessions.ts";
 import { isTotpEnrolled } from "./two-factor-store.ts";
@@ -96,6 +96,11 @@ export interface AccountVaultTokenDeps {
   hubOrigin: string;
   /** Test seam for the clock (rate limiter + mint). */
   now?: () => Date;
+  /**
+   * Test seam (hub#873): runs after `signAccessToken` and before
+   * `recordTokenMint`. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
@@ -291,20 +296,32 @@ export async function handleAccountVaultTokenPost(
     vaultScope: [vaultName],
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject: user.id,
-    // Anchor the registry row to the friend's user id so the operator's
-    // token registry + the revocation list attribute it correctly, and a
-    // future per-user revoke surface can find it.
-    userId: user.id,
-    clientId: ACCOUNT_VAULT_TOKEN_CLIENT_ID,
-    scopes: [scope],
-    expiresAt: minted.expiresAt,
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  if (deps.afterSign) {
+    await deps.afterSign({ token: minted.token, jti: minted.jti, userId: user.id });
+  }
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: user.id,
+      // Anchor the registry row to the friend's user id so the operator's
+      // token registry + the revocation list attribute it correctly, and a
+      // future per-user revoke surface can find it. Pin updated_at so a
+      // resetUserPassword racing the crypto await cannot land a live row
+      // (hub#873).
+      userId: user.id,
+      userUpdatedAt: user.updatedAt,
+      clientId: ACCOUNT_VAULT_TOKEN_CLIENT_ID,
+      scopes: [scope],
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return renderHome(409, { mintError: err.message });
+    }
+    throw err;
+  }
 
   return renderHome(200, {
     mintedToken: {

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -537,31 +537,62 @@ describe("listAccountTokens / mintAccountToken", () => {
 });
 
 describe("verifyPubkeyLink", () => {
+  const event = {
+    id: "a",
+    pubkey: "b",
+    created_at: 1,
+    kind: 27235,
+    tags: [] as string[][],
+    content: "x",
+    sig: "c",
+  };
+
   it("surfaces first-link password_required instead of bouncing to login", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
         jsonResponse(401, {
           error: "password_required",
-          error_description:
-            "Re-enter your current password to link your first key to this account.",
+          error_description: "please confirm",
         }),
       ),
     );
     const api = await import("./api.ts");
-    await expect(
-      api.verifyPubkeyLink("csrf-x", {
-        event: {
-          id: "a",
-          pubkey: "b",
-          created_at: 1,
-          kind: 27235,
-          tags: [],
-          content: "x",
-          sig: "c",
-        },
-      }),
-    ).rejects.toMatchObject({ status: 401, message: expect.stringMatching(/re-enter/i) });
+    await expect(api.verifyPubkeyLink("csrf-x", { event })).rejects.toMatchObject({
+      status: 401,
+      message: "please confirm",
+    });
     expect(auth.redirectToLoginAndHang).not.toHaveBeenCalled();
+  });
+
+  it("surfaces proof_failed / invalid_credentials without bouncing to login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(401, { error: "proof_failed", error_description: "nope" })),
+    );
+    const api = await import("./api.ts");
+    await expect(api.verifyPubkeyLink("csrf-x", { event })).rejects.toMatchObject({
+      status: 401,
+      message: "nope",
+    });
+    expect(auth.redirectToLoginAndHang).not.toHaveBeenCalled();
+  });
+
+  it("bounces to login on unauthenticated", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(401, { error: "unauthenticated", error_description: "no session" }),
+      ),
+    );
+    const api = await import("./api.ts");
+    const pending = api.verifyPubkeyLink("csrf-x", { event });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(auth.redirectToLoginAndHang).toHaveBeenCalledTimes(1);
+    const winner = await Promise.race([
+      pending.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("hung"), 10)),
+    ]);
+    expect(winner).toBe("hung");
   });
 });

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -2199,17 +2199,23 @@ export async function verifyPubkeyLink(
   if (opts.password !== undefined) body.password = opts.password;
   const res = await postAccount("/pubkeys/verify", csrf, body);
   if (res.status === 401) {
-    const message = await readError(res);
-    const lower = message.toLowerCase();
-    if (
-      lower.includes("re-enter") ||
-      lower.includes("password") ||
-      lower.includes("signature") ||
-      lower.includes("incorrect")
-    ) {
-      throw new HttpError(401, message);
+    // Session-gone vs first-link step-up / bad proof. Discriminate on the
+    // structured `error` code, not English in `error_description` — a copy
+    // tweak of password_required must not bounce the operator to /login.
+    const text = await res.text();
+    let code: string | undefined;
+    let message = text || "401 Unauthorized";
+    try {
+      const parsed = JSON.parse(text) as { error?: string; error_description?: string };
+      code = parsed.error;
+      message = parsed.error_description || parsed.error || message;
+    } catch {
+      // not JSON
     }
-    return redirectToLoginAndHang<LinkedPubkeyResult>();
+    if (code === "unauthenticated" || code === undefined) {
+      return redirectToLoginAndHang<LinkedPubkeyResult>();
+    }
+    throw new HttpError(401, message);
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
   return (await res.json()) as LinkedPubkeyResult;

--- a/web/ui/src/routes/Home.test.tsx
+++ b/web/ui/src/routes/Home.test.tsx
@@ -98,12 +98,14 @@ describe("Administer group", () => {
     renderRoute();
 
     const administer = await screen.findByTestId("home-administer");
-    // These six sections should be present; /vaults should not.
+    // Hub-native sections; /vaults is module-owned and must not appear.
     for (const path of [
       "/connections",
       "/modules",
       "/users",
+      "/account",
       "/tokens",
+      "/grants",
       "/permissions",
       "/settings",
     ]) {

--- a/web/ui/src/routes/Home.tsx
+++ b/web/ui/src/routes/Home.tsx
@@ -74,12 +74,22 @@ const HUB_SECTIONS: readonly HubSection[] = [
   {
     to: "/connections",
     label: "Connections",
-    desc: "Wire a module event to another module's action.",
+    desc: "Wire a module event to another module's action (IFTTT).",
   },
   { to: "/modules", label: "Modules", desc: "Install, upgrade, and manage modules." },
   { to: "/users", label: "Users", desc: "Manage operators and invite members." },
-  { to: "/tokens", label: "Tokens", desc: "Mint and revoke access tokens." },
-  { to: "/permissions", label: "Permissions", desc: "OAuth consent grants per app." },
+  {
+    to: "/account",
+    label: "My account",
+    desc: "Your password, 2FA, API tokens, and linked Nostr keys.",
+  },
+  {
+    to: "/tokens",
+    label: "Tokens",
+    desc: "Operator registry — every CLI / OAuth / operator-mint on this hub.",
+  },
+  { to: "/grants", label: "Grants", desc: "Agent-connector approvals." },
+  { to: "/permissions", label: "Permissions", desc: "OAuth consent skip-list per app." },
   { to: "/settings", label: "Settings", desc: "Canonical URL, install channel, more." },
 ];
 

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -19,7 +19,7 @@
  * before posting.
  */
 import { type FormEvent, useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   type AdminTokenCreatedVia,
   type AdminTokenListing,
@@ -257,9 +257,11 @@ export function Tokens() {
       </div>
 
       <p className="muted">
-        The hub's token registry. Every CLI / OAuth / operator-mint writes a row here. Revoking
-        flips <code>revoked_at</code>; resource servers on{" "}
-        <code>@openparachute/scope-guard@^0.2.0</code> reject within ~60s of the next poll.
+        The operator registry. Every CLI / OAuth / operator-mint writes a row here. Your own tokens
+        — the ones a friend can mint without this page — live on{" "}
+        <Link to="/account">My account</Link>. Revoking flips <code>revoked_at</code>; resource
+        servers on <code>@openparachute/scope-guard@^0.2.0</code> reject within ~60s of the next
+        poll.
       </p>
 
       {mint.kind === "minted" ? (
@@ -482,7 +484,11 @@ function renderList({
   filtersActive,
 }: RenderListProps) {
   if (list.kind === "loading") {
-    return <p className="muted" data-loading="true">Loading…</p>;
+    return (
+      <p className="muted" data-loading="true">
+        Loading…
+      </p>
+    );
   }
   if (list.kind === "error") {
     return (


### PR DESCRIPTION
Closes #873. Towards #833, does not close it.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

Leftover stack after #872 + #874 (already on `next`):

## CAS pin on the last person-mint doors

#872 pinned `users.updated_at` on HTTP/CLI/account-door/operator mint. Two cookie/HTML doors and the vault-create handoff still only existence-CAS'd. `resetUserPassword` racing the crypto await could land a live JWT.

Now all three snapshot `updatedAt` **before** `signAccessToken`, CAS-insert, and withhold the JWT on `TokenMintPrincipalGoneError`:

- `POST /account/vault-token/<name>` → 409, no minted banner
- `POST /account/vault-admin-token/<name>` → 409, no `Location` fragment
- `POST /account/vaults` create handoff → existing `vault_created_token_mint_failed` (vault exists; no JWT)

`afterSign` race tests watch the reset-during-await case.

## First-link 401 discriminator

`verifyPubkeyLink` now branches on the structured `error` code (`unauthenticated` → login hang; `password_required` / `proof_failed` / `invalid_credentials` stay on the page). Independent review of #874 flagged the English-substring matcher.

## Admin Home copy

Home's Administer group was missing **My account** and **Grants**, and Tokens read as "mint tokens" — which is the #833 hole. Tokens vs Account are now labeled as operator registry vs my tokens. `/admin/vaults` still not in that group (module-owned).

## Verify

- Targeted hub: account-vault-token + account-vault-admin-token + account-api (includes the three race tests).
- SPA: api.test (401 codes), Home.test, Tokens.test, App.test.
- Full `bun test ./src` not run on this box (hub#840). CI is the suite.
- Did not bun-link, did not touch live `:1939` / `:1940`.
