### PR TITLE
release: hub 0.7.18-rc.1 — person-mint users.id, Account SPA, leftover CAS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.1] - 2026-08-26
+
+**Person-mint principal is `users.id`; self-service Account tokens and pubkey
+link.** Three PRs on `next` after 0.7.17-rc.1. Does not include 0.7.17 stable
+(that is a suffix-drop of rc.1 on `main`).
+
+- **Person-mint JWT `sub` is `users.id` (#872).** `tokens.subject` is a label.
+  `--sub` / body `subject` are deprecated; `--user` / `--label` / `--service`.
+  Operator mint sets `user_id`. Token insert is CAS against `users.updated_at`
+  (password-reset racing the crypto await). `TokenMintPrincipalGoneError`.
+  Cookie+CSRF `GET/POST /api/account/tokens` and `POST .../:jti/revoke`
+  (self-only). Operator registry stays at `/api/auth/tokens`. `skipped:
+  sub-not-user` when mint would throw for a non-users sub.
+
+- **Account SPA: my-tokens + pubkey-link (#874).** `/admin/account` lists,
+  mints, and revokes the signed-in person's tokens, and links/unlinks a
+  Nostr pubkey. Operator `/admin/tokens` stays the registry. `GET
+  /api/account/tokens` returns `next_cursor` (page size 50).
+
+- **CAS pin leftover + first-link 401 code (#875, closes #873).** Vault-create
+  handoff and cookie vault-token / vault-admin-token doors pin
+  `users.updated_at` before sign. `verifyPubkeyLink` discriminates 401 on the
+  structured `error` code, not English. Home Administer group gains My
+  account + Grants; Tokens copy names the operator registry.
+
+NIP-98 / key-as-account is not this rc.
+
 ## [0.7.17-rc.1] - 2026-08-24
 
 **Username chokepoint, attribution that survives unlink, and an rc-before-stable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.17-rc.1",
+  "version": "0.7.18-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
Cuts `@openparachute/hub` **0.7.18-rc.1** on `next`. Merging this does **not** publish. The follow-up `next` → `main` click publishes `@rc`.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

**Version + changelog only. No new code in this PR.** The train is already on `next`.

## What is in this rc (on `next` after 0.7.17-rc.1)

- #872 person-mint JWT `sub` is `users.id`; CAS against `users.updated_at`; cookie+CSRF `/api/account/tokens`
- #874 Account SPA `/admin/account` — my-tokens + pubkey-link
- #875 CAS leftover on vault-create/cookie vault-token doors + first-link 401 code (closes #873)

Does **not** include 0.7.17 stable (that is a suffix-drop of 0.7.17-rc.1 on `main`, hub#876). NIP-98 / key-as-account is not this rc.

## Verification

- Diff vs `origin/next`: `package.json` + `CHANGELOG.md` only.
- `release-check.sh` vs `origin/main`: version `0.7.17-rc.1` → `0.7.18-rc.1` (the rest of `next` is already-reviewed #872/#874/#875).
- Did **not** re-run `bun run typecheck` locally (unchanged TypeScript; no `node_modules` in this worktree). CI is the gate.
- Did **not** run `bun test ./src` on this live operator box — launchd-touching tests still ignore `PARACHUTE_HOME` (hub#840 / hub#867). Full suite is CI.

## After merge to `next`

Do **not** open `next` → `main` until hub#876 (0.7.17 suffix-drop) is on `main`. Then that click publishes `@rc`. Then `parachute upgrade hub --channel rc` on this box (not bun-link).
