### PR TITLE
release: hub 0.7.18-rc.1 (next → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.1] - 2026-08-26
+
+**Person-mint principal is `users.id`; self-service Account tokens and pubkey
+link.** Three PRs on `next` after 0.7.17-rc.1. Does not include 0.7.17 stable
+(that is a suffix-drop of rc.1 on `main`).
+
+- **Person-mint JWT `sub` is `users.id` (#872).** `tokens.subject` is a label.
+  `--sub` / body `subject` are deprecated; `--user` / `--label` / `--service`.
+  Operator mint sets `user_id`. Token insert is CAS against `users.updated_at`
+  (password-reset racing the crypto await). `TokenMintPrincipalGoneError`.
+  Cookie+CSRF `GET/POST /api/account/tokens` and `POST .../:jti/revoke`
+  (self-only). Operator registry stays at `/api/auth/tokens`. `skipped:
+  sub-not-user` when mint would throw for a non-users sub.
+
+- **Account SPA: my-tokens + pubkey-link (#874).** `/admin/account` lists,
+  mints, and revokes the signed-in person's tokens, and links/unlinks a
+  Nostr pubkey. Operator `/admin/tokens` stays the registry. `GET
+  /api/account/tokens` returns `next_cursor` (page size 50).
+
+- **CAS pin leftover + first-link 401 code (#875, closes #873).** Vault-create
+  handoff and cookie vault-token / vault-admin-token doors pin
+  `users.updated_at` before sign. `verifyPubkeyLink` discriminates 401 on the
+  structured `error` code, not English. Home Administer group gains My
+  account + Grants; Tokens copy names the operator registry.
+
+NIP-98 / key-as-account is not this rc.
+
 ## [0.7.17-rc.1] - 2026-08-24
 
 **Username chokepoint, attribution that survives unlink, and an rc-before-stable

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.17-rc.1",
+  "version": "0.7.18-rc.1",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -31,7 +31,7 @@ import {
 } from "../jwt-sign.ts";
 import { upsertService } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
-import { createUser } from "../users.ts";
+import { createUser, resetUserPassword } from "../users.ts";
 import { getVaultCap } from "../vault-caps.ts";
 
 const ISSUER = "http://127.0.0.1:1939";
@@ -95,7 +95,10 @@ function makeHarness(vaultNames: string[] = ["beta", "personal"]): Harness {
 
 function deps(
   h: Harness,
-  extra: Partial<{ runCommand: (cmd: readonly string[]) => Promise<RunResult> }> = {},
+  extra: Partial<{
+    runCommand: (cmd: readonly string[]) => Promise<RunResult>;
+    afterSign: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
+  }> = {},
 ) {
   return { db: h.db, issuer: ISSUER, manifestPath: h.manifestPath, ...extra };
 }
@@ -736,6 +739,47 @@ describe("handleAccountCreateVault", () => {
       expect(body.message).toContain("WAS created");
       // And it must NOT leak the CLI bootstrap admin token as a consolation.
       expect(JSON.stringify(body)).not.toContain("hubjwt.work.admin");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("resetUserPassword during afterSign → vault exists, no JWT returned, no live unrevoked row (hub#873)", async () => {
+    const h = makeHarness(["default"]);
+    try {
+      const user = await createUser(h.db, "owner", "owner-password-123");
+      const token = await bearer(h, [ACCOUNT_WRITE_SCOPE], user.id);
+      let signedJti: string | undefined;
+      const runCommand = async (_cmd: readonly string[]): Promise<RunResult> => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work", "hubjwt.work.access"), stderr: "" };
+      };
+      const res = await handleAccountCreateVault(
+        jsonReq("/account/vaults", token, "POST", { name: "work" }),
+        deps(h, {
+          runCommand,
+          afterSign: async ({ jti }) => {
+            signedJti = jti;
+            await resetUserPassword(h.db, user.id, "new-password-after-reset");
+          },
+        }),
+      );
+      expect(res.status).toBe(500);
+      const body = (await res.json()) as { error: string; vault_token?: string };
+      expect(body.error).toBe("vault_created_token_mint_failed");
+      expect(body.vault_token).toBeUndefined();
+      expect(signedJti).toBeDefined();
+      const row = findTokenRowByJti(h.db, signedJti!);
+      expect(row === null || row.revokedAt !== null).toBe(true);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -1009,7 +1009,8 @@ describe("handleAccountMintVaultToken", () => {
   test("mints a vault token with aud=vault.<name> and default read+write scope", async () => {
     const h = makeHarness(["field-notes"]);
     try {
-      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const u = await createUser(h.db, "owner", "pw");
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE], u.id);
       const res = await handleAccountMintVaultToken(
         withBearer("/account/vaults/field-notes/token", token, { method: "POST" }),
         "field-notes",
@@ -1038,7 +1039,8 @@ describe("handleAccountMintVaultToken", () => {
   test("honors an explicit scopes list", async () => {
     const h = makeHarness(["field-notes"]);
     try {
-      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const u = await createUser(h.db, "owner", "pw");
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE], u.id);
       const res = await handleAccountMintVaultToken(
         jsonReq("/account/vaults/field-notes/token", token, "POST", {
           scopes: ["vault:field-notes:read"],
@@ -1050,6 +1052,30 @@ describe("handleAccountMintVaultToken", () => {
       const body = (await res.json()) as { vault_token: string };
       const validated = await validateAccessToken(h.db, body.vault_token, ISSUER);
       expect(validated.payload.scope).toBe("vault:field-notes:read");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("non-user bearer sub fails closed instead of minting with user_id NULL", async () => {
+    const h = makeHarness(["field-notes"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE], "not-a-user");
+      const res = await handleAccountMintVaultToken(
+        withBearer("/account/vaults/field-notes/token", token, { method: "POST" }),
+        "field-notes",
+        deps(h),
+      );
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("invalid_subject");
+      const n =
+        h.db
+          .query<{ n: number }, []>(
+            "SELECT COUNT(*) AS n FROM tokens WHERE created_via = 'cli_mint'",
+          )
+          .get()?.n ?? 0;
+      expect(n).toBe(0);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-vault-admin-token.test.ts
+++ b/src/__tests__/account-vault-admin-token.test.ts
@@ -27,9 +27,10 @@ import { handleAccountVaultAdminTokenPost } from "../account-vault-admin-token.t
 import { VAULT_ADMIN_TOKEN_TTL_SECONDS } from "../admin-vault-admin-token.ts";
 import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { validateAccessToken } from "../jwt-sign.ts";
+import { findTokenRowByJti, validateAccessToken } from "../jwt-sign.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
-import { createUser } from "../users.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser, resetUserPassword } from "../users.ts";
 
 const ISSUER = "https://hub.test";
 
@@ -329,5 +330,29 @@ describe("handleAccountVaultAdminTokenPost — CSRF + method", () => {
       deps(),
     );
     expect(res.status).toBe(400);
+  });
+});
+
+describe("handleAccountVaultAdminTokenPost — CAS after crypto await (hub#873)", () => {
+  test("resetUserPassword during afterSign → 409, no Location token, no live unrevoked row", async () => {
+    rotateSigningKey(harness.db);
+    const { friendId, cookie, csrfToken } = await seedFriend(["work"]);
+    let signedJti: string | undefined;
+    const res = await handleAccountVaultAdminTokenPost(
+      mintReq("work", { cookie, csrfToken }),
+      "work",
+      {
+        ...deps(),
+        afterSign: async ({ jti }) => {
+          signedJti = jti;
+          await resetUserPassword(harness.db, friendId, "new-password-after-reset");
+        },
+      },
+    );
+    expect(res.status).toBe(409);
+    expect(res.headers.get("location")).toBeNull();
+    expect(signedJti).toBeDefined();
+    const row = findTokenRowByJti(harness.db, signedJti!);
+    expect(row === null || row.revokedAt !== null).toBe(true);
   });
 });

--- a/src/__tests__/account-vault-token.test.ts
+++ b/src/__tests__/account-vault-token.test.ts
@@ -28,10 +28,11 @@ import { ACCOUNT_VAULT_TOKEN_TTL_SECONDS } from "../account-home-ui.ts";
 import { handleAccountVaultTokenPost } from "../account-vault-token.ts";
 import { CSRF_FIELD_NAME, buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { validateAccessToken } from "../jwt-sign.ts";
+import { findTokenRowByJti, validateAccessToken } from "../jwt-sign.ts";
 import { __resetForTests } from "../rate-limit.ts";
 import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
-import { createUser } from "../users.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser, resetUserPassword } from "../users.ts";
 
 const ISSUER = "https://hub.test";
 
@@ -406,5 +407,30 @@ describe("handleAccountVaultTokenPost — CSRF + method + rate limit", () => {
       deps(),
     );
     expect(ok.status).toBe(200);
+  });
+});
+
+describe("handleAccountVaultTokenPost — CAS after crypto await (hub#873)", () => {
+  test("resetUserPassword during afterSign → 409, no minted banner, no live unrevoked row", async () => {
+    rotateSigningKey(harness.db);
+    const { friendId, cookie, csrfToken } = await seedFriend(["work"]);
+    let signedJti: string | undefined;
+    const res = await handleAccountVaultTokenPost(
+      mintReq("work", { cookie, csrfToken, verb: "read" }),
+      "work",
+      {
+        ...deps(),
+        afterSign: async ({ jti }) => {
+          signedJti = jti;
+          await resetUserPassword(harness.db, friendId, "new-password-after-reset");
+        },
+      },
+    );
+    expect(res.status).toBe(409);
+    const html = await res.text();
+    expect(html).not.toContain('data-testid="minted-token-banner"');
+    expect(signedJti).toBeDefined();
+    const row = findTokenRowByJti(harness.db, signedJti!);
+    expect(row === null || row.revokedAt !== null).toBe(true);
   });
 });

--- a/src/__tests__/api-account-tokens.test.ts
+++ b/src/__tests__/api-account-tokens.test.ts
@@ -123,14 +123,67 @@ describe("GET /api/account/tokens", () => {
 
     const ownerList = await call("GET", "", owner.cookie);
     expect(ownerList.status).toBe(200);
-    const ownerBody = (await ownerList.json()) as { tokens: { user_id: string; jti: string }[] };
+    const ownerBody = (await ownerList.json()) as {
+      tokens: { user_id: string; jti: string }[];
+      next_cursor: string | null;
+    };
     expect(ownerBody.tokens.every((t) => t.user_id === owner.userId)).toBe(true);
     expect(ownerBody.tokens.length).toBeGreaterThan(0);
+    expect(ownerBody.next_cursor).toBeNull();
 
     const friendList = await call("GET", "", friend.cookie);
-    const friendBody = (await friendList.json()) as { tokens: { user_id: string }[] };
+    const friendBody = (await friendList.json()) as {
+      tokens: { user_id: string }[];
+      next_cursor: string | null;
+    };
     expect(friendBody.tokens.every((t) => t.user_id === friend.userId)).toBe(true);
     expect(friendBody.tokens.length).toBe(1);
+    expect(friendBody.next_cursor).toBeNull();
+  });
+
+  test("pages at 50 and returns next_cursor when more rows exist", async () => {
+    const { recordTokenMint } = await import("../jwt-sign.ts");
+    const owner = await userWithSession("owner");
+    const stamp = new Date("2026-08-25T12:00:00.000Z");
+    const user = db
+      .query<{ updated_at: string }, [string]>("SELECT updated_at FROM users WHERE id = ?")
+      .get(owner.userId);
+    if (!user) throw new Error("owner missing");
+    for (let i = 0; i < 51; i++) {
+      recordTokenMint(db, {
+        jti: `acct-page-${String(i).padStart(3, "0")}`,
+        createdVia: "cli_mint",
+        subject: "page",
+        userId: owner.userId,
+        userUpdatedAt: user.updated_at,
+        clientId: "parachute-account",
+        scopes: ["scribe:transcribe"],
+        expiresAt: "2030-01-01T00:00:00.000Z",
+        now: () => new Date(stamp.getTime() + i * 1000),
+      });
+    }
+    const first = await call("GET", "", owner.cookie);
+    expect(first.status).toBe(200);
+    const firstBody = (await first.json()) as {
+      tokens: { jti: string }[];
+      next_cursor: string | null;
+    };
+    expect(firstBody.tokens).toHaveLength(50);
+    expect(firstBody.next_cursor).toBeTruthy();
+    const second = await call(
+      "GET",
+      `?cursor=${encodeURIComponent(firstBody.next_cursor!)}`,
+      owner.cookie,
+    );
+    expect(second.status).toBe(200);
+    const secondBody = (await second.json()) as {
+      tokens: { jti: string }[];
+      next_cursor: string | null;
+    };
+    expect(secondBody.tokens.length).toBeGreaterThanOrEqual(1);
+    expect(secondBody.next_cursor).toBeNull();
+    const firstJtis = new Set(firstBody.tokens.map((t) => t.jti));
+    expect(secondBody.tokens.some((t) => firstJtis.has(t.jti))).toBe(false);
   });
 });
 

--- a/src/__tests__/api-account-tokens.test.ts
+++ b/src/__tests__/api-account-tokens.test.ts
@@ -1,0 +1,230 @@
+/**
+ * `/api/account/tokens*` — self-service list/mint/revoke (hub#833).
+ *
+ * Coverage:
+ *   - cookie + CSRF posture (401 / 403), self-only
+ *   - mint as session user_id; JWT sub is users.id
+ *   - friend cannot mint parachute:host:*
+ *   - friend with assigned vaults can mint vault:<assigned>:<verb>
+ *   - revoke 404 for someone else's jti (no existence oracle)
+ */
+import type { Database } from "bun:sqlite";
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { handleApiAccount } from "../api-account-2fa.ts";
+import { CSRF_COOKIE_NAME } from "../csrf.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { validateAccessToken } from "../jwt-sign.ts";
+import { mintOperatorToken } from "../operator-token.ts";
+import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
+import { SESSION_TTL_MS, buildSessionCookie, createSession } from "../sessions.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const TEST_CSRF = "csrf-account-tokens";
+const CSRF_COOKIE = `${CSRF_COOKIE_NAME}=${TEST_CSRF}`;
+const ORIGIN = "https://hub.example";
+const ISSUER = "http://127.0.0.1:1939";
+const PASSWORD = "correct-horse-battery";
+
+let db: Database;
+let configDir: string;
+
+beforeEach(() => {
+  configDir = mkdtempSync(join(tmpdir(), "phub-api-acct-tokens-"));
+  db = openHubDb(hubDbPath(configDir));
+  rotateSigningKey(db);
+  resetRateLimit();
+});
+
+afterEach(() => {
+  db.close();
+  rmSync(configDir, { recursive: true, force: true });
+});
+
+interface TestUser {
+  userId: string;
+  username: string;
+  cookie: string;
+}
+
+async function userWithSession(
+  username: string,
+  extra: { assignedVaults?: string[]; allowMulti?: boolean } = {},
+): Promise<TestUser> {
+  const u = await createUser(db, username, PASSWORD, {
+    allowMulti: extra.allowMulti ?? username !== "owner",
+    passwordChanged: true,
+    ...(extra.assignedVaults ? { assignedVaults: extra.assignedVaults } : {}),
+  });
+  const session = createSession(db, { userId: u.id });
+  return {
+    userId: u.id,
+    username: u.username,
+    cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+  };
+}
+
+function call(
+  method: string,
+  subpath: string,
+  cookie: string | null,
+  body?: Record<string, unknown>,
+): Promise<Response> {
+  const url = `${ORIGIN}/api/account/tokens${subpath}`;
+  const req = new Request(url, {
+    method,
+    headers: {
+      "content-type": "application/json",
+      origin: ORIGIN,
+      ...(cookie ? { cookie } : {}),
+    },
+    ...(body === undefined ? {} : { body: JSON.stringify(body) }),
+  });
+  return handleApiAccount(req, `/tokens${subpath.split("?")[0]}`, {
+    db,
+    issuer: ISSUER,
+  });
+}
+
+describe("auth posture", () => {
+  test("every route needs a session", async () => {
+    for (const [method, path, body] of [
+      ["GET", "", undefined],
+      ["POST", "", { __csrf: TEST_CSRF, scope: "vault:work:read" }],
+      ["POST", "/no-such/revoke", { __csrf: TEST_CSRF }],
+    ] as const) {
+      const res = await call(method, path, null, body as Record<string, unknown> | undefined);
+      expect(res.status).toBe(401);
+    }
+  });
+
+  test("every mutation needs a valid CSRF token", async () => {
+    const owner = await userWithSession("owner");
+    const mint = await call("POST", "", owner.cookie, { scope: "scribe:transcribe" });
+    expect(mint.status).toBe(403);
+    const revoke = await call("POST", "/abc/revoke", owner.cookie, {});
+    expect(revoke.status).toBe(403);
+  });
+});
+
+describe("GET /api/account/tokens", () => {
+  test("lists only this user's tokens; unrevoked default", async () => {
+    const owner = await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    await mintOperatorToken(db, owner.userId, { issuer: ISSUER });
+    const minted = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "vault:work:read",
+    });
+    expect(minted.status).toBe(200);
+
+    const ownerList = await call("GET", "", owner.cookie);
+    expect(ownerList.status).toBe(200);
+    const ownerBody = (await ownerList.json()) as { tokens: { user_id: string; jti: string }[] };
+    expect(ownerBody.tokens.every((t) => t.user_id === owner.userId)).toBe(true);
+    expect(ownerBody.tokens.length).toBeGreaterThan(0);
+
+    const friendList = await call("GET", "", friend.cookie);
+    const friendBody = (await friendList.json()) as { tokens: { user_id: string }[] };
+    expect(friendBody.tokens.every((t) => t.user_id === friend.userId)).toBe(true);
+    expect(friendBody.tokens.length).toBe(1);
+  });
+});
+
+describe("POST /api/account/tokens", () => {
+  test("mints as the session user_id; JWT sub is users.id", async () => {
+    const owner = await userWithSession("owner");
+    const res = await call("POST", "", owner.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "scribe:transcribe",
+      label: "laptop",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { jti: string; token: string; scope: string };
+    expect(body.scope).toBe("scribe:transcribe");
+    const validated = await validateAccessToken(db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(owner.userId);
+    const row = db
+      .query<{ user_id: string; subject: string }, [string]>(
+        "SELECT user_id, subject FROM tokens WHERE jti = ?",
+      )
+      .get(body.jti);
+    expect(row?.user_id).toBe(owner.userId);
+    expect(row?.subject).toBe("laptop");
+  });
+
+  test("friend cannot mint parachute:host:*", async () => {
+    await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const res = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "parachute:host:admin",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string; error_description: string };
+    expect(body.error).toBe("invalid_scope");
+    expect(body.error_description).toContain("parachute:host:admin");
+  });
+
+  test("friend with assigned vaults can mint vault:<assigned>:<verb>", async () => {
+    await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const res = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "vault:work:read",
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { token: string };
+    const validated = await validateAccessToken(db, body.token, ISSUER);
+    expect(validated.payload.sub).toBe(friend.userId);
+    expect(validated.payload.scope).toBe("vault:work:read");
+  });
+
+  test("friend cannot mint a vault they are not assigned", async () => {
+    await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const res = await call("POST", "", friend.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "vault:other:read",
+    });
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { error: string };
+    expect(body.error).toBe("invalid_scope");
+  });
+});
+
+describe("POST /api/account/tokens/:jti/revoke", () => {
+  test("404 for someone else's jti (no existence oracle)", async () => {
+    const owner = await userWithSession("owner");
+    const friend = await userWithSession("friend", { assignedVaults: ["work"] });
+    const minted = await call("POST", "", owner.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "scribe:transcribe",
+    });
+    expect(minted.status).toBe(200);
+    const { jti } = (await minted.json()) as { jti: string };
+
+    const asFriend = await call("POST", `/${jti}/revoke`, friend.cookie, { __csrf: TEST_CSRF });
+    expect(asFriend.status).toBe(404);
+    const missing = await call("POST", "/no-such-jti/revoke", friend.cookie, { __csrf: TEST_CSRF });
+    expect(missing.status).toBe(404);
+    expect(await asFriend.text()).toBe(await missing.clone().text());
+  });
+
+  test("owner can revoke their own jti", async () => {
+    const owner = await userWithSession("owner");
+    const minted = await call("POST", "", owner.cookie, {
+      __csrf: TEST_CSRF,
+      scope: "scribe:transcribe",
+    });
+    const { jti } = (await minted.json()) as { jti: string };
+    const res = await call("POST", `/${jti}/revoke`, owner.cookie, { __csrf: TEST_CSRF });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as { revoked: boolean; jti: string };
+    expect(body.revoked).toBe(true);
+    expect(body.jti).toBe(jti);
+  });
+});

--- a/src/__tests__/api-mint-token.test.ts
+++ b/src/__tests__/api-mint-token.test.ts
@@ -4,10 +4,10 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { handleApiMintToken } from "../api-mint-token.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import { signAccessToken, validateAccessToken } from "../jwt-sign.ts";
+import { findTokenRowByJti, signAccessToken, validateAccessToken } from "../jwt-sign.ts";
 import { mintOperatorToken } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
-import { createUser } from "../users.ts";
+import { createUser, deleteUser, resetUserPassword } from "../users.ts";
 
 interface Harness {
   dir: string;
@@ -895,10 +895,36 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     });
 
     // Item A (subject-pin) — audit-attribution forgery. A non-operator
-    // (vault-admin-only) bearer may NOT override the minted token's `sub`:
-    // forging a foreign subject would mis-attribute the registry + revocation
-    // rows. It may still mint under its OWN sub (subject omitted / equal).
-    test("subject override by non-operator bearer → 403 (forgery blocked)", async () => {
+    // (vault-admin-only) bearer may NOT mint as another account via `user`.
+    // A deprecated `subject` that does not match a hub account is a label,
+    // not a principal override.
+    test("user override by non-operator bearer → 403 (forgery blocked)", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const other = await createUser(db, "friend", "pw", { allowMulti: true });
+          const bearer = await mintVaultAdminBearer(db, userId, "work");
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", user: other.id },
+              { authorization: `Bearer ${bearer}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(403);
+          const body = (await resp.json()) as { error: string; error_description: string };
+          expect(body.error).toBe("insufficient_scope");
+          expect(body.error_description).toContain("non-operator");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("deprecated subject that is not a hub account is a label, JWT sub stays own", async () => {
       const h = makeHarness();
       try {
         const { db, userId } = await bootstrap(h.dir);
@@ -911,10 +937,18 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
             ),
             { db, issuer: ISSUER },
           );
-          expect(resp.status).toBe(403);
-          const body = (await resp.json()) as { error: string; error_description: string };
-          expect(body.error).toBe("insufficient_scope");
-          expect(body.error_description).toContain("non-operator");
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string; warnings?: string[] };
+          expect(body.warnings?.some((w) => w.includes("deprecated"))).toBe(true);
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(userId);
+          const row = db
+            .query<{ subject: string; user_id: string }, [string]>(
+              "SELECT subject, user_id FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.subject).toBe("someone-else");
+          expect(row?.user_id).toBe(userId);
         } finally {
           db.close();
         }
@@ -951,12 +985,160 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
     });
   });
 
-  // Item A (subject-pin) — the operator carve-out: a host operator
-  // (parachute:host:auth / parachute:host:admin) MAY override `sub` to stamp a
-  // service-account subject. This is the documented service-account override
-  // that the non-operator pin above must NOT break.
-  describe("subject override — operator carve-out (item A)", () => {
-    test("host:auth operator overrides subject → 200, registry row carries override", async () => {
+  // hub#833 — `subject` is a deprecated label; `service` is the remaining
+  // non-account principal; `user` mints as that account.
+  describe("principal is users.id (hub#833)", () => {
+    test("person-mint writes user_id and JWT sub is users.id", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest({ scope: "scribe:transcribe" }, { authorization: `Bearer ${op.token}` }),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(userId);
+          const row = db
+            .query<{ user_id: string; subject: string }, [string]>(
+              "SELECT user_id, subject FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.user_id).toBe(userId);
+          expect(row?.subject).toBe(userId);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("label sets tokens.subject; JWT sub stays the account id", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "scribe:transcribe", label: "laptop" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(userId);
+          const row = db
+            .query<{ user_id: string; subject: string }, [string]>(
+              "SELECT user_id, subject FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.user_id).toBe(userId);
+          expect(row?.subject).toBe("laptop");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("operator user field mints as that account", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", user: "friend" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(friend.id);
+          const row = db
+            .query<{ user_id: string }, [string]>("SELECT user_id FROM tokens WHERE jti = ?")
+            .get(body.jti);
+          expect(row?.user_id).toBe(friend.id);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("operator service field mints with user_id NULL and JWT sub = service name", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", service: "svc-account" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { jti: string; token: string };
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe("svc-account");
+          const row = db
+            .query<{ user_id: string | null; subject: string }, [string]>(
+              "SELECT user_id, subject FROM tokens WHERE jti = ?",
+            )
+            .get(body.jti);
+          expect(row?.user_id).toBeNull();
+          expect(row?.subject).toBe("svc-account");
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("deprecated subject matching a username is treated as user", async () => {
+      const h = makeHarness();
+      try {
+        const { db, userId } = await bootstrap(h.dir);
+        try {
+          const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+          const op = await mintOperatorToken(db, userId, { issuer: ISSUER, scopeSet: "auth" });
+          const resp = await handleApiMintToken(
+            jsonRequest(
+              { scope: "vault:work:read", subject: "friend" },
+              { authorization: `Bearer ${op.token}` },
+            ),
+            { db, issuer: ISSUER },
+          );
+          expect(resp.status).toBe(200);
+          const body = (await resp.json()) as { token: string; warnings?: string[] };
+          expect(body.warnings?.some((w) => w.includes("treating as `user`"))).toBe(true);
+          const validated = await validateAccessToken(db, body.token, ISSUER);
+          expect(validated.payload.sub).toBe(friend.id);
+        } finally {
+          db.close();
+        }
+      } finally {
+        h.cleanup();
+      }
+    });
+
+    test("host:auth operator deprecated subject that is not an account is a label", async () => {
       const h = makeHarness();
       try {
         const { db, userId } = await bootstrap(h.dir);
@@ -972,36 +1154,14 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
           expect(resp.status).toBe(200);
           const body = (await resp.json()) as { jti: string; token: string };
           const validated = await validateAccessToken(db, body.token, ISSUER);
-          expect(validated.payload.sub).toBe("svc-account");
+          expect(validated.payload.sub).toBe(userId);
           const row = db
-            .query<{ subject: string }, [string]>("SELECT subject FROM tokens WHERE jti = ?")
+            .query<{ subject: string; user_id: string }, [string]>(
+              "SELECT subject, user_id FROM tokens WHERE jti = ?",
+            )
             .get(body.jti);
           expect(row?.subject).toBe("svc-account");
-        } finally {
-          db.close();
-        }
-      } finally {
-        h.cleanup();
-      }
-    });
-
-    test("host:admin operator overrides subject → 200", async () => {
-      const h = makeHarness();
-      try {
-        const { db, userId } = await bootstrap(h.dir);
-        try {
-          const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
-          const resp = await handleApiMintToken(
-            jsonRequest(
-              { scope: "vault:work:admin", subject: "svc-account" },
-              { authorization: `Bearer ${op.token}` },
-            ),
-            { db, issuer: ISSUER },
-          );
-          expect(resp.status).toBe(200);
-          const body = (await resp.json()) as { token: string };
-          const validated = await validateAccessToken(db, body.token, ISSUER);
-          expect(validated.payload.sub).toBe("svc-account");
+          expect(row?.user_id).toBe(userId);
         } finally {
           db.close();
         }
@@ -1408,6 +1568,149 @@ describe("POST /api/auth/mint-token (hub#212 Phase 1)", () => {
         const req = new Request("http://localhost/api/auth/mint-token", { method: "GET" });
         const resp = await handleApiMintToken(req, { db, issuer: ISSUER });
         expect(resp.status).toBe(405);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+// hub#833 fold 2 — CAS insert after the crypto await. `afterSign` is the
+// test seam: it runs after `signAccessToken` and before `recordTokenMint`,
+// so the race is deterministic (no wall-clock). Watched failing before the
+// CAS existed (plain insert landed a live unrevoked row + returned the JWT).
+describe("CAS after crypto await (hub#833)", () => {
+  test("deleteUser during afterSign → 409, no token in body, no live unrevoked row", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        let signedJti: string | undefined;
+        let signedToken: string | undefined;
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          {
+            db,
+            issuer: ISSUER,
+            afterSign: ({ token, jti }) => {
+              signedToken = token;
+              signedJti = jti;
+              deleteUser(db, userId);
+            },
+          },
+        );
+        expect(resp.status).toBe(409);
+        const body = (await resp.json()) as { error?: string; token?: string };
+        expect(body.token).toBeUndefined();
+        expect(body.error).toBe("conflict");
+        expect(signedJti).toBeDefined();
+        const row = findTokenRowByJti(db, signedJti!);
+        expect(row === null || row.revokedAt !== null).toBe(true);
+        // The signed JWT was never returned. Missing-row bypass in
+        // validateAccessToken is out of this PR (historical pre-v6 tokens);
+        // fail-closed for NEW mints is the insert gate + not emitting the JWT.
+        expect(signedToken).toBeDefined();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unlink racing mint does not leave a dangling user_id (INSERT-time snapshot)", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const { issuePubkeyChallenge, linkPubkey, unlinkPubkey } = await import(
+          "../pubkey-links.ts"
+        );
+        const now = new Date();
+        const { challenge } = issuePubkeyChallenge(db, userId, now);
+        const pubkey = "a".repeat(64);
+        const linked = linkPubkey(db, {
+          userId,
+          pubkey,
+          challenge,
+          proofEvent: JSON.stringify({
+            id: "0".repeat(64),
+            pubkey,
+            kind: 27235,
+            tags: [["challenge", challenge]],
+          }),
+          now,
+        });
+        expect(linked.ok).toBe(true);
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          {
+            db,
+            issuer: ISSUER,
+            afterSign: () => {
+              expect(unlinkPubkey(db, userId, pubkey)).toBe(true);
+            },
+          },
+        );
+        expect(resp.status).toBe(200);
+        const body = (await resp.json()) as { jti: string; token: string };
+        const row = db
+          .query<{ user_id: string | null; subject_pubkey: string | null }, [string]>(
+            "SELECT user_id, subject_pubkey FROM tokens WHERE jti = ?",
+          )
+          .get(body.jti);
+        expect(row?.user_id).toBe(userId);
+        // Snapshot is taken at INSERT, after the unlink, so it is NULL. The
+        // user row is still there — unlink is not logout (v17 snapshot).
+        expect(row?.subject_pubkey).toBeNull();
+        const validated = await validateAccessToken(db, body.token, ISSUER);
+        expect(validated.payload.sub).toBe(userId);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("resetUserPassword during afterSign → 409, no token in body, no live unrevoked row", async () => {
+    const h = makeHarness();
+    try {
+      const { db, userId } = await bootstrap(h.dir);
+      try {
+        const op = await mintOperatorToken(db, userId, { issuer: ISSUER });
+        let signedJti: string | undefined;
+        const resp = await handleApiMintToken(
+          jsonRequest(
+            { scope: "scribe:transcribe", expires_in: 3600 },
+            { authorization: `Bearer ${op.token}` },
+          ),
+          {
+            db,
+            issuer: ISSUER,
+            afterSign: async ({ jti }) => {
+              signedJti = jti;
+              await resetUserPassword(db, userId, "new-password-after-reset");
+            },
+          },
+        );
+        expect(resp.status).toBe(409);
+        const body = (await resp.json()) as { error?: string; token?: string };
+        expect(body.token).toBeUndefined();
+        expect(body.error).toBe("conflict");
+        expect(signedJti).toBeDefined();
+        const row = findTokenRowByJti(db, signedJti!);
+        expect(row === null || row.revokedAt !== null).toBe(true);
       } finally {
         db.close();
       }

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -15,7 +15,7 @@ import {
   readOperatorTokenFile,
   writeOperatorTokenFile,
 } from "../operator-token.ts";
-import { createUser, listUsers, verifyPassword } from "../users.ts";
+import { createUser, deleteUser, listUsers, verifyPassword } from "../users.ts";
 
 function makeRunner(result: number | (() => Promise<number>) = 0): {
   runner: Runner;
@@ -1799,7 +1799,43 @@ describe("parachute auth mint-token", () => {
     }
   });
 
-  test("--sub override emits the JWT with that subject", async () => {
+  test("--sub that is not a hub account is a label; JWT sub stays the account id", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe", "--sub", "agent:scribe-runner"], deps),
+      );
+      expect(code).toBe(0);
+      expect(stderr).toContain("--sub is deprecated");
+      expect(stderr).toContain("treating as --label");
+      const token = stdout.trim();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token);
+        const users = listUsers(db);
+        expect(validated.payload.sub).toBe(users[0]!.id);
+        const row = db
+          .query<{ subject: string; user_id: string }, [string]>(
+            "SELECT subject, user_id FROM tokens WHERE jti = ?",
+          )
+          .get(validated.payload.jti as string);
+        expect(row?.subject).toBe("agent:scribe-runner");
+        expect(row?.user_id).toBe(users[0]!.id);
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--label sets tokens.subject; JWT sub stays the account id", async () => {
     const tmp = makeTmp();
     try {
       const deps: AuthDeps = {
@@ -1809,17 +1845,84 @@ describe("parachute auth mint-token", () => {
       };
       await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
       const { code, stdout } = await captureOutput(() =>
-        auth(["mint-token", "--scope", "scribe:transcribe", "--sub", "agent:scribe-runner"], deps),
+        auth(["mint-token", "--scope", "scribe:transcribe", "--label", "laptop"], deps),
       );
       expect(code).toBe(0);
       const token = stdout.trim();
       const db = openHubDb(tmp.dbPath);
       try {
         const validated = await validateAccessToken(db, token);
-        expect(validated.payload.sub).toBe("agent:scribe-runner");
+        const users = listUsers(db);
+        expect(validated.payload.sub).toBe(users[0]!.id);
+        const row = db
+          .query<{ subject: string }, [string]>("SELECT subject FROM tokens WHERE jti = ?")
+          .get(validated.payload.jti as string);
+        expect(row?.subject).toBe("laptop");
       } finally {
         db.close();
       }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("--service mints a non-account principal (user_id NULL, JWT sub = name)", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe", "--service", "surface:notes"], deps),
+      );
+      expect(code).toBe(0);
+      const token = stdout.trim();
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const validated = await validateAccessToken(db, token);
+        expect(validated.payload.sub).toBe("surface:notes");
+        const row = db
+          .query<{ user_id: string | null; subject: string }, [string]>(
+            "SELECT user_id, subject FROM tokens WHERE jti = ?",
+          )
+          .get(validated.payload.jti as string);
+        expect(row?.user_id).toBeNull();
+        expect(row?.subject).toBe("surface:notes");
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("CAS: deleteUser during afterSign fails closed and does not print the JWT", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = {
+        dbPath: tmp.dbPath,
+        configDir: tmp.dir,
+        isInteractive: () => false,
+        afterSign: ({ userId }) => {
+          if (!userId) return;
+          const db = openHubDb(tmp.dbPath);
+          try {
+            deleteUser(db, userId);
+          } finally {
+            db.close();
+          }
+        },
+      };
+      await captureOutput(() => auth(["set-password", "--password", "pw"], deps));
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["mint-token", "--scope", "scribe:transcribe"], deps),
+      );
+      expect(code).toBe(1);
+      expect(stdout.trim()).toBe("");
+      expect(stderr).toContain("no longer exists");
     } finally {
       tmp.cleanup();
     }

--- a/src/__tests__/hub-db.test.ts
+++ b/src/__tests__/hub-db.test.ts
@@ -416,6 +416,42 @@ describe("openHubDb + migrate", () => {
     }
   });
 
+  test("v19 backfills tokens.user_id where subject equals a users.id; leaves the rest", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        const stamp = new Date().toISOString();
+        db.prepare(
+          `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+           VALUES (?, ?, 'x', ?, ?, 1)`,
+        ).run("user-backfill", "owner", stamp, stamp);
+        db.prepare(
+          `INSERT INTO tokens (jti, user_id, client_id, scopes, expires_at, created_at, created_via, subject)
+           VALUES (?, NULL, 'c', 'vault:read', ?, ?, 'cli_mint', ?)`,
+        ).run("t-account", stamp, stamp, "user-backfill");
+        db.prepare(
+          `INSERT INTO tokens (jti, user_id, client_id, scopes, expires_at, created_at, created_via, subject)
+           VALUES (?, NULL, 'c', 'vault:read', ?, ?, 'operator_mint', 'operator')`,
+        ).run("t-operator", stamp, stamp);
+        db.exec("DELETE FROM schema_version WHERE version = 19");
+        migrate(db);
+        const account = db
+          .query<{ user_id: string | null }, [string]>("SELECT user_id FROM tokens WHERE jti = ?")
+          .get("t-account");
+        const operator = db
+          .query<{ user_id: string | null }, [string]>("SELECT user_id FROM tokens WHERE jti = ?")
+          .get("t-operator");
+        expect(account?.user_id).toBe("user-backfill");
+        expect(operator?.user_id).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("v10 FK cascade: deleting a user drops their user_vaults rows", () => {
     const h = makeHarness();
     try {

--- a/src/__tests__/jwt-sign.test.ts
+++ b/src/__tests__/jwt-sign.test.ts
@@ -8,6 +8,7 @@ import {
   ACCESS_TOKEN_TTL_SECONDS,
   REFRESH_TOKEN_TTL_MS,
   RefreshTokenInsertError,
+  TokenMintPrincipalGoneError,
   findRefreshToken,
   findTokenRowByJti,
   linkRotation,
@@ -480,6 +481,52 @@ describe("token registry (hub#212 Phase 1)", () => {
       expect(byName.has("subject")).toBe(true);
       // created_via has the back-compat default for pre-v6 rows.
       expect(byName.get("created_via")?.dflt_value).toMatch(/oauth_refresh/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("person-mint CAS misses when the user is gone", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "owner", "pw");
+      const expiresAt = new Date(Date.now() + 86400_000).toISOString();
+      db.prepare("DELETE FROM users WHERE id = ?").run(u.id);
+      expect(() =>
+        recordTokenMint(db, {
+          jti: "jti-cas-gone",
+          createdVia: "cli_mint",
+          subject: u.id,
+          userId: u.id,
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt,
+        }),
+      ).toThrow(TokenMintPrincipalGoneError);
+      expect(findTokenRowByJti(db, "jti-cas-gone")).toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("person-mint CAS misses when updated_at no longer matches (reset pin)", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "owner", "pw");
+      const expiresAt = new Date(Date.now() + 86400_000).toISOString();
+      expect(() =>
+        recordTokenMint(db, {
+          jti: "jti-cas-reset",
+          createdVia: "cli_mint",
+          subject: u.id,
+          userId: u.id,
+          userUpdatedAt: "1999-01-01T00:00:00.000Z",
+          clientId: "parachute-hub",
+          scopes: ["vault:read"],
+          expiresAt,
+        }),
+      ).toThrow(TokenMintPrincipalGoneError);
+      expect(findTokenRowByJti(db, "jti-cas-reset")).toBeNull();
     } finally {
       cleanup();
     }

--- a/src/__tests__/operator-token-issuer-self-heal.test.ts
+++ b/src/__tests__/operator-token-issuer-self-heal.test.ts
@@ -22,6 +22,7 @@ import {
   OPERATOR_TOKEN_AUDIENCE,
   OPERATOR_TOKEN_CLIENT_ID,
   OPERATOR_TOKEN_FILENAME,
+  OPERATOR_TOKEN_SCOPE_SETS,
   OPERATOR_TOKEN_SCOPE_SET_CLAIM,
   issueOperatorToken,
   operatorTokenPath,
@@ -323,6 +324,40 @@ describe("selfHealOperatorTokenIssuer", () => {
         });
         expect(status.kind).toBe("skipped");
         if (status.kind === "skipped") expect(status.reason).toBe("no-sub");
+
+        const onDisk = await readOperatorTokenFile(h.dir);
+        expect(onDisk).toBe(signed.token);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("sub is not a users row (stale iss, aud=operator, valid scope-set) → skipped:sub-not-user, untouched", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        plantOperatorUsers(db);
+        const signed = await signAccessToken(db, {
+          sub: "operator",
+          scopes: [...OPERATOR_TOKEN_SCOPE_SETS.admin],
+          audience: OPERATOR_TOKEN_AUDIENCE,
+          clientId: OPERATOR_TOKEN_CLIENT_ID,
+          issuer: LOOPBACK_ISSUER,
+          extraClaims: { [OPERATOR_TOKEN_SCOPE_SET_CLAIM]: "admin" },
+        });
+        await writeOperatorTokenFile(signed.token, h.dir);
+
+        const status = await selfHealOperatorTokenIssuer(db, {
+          issuer: PUBLIC_ISSUER,
+          configDir: h.dir,
+        });
+        expect(status.kind).toBe("skipped");
+        if (status.kind === "skipped") expect(status.reason).toBe("sub-not-user");
 
         const onDisk = await readOperatorTokenFile(h.dir);
         expect(onDisk).toBe(signed.token);

--- a/src/__tests__/operator-token-issuer-self-heal.test.ts
+++ b/src/__tests__/operator-token-issuer-self-heal.test.ts
@@ -31,6 +31,16 @@ import {
 } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
+function plantOperatorUsers(db: ReturnType<typeof openHubDb>): void {
+  const stamp = new Date().toISOString();
+  const insert = db.prepare(
+    `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+     VALUES (?, ?, 'x', ?, ?, 1)`,
+  );
+  insert.run("user-abc", "owner", stamp, stamp);
+  insert.run("user-xyz", "other", stamp, stamp);
+}
+
 interface Harness {
   dir: string;
   cleanup: () => void;
@@ -51,6 +61,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint at loopback issuer with a non-default scope-set ("start").
         await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
@@ -90,6 +101,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: PUBLIC_ISSUER,
@@ -119,6 +131,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const status = await selfHealOperatorTokenIssuer(db, {
           issuer: PUBLIC_ISSUER,
           configDir: h.dir,
@@ -138,6 +151,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint a real token at loopback, then corrupt its signature segment so
         // it no longer verifies against the hub's keys.
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -184,6 +198,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint a token that expired in the past — jose's exp check throws on
         // validate, so the self-heal must classify it unverifiable.
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -217,6 +232,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // A hub-signed token with the WRONG audience must not be re-minted as
         // an operator token (privilege guard).
         const signed = await signAccessToken(db, {
@@ -252,6 +268,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // aud=operator + stale iss + NO pa_scope_set claim. Falling back to a
         // default scope-set would silently widen to admin (hub#224); refuse.
         const signed = await signAccessToken(db, {
@@ -287,6 +304,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // aud=operator + recognized scope-set + stale iss but NO sub — we can't
         // re-mint a token we can't attribute.
         const signed = await signAccessToken(db, {
@@ -322,6 +340,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // A good PUBLIC-issuer token; calling self-heal with a loopback target
         // must never downgrade it.
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -356,6 +375,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         await issueOperatorToken(db, "user-xyz", {
           dir: h.dir,
           issuer: LOOPBACK_ISSUER,
@@ -388,6 +408,7 @@ describe("selfHealOperatorTokenIssuer", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: LOOPBACK_ISSUER,

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -26,6 +26,18 @@ import {
 } from "../operator-token.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 
+/** Operator mint is a person-mint (hub#833): the user row must exist. */
+function plantOperatorUsers(db: ReturnType<typeof openHubDb>): void {
+  const stamp = new Date().toISOString();
+  const insert = db.prepare(
+    `INSERT INTO users (id, username, password_hash, created_at, updated_at, password_changed)
+     VALUES (?, ?, 'x', ?, ?, 1)`,
+  );
+  insert.run("user-abc", "owner", stamp, stamp);
+  insert.run("user-xyz", "other", stamp, stamp);
+  insert.run("u", "shortn", stamp, stamp);
+}
+
 interface Harness {
   dir: string;
   cleanup: () => void;
@@ -45,6 +57,7 @@ describe("mintOperatorToken", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint at the real clock (no pinned `now`): `validateAccessToken` below
         // enforces `exp` against jose's real clock, which has no override, so a
         // pinned past mint date would eventually push `exp` into the past and
@@ -140,6 +153,7 @@ describe("issueOperatorToken", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const issued = await issueOperatorToken(db, "user-xyz", {
           dir: h.dir,
           issuer: TEST_ISSUER,
@@ -176,6 +190,7 @@ describe("mintOperatorToken scope-sets (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "user-abc", { issuer: TEST_ISSUER });
         expect(minted.scopeSet).toBe("admin");
         const validated = await validateAccessToken(db, minted.token, TEST_ISSUER);
@@ -195,6 +210,7 @@ describe("mintOperatorToken scope-sets (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "user-abc", {
           issuer: TEST_ISSUER,
           scopeSet: "start",
@@ -217,6 +233,7 @@ describe("mintOperatorToken scope-sets (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "u", {
           issuer: TEST_ISSUER,
           scopeSet: "install",
@@ -293,6 +310,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const issued = await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: TEST_ISSUER,
@@ -320,6 +338,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint with a 1-day TTL — well below the 7d threshold.
         const original = await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
@@ -358,6 +377,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Hand-sign a narrow JWT with aud=scribe (not "operator") and a
         // 1-hour TTL. Even though it's within the rotation window, the
         // helper must not silently upgrade it to a full operator token.
@@ -403,6 +423,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // aud=operator + 1h TTL + NO pa_scope_set claim. Pre-#224 this would
         // fall back to OPERATOR_TOKEN_DEFAULT_SCOPE_SET (admin) on rotation
         // — a silent widening of a token of unknown provenance.
@@ -444,6 +465,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const used = await useOperatorTokenWithAutoRotate(db, {
           configDir: h.dir,
           issuer: TEST_ISSUER,
@@ -463,6 +485,7 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         // Mint a token that's already expired.
         const expiredAt = new Date("2026-01-01T00:00:00Z");
         const issued = await issueOperatorToken(db, "user-abc", {
@@ -542,6 +565,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // Mint the operator token under the hub's PUBLIC origin — what
           // happens on an exposed box (selfHealOperatorTokenIssuer re-mints to
           // the public iss).
@@ -577,6 +601,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           const issued = await issueOperatorToken(db, "user-abc", {
             dir: h.dir,
             issuer: TEST_ISSUER,
@@ -605,6 +630,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // Hub-SIGNED (so the signature gate passes) but stamped with an iss
           // that's neither loopback nor in expose-state nor env. Must reject.
           const issued = await issueOperatorToken(db, "user-abc", {
@@ -640,7 +666,9 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const foreignDb = openHubDb(hubDbPath(foreign.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           rotateSigningKey(foreignDb);
+          plantOperatorUsers(foreignDb);
           const foreignToken = await mintOperatorToken(foreignDb, "user-abc", {
             issuer: PUBLIC_ISSUER,
           });
@@ -670,6 +698,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // A loopback-iss token is accepted (loopback alias is always in the set).
           const loopbackTok = await issueOperatorToken(db, "user-abc", {
             dir: h.dir,
@@ -708,6 +737,7 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
         const db = openHubDb(hubDbPath(h.dir));
         try {
           rotateSigningKey(db);
+          plantOperatorUsers(db);
           // Public-iss + 1-day TTL (below the 7d threshold). Validates via the
           // known set (expose-state public origin), then auto-rotates.
           const original = await issueOperatorToken(db, "user-abc", {
@@ -762,12 +792,13 @@ describe("useOperatorTokenWithAutoRotate known-issuer set (hub#516)", () => {
 // registry so they show up in the revocation list and admin UI alongside
 // OAuth refresh tokens and CLI mints.
 describe("mintOperatorToken registry write (#212)", () => {
-  test("writes a tokens row with created_via='operator_mint', subject='operator', user_id NULL", async () => {
+  test("writes a tokens row with created_via='operator_mint', subject='operator', user_id set", async () => {
     const h = makeHarness();
     try {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const minted = await mintOperatorToken(db, "user-abc", {
           issuer: TEST_ISSUER,
           scopeSet: "start",
@@ -788,7 +819,7 @@ describe("mintOperatorToken registry write (#212)", () => {
           )
           .get(minted.jti);
         expect(row).not.toBeNull();
-        expect(row?.user_id).toBeNull();
+        expect(row?.user_id).toBe("user-abc");
         expect(row?.subject).toBe("operator");
         expect(row?.created_via).toBe("operator_mint");
         expect(row?.scopes).toBe("parachute:host:start");
@@ -807,6 +838,7 @@ describe("mintOperatorToken registry write (#212)", () => {
       const db = openHubDb(hubDbPath(h.dir));
       try {
         rotateSigningKey(db);
+        plantOperatorUsers(db);
         const original = await issueOperatorToken(db, "user-abc", {
           dir: h.dir,
           issuer: TEST_ISSUER,

--- a/src/__tests__/operator-token.test.ts
+++ b/src/__tests__/operator-token.test.ts
@@ -459,6 +459,48 @@ describe("useOperatorTokenWithAutoRotate (#213)", () => {
     }
   });
 
+  test("skips auto-rotate when sub is not a users row (skipped: sub-not-user)", async () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(hubDbPath(h.dir));
+      try {
+        rotateSigningKey(db);
+        plantOperatorUsers(db);
+        // Legacy sentinel principal: aud=operator + recognized scope-set +
+        // short TTL, but sub is the old "operator" label, not a users.id.
+        // mintOperatorToken would throw; auto-rotate must skip, not crash.
+        const signed = await signAccessToken(db, {
+          sub: "operator",
+          scopes: [...OPERATOR_TOKEN_SCOPE_SETS.admin],
+          audience: OPERATOR_TOKEN_AUDIENCE,
+          clientId: OPERATOR_TOKEN_CLIENT_ID,
+          issuer: TEST_ISSUER,
+          ttlSeconds: 3600,
+          extraClaims: { [OPERATOR_TOKEN_SCOPE_SET_CLAIM]: "admin" },
+        });
+        await writeOperatorTokenFile(signed.token, h.dir);
+
+        const used = await useOperatorTokenWithAutoRotate(db, {
+          configDir: h.dir,
+          issuer: TEST_ISSUER,
+        });
+        expect(used).not.toBeNull();
+        expect(used?.status.kind).toBe("skipped");
+        if (used?.status.kind === "skipped") {
+          expect(used.status.reason).toBe("sub-not-user");
+        }
+        expect(used?.rotated).toBeUndefined();
+        expect(used?.token).toBe(signed.token);
+        const onDisk = await readOperatorTokenFile(h.dir);
+        expect(onDisk).toBe(signed.token);
+      } finally {
+        db.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("returns null when no operator token file exists", async () => {
     const h = makeHarness();
     try {

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -167,6 +167,11 @@ export interface AccountApiDeps {
   manifestPath?: string;
   /** Test seam for the clock (mint + registry row). */
   now?: () => Date;
+  /**
+   * Test seam (hub#873): runs after `signAccessToken` and before
+   * `recordTokenMint` on the create-vault handoff. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
   /** Test seam threaded into `provisionVault` so create can be exercised
    * without spawning the real `parachute-vault create` binary. */
   runCommand?: (cmd: readonly string[]) => Promise<{
@@ -591,6 +596,10 @@ export async function handleAccountCreateVault(
     // below tells caller and operator exactly what state the box is in: the
     // vault EXISTS, only the handoff failed.
     try {
+      // Snapshot the users row BEFORE the crypto await (hub#873). A
+      // reset/delete racing sign used to re-fetch after sign and mint with
+      // user_id NULL — a live JWT the account-delete revoke set misses.
+      const subjectUser = getUserById(deps.db, auth.sub);
       const minted = await signAccessToken(deps.db, {
         sub: auth.sub,
         scopes,
@@ -601,7 +610,13 @@ export async function handleAccountCreateVault(
         vaultScope: [entry.name],
         ...(deps.now !== undefined ? { now: deps.now } : {}),
       });
-      const subjectIsUser = getUserById(deps.db, auth.sub) !== null;
+      if (deps.afterSign) {
+        await deps.afterSign({
+          token: minted.token,
+          jti: minted.jti,
+          userId: subjectUser?.id ?? null,
+        });
+      }
       recordTokenMint(deps.db, {
         jti: minted.jti,
         // hub#848: distinct from `cli_mint` — this row is a hub-signed
@@ -609,7 +624,7 @@ export async function handleAccountCreateVault(
         // door stamps, so registry forensics can find both.
         createdVia: "vault_create_handoff",
         subject: auth.sub,
-        ...(subjectIsUser ? { userId: auth.sub } : {}),
+        ...(subjectUser ? { userId: subjectUser.id, userUpdatedAt: subjectUser.updatedAt } : {}),
         clientId,
         scopes,
         expiresAt: minted.expiresAt,

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -59,6 +59,7 @@ import { activePublicSignupPath } from "./invites.ts";
 import { inferAudience } from "./jwt-audience.ts";
 import {
   ACCESS_TOKEN_TTL_SECONDS,
+  TokenMintPrincipalGoneError,
   recordTokenMint,
   signAccessToken,
   validateAccessToken,
@@ -738,8 +739,19 @@ export async function handleAccountMintVaultToken(
 
   const scopes = parsed.scopes;
   const audience = inferAudience(scopes); // → vault.<name>
+  // Person-mint (hub#833): JWT sub must resolve to a users row. Operator
+  // tokens now carry user_id, so a missing user is fail-closed rather than
+  // minting with user_id NULL. Check before signing so a signed JWT is
+  // never minted for a non-user principal.
+  const subjectUser = getUserById(deps.db, ctx.sub);
+  if (!subjectUser) {
+    return json(403, {
+      error: "invalid_subject",
+      message: "bearer subject is not a hub user",
+    });
+  }
   const minted = await signAccessToken(deps.db, {
-    sub: ctx.sub,
+    sub: subjectUser.id,
     scopes,
     audience,
     clientId: ACCOUNT_API_CLIENT_ID,
@@ -748,21 +760,24 @@ export async function handleAccountMintVaultToken(
     vaultScope: [vaultName],
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-  // Registry row so the operator token registry + revocation list attribute it.
-  // Anchor to the subject's user_id only when it names a real user row (an
-  // operator token's `sub` may be the "operator" sentinel, which is not a
-  // `users` row — pass it as `subject` but omit `user_id` to avoid a dangling FK).
-  const subjectIsUser = getUserById(deps.db, ctx.sub) !== null;
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject: ctx.sub,
-    ...(subjectIsUser ? { userId: ctx.sub } : {}),
-    clientId: ACCOUNT_API_CLIENT_ID,
-    scopes,
-    expiresAt: minted.expiresAt,
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: subjectUser.id,
+      userId: subjectUser.id,
+      userUpdatedAt: subjectUser.updatedAt,
+      clientId: ACCOUNT_API_CLIENT_ID,
+      scopes,
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return json(409, { error: "conflict", message: err.message });
+    }
+    throw err;
+  }
 
   return json(200, {
     vault_token: minted.token,

--- a/src/account-vault-admin-token.ts
+++ b/src/account-vault-admin-token.ts
@@ -61,7 +61,7 @@ import type { Database } from "bun:sqlite";
 import { renderAdminError } from "./admin-login-ui.ts";
 import { VAULT_ADMIN_TOKEN_TTL_SECONDS } from "./admin-vault-admin-token.ts";
 import { CSRF_FIELD_NAME, verifyCsrfToken } from "./csrf.ts";
-import { recordTokenMint, signAccessToken } from "./jwt-sign.ts";
+import { TokenMintPrincipalGoneError, recordTokenMint, signAccessToken } from "./jwt-sign.ts";
 import { findActiveSession } from "./sessions.ts";
 import { getUserById, vaultVerbsForUserVault } from "./users.ts";
 import { VAULT_NAME_CHARSET_RE } from "./vault-name.ts";
@@ -87,6 +87,11 @@ export interface AccountVaultAdminTokenDeps {
   managementUrl?: string;
   /** Test seam for the clock (mint). */
   now?: () => Date;
+  /**
+   * Test seam (hub#873): runs after `signAccessToken` and before
+   * `recordTokenMint`. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
@@ -238,19 +243,37 @@ export async function handleAccountVaultAdminTokenPost(
     vaultScope: [vaultName],
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject: user.id,
-    // Anchor the registry row to the user's id so the operator's token registry
-    // + the revocation list attribute it correctly.
-    userId: user.id,
-    clientId: ACCOUNT_VAULT_ADMIN_CLIENT_ID,
-    scopes: [scope],
-    expiresAt: minted.expiresAt,
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  if (deps.afterSign) {
+    await deps.afterSign({ token: minted.token, jti: minted.jti, userId: user.id });
+  }
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: user.id,
+      // Anchor the registry row to the user's id so the operator's token registry
+      // + the revocation list attribute it correctly. Pin updated_at so a
+      // resetUserPassword racing the crypto await cannot land a live row
+      // (hub#873).
+      userId: user.id,
+      userUpdatedAt: user.updatedAt,
+      clientId: ACCOUNT_VAULT_ADMIN_CLIENT_ID,
+      scopes: [scope],
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return htmlResponse(
+        renderAdminError({
+          title: "Could not mint a token",
+          message: err.message,
+        }),
+        409,
+      );
+    }
+    throw err;
+  }
 
   // Build the redirect target: <vault-url>/<managementUrl>#token=<jwt>. The
   // vault URL is the hub-mounted path (`<hubOrigin>/vault/<name>`); the

--- a/src/account-vault-token.ts
+++ b/src/account-vault-token.ts
@@ -71,7 +71,7 @@ import { renderAdminError } from "./admin-login-ui.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
 import { userHasExternalAiGrant } from "./grants.ts";
 import { inferAudience } from "./jwt-audience.ts";
-import { recordTokenMint, signAccessToken } from "./jwt-sign.ts";
+import { TokenMintPrincipalGoneError, recordTokenMint, signAccessToken } from "./jwt-sign.ts";
 import { vaultTokenMintRateLimiter } from "./rate-limit.ts";
 import { findActiveSession } from "./sessions.ts";
 import { isTotpEnrolled } from "./two-factor-store.ts";
@@ -96,6 +96,11 @@ export interface AccountVaultTokenDeps {
   hubOrigin: string;
   /** Test seam for the clock (rate limiter + mint). */
   now?: () => Date;
+  /**
+   * Test seam (hub#873): runs after `signAccessToken` and before
+   * `recordTokenMint`. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 function htmlResponse(body: string, status = 200, extra: Record<string, string> = {}): Response {
@@ -291,20 +296,32 @@ export async function handleAccountVaultTokenPost(
     vaultScope: [vaultName],
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
-
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject: user.id,
-    // Anchor the registry row to the friend's user id so the operator's
-    // token registry + the revocation list attribute it correctly, and a
-    // future per-user revoke surface can find it.
-    userId: user.id,
-    clientId: ACCOUNT_VAULT_TOKEN_CLIENT_ID,
-    scopes: [scope],
-    expiresAt: minted.expiresAt,
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  if (deps.afterSign) {
+    await deps.afterSign({ token: minted.token, jti: minted.jti, userId: user.id });
+  }
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: user.id,
+      // Anchor the registry row to the friend's user id so the operator's
+      // token registry + the revocation list attribute it correctly, and a
+      // future per-user revoke surface can find it. Pin updated_at so a
+      // resetUserPassword racing the crypto await cannot land a live row
+      // (hub#873).
+      userId: user.id,
+      userUpdatedAt: user.updatedAt,
+      clientId: ACCOUNT_VAULT_TOKEN_CLIENT_ID,
+      scopes: [scope],
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return renderHome(409, { mintError: err.message });
+    }
+    throw err;
+  }
 
   return renderHome(200, {
     mintedToken: {

--- a/src/api-account-2fa.ts
+++ b/src/api-account-2fa.ts
@@ -17,6 +17,10 @@
  *                                   → the hub#833 phase-1a linkage ceremony
  *                                     (implementation in
  *                                     `api-account-pubkeys.ts`)
+ *   GET  /api/account/tokens       → this user's tokens (unrevoked default)
+ *   POST /api/account/tokens       → mint as the session user
+ *   POST /api/account/tokens/:jti/revoke
+ *                                   → revoke own jti only (hub#833)
  *
  * Auth posture: every endpoint is **self-service** — it acts on the
  * SIGNED-IN user's OWN account (`session.userId`), never a client-supplied
@@ -45,6 +49,7 @@ import type { Database } from "bun:sqlite";
 import { hash as argonHash } from "@node-rs/argon2";
 import QRCode from "qrcode";
 import { handleAccountPubkeys } from "./api-account-pubkeys.ts";
+import { handleAccountTokens } from "./api-account-tokens.ts";
 import { verifyCsrfToken } from "./csrf.ts";
 import { changePasswordRateLimiter, totpEnrollConfirmRateLimiter } from "./rate-limit.ts";
 import { findActiveSession } from "./sessions.ts";
@@ -72,6 +77,11 @@ export interface ApiAccount2faDeps {
    * event's `u` tag to one of them. See `AccountPubkeysDeps.hubBoundOrigins`.
    */
   hubBoundOrigins?: readonly string[];
+  /**
+   * Hub origin — `iss` of tokens minted on `POST /api/account/tokens`.
+   * Production always passes it; tests that don't mint may omit it.
+   */
+  issuer?: string;
   /** Test seam — defaults to the real clock. */
   now?: () => Date;
 }
@@ -154,10 +164,10 @@ function passwordRateLimit(userId: string, now: () => Date): Response | null {
  *
  * The 2FA + password routes are POST-only (all state-changing); the read-side
  * 2FA status the SPA renders comes from `/api/me`'s `two_factor_enabled`
- * field. The `/pubkeys` sub-surface (hub#833) is the one exception — it has a
- * read route — so it is dispatched BEFORE the POST-only gate and owns its own
- * method handling. The gate is left in place verbatim for the pre-existing
- * routes so their "405 before the session check" behavior is unchanged.
+ * field. `/pubkeys` and `/tokens` (hub#833) have GET routes, so they are
+ * dispatched BEFORE the POST-only gate and own their own method handling.
+ * The gate is left in place verbatim for the pre-existing routes so their
+ * "405 before the session check" behavior is unchanged.
  */
 export async function handleApiAccount(
   req: Request,
@@ -181,6 +191,24 @@ export async function handleApiAccount(
       subpath.slice("/pubkeys".length),
       { id: pubkeyGate.user.id, username: pubkeyGate.user.username },
       pubkeyBody,
+      deps,
+    );
+  }
+
+  // Self-service tokens (hub#833). Same session + CSRF posture as /pubkeys;
+  // GET is the list, so this is dispatched BEFORE the POST-only gate.
+  if (subpath === "/tokens" || subpath.startsWith("/tokens/")) {
+    const tokensGate = requireUser(deps.db, req);
+    if (!tokensGate.ok) return tokensGate.res;
+    const tokensBody = req.method === "GET" ? {} : await readJsonBody(req);
+    if (req.method !== "GET" && !checkCsrf(req, tokensBody)) {
+      return jsonError(403, "csrf_failed", "missing or invalid CSRF token");
+    }
+    return handleAccountTokens(
+      req,
+      subpath.slice("/tokens".length),
+      tokensGate.user,
+      tokensBody,
       deps,
     );
   }

--- a/src/api-account-2fa.ts
+++ b/src/api-account-2fa.ts
@@ -17,7 +17,8 @@
  *                                   → the hub#833 phase-1a linkage ceremony
  *                                     (implementation in
  *                                     `api-account-pubkeys.ts`)
- *   GET  /api/account/tokens       → this user's tokens (unrevoked default)
+ *   GET  /api/account/tokens       → this user's tokens (unrevoked default;
+ *                                     `?cursor=` pages 50; `next_cursor`)
  *   POST /api/account/tokens       → mint as the session user
  *   POST /api/account/tokens/:jti/revoke
  *                                   → revoke own jti only (hub#833)

--- a/src/api-account-tokens.ts
+++ b/src/api-account-tokens.ts
@@ -1,0 +1,280 @@
+/**
+ * `/api/account/tokens*` — self-service token list / mint / revoke (hub#833).
+ *
+ * Mounted under `/api/account/*` (`api-account-2fa.ts` routes here), so it
+ * inherits that surface's posture:
+ *
+ *   1. session cookie (else 401) — identity from `session.userId`, never a
+ *      client-supplied user id.
+ *   2. CSRF double-submit `__csrf` on every mutation (else 403).
+ *   3. same-origin belt, applied by the hub-server dispatcher before we run.
+ *
+ * Routes (`subpath` is relative to `/api/account/tokens`):
+ *
+ *   GET  ""                 → this user's tokens (unrevoked default;
+ *                             `?revoked=all|true|false`)
+ *   POST ""                 → mint as the session user
+ *   POST "/:jti/revoke"     → revoke own jti only; 404 if not yours
+ *                             (no cross-account existence oracle)
+ *
+ * Operator `/api/auth/tokens` and `/admin/tokens` stay the operator
+ * registry. This surface is how a non-operator actually mints without
+ * the operator bearer. Attenuation is a subset of THEIR authority
+ * (assigned-vault verbs; first-admin requestable scopes). Nobody can
+ * mint `parachute:host:*` here.
+ *
+ * Reuses `signAccessToken` + `recordTokenMint` + assigned-vault
+ * authority. No second mint stack.
+ */
+import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULT_TOKEN_TTL_SECONDS } from "./account-home-ui.ts";
+import { inferAudience } from "./jwt-audience.ts";
+import {
+  TokenMintPrincipalGoneError,
+  findTokenRowByJti,
+  listTokens,
+  recordTokenMint,
+  revokeTokenByJti,
+  signAccessToken,
+} from "./jwt-sign.ts";
+import { vaultTokenMintRateLimiter } from "./rate-limit.ts";
+import {
+  isNonRequestableScope,
+  isWellFormedOrNonVaultScope,
+  vaultScopeName,
+} from "./scope-explanations.ts";
+import { type User, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
+
+export interface AccountTokensDeps {
+  db: Database;
+  /** Hub origin — `iss` of minted tokens. Required on POST mint. */
+  issuer?: string;
+  now?: () => Date;
+}
+
+const ACCOUNT_TOKENS_CLIENT_ID = "parachute-account";
+const MAX_TTL_SECONDS = 365 * 24 * 60 * 60;
+const REVOKE_PATH = /^\/([^/]+)\/revoke$/;
+
+function json(status: number, body: unknown, extra: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", "cache-control": "no-store", ...extra },
+  });
+}
+
+function jsonError(status: number, error: string, description: string): Response {
+  return json(status, { error, error_description: description });
+}
+
+/**
+ * Can this session user mint `requestedScope` on the self-service surface?
+ * First admin: any requestable scope except `parachute:host:*`. Friend:
+ * `vault:<assigned>:<verb>` they hold. Nobody mints host operator scopes
+ * here — those stay on `/api/auth/mint-token`.
+ */
+export function canAccountSelfMint(db: Database, user: User, scope: string): boolean {
+  if (scope.toLowerCase().startsWith("parachute:host:")) return false;
+  if (isFirstAdmin(db, user.id)) return !isNonRequestableScope(scope);
+  const name = vaultScopeName(scope);
+  if (name === null) return false;
+  const verb = scope.split(":")[2];
+  if (!verb) return false;
+  const held = vaultVerbsForUserVault(db, user.id, name);
+  return held !== null && (held as readonly string[]).includes(verb);
+}
+
+function hasAccountMintAuthority(db: Database, user: User): boolean {
+  if (isFirstAdmin(db, user.id)) return true;
+  return user.assignedVaults.some((name) => {
+    const held = vaultVerbsForUserVault(db, user.id, name);
+    return held !== null && held.length > 0;
+  });
+}
+
+/**
+ * Router. `subpath` is relative to `/api/account/tokens` ("" for the
+ * collection). The caller (`handleApiAccount`) has already established the
+ * session and, for POSTs, the CSRF token.
+ */
+export async function handleAccountTokens(
+  req: Request,
+  subpath: string,
+  user: User,
+  body: Record<string, unknown>,
+  deps: AccountTokensDeps,
+): Promise<Response> {
+  if (req.method === "GET") {
+    if (subpath !== "") return jsonError(404, "not_found", "no account route at that path");
+    return handleList(req, user, deps);
+  }
+  if (req.method !== "POST") {
+    return jsonError(405, "method_not_allowed", "use GET or POST");
+  }
+  if (subpath === "") return handleMint(req, user, body, deps);
+  const revoke = REVOKE_PATH.exec(subpath);
+  if (revoke) return handleRevoke(user, revoke[1]!, deps);
+  return jsonError(404, "not_found", `no account route at /api/account/tokens${subpath}`);
+}
+
+function handleList(req: Request, user: User, deps: AccountTokensDeps): Response {
+  const url = new URL(req.url);
+  const raw = url.searchParams.get("revoked") ?? "false";
+  if (raw !== "true" && raw !== "false" && raw !== "all") {
+    return jsonError(400, "invalid_request", "revoked must be true, false, or all");
+  }
+  const page = listTokens(deps.db, { filter: { userId: user.id, revoked: raw } });
+  return json(200, {
+    tokens: page.rows.map((row) => ({
+      jti: row.jti,
+      user_id: row.userId,
+      subject: row.subject,
+      client_id: row.clientId,
+      scopes: row.scopes,
+      expires_at: row.expiresAt,
+      revoked_at: row.revokedAt,
+      created_at: row.createdAt,
+      created_via: row.createdVia,
+      subject_pubkey: row.subjectPubkey,
+    })),
+  });
+}
+
+async function handleMint(
+  _req: Request,
+  user: User,
+  body: Record<string, unknown>,
+  deps: AccountTokensDeps,
+): Promise<Response> {
+  if (!deps.issuer) {
+    return jsonError(500, "server_error", "hub issuer is not configured");
+  }
+  if (!user.passwordChanged) {
+    return jsonError(
+      403,
+      "password_change_required",
+      "change your password before minting a token",
+    );
+  }
+  if (!hasAccountMintAuthority(deps.db, user)) {
+    return jsonError(
+      403,
+      "insufficient_scope",
+      "this account holds no minting authority (no assigned vaults)",
+    );
+  }
+  if (typeof body.scope !== "string" || body.scope.trim().length === 0) {
+    return jsonError(400, "invalid_request", "scope is required and must be a non-empty string");
+  }
+  const scopes = body.scope.split(/\s+/).filter((s) => s.length > 0);
+  if (scopes.length === 0) {
+    return jsonError(400, "invalid_request", "scope must contain at least one scope");
+  }
+  const malformed = scopes.filter((s) => !isWellFormedOrNonVaultScope(s));
+  if (malformed.length > 0) {
+    return jsonError(
+      400,
+      "invalid_scope",
+      `malformed vault scope ${malformed.join(", ")}; expected vault:<name>:<read|write|admin>`,
+    );
+  }
+  const blocked = scopes.filter((s) => !canAccountSelfMint(deps.db, user, s));
+  if (blocked.length > 0) {
+    return jsonError(
+      400,
+      "invalid_scope",
+      `scope ${blocked.join(", ")} is not grantable by this account`,
+    );
+  }
+
+  let ttlSeconds = ACCOUNT_VAULT_TOKEN_TTL_SECONDS;
+  if (body.expires_in !== undefined) {
+    if (
+      typeof body.expires_in !== "number" ||
+      !Number.isInteger(body.expires_in) ||
+      body.expires_in <= 0
+    ) {
+      return jsonError(400, "invalid_request", "expires_in must be a positive integer (seconds)");
+    }
+    if (body.expires_in > MAX_TTL_SECONDS) {
+      return jsonError(
+        400,
+        "invalid_request",
+        `expires_in exceeds 365d cap (${MAX_TTL_SECONDS} seconds)`,
+      );
+    }
+    ttlSeconds = body.expires_in;
+  }
+
+  let label: string = user.id;
+  if (body.label !== undefined) {
+    if (typeof body.label !== "string" || body.label.length === 0) {
+      return jsonError(400, "invalid_request", "label must be a non-empty string when present");
+    }
+    label = body.label;
+  }
+
+  const now = deps.now ?? (() => new Date());
+  const gate = vaultTokenMintRateLimiter.checkAndRecord(user.id, now());
+  if (!gate.allowed) {
+    const retryAfter = gate.retryAfterSeconds ?? 1;
+    return json(
+      429,
+      {
+        error: "too_many_attempts",
+        error_description: `Too many token-mint attempts. Try again in ${retryAfter} seconds.`,
+      },
+      { "retry-after": String(retryAfter) },
+    );
+  }
+
+  const vaultScopePin = [
+    ...new Set(scopes.map((s) => vaultScopeName(s)).filter((n): n is string => n !== null)),
+  ];
+  const minted = await signAccessToken(deps.db, {
+    sub: user.id,
+    scopes,
+    audience: inferAudience(scopes),
+    clientId: ACCOUNT_TOKENS_CLIENT_ID,
+    issuer: deps.issuer,
+    ttlSeconds,
+    vaultScope: vaultScopePin,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+  });
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: label,
+      userId: user.id,
+      userUpdatedAt: user.updatedAt,
+      clientId: ACCOUNT_TOKENS_CLIENT_ID,
+      scopes,
+      expiresAt: minted.expiresAt,
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return jsonError(409, "conflict", err.message);
+    }
+    throw err;
+  }
+
+  return json(200, {
+    jti: minted.jti,
+    token: minted.token,
+    expires_at: minted.expiresAt,
+    scope: scopes.join(" "),
+  });
+}
+
+function handleRevoke(user: User, jti: string, deps: AccountTokensDeps): Response {
+  const row = findTokenRowByJti(deps.db, jti);
+  // Same 404 for "not yours" and "does not exist" — no cross-account oracle.
+  if (!row || row.userId !== user.id) {
+    return jsonError(404, "not_found", "no token with that jti");
+  }
+  const now = deps.now?.() ?? new Date();
+  if (!row.revokedAt) revokeTokenByJti(deps.db, jti, now);
+  return json(200, { revoked: true, jti });
+}

--- a/src/api-account-tokens.ts
+++ b/src/api-account-tokens.ts
@@ -12,7 +12,8 @@
  * Routes (`subpath` is relative to `/api/account/tokens`):
  *
  *   GET  ""                 → this user's tokens (unrevoked default;
- *                             `?revoked=all|true|false`)
+ *                             `?revoked=all|true|false`; `?cursor=` pages;
+ *                             page size 50, `next_cursor` when more)
  *   POST ""                 → mint as the session user
  *   POST "/:jti/revoke"     → revoke own jti only; 404 if not yours
  *                             (no cross-account existence oracle)
@@ -123,7 +124,11 @@ function handleList(req: Request, user: User, deps: AccountTokensDeps): Response
   if (raw !== "true" && raw !== "false" && raw !== "all") {
     return jsonError(400, "invalid_request", "revoked must be true, false, or all");
   }
-  const page = listTokens(deps.db, { filter: { userId: user.id, revoked: raw } });
+  const cursor = url.searchParams.get("cursor");
+  const page = listTokens(deps.db, {
+    filter: { userId: user.id, revoked: raw },
+    ...(cursor ? { cursor } : {}),
+  });
   return json(200, {
     tokens: page.rows.map((row) => ({
       jti: row.jti,
@@ -137,6 +142,7 @@ function handleList(req: Request, user: User, deps: AccountTokensDeps): Response
       created_via: row.createdVia,
       subject_pubkey: row.subjectPubkey,
     })),
+    next_cursor: page.nextCursor,
   });
 }
 

--- a/src/api-mint-token.ts
+++ b/src/api-mint-token.ts
@@ -46,7 +46,12 @@
  */
 import type { Database } from "bun:sqlite";
 import { inferAudience } from "./jwt-audience.ts";
-import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import {
+  TokenMintPrincipalGoneError,
+  recordTokenMint,
+  signAccessToken,
+  validateAccessToken,
+} from "./jwt-sign.ts";
 import {
   MINT_HOST_ADMIN_SCOPE,
   MINT_HOST_AUTH_SCOPE,
@@ -59,6 +64,7 @@ import {
   isWellFormedOrNonVaultScope,
   vaultScopeName,
 } from "./scope-explanations.ts";
+import { getUserById, resolveUser } from "./users.ts";
 
 // Re-export `canGrant` so existing importers (and the symmetric revoke path)
 // have a single name to reach for; the implementation lives in the shared
@@ -115,13 +121,25 @@ export interface ApiMintTokenDeps {
   knownVaultNames?: ReadonlySet<string>;
   /** Test seam for time. */
   now?: () => Date;
+  /**
+   * Test seam (hub#833): runs after `signAccessToken` and before
+   * `recordTokenMint`. The CAS insert is what keeps a signed JWT from
+   * leaking when the target account vanishes during the crypto await;
+   * this hook is how the race test deletes / resets the user in that
+   * window. Production callers omit it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 interface MintTokenRequest {
   scope?: unknown;
   audience?: unknown;
   expires_in?: unknown;
+  /** @deprecated Use `label` (display) or `user` (account principal). */
   subject?: unknown;
+  label?: unknown;
+  user?: unknown;
+  service?: unknown;
   permissions?: unknown;
 }
 
@@ -313,28 +331,111 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     ttlSeconds = body.expires_in;
   }
 
-  let subject: string;
-  if (body.subject === undefined) {
-    subject = bearerSub;
-  } else if (typeof body.subject === "string" && body.subject.length > 0) {
-    // Subject override is an OPERATOR-only capability (audit-attribution
-    // forgery otherwise). A host operator (`parachute:host:auth` /
-    // `parachute:host:admin`) may stamp a service-account `sub` other than its
-    // own — the documented service-account override. A merely vault-scoped
-    // bearer (`vault:<N>:admin` only, no host authority) has no business
-    // forging the minted token's subject: it would let a vault admin mint a
-    // token the registry + revocation list attribute to a foreign subject. So
-    // a non-operator bearer may only mint tokens carrying its OWN `sub`.
-    if (!isOperatorBearer(bearerScopes) && body.subject !== bearerSub) {
+  // Identity (hub#833): person-mint JWT `sub` is always `users.id`.
+  // `tokens.subject` is a display label. `subject` (body) is a deprecated
+  // alias of `label`, unless the value matches a hub account — then it is
+  // treated as `user` (one-release back-compat). Never silently mint a
+  // fake principal.
+  const warnings: string[] = [];
+  const asNonEmpty = (v: unknown): string | null =>
+    typeof v === "string" && v.length > 0 ? v : null;
+
+  const readOptional = (
+    value: unknown,
+    present: boolean,
+    field: string,
+  ): { ok: true; value: string | null } | { ok: false; res: Response } => {
+    if (!present) return { ok: true, value: null };
+    const parsed = asNonEmpty(value);
+    if (parsed === null) {
+      return {
+        ok: false,
+        res: jsonError(400, "invalid_request", `${field} must be a non-empty string when present`),
+      };
+    }
+    return { ok: true, value: parsed };
+  };
+  const labelField = readOptional(body.label, body.label !== undefined, "label");
+  if (!labelField.ok) return labelField.res;
+  const userField = readOptional(body.user, body.user !== undefined, "user");
+  if (!userField.ok) return userField.res;
+  const serviceField = readOptional(body.service, body.service !== undefined, "service");
+  if (!serviceField.ok) return serviceField.res;
+  const subjectField = readOptional(body.subject, body.subject !== undefined, "subject");
+  if (!subjectField.ok) return subjectField.res;
+
+  if (userField.value && serviceField.value) {
+    return jsonError(400, "invalid_request", "pass user OR service, not both");
+  }
+
+  let asUser = userField.value;
+  const asService = serviceField.value;
+  let asLabel = labelField.value;
+  if (subjectField.value !== null) {
+    if (asUser || asService || asLabel) {
+      return jsonError(
+        400,
+        "invalid_request",
+        "`subject` is deprecated; pass `user`, `label`, or `service` instead (not together with `subject`)",
+      );
+    }
+    const matched = resolveUser(deps.db, subjectField.value);
+    if (matched) {
+      warnings.push(
+        "`subject` is deprecated; treating as `user` because it matches a hub account. JWT sub is the account id.",
+      );
+      asUser = matched.id;
+    } else {
+      warnings.push(
+        "`subject` is deprecated; treating as `label`. JWT sub stays the bearer account id.",
+      );
+      asLabel = subjectField.value;
+    }
+  }
+
+  let jwtSub: string;
+  let mintUserId: string | null = null;
+  let mintUserUpdatedAt: string | undefined;
+  let subjectLabel: string;
+  if (asService) {
+    if (!isOperatorBearer(bearerScopes)) {
       return jsonError(
         403,
         "insufficient_scope",
-        "non-operator bearers may not override subject; omit `subject` to mint under your own identity",
+        "non-operator bearers may not mint a service principal; omit `service` to mint under your own account",
       );
     }
-    subject = body.subject;
+    jwtSub = asService;
+    subjectLabel = asLabel ?? asService;
+  } else if (asUser) {
+    const target = resolveUser(deps.db, asUser);
+    if (!target) {
+      return jsonError(400, "invalid_request", `no hub account matching user "${asUser}"`);
+    }
+    if (!isOperatorBearer(bearerScopes) && target.id !== bearerSub) {
+      return jsonError(
+        403,
+        "insufficient_scope",
+        "non-operator bearers may not mint as another account; omit `user` to mint under your own identity",
+      );
+    }
+    jwtSub = target.id;
+    mintUserId = target.id;
+    mintUserUpdatedAt = target.updatedAt;
+    subjectLabel = asLabel ?? target.id;
   } else {
-    return jsonError(400, "invalid_request", "subject must be a non-empty string when present");
+    const bearerUser = getUserById(deps.db, bearerSub);
+    if (!bearerUser) {
+      return jsonError(
+        401,
+        "unauthenticated",
+        "bearer subject is not a hub user; person-mint requires a users.id principal",
+      );
+    }
+    jwtSub = bearerUser.id;
+    mintUserId = bearerUser.id;
+    mintUserUpdatedAt = bearerUser.updatedAt;
+    subjectLabel = asLabel ?? bearerUser.id;
   }
 
   let permissionsClaim: Record<string, unknown> | undefined;
@@ -385,9 +486,12 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
   }
   const vaultScopePin = [...vaultScopePinSet];
 
-  // 6. Mint + register.
+  // 6. Mint + register. Person-mint JWT sub is users.id; service mint uses
+  // the service name. Registry insert for person-mints is a CAS against the
+  // users row (hub#833) so a delete/reset racing the crypto await cannot
+  // land a live unregistered JWT.
   const minted = await signAccessToken(deps.db, {
-    sub: subject,
+    sub: jwtSub,
     scopes,
     audience,
     clientId: API_MINT_TOKEN_CLIENT_ID,
@@ -406,20 +510,30 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
     ...(deps.now !== undefined ? { now: deps.now } : {}),
   });
 
-  recordTokenMint(deps.db, {
-    jti: minted.jti,
-    createdVia: "cli_mint",
-    subject,
-    // user_id intentionally omitted — CLI-mint rows store subject only,
-    // matching the CLI path's shape (so HTTP and CLI mints look identical
-    // in the registry). The bearer's user identity is implicit via the
-    // bearer's own user_id (which is in its own tokens row).
-    clientId: API_MINT_TOKEN_CLIENT_ID,
-    scopes,
-    expiresAt: minted.expiresAt,
-    ...(permissionsCanonical !== undefined ? { permissions: permissionsCanonical } : {}),
-    ...(deps.now !== undefined ? { now: deps.now } : {}),
-  });
+  if (deps.afterSign) {
+    await deps.afterSign({ token: minted.token, jti: minted.jti, userId: mintUserId });
+  }
+
+  try {
+    recordTokenMint(deps.db, {
+      jti: minted.jti,
+      createdVia: "cli_mint",
+      subject: subjectLabel,
+      ...(mintUserId
+        ? { userId: mintUserId, ...(mintUserUpdatedAt ? { userUpdatedAt: mintUserUpdatedAt } : {}) }
+        : {}),
+      clientId: API_MINT_TOKEN_CLIENT_ID,
+      scopes,
+      expiresAt: minted.expiresAt,
+      ...(permissionsCanonical !== undefined ? { permissions: permissionsCanonical } : {}),
+      ...(deps.now !== undefined ? { now: deps.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return jsonError(409, "conflict", err.message);
+    }
+    throw err;
+  }
 
   return new Response(
     JSON.stringify({
@@ -428,6 +542,7 @@ export async function handleApiMintToken(req: Request, deps: ApiMintTokenDeps): 
       expires_at: minted.expiresAt,
       scope: scopes.join(" "),
       ...(permissionsClaim !== undefined ? { permissions: permissionsClaim } : {}),
+      ...(warnings.length > 0 ? { warnings } : {}),
     }),
     {
       status: 200,

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -40,6 +40,7 @@ import { openHubDb } from "../hub-db.ts";
 import { resolveHubIssuer } from "../hub-issuer.ts";
 import { inferAudience } from "../jwt-audience.ts";
 import {
+  TokenMintPrincipalGoneError,
   findTokenRowByJti,
   recordTokenMint,
   revokeTokenByJti,
@@ -69,8 +70,10 @@ import {
   SingleUserModeError,
   UsernameTakenError,
   createUser,
+  getUserById,
   getUserByUsername,
   listUsers,
+  resolveUser,
   setPassword,
   userCount,
 } from "../users.ts";
@@ -131,13 +134,19 @@ Usage:
                                        default admin)
   parachute auth mint-token --scope <scope> [--aud <aud>]
                                             [--ephemeral | --expires-in <seconds>]
-                                            [--sub <sub>] [--permissions <json>]
-                                       Mint a scope-narrow JWT against the
-                                       operator's identity (stdout = JWT).
-                                       --ephemeral = short-lived (1h), ideal for
-                                       scripting; default lifetime is 90d.
-                                       --ttl <duration> is the deprecated
-                                       alias (use --expires-in seconds).
+                                            [--label <label>] [--user <username|id>]
+                                            [--service <name>] [--permissions <json>]
+                                       Mint a scope-narrow JWT. Person-mint
+                                       JWT sub is the hub account id (stdout =
+                                       JWT). --label is the display label
+                                       (tokens.subject). --user (operator)
+                                       mints as that account. --service mints
+                                       a non-account principal. --sub is the
+                                       deprecated alias of --label (or --user
+                                       when the value matches an account).
+                                       --ephemeral = short-lived (1h); default
+                                       lifetime is 90d. --ttl is the deprecated
+                                       lifetime alias.
   parachute auth revoke-token <jti>    Mark a registry-row token revoked
                                        by jti. Idempotent: a re-revoke
                                        prints the existing revoked_at and
@@ -302,6 +311,11 @@ export interface AuthDeps {
    * for `PARACHUTE_HUB_ORIGIN` so the token's iss matches what services see.
    */
   hubOrigin?: string;
+  /**
+   * Test seam (hub#833): runs after `signAccessToken` and before
+   * `recordTokenMint` on `mint-token`. Production omits it.
+   */
+  afterSign?: (ctx: { token: string; jti: string; userId: string | null }) => void | Promise<void>;
 }
 
 function defaultRotateKey(): { kid: string; createdAt: string } {
@@ -978,7 +992,11 @@ interface MintTokenFlags {
   aud?: string;
   ttl?: string;
   expiresIn?: string;
+  /** @deprecated Use --label or --user. */
   sub?: string;
+  label?: string;
+  user?: string;
+  service?: string;
   permissions?: string;
   /** True when --ttl was used (deprecated alias). Triggers a one-line stderr warning. */
   ttlDeprecationSeen?: boolean;
@@ -993,6 +1011,9 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
   let ttl: string | undefined;
   let expiresIn: string | undefined;
   let sub: string | undefined;
+  let label: string | undefined;
+  let user: string | undefined;
+  let service: string | undefined;
   let permissions: string | undefined;
   let ttlDeprecationSeen = false;
   let ephemeral = false;
@@ -1035,6 +1056,27 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
     } else if (a?.startsWith("--sub=")) {
       sub = a.slice("--sub=".length);
       if (!sub) return { error: "--sub requires a value" };
+    } else if (a === "--label") {
+      const v = args[++i];
+      if (!v) return { error: "--label requires a value" };
+      label = v;
+    } else if (a?.startsWith("--label=")) {
+      label = a.slice("--label=".length);
+      if (!label) return { error: "--label requires a value" };
+    } else if (a === "--user") {
+      const v = args[++i];
+      if (!v) return { error: "--user requires a value" };
+      user = v;
+    } else if (a?.startsWith("--user=")) {
+      user = a.slice("--user=".length);
+      if (!user) return { error: "--user requires a value" };
+    } else if (a === "--service") {
+      const v = args[++i];
+      if (!v) return { error: "--service requires a value" };
+      service = v;
+    } else if (a?.startsWith("--service=")) {
+      service = a.slice("--service=".length);
+      if (!service) return { error: "--service requires a value" };
     } else if (a === "--permissions") {
       const v = args[++i];
       if (!v) return { error: "--permissions requires a value" };
@@ -1056,7 +1098,28 @@ function parseMintTokenFlags(args: readonly string[]): MintTokenFlags {
       error: "pass --ephemeral OR an explicit lifetime (--expires-in/--ttl), not both",
     };
   }
-  return { scope, aud, ttl, expiresIn, sub, permissions, ttlDeprecationSeen, ephemeral };
+  if (user !== undefined && service !== undefined) {
+    return { error: "pass --user OR --service, not both" };
+  }
+  if (sub !== undefined && (label !== undefined || user !== undefined || service !== undefined)) {
+    return {
+      error:
+        "--sub is deprecated; pass --user, --label, or --service instead (not together with --sub)",
+    };
+  }
+  return {
+    scope,
+    aud,
+    ttl,
+    expiresIn,
+    sub,
+    label,
+    user,
+    service,
+    permissions,
+    ttlDeprecationSeen,
+    ephemeral,
+  };
 }
 
 const MINT_TOKEN_TTL_DEFAULT_SECONDS = 90 * 24 * 60 * 60;
@@ -1119,7 +1182,7 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
   if (!flags.scope) {
     console.error("parachute auth mint-token: --scope is required");
     console.error(
-      "usage: parachute auth mint-token --scope <scope> [--aud <aud>] [--ephemeral | --expires-in <seconds>] [--sub <sub>] [--permissions <json>]",
+      "usage: parachute auth mint-token --scope <scope> [--aud <aud>] [--ephemeral | --expires-in <seconds>] [--label <label>] [--user <username|id>] [--service <name>] [--permissions <json>]",
     );
     return 1;
   }
@@ -1257,11 +1320,59 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
     }
 
     const audience = flags.aud ?? inferAudience(scopes);
-    const subjectForMint = flags.sub ?? operatorSub;
     const permissionsClaim = permissions !== undefined ? JSON.parse(permissions) : undefined;
 
+    let asUser = flags.user;
+    const asService = flags.service;
+    let asLabel = flags.label;
+    if (flags.sub) {
+      const matched = resolveUser(db, flags.sub);
+      if (matched) {
+        console.error(
+          "parachute auth mint-token: --sub is deprecated; treating as --user because it matches a hub account. JWT sub is the account id.",
+        );
+        asUser = matched.id;
+      } else {
+        console.error(
+          "parachute auth mint-token: --sub is deprecated; treating as --label. JWT sub stays the bearer account id.",
+        );
+        asLabel = flags.sub;
+      }
+    }
+
+    let jwtSub: string;
+    let mintUserId: string | null = null;
+    let mintUserUpdatedAt: string | undefined;
+    let subjectLabel: string;
+    if (asService) {
+      jwtSub = asService;
+      subjectLabel = asLabel ?? asService;
+    } else if (asUser) {
+      const target = resolveUser(db, asUser);
+      if (!target) {
+        console.error(`parachute auth mint-token: no hub account matching --user "${asUser}"`);
+        return 1;
+      }
+      jwtSub = target.id;
+      mintUserId = target.id;
+      mintUserUpdatedAt = target.updatedAt;
+      subjectLabel = asLabel ?? target.id;
+    } else {
+      const bearerUser = getUserById(db, operatorSub);
+      if (!bearerUser) {
+        console.error(
+          "parachute auth mint-token: operator token sub is not a hub user; person-mint requires a users.id principal",
+        );
+        return 1;
+      }
+      jwtSub = bearerUser.id;
+      mintUserId = bearerUser.id;
+      mintUserUpdatedAt = bearerUser.updatedAt;
+      subjectLabel = asLabel ?? bearerUser.id;
+    }
+
     const minted = await signAccessToken(db, {
-      sub: subjectForMint,
+      sub: jwtSub,
       scopes,
       audience,
       clientId: OPERATOR_TOKEN_CLIENT_ID,
@@ -1271,20 +1382,37 @@ async function runMintToken(args: readonly string[], deps: AuthDeps): Promise<nu
       ...(permissionsClaim !== undefined ? { extraClaims: { permissions: permissionsClaim } } : {}),
     });
 
-    // Write a registry row (hub#212 Phase 1). Powers the revocation list
-    // endpoint and admin UI introspection. Per design: CLI-mint rows have
-    // user_id NULL; the subject column carries the chosen mint subject
-    // (--sub overrides operator-sub). The JWT is its own access token,
-    // not a refresh token, so refresh_token_hash + family_id stay NULL.
-    recordTokenMint(db, {
-      jti: minted.jti,
-      createdVia: "cli_mint",
-      subject: subjectForMint,
-      clientId: OPERATOR_TOKEN_CLIENT_ID,
-      scopes,
-      expiresAt: minted.expiresAt,
-      ...(permissions !== undefined ? { permissions } : {}),
-    });
+    if (deps.afterSign) {
+      await deps.afterSign({ token: minted.token, jti: minted.jti, userId: mintUserId });
+    }
+
+    // Write a registry row (hub#212 Phase 1 / hub#833). Person-mint JWT
+    // sub is users.id and user_id is set; tokens.subject is the display
+    // label. Service mints leave user_id NULL. The JWT is its own access
+    // token, so refresh_token_hash + family_id stay NULL.
+    try {
+      recordTokenMint(db, {
+        jti: minted.jti,
+        createdVia: "cli_mint",
+        subject: subjectLabel,
+        ...(mintUserId
+          ? {
+              userId: mintUserId,
+              ...(mintUserUpdatedAt ? { userUpdatedAt: mintUserUpdatedAt } : {}),
+            }
+          : {}),
+        clientId: OPERATOR_TOKEN_CLIENT_ID,
+        scopes,
+        expiresAt: minted.expiresAt,
+        ...(permissions !== undefined ? { permissions } : {}),
+      });
+    } catch (err) {
+      if (err instanceof TokenMintPrincipalGoneError) {
+        console.error(`parachute auth mint-token: ${err.message}`);
+        return 1;
+      }
+      throw err;
+    }
 
     console.log(minted.token);
     return 0;

--- a/src/commands/expose-supervisor.ts
+++ b/src/commands/expose-supervisor.ts
@@ -237,6 +237,11 @@ export async function restartHubDependentViaSupervisor(args: {
       });
       if (status.kind === "rotated") {
         log(`  refreshed operator.token issuer → ${hubOrigin} (was stale after exposure)`);
+      } else if (status.kind === "skipped") {
+        // Name the cause so a legacy `"operator"` sentinel / deleted-user
+        // sub is visible (`skipped: sub-not-user`) rather than a catch-all
+        // try-wrap. Other skip reasons (aud-mismatch, no-sub, …) too.
+        log(`  note: operator.token issuer self-heal skipped: ${status.reason}`);
       }
     } catch (err) {
       // A self-heal failure must never block the restart — degrade to a note.

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -9,7 +9,9 @@
  * multi-use public-signup links + email-as-username + the `vault_caps`
  * per-vault storage-cap table), and Nostr-pubkey ↔ user linkage plus the
  * additive `tokens.subject_pubkey` attribution snapshot (v17, hub#833
- * phase 1), and the durable attribution proof archive (v18, hub#860).
+ * phase 1), the durable attribution proof archive (v18, hub#860), and a
+ * live `tokens.user_id` backfill where `subject` already equals a
+ * `users.id` (v19, hub#833 per-account mint).
  *
  * Each open() runs `migrate()` to bring the schema up to date. A
  * `schema_version` table records every applied migration so re-opens are
@@ -691,6 +693,21 @@ const MIGRATIONS: readonly Migration[] = [
         (subject, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at)
       SELECT user_id, pubkey, label, proof_event, proof_event_id, linked_at, last_verified_at
       FROM user_pubkeys;
+    `,
+  },
+  {
+    version: 19,
+    sql: `
+      -- Backfill tokens.user_id where subject already is a users.id (hub#833).
+      -- Person-mints going forward always set user_id; this recovers live
+      -- rows whose subject was the account id. Leave the rest grandfathered
+      -- (operator/service labels, friend-named strings). Do not rewrite
+      -- already-issued JWTs — they expire / rotate.
+      UPDATE tokens
+         SET user_id = subject
+       WHERE user_id IS NULL
+         AND subject IS NOT NULL
+         AND EXISTS (SELECT 1 FROM users WHERE id = tokens.subject);
     `,
   },
 ];

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -107,7 +107,7 @@
  *   /api/account/pubkeys/challenge (POST)      → mint a single-use, user-bound linkage challenge + the event template to sign (cookie-gated; CSRF)
  *   /api/account/pubkeys/verify   (POST)       → present a signed NIP-01 (kind 27235) event; verify BIP-340 possession + consume the challenge → link (cookie-gated; CSRF)
  *   /api/account/pubkeys/unlink   (POST)       → drop one of the caller's own links (cookie-gated; CSRF; does NOT rewrite tokens.subject_pubkey history)
- *   /api/account/tokens           (GET)        → this user's tokens (cookie-gated; self-only; unrevoked default, ?revoked=all|true|false) — hub#833
+ *   /api/account/tokens           (GET)        → this user's tokens (cookie-gated; self-only; unrevoked default, ?revoked=all|true|false, ?cursor= pages 50, next_cursor) — hub#833
  *   /api/account/tokens           (POST)       → mint as session user (cookie-gated; CSRF; self-only; cannot mint parachute:host:*) — hub#833
  *   /api/account/tokens/:jti/revoke (POST)     → revoke own jti only (cookie-gated; CSRF; 404 if not yours) — hub#833
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -107,6 +107,9 @@
  *   /api/account/pubkeys/challenge (POST)      → mint a single-use, user-bound linkage challenge + the event template to sign (cookie-gated; CSRF)
  *   /api/account/pubkeys/verify   (POST)       → present a signed NIP-01 (kind 27235) event; verify BIP-340 possession + consume the challenge → link (cookie-gated; CSRF)
  *   /api/account/pubkeys/unlink   (POST)       → drop one of the caller's own links (cookie-gated; CSRF; does NOT rewrite tokens.subject_pubkey history)
+ *   /api/account/tokens           (GET)        → this user's tokens (cookie-gated; self-only; unrevoked default, ?revoked=all|true|false) — hub#833
+ *   /api/account/tokens           (POST)       → mint as session user (cookie-gated; CSRF; self-only; cannot mint parachute:host:*) — hub#833
+ *   /api/account/tokens/:jti/revoke (POST)     → revoke own jti only (cookie-gated; CSRF; 404 if not yours) — hub#833
  *   /api/hub                      (GET)        → hub version + uptime + install-source (host:admin)
  *   /api/hub/upgrade              (POST)       → SPA-driven hub self-upgrade → 202 + detached helper (host:admin, §5.3/D4)
  *   /api/hub/upgrade/status       (GET)        → poll the on-disk hub-upgrade status (host:admin)
@@ -3480,6 +3483,7 @@ export function hubFetch(
         const subpath = pathname.slice("/api/account".length);
         return handleApiAccount(req, subpath, {
           db: getDb(),
+          issuer: oauthDeps(req).issuer,
           // Only the /pubkeys sub-surface reads this — the hub#833 linkage
           // ceremony binds the signed event's `u` tag to an origin this hub
           // actually answers on, so a NIP-98 signature harvested for another

--- a/src/jwt-sign.ts
+++ b/src/jwt-sign.ts
@@ -227,6 +227,17 @@ export class RefreshTokenInsertError extends Error {
   }
 }
 
+/**
+ * Person-mint CAS miss (hub#833): `INSERT ... SELECT ... FROM users WHERE id = ?`
+ * matched zero rows, so the target account was deleted (or password-reset,
+ * when `userUpdatedAt` is pinned) during the crypto await. The mint handler
+ * must NOT return the signed JWT — a signed-but-unregistered token leaks
+ * because `validateAccessToken` still treats a missing registry row as valid.
+ */
+export class TokenMintPrincipalGoneError extends Error {
+  override name = "TokenMintPrincipalGoneError";
+}
+
 export function signRefreshToken(db: Database, opts: SignRefreshTokenOpts): SignedRefreshToken {
   const token = randomBytes(32).toString("base64url");
   const refreshTokenHash = createHash("sha256").update(token).digest("hex");
@@ -293,6 +304,15 @@ export interface RecordTokenMintOpts {
    */
   subjectPubkey?: string | null;
   now?: () => Date;
+  /**
+   * Person-mint CAS pin (hub#833). When set with `userId`, the insert is
+   * `INSERT ... SELECT ... FROM users WHERE id = ? AND updated_at = ?`.
+   * Zero rows — account deleted, or `resetUserPassword` racing the crypto
+   * await (it bumps `updated_at`) — throws `TokenMintPrincipalGoneError`.
+   * Omit on service mints (`userId` unset) and on callers that only need
+   * the existence check.
+   */
+  userUpdatedAt?: string;
 }
 
 /**
@@ -318,7 +338,48 @@ export function recordTokenMint(db: Database, opts: RecordTokenMintOpts): void {
     opts.subjectPubkey !== undefined
       ? opts.subjectPubkey
       : attributionPubkey(db, { userId: opts.userId, subject: opts.subject });
+  const createdAt = now.toISOString();
+  const scopes = opts.scopes.join(" ");
   try {
+    if (opts.userId) {
+      // Person-mint CAS (hub#833): the user row must still exist at INSERT.
+      // Pin `updated_at` when the caller snapshotted it before `signAccessToken`
+      // so a password-reset racing the crypto await also misses.
+      const pinUpdatedAt = opts.userUpdatedAt !== undefined;
+      const sql = pinUpdatedAt
+        ? `INSERT INTO tokens (
+             jti, user_id, client_id, scopes, expires_at, created_at,
+             permissions, created_via, subject, subject_pubkey
+           )
+           SELECT ?, u.id, ?, ?, ?, ?, ?, ?, ?, ?
+           FROM users u WHERE u.id = ? AND u.updated_at = ?`
+        : `INSERT INTO tokens (
+             jti, user_id, client_id, scopes, expires_at, created_at,
+             permissions, created_via, subject, subject_pubkey
+           )
+           SELECT ?, u.id, ?, ?, ?, ?, ?, ?, ?, ?
+           FROM users u WHERE u.id = ?`;
+      const args: (string | null)[] = [
+        opts.jti,
+        opts.clientId,
+        scopes,
+        opts.expiresAt,
+        createdAt,
+        opts.permissions ?? null,
+        opts.createdVia,
+        opts.subject,
+        subjectPubkey,
+        opts.userId,
+      ];
+      if (pinUpdatedAt) args.push(opts.userUpdatedAt ?? null);
+      const result = db.prepare(sql).run(...args);
+      if (Number(result.changes) === 0) {
+        throw new TokenMintPrincipalGoneError(
+          `account ${opts.userId} no longer exists (or was reset) at mint insert; refusing to register jti=${opts.jti}`,
+        );
+      }
+      return;
+    }
     db.prepare(
       `INSERT INTO tokens (
         jti, user_id, client_id, scopes, expires_at, created_at,
@@ -326,17 +387,18 @@ export function recordTokenMint(db: Database, opts: RecordTokenMintOpts): void {
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
     ).run(
       opts.jti,
-      opts.userId ?? null,
+      null,
       opts.clientId,
-      opts.scopes.join(" "),
+      scopes,
       opts.expiresAt,
-      now.toISOString(),
+      createdAt,
       opts.permissions ?? null,
       opts.createdVia,
       opts.subject,
       subjectPubkey,
     );
   } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) throw err;
     throw new RefreshTokenInsertError(
       `failed to insert token registry row (jti=${opts.jti}, created_via=${opts.createdVia}): ${err instanceof Error ? err.message : String(err)}`,
       err,
@@ -415,6 +477,8 @@ export interface ListTokensFilter {
   revoked?: "true" | "false" | "all";
   subject?: string;
   createdVia?: TokenCreatedVia;
+  /** Exact match on `tokens.user_id`. Self-service account list uses this. */
+  userId?: string;
 }
 
 /**
@@ -483,6 +547,10 @@ export function listTokens(
   if (typeof filter.subject === "string" && filter.subject.length > 0) {
     wheres.push("(user_id = ? OR subject = ?)");
     params.push(filter.subject, filter.subject);
+  }
+  if (typeof filter.userId === "string" && filter.userId.length > 0) {
+    wheres.push("user_id = ?");
+    params.push(filter.userId);
   }
   if (filter.createdVia) {
     wheres.push("created_via = ?");

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -34,8 +34,14 @@ import { EXPOSE_STATE_PATH, readExposeState } from "./expose-state.ts";
 import { validateHostAdminToken } from "./host-admin-token-validation.ts";
 import { readHubPort } from "./hub-control.ts";
 import { HUB_UNIT_DEFAULT_PORT } from "./hub-unit.ts";
-import { recordTokenMint, signAccessToken, validateAccessToken } from "./jwt-sign.ts";
+import {
+  TokenMintPrincipalGoneError,
+  recordTokenMint,
+  signAccessToken,
+  validateAccessToken,
+} from "./jwt-sign.ts";
 import { buildHubBoundOrigins } from "./origin-check.ts";
+import { getUserById } from "./users.ts";
 import { isLoopbackOrigin } from "./vault-hub-origin-env.ts";
 
 export const OPERATOR_TOKEN_FILENAME = "operator.token";
@@ -156,10 +162,16 @@ export async function mintOperatorToken(
   userId: string,
   opts: MintOperatorTokenOpts,
 ): Promise<{ token: string; jti: string; expiresAt: string; scopeSet: OperatorScopeSet }> {
+  const user = getUserById(db, userId);
+  if (!user) {
+    throw new TokenMintPrincipalGoneError(
+      `mintOperatorToken: no hub user ${userId}; operator mint is a person-mint`,
+    );
+  }
   const scopeSet = opts.scopeSet ?? OPERATOR_TOKEN_DEFAULT_SCOPE_SET;
   const scopes = [...OPERATOR_TOKEN_SCOPE_SETS[scopeSet]];
   const minted = await signAccessToken(db, {
-    sub: userId,
+    sub: user.id,
     scopes,
     audience: opts.audience ?? OPERATOR_TOKEN_AUDIENCE,
     clientId: OPERATOR_TOKEN_CLIENT_ID,
@@ -174,16 +186,15 @@ export async function mintOperatorToken(
     ...(opts.now !== undefined ? { now: opts.now } : {}),
   });
   // Register every operator-mint with the unified token registry (hub#212
-  // Phase 1). Per design: operator-mint rows have user_id NULL; the
-  // subject column carries the canonical "operator" identity string.
-  // (Storing user_id here would require an FK-valid users row, which the
-  // operator-mint path doesn't always have access to in test fixtures —
-  // and conceptually the operator is a role, not a hub user.) Powers the
-  // revocation list endpoint.
+  // Phase 1 / hub#833). JWT sub is the hub user id; user_id is set so
+  // account delete / password-reset revoke this row. subject stays the
+  // "operator" display label.
   recordTokenMint(db, {
     jti: minted.jti,
     createdVia: "operator_mint",
     subject: "operator",
+    userId: user.id,
+    userUpdatedAt: user.updatedAt,
     clientId: OPERATOR_TOKEN_CLIENT_ID,
     scopes,
     expiresAt: minted.expiresAt,

--- a/src/operator-token.ts
+++ b/src/operator-token.ts
@@ -344,11 +344,20 @@ export interface UseOperatorTokenOpts {
  *       `issueOperatorToken`); a token without it is either a hand-crafted
  *       JWT (don't widen) or a pre-#213 legacy token (operator should
  *       explicitly `parachute auth rotate-operator` to recover).
+ *     - `sub-not-user`: `sub` is present but is not a `users` row (the old
+ *       `"operator"` sentinel, or a deleted user). `mintOperatorToken` is a
+ *       person-mint as of hub#833 and throws `TokenMintPrincipalGoneError`
+ *       for those; catching it here keeps auto-rotate fail-closed without
+ *       turning a legacy file into a CLI exception. Recover via explicit
+ *       `parachute auth rotate-operator` against a real users row.
  */
 export type RotationStatus =
   | { kind: "fresh" }
   | { kind: "rotated" }
-  | { kind: "skipped"; reason: "aud-mismatch" | "no-sub" | "no-scope-set" };
+  | {
+      kind: "skipped";
+      reason: "aud-mismatch" | "no-sub" | "no-scope-set" | "sub-not-user";
+    };
 
 export interface UsedOperatorToken {
   /** The operator token plaintext to present as bearer. After auto-rotation, this is the freshly-minted token. */
@@ -550,12 +559,24 @@ export async function useOperatorTokenWithAutoRotate(
     return { token, payload, status: { kind: "skipped", reason: "no-scope-set" } };
   }
   const scopeSet: OperatorScopeSet = claimedSet;
-  const issued = await issueOperatorToken(db, sub, {
-    dir,
-    issuer: opts.issuer,
-    scopeSet,
-    now: opts.now,
-  });
+  let issued: IssueOperatorTokenResult;
+  try {
+    issued = await issueOperatorToken(db, sub, {
+      dir,
+      issuer: opts.issuer,
+      scopeSet,
+      now: opts.now,
+    });
+  } catch (err) {
+    // Person-mint as of hub#833: a legacy `"operator"` sentinel or a
+    // deleted-user `sub` is not a users row. Skip rather than throw so
+    // callers (expose-supervisor, CLI try-wraps) can log `skipped:
+    // sub-not-user` instead of treating this as a crash.
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return { token, payload, status: { kind: "skipped", reason: "sub-not-user" } };
+    }
+    throw err;
+  }
   const reValidated = await validateAccessToken(db, issued.token, opts.issuer);
   return {
     token: issued.token,
@@ -605,6 +626,9 @@ export interface SelfHealOperatorTokenOpts {
  *     - `no-scope-set`: the token lacks (or has an unrecognized) `pa_scope_set`
  *       claim. Falling back to a default would widen scope (hub#224 hardening);
  *       refuse instead. Operator recovers via explicit rotate-operator.
+ *     - `sub-not-user`: `sub` is present but is not a `users` row. Same
+ *       person-mint fail-close as auto-rotate (`mintOperatorToken` throws
+ *       `TokenMintPrincipalGoneError`). The on-disk file is left untouched.
  *     - `issuer-loopback`: the TARGET issuer is loopback. Re-minting to a
  *       loopback `iss` would downgrade a good public token; never do it.
  */
@@ -614,7 +638,13 @@ export type OperatorIssuerHealStatus =
   | { kind: "rotated"; path: string; scopeSet: OperatorScopeSet; expiresAt: string }
   | {
       kind: "skipped";
-      reason: "unverifiable" | "aud-mismatch" | "no-sub" | "no-scope-set" | "issuer-loopback";
+      reason:
+        | "unverifiable"
+        | "aud-mismatch"
+        | "no-sub"
+        | "no-scope-set"
+        | "sub-not-user"
+        | "issuer-loopback";
     };
 
 /**
@@ -701,12 +731,20 @@ export async function selfHealOperatorTokenIssuer(
 
   // Re-mint preserving scope-set + sub. `issueOperatorToken` writes the new
   // token to disk atomically (mint → writeOperatorTokenFile).
-  const issued = await issueOperatorToken(db, sub, {
-    dir,
-    issuer: opts.issuer,
-    scopeSet: claimedSet,
-    ...(opts.now !== undefined ? { now: opts.now } : {}),
-  });
+  let issued: IssueOperatorTokenResult;
+  try {
+    issued = await issueOperatorToken(db, sub, {
+      dir,
+      issuer: opts.issuer,
+      scopeSet: claimedSet,
+      ...(opts.now !== undefined ? { now: opts.now } : {}),
+    });
+  } catch (err) {
+    if (err instanceof TokenMintPrincipalGoneError) {
+      return { kind: "skipped", reason: "sub-not-user" };
+    }
+    throw err;
+  }
   return {
     kind: "rotated",
     path: issued.path,

--- a/src/users.ts
+++ b/src/users.ts
@@ -384,6 +384,16 @@ export function getUserById(db: Database, id: string): User | null {
   return row ? rowToUser(row, readVaultsForUser(db, row.id)) : null;
 }
 
+/**
+ * Resolve a hub user by id, else username (case-insensitive). Used by the
+ * mint `--user` / body `user` flags (hub#833) so operators can name an
+ * account either way.
+ */
+export function resolveUser(db: Database, ident: string): User | null {
+  if (ident.length === 0) return null;
+  return getUserById(db, ident) ?? getUserByUsernameCI(db, ident);
+}
+
 export function listUsers(db: Database): User[] {
   const rows = db.query<Row, []>("SELECT * FROM users ORDER BY created_at ASC").all();
   if (rows.length === 0) return [];

--- a/web/ui/src/App.test.tsx
+++ b/web/ui/src/App.test.tsx
@@ -28,6 +28,8 @@ vi.mock("./lib/api.ts", async (orig) => {
     listVaults: vi.fn().mockResolvedValue({ vaults: [], moduleInstalled: false }),
     listGrants: vi.fn().mockResolvedValue([]),
     listTokens: vi.fn().mockResolvedValue({ tokens: [], next_cursor: null }),
+    listAccountTokens: vi.fn().mockResolvedValue({ tokens: [], next_cursor: null }),
+    listAccountPubkeys: vi.fn().mockResolvedValue([]),
     listModules: vi.fn().mockResolvedValue({ modules: [], supervisor_available: false }),
     // App's useEffect hits getMe() on mount. Default mock = signed-out so
     // the AuthIndicator renders the deterministic "Sign in" link rather

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -537,31 +537,62 @@ describe("listAccountTokens / mintAccountToken", () => {
 });
 
 describe("verifyPubkeyLink", () => {
+  const event = {
+    id: "a",
+    pubkey: "b",
+    created_at: 1,
+    kind: 27235,
+    tags: [] as string[][],
+    content: "x",
+    sig: "c",
+  };
+
   it("surfaces first-link password_required instead of bouncing to login", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async () =>
         jsonResponse(401, {
           error: "password_required",
-          error_description:
-            "Re-enter your current password to link your first key to this account.",
+          error_description: "please confirm",
         }),
       ),
     );
     const api = await import("./api.ts");
-    await expect(
-      api.verifyPubkeyLink("csrf-x", {
-        event: {
-          id: "a",
-          pubkey: "b",
-          created_at: 1,
-          kind: 27235,
-          tags: [],
-          content: "x",
-          sig: "c",
-        },
-      }),
-    ).rejects.toMatchObject({ status: 401, message: expect.stringMatching(/re-enter/i) });
+    await expect(api.verifyPubkeyLink("csrf-x", { event })).rejects.toMatchObject({
+      status: 401,
+      message: "please confirm",
+    });
     expect(auth.redirectToLoginAndHang).not.toHaveBeenCalled();
+  });
+
+  it("surfaces proof_failed / invalid_credentials without bouncing to login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => jsonResponse(401, { error: "proof_failed", error_description: "nope" })),
+    );
+    const api = await import("./api.ts");
+    await expect(api.verifyPubkeyLink("csrf-x", { event })).rejects.toMatchObject({
+      status: 401,
+      message: "nope",
+    });
+    expect(auth.redirectToLoginAndHang).not.toHaveBeenCalled();
+  });
+
+  it("bounces to login on unauthenticated", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(401, { error: "unauthenticated", error_description: "no session" }),
+      ),
+    );
+    const api = await import("./api.ts");
+    const pending = api.verifyPubkeyLink("csrf-x", { event });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(auth.redirectToLoginAndHang).toHaveBeenCalledTimes(1);
+    const winner = await Promise.race([
+      pending.then(() => "resolved"),
+      new Promise((r) => setTimeout(() => r("hung"), 10)),
+    ]);
+    expect(winner).toBe("hung");
   });
 });

--- a/web/ui/src/lib/api.test.ts
+++ b/web/ui/src/lib/api.test.ts
@@ -488,3 +488,80 @@ describe("resolveManagementUrl", () => {
     ).toBe("https://elsewhere.example/manage");
   });
 });
+
+describe("listAccountTokens / mintAccountToken", () => {
+  it("GETs /api/account/tokens with same-origin credentials and parses next_cursor", async () => {
+    const fetchMock = vi.fn(async () => jsonResponse(200, { tokens: [], next_cursor: "abc" }));
+    vi.stubGlobal("fetch", fetchMock);
+    const api = await import("./api.ts");
+    const page = await api.listAccountTokens({ cursor: "prev" });
+    expect(page.next_cursor).toBe("abc");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/account/tokens?cursor=prev",
+      expect.objectContaining({
+        method: "GET",
+        credentials: "same-origin",
+      }),
+    );
+  });
+
+  it("POSTs mint with CSRF + scope + label", async () => {
+    const fetchMock = vi.fn(async () =>
+      jsonResponse(200, {
+        jti: "j1",
+        token: "eyJ",
+        expires_at: "2030-01-01T00:00:00.000Z",
+        scope: "vault:work:read",
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const api = await import("./api.ts");
+    const minted = await api.mintAccountToken("csrf-x", {
+      scope: "vault:work:read",
+      label: "laptop",
+    });
+    expect(minted.jti).toBe("j1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "/api/account/tokens",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        body: JSON.stringify({
+          __csrf: "csrf-x",
+          scope: "vault:work:read",
+          label: "laptop",
+        }),
+      }),
+    );
+  });
+});
+
+describe("verifyPubkeyLink", () => {
+  it("surfaces first-link password_required instead of bouncing to login", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () =>
+        jsonResponse(401, {
+          error: "password_required",
+          error_description:
+            "Re-enter your current password to link your first key to this account.",
+        }),
+      ),
+    );
+    const api = await import("./api.ts");
+    await expect(
+      api.verifyPubkeyLink("csrf-x", {
+        event: {
+          id: "a",
+          pubkey: "b",
+          created_at: 1,
+          kind: 27235,
+          tags: [],
+          content: "x",
+          sig: "c",
+        },
+      }),
+    ).rejects.toMatchObject({ status: 401, message: expect.stringMatching(/re-enter/i) });
+    expect(auth.redirectToLoginAndHang).not.toHaveBeenCalled();
+  });
+});

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -2199,17 +2199,23 @@ export async function verifyPubkeyLink(
   if (opts.password !== undefined) body.password = opts.password;
   const res = await postAccount("/pubkeys/verify", csrf, body);
   if (res.status === 401) {
-    const message = await readError(res);
-    const lower = message.toLowerCase();
-    if (
-      lower.includes("re-enter") ||
-      lower.includes("password") ||
-      lower.includes("signature") ||
-      lower.includes("incorrect")
-    ) {
-      throw new HttpError(401, message);
+    // Session-gone vs first-link step-up / bad proof. Discriminate on the
+    // structured `error` code, not English in `error_description` — a copy
+    // tweak of password_required must not bounce the operator to /login.
+    const text = await res.text();
+    let code: string | undefined;
+    let message = text || "401 Unauthorized";
+    try {
+      const parsed = JSON.parse(text) as { error?: string; error_description?: string };
+      code = parsed.error;
+      message = parsed.error_description || parsed.error || message;
+    } catch {
+      // not JSON
     }
-    return redirectToLoginAndHang<LinkedPubkeyResult>();
+    if (code === "unauthenticated" || code === undefined) {
+      return redirectToLoginAndHang<LinkedPubkeyResult>();
+    }
+    throw new HttpError(401, message);
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
   return (await res.json()) as LinkedPubkeyResult;

--- a/web/ui/src/lib/api.ts
+++ b/web/ui/src/lib/api.ts
@@ -2041,3 +2041,185 @@ export async function changeAccountPassword(
   }
   if (!res.ok) throw new HttpError(res.status, await readError(res));
 }
+
+// ---------------------------------------------------------------------------
+// Self-service account tokens + pubkey linkage (hub#833 (b))
+//
+// Same cookie + CSRF posture as password/2FA above. Operator `/admin/tokens`
+// stays the registry; these helpers are "my tokens" and "my keys" for the
+// signed-in user. Identity is always `session.userId`.
+// ---------------------------------------------------------------------------
+
+export interface AccountTokenListing {
+  jti: string;
+  user_id: string;
+  subject: string | null;
+  client_id: string;
+  scopes: string[];
+  expires_at: string;
+  revoked_at: string | null;
+  created_at: string;
+  created_via: string;
+  subject_pubkey: string | null;
+}
+
+export interface AccountTokensPage {
+  tokens: AccountTokenListing[];
+  next_cursor: string | null;
+}
+
+export interface MintAccountTokenInput {
+  scope: string;
+  expires_in?: number;
+  label?: string;
+}
+
+export interface MintedAccountToken {
+  jti: string;
+  token: string;
+  expires_at: string;
+  scope: string;
+}
+
+export interface AccountPubkey {
+  pubkey: string;
+  label: string | null;
+  proof_event_id: string;
+  linked_at: string;
+  last_verified_at: string;
+}
+
+export interface PubkeyChallenge {
+  challenge: string;
+  expires_at: string;
+  event_template: {
+    kind: number;
+    content: string;
+    tags: string[][];
+  };
+}
+
+export interface SignedNostrEvent {
+  id: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+  sig: string;
+}
+
+export interface LinkedPubkeyResult extends AccountPubkey {
+  linked: true;
+  relinked: boolean;
+}
+
+async function getAccount(subpath: string): Promise<Response> {
+  return await fetch(`/api/account${subpath}`, {
+    method: "GET",
+    headers: { accept: "application/json" },
+    credentials: "same-origin",
+  });
+}
+
+/**
+ * GET /api/account/tokens — this user's tokens. Default is unrevoked.
+ * Cursor pagination: pass `cursor` from the previous page's `next_cursor`.
+ */
+export async function listAccountTokens(
+  opts: { revoked?: "true" | "false" | "all"; cursor?: string } = {},
+): Promise<AccountTokensPage> {
+  const params = new URLSearchParams();
+  if (opts.revoked) params.set("revoked", opts.revoked);
+  if (opts.cursor) params.set("cursor", opts.cursor);
+  const query = params.toString();
+  const res = await getAccount(query ? `/tokens?${query}` : "/tokens");
+  if (res.status === 401) return redirectToLoginAndHang<AccountTokensPage>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as AccountTokensPage;
+}
+
+/**
+ * POST /api/account/tokens — mint as the session user. JWT is shown once.
+ * Cannot mint `parachute:host:*` (that stays on the operator registry).
+ */
+export async function mintAccountToken(
+  csrf: string,
+  input: MintAccountTokenInput,
+): Promise<MintedAccountToken> {
+  const body: Record<string, unknown> = { scope: input.scope };
+  if (input.expires_in !== undefined) body.expires_in = input.expires_in;
+  if (input.label !== undefined) body.label = input.label;
+  const res = await postAccount("/tokens", csrf, body);
+  if (res.status === 401) return redirectToLoginAndHang<MintedAccountToken>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as MintedAccountToken;
+}
+
+/** POST /api/account/tokens/:jti/revoke — revoke own jti only. */
+export async function revokeAccountToken(csrf: string, jti: string): Promise<void> {
+  const res = await postAccount(`/tokens/${encodeURIComponent(jti)}/revoke`, csrf);
+  if (res.status === 401) {
+    await redirectToLoginAndHang<void>();
+    return;
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+}
+
+/** GET /api/account/pubkeys — the caller's linked Nostr keys. */
+export async function listAccountPubkeys(): Promise<AccountPubkey[]> {
+  const res = await getAccount("/pubkeys");
+  if (res.status === 401) return redirectToLoginAndHang<AccountPubkey[]>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { pubkeys: AccountPubkey[] };
+  return body.pubkeys ?? [];
+}
+
+/** POST /api/account/pubkeys/challenge — mint a single-use event template. */
+export async function startPubkeyChallenge(csrf: string): Promise<PubkeyChallenge> {
+  const res = await postAccount("/pubkeys/challenge", csrf);
+  if (res.status === 401) return redirectToLoginAndHang<PubkeyChallenge>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as PubkeyChallenge;
+}
+
+/**
+ * POST /api/account/pubkeys/verify — present a signed NIP-01 event.
+ *
+ * First-link requires `password` (401 `password_required` if omitted). That
+ * 401 is NOT a gone session — surface it; only a message that isn't a
+ * step-up / proof failure bounces to login.
+ */
+export async function verifyPubkeyLink(
+  csrf: string,
+  opts: { event: SignedNostrEvent; label?: string; password?: string },
+): Promise<LinkedPubkeyResult> {
+  const body: Record<string, unknown> = { event: opts.event };
+  if (opts.label !== undefined) body.label = opts.label;
+  if (opts.password !== undefined) body.password = opts.password;
+  const res = await postAccount("/pubkeys/verify", csrf, body);
+  if (res.status === 401) {
+    const message = await readError(res);
+    const lower = message.toLowerCase();
+    if (
+      lower.includes("re-enter") ||
+      lower.includes("password") ||
+      lower.includes("signature") ||
+      lower.includes("incorrect")
+    ) {
+      throw new HttpError(401, message);
+    }
+    return redirectToLoginAndHang<LinkedPubkeyResult>();
+  }
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  return (await res.json()) as LinkedPubkeyResult;
+}
+
+/** POST /api/account/pubkeys/unlink — drop one of the caller's own links. */
+export async function unlinkAccountPubkey(csrf: string, pubkey: string): Promise<boolean> {
+  const res = await postAccount("/pubkeys/unlink", csrf, { pubkey });
+  if (res.status === 401) return redirectToLoginAndHang<boolean>();
+  if (!res.ok) throw new HttpError(res.status, await readError(res));
+  const body = (await res.json()) as { unlinked: boolean };
+  return body.unlinked;
+}

--- a/web/ui/src/routes/Account.test.tsx
+++ b/web/ui/src/routes/Account.test.tsx
@@ -20,11 +20,20 @@ vi.mock("../lib/api.ts", async (orig) => {
     startTwoFactor: vi.fn(),
     confirmTwoFactor: vi.fn(),
     disableTwoFactor: vi.fn(),
+    listAccountTokens: vi.fn(),
+    mintAccountToken: vi.fn(),
+    revokeAccountToken: vi.fn(),
+    listAccountPubkeys: vi.fn(),
+    startPubkeyChallenge: vi.fn(),
+    verifyPubkeyLink: vi.fn(),
+    unlinkAccountPubkey: vi.fn(),
   };
 });
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.mocked(api.listAccountTokens).mockResolvedValue({ tokens: [], next_cursor: null });
+  vi.mocked(api.listAccountPubkeys).mockResolvedValue([]);
 });
 
 afterEach(() => {
@@ -250,5 +259,214 @@ describe("Account — 2FA disable", () => {
       expect(screen.getByTestId("account-2fa-error")).toHaveTextContent(/current password/i),
     );
     expect(api.disableTwoFactor).not.toHaveBeenCalled();
+  });
+});
+
+describe("Account — API tokens", () => {
+  const tokenRow = (
+    jti: string,
+    overrides: Partial<api.AccountTokenListing> = {},
+  ): api.AccountTokenListing => ({
+    jti,
+    user_id: "u1",
+    subject: "laptop",
+    client_id: "parachute-account",
+    scopes: ["vault:work:read"],
+    expires_at: "2030-01-01T00:00:00.000Z",
+    revoked_at: null,
+    created_at: "2026-08-25T12:00:00.000Z",
+    created_via: "cli_mint",
+    subject_pubkey: null,
+    ...overrides,
+  });
+
+  it("renders the empty state when this account has no live tokens", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    expect(await screen.findByTestId("account-tokens-empty")).toBeInTheDocument();
+  });
+
+  it("lists a token row and mints, showing the JWT once", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.listAccountTokens)
+      .mockResolvedValueOnce({ tokens: [], next_cursor: null })
+      .mockResolvedValueOnce({
+        tokens: [tokenRow("aaaaaaaaXXXXXXXbbbb")],
+        next_cursor: null,
+      });
+    vi.mocked(api.mintAccountToken).mockResolvedValue({
+      jti: "aaaaaaaaXXXXXXXbbbb",
+      token: "eyJhbGciOi.test",
+      expires_at: "2030-01-01T00:00:00.000Z",
+      scope: "vault:work:read",
+    });
+    renderRoute();
+    await screen.findByTestId("account-token-mint-toggle");
+    fireEvent.click(screen.getByTestId("account-token-mint-toggle"));
+    fireEvent.change(screen.getByTestId("account-token-scope"), {
+      target: { value: "vault:work:read" },
+    });
+    fireEvent.change(screen.getByTestId("account-token-label"), { target: { value: "laptop" } });
+    fireEvent.click(screen.getByTestId("account-token-mint"));
+
+    await waitFor(() =>
+      expect(api.mintAccountToken).toHaveBeenCalledWith("csrf-abc", {
+        scope: "vault:work:read",
+        label: "laptop",
+      }),
+    );
+    expect(await screen.findByTestId("account-token-jwt")).toHaveTextContent("eyJhbGciOi.test");
+  });
+
+  it("revokes a live token after confirm", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.listAccountTokens)
+      .mockResolvedValueOnce({
+        tokens: [tokenRow("jti-live-0001")],
+        next_cursor: null,
+      })
+      .mockResolvedValueOnce({ tokens: [], next_cursor: null });
+    vi.mocked(api.revokeAccountToken).mockResolvedValue();
+    renderRoute();
+    await screen.findByTestId("account-token-revoke-jti-live-0001");
+    fireEvent.click(screen.getByTestId("account-token-revoke-jti-live-0001"));
+    fireEvent.click(screen.getByTestId("account-token-revoke-confirm-jti-live-0001"));
+    await waitFor(() =>
+      expect(api.revokeAccountToken).toHaveBeenCalledWith("csrf-abc", "jti-live-0001"),
+    );
+    await waitFor(() => expect(screen.getByTestId("account-tokens-empty")).toBeInTheDocument());
+  });
+
+  it("Load more appends the next page and is disabled while in flight", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    const listMock = vi.mocked(api.listAccountTokens);
+    listMock.mockResolvedValueOnce({
+      tokens: [tokenRow("page-one-aaaaaa")],
+      next_cursor: "cursor-2",
+    });
+    let resolveSecond: (page: api.AccountTokensPage) => void = () => {};
+    listMock.mockReturnValueOnce(
+      new Promise<api.AccountTokensPage>((resolve) => {
+        resolveSecond = resolve;
+      }),
+    );
+    renderRoute();
+    const more = await screen.findByTestId("account-tokens-load-more");
+    fireEvent.click(more);
+    await waitFor(() => expect(screen.getByTestId("account-tokens-load-more")).toBeDisabled());
+    fireEvent.click(screen.getByTestId("account-tokens-load-more"));
+    expect(listMock.mock.calls.filter((c) => c[0]?.cursor === "cursor-2")).toHaveLength(1);
+    resolveSecond({ tokens: [tokenRow("page-two-bbbbbb")], next_cursor: null });
+    expect(await screen.findByTestId("account-token-row-page-two-bbbbbb")).toBeInTheDocument();
+    expect(screen.getByTestId("account-token-row-page-one-aaaaaa")).toBeInTheDocument();
+    expect(screen.queryByTestId("account-tokens-load-more")).toBeNull();
+  });
+});
+
+describe("Account — Nostr keys", () => {
+  it("renders empty state and starts the challenge flow", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
+      challenge: "aa".repeat(32),
+      expires_at: "2026-08-25T12:05:00.000Z",
+      event_template: {
+        kind: 27235,
+        content: 'Link this key to account "aaron" on this hub.',
+        tags: [
+          ["u", "https://hub.example/api/account/pubkeys/verify"],
+          ["method", "POST"],
+          ["challenge", "aa".repeat(32)],
+        ],
+      },
+    });
+    renderRoute();
+    expect(await screen.findByTestId("account-pubkeys-empty")).toBeInTheDocument();
+    fireEvent.click(screen.getByTestId("account-pubkey-link"));
+    await waitFor(() => expect(api.startPubkeyChallenge).toHaveBeenCalledWith("csrf-abc"));
+    expect(await screen.findByTestId("account-pubkey-statement")).toHaveTextContent(
+      /link this key/i,
+    );
+    expect(screen.getByTestId("account-pubkey-password")).toBeInTheDocument();
+  });
+
+  it("posts the pasted event + first-link password", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
+      challenge: "bb".repeat(32),
+      expires_at: "2026-08-25T12:05:00.000Z",
+      event_template: {
+        kind: 27235,
+        content: "statement",
+        tags: [["u", "https://hub.example/api/account/pubkeys/verify"]],
+      },
+    });
+    vi.mocked(api.verifyPubkeyLink).mockResolvedValue({
+      linked: true,
+      relinked: false,
+      pubkey: "aa".repeat(32),
+      label: "phone",
+      proof_event_id: "cc".repeat(32),
+      linked_at: "2026-08-25T12:00:00.000Z",
+      last_verified_at: "2026-08-25T12:00:00.000Z",
+    });
+    vi.mocked(api.listAccountPubkeys)
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([
+        {
+          pubkey: "aa".repeat(32),
+          label: "phone",
+          proof_event_id: "cc".repeat(32),
+          linked_at: "2026-08-25T12:00:00.000Z",
+          last_verified_at: "2026-08-25T12:00:00.000Z",
+        },
+      ]);
+    renderRoute();
+    await screen.findByTestId("account-pubkey-link");
+    fireEvent.click(screen.getByTestId("account-pubkey-link"));
+    await screen.findByTestId("account-pubkey-event");
+    const event = {
+      id: "dd".repeat(32),
+      pubkey: "aa".repeat(32),
+      created_at: 1,
+      kind: 27235,
+      tags: [] as string[][],
+      content: "statement",
+      sig: "ee".repeat(32),
+    };
+    fireEvent.change(screen.getByTestId("account-pubkey-event"), {
+      target: { value: JSON.stringify(event) },
+    });
+    fireEvent.change(screen.getByTestId("account-pubkey-label"), { target: { value: "phone" } });
+    fireEvent.change(screen.getByTestId("account-pubkey-password"), {
+      target: { value: "correct-horse-battery" },
+    });
+    fireEvent.click(screen.getByTestId("account-pubkey-verify"));
+    await waitFor(() =>
+      expect(api.verifyPubkeyLink).toHaveBeenCalledWith("csrf-abc", {
+        event,
+        label: "phone",
+        password: "correct-horse-battery",
+      }),
+    );
+    expect(await screen.findByTestId(`account-pubkey-row-${"aa".repeat(32)}`)).toBeInTheDocument();
+  });
+
+  it("rejects non-JSON event client-side (no POST)", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
+      challenge: "bb".repeat(32),
+      expires_at: "2026-08-25T12:05:00.000Z",
+      event_template: { kind: 27235, content: "statement", tags: [] },
+    });
+    renderRoute();
+    await screen.findByTestId("account-pubkey-link");
+    fireEvent.click(screen.getByTestId("account-pubkey-link"));
+    await screen.findByTestId("account-pubkey-event");
+    fireEvent.change(screen.getByTestId("account-pubkey-event"), { target: { value: "not-json" } });
+    fireEvent.click(screen.getByTestId("account-pubkey-verify"));
+    await waitFor(() =>
+      expect(screen.getByTestId("account-pubkeys-form-error")).toHaveTextContent(/not valid json/i),
+    );
+    expect(api.verifyPubkeyLink).not.toHaveBeenCalled();
   });
 });

--- a/web/ui/src/routes/Account.tsx
+++ b/web/ui/src/routes/Account.tsx
@@ -1,32 +1,49 @@
 /**
- * /admin/account — "My account": self-service password + 2FA for the
- * signed-in user (hub#85). Aaron chose option B — native in the SPA rather
- * than a link out to the server-rendered `/account/`.
+ * /admin/account — "My account": self-service password, 2FA, my-tokens, and
+ * pubkey-link for the signed-in user (hub#85 + hub#833 (b)).
  *
  * The owner is NOT special here: `two_factor_enabled` comes from `/api/me`
  * (keyed off the session's own user), and every action POSTs to
  * `/api/account/*`, which act on `session.userId`. Same path for the first
  * admin and any friend user.
  *
- * Two sections:
+ * Four sections:
  *   - Password — current → new (+ confirm). 12-char floor mirrors the server
  *     validator; the server is authoritative (its 400/401 message surfaces).
  *   - Two-factor — status pill; when off, an enroll flow (QR + secret + verify
  *     a code → backup codes shown ONCE); when on, a password-gated disable.
+ *   - API tokens — list / mint / revoke THIS user's tokens. Operator registry
+ *     stays at `/admin/tokens`. JWT shown once. Cookie+CSRF, cannot mint
+ *     `parachute:host:*`.
+ *   - Nostr keys — list / link / unlink. A linked key is an attribution
+ *     label; it grants nothing. First-link is password-gated.
  *
  * The CSRF token + 2FA status are read from `/api/me` (the single who-am-I
  * read App.tsx already does). We refetch it after a 2FA change so the status
  * pill + section swap without a full reload.
  */
 import { type FormEvent, useCallback, useEffect, useState } from "react";
+import { Link } from "react-router-dom";
 import {
+  type AccountPubkey,
+  type AccountTokenListing,
   type MeResponse,
+  type MintedAccountToken,
+  type PubkeyChallenge,
+  type SignedNostrEvent,
   type TwoFactorStart,
   changeAccountPassword,
   confirmTwoFactor,
   disableTwoFactor,
   getMe,
+  listAccountPubkeys,
+  listAccountTokens,
+  mintAccountToken,
+  revokeAccountToken,
+  startPubkeyChallenge,
   startTwoFactor,
+  unlinkAccountPubkey,
+  verifyPubkeyLink,
 } from "../lib/api.ts";
 
 type LoadState =
@@ -71,7 +88,8 @@ export function Account() {
     <section className="settings" data-testid="account-page">
       <h1>My account</h1>
       <p className="muted">
-        Manage your own sign-in credentials. Changes here apply to your account only.
+        Manage your own sign-in credentials, API tokens, and linked Nostr keys. Changes here apply
+        to your account only. The operator token registry is a separate page.
       </p>
 
       <PasswordSection csrf={state.csrf} />
@@ -80,6 +98,8 @@ export function Account() {
         enabled={state.twoFactorEnabled}
         onChanged={() => void refresh()}
       />
+      <TokensSection csrf={state.csrf} />
+      <PubkeysSection csrf={state.csrf} />
     </section>
   );
 }
@@ -419,4 +439,717 @@ function TwoFactorSection({
       )}
     </section>
   );
+}
+
+// ---------------------------------------------------------------------------
+// API tokens (self-service)
+// ---------------------------------------------------------------------------
+
+type TokenListState =
+  | { kind: "loading" }
+  | { kind: "ok"; tokens: AccountTokenListing[]; nextCursor: string | null }
+  | { kind: "error"; message: string };
+
+type TokenMintState =
+  | { kind: "idle" }
+  | { kind: "submitting" }
+  | { kind: "minted"; token: MintedAccountToken }
+  | { kind: "error"; message: string };
+
+type TokenRevokeState =
+  | { kind: "idle" }
+  | { kind: "confirming"; jti: string }
+  | { kind: "revoking"; jti: string }
+  | { kind: "error"; jti: string; message: string };
+
+function TokensSection({ csrf }: { csrf: string }) {
+  const [list, setList] = useState<TokenListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [mint, setMint] = useState<TokenMintState>({ kind: "idle" });
+  const [revoke, setRevoke] = useState<TokenRevokeState>({ kind: "idle" });
+  const [showForm, setShowForm] = useState(false);
+  const [loadingMore, setLoadingMore] = useState(false);
+  const [scope, setScope] = useState("");
+  const [label, setLabel] = useState("");
+  const [expiresIn, setExpiresIn] = useState("");
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setList({ kind: "loading" });
+    listAccountTokens()
+      .then((page) => {
+        if (cancelled) return;
+        setList({ kind: "ok", tokens: page.tokens, nextCursor: page.next_cursor });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setList({
+          kind: "error",
+          message: err instanceof Error ? err.message : String(err),
+        });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  async function loadMore(): Promise<void> {
+    if (list.kind !== "ok" || !list.nextCursor || loadingMore) return;
+    setLoadingMore(true);
+    try {
+      const page = await listAccountTokens({ cursor: list.nextCursor });
+      setList({
+        kind: "ok",
+        tokens: [...list.tokens, ...page.tokens],
+        nextCursor: page.next_cursor,
+      });
+    } catch (err) {
+      setList({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setLoadingMore(false);
+    }
+  }
+
+  async function onSubmitMint(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    const trimmed = scope.trim();
+    if (trimmed.length === 0) {
+      setMint({ kind: "error", message: "scope is required" });
+      return;
+    }
+    let ttl: number | undefined;
+    if (expiresIn.trim().length > 0) {
+      const n = Number(expiresIn);
+      if (!Number.isInteger(n) || n <= 0) {
+        setMint({ kind: "error", message: "expires_in must be a positive integer (seconds)" });
+        return;
+      }
+      ttl = n;
+    }
+    setMint({ kind: "submitting" });
+    try {
+      const minted = await mintAccountToken(csrf, {
+        scope: trimmed,
+        ...(ttl !== undefined ? { expires_in: ttl } : {}),
+        ...(label.trim() ? { label: label.trim() } : {}),
+      });
+      setMint({ kind: "minted", token: minted });
+      setScope("");
+      setLabel("");
+      setExpiresIn("");
+      setShowForm(false);
+      setReload((n) => n + 1);
+    } catch (err) {
+      setMint({
+        kind: "error",
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  async function onConfirmRevoke(jti: string): Promise<void> {
+    setRevoke({ kind: "revoking", jti });
+    try {
+      await revokeAccountToken(csrf, jti);
+      setRevoke({ kind: "idle" });
+      setReload((n) => n + 1);
+    } catch (err) {
+      setRevoke({
+        kind: "error",
+        jti,
+        message: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  function copyToken(token: string): void {
+    if (typeof navigator !== "undefined" && navigator.clipboard) {
+      void navigator.clipboard.writeText(token);
+    }
+  }
+
+  return (
+    <section
+      className="settings-block"
+      aria-labelledby="account-tokens-heading"
+      data-testid="account-tokens"
+    >
+      <h2 id="account-tokens-heading">API tokens</h2>
+      <p className="muted">
+        Tokens minted as you. A friend can mint a subset of their own authority (assigned vaults);
+        nobody mints <code>parachute:host:*</code> here. The operator registry — every CLI / OAuth /
+        operator-mint on this hub — stays on <Link to="/tokens">Tokens</Link>.
+      </p>
+
+      {mint.kind === "minted" ? (
+        <div className="mint-banner" data-testid="account-token-minted">
+          <h3>Minted</h3>
+          <p>
+            Your new access token (jti: <code>{mint.token.jti}</code>):
+          </p>
+          <div className="token-box">
+            <code data-testid="account-token-jwt">{mint.token.token}</code>
+          </div>
+          <p className="warn">This is the only time the JWT is shown. Copy it now.</p>
+          <div className="actions">
+            <button type="button" onClick={() => copyToken(mint.token.token)}>
+              Copy
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => setMint({ kind: "idle" })}
+              data-testid="account-token-minted-dismiss"
+            >
+              Dismiss
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      <div className="actions" style={{ marginBottom: "0.75rem" }}>
+        <button
+          type="button"
+          onClick={() => setShowForm((s) => !s)}
+          data-testid="account-token-mint-toggle"
+        >
+          {showForm ? "Hide form" : "Mint a token"}
+        </button>
+      </div>
+
+      {showForm ? (
+        <form onSubmit={(e) => void onSubmitMint(e)} className="settings-form">
+          <label>
+            Scope (space-separated)
+            <input
+              type="text"
+              value={scope}
+              onChange={(e) => setScope(e.target.value)}
+              placeholder="e.g. vault:work:read"
+              data-testid="account-token-scope"
+            />
+          </label>
+          <label>
+            Label (optional)
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="laptop, backup, …"
+              data-testid="account-token-label"
+            />
+          </label>
+          <label>
+            Expires in (seconds, optional)
+            <input
+              type="text"
+              inputMode="numeric"
+              value={expiresIn}
+              onChange={(e) => setExpiresIn(e.target.value)}
+              placeholder="default 90d"
+              data-testid="account-token-expires"
+            />
+          </label>
+          {mint.kind === "error" ? (
+            <div className="error" data-testid="account-token-mint-error">
+              {mint.message}
+            </div>
+          ) : null}
+          <div className="actions">
+            <button
+              type="submit"
+              disabled={mint.kind === "submitting"}
+              data-testid="account-token-mint"
+            >
+              {mint.kind === "submitting" ? "Minting…" : "Mint"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              onClick={() => {
+                setShowForm(false);
+                setMint({ kind: "idle" });
+              }}
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {list.kind === "loading" ? (
+        <p className="muted">Loading tokens…</p>
+      ) : list.kind === "error" ? (
+        <div className="error" data-testid="account-tokens-error">
+          {list.message}
+        </div>
+      ) : list.tokens.length === 0 ? (
+        <p className="muted" data-testid="account-tokens-empty">
+          No live tokens on this account yet.
+        </p>
+      ) : (
+        <div data-testid="account-tokens-list">
+          {list.tokens.map((t) => {
+            const isConfirming = revoke.kind === "confirming" && revoke.jti === t.jti;
+            const isRevoking = revoke.kind === "revoking" && revoke.jti === t.jti;
+            const rowError = revoke.kind === "error" && revoke.jti === t.jti ? revoke : null;
+            const live = !t.revoked_at;
+            return (
+              <div key={t.jti} className="vault-row" data-testid={`account-token-row-${t.jti}`}>
+                <div className="body">
+                  <div className="name">
+                    <code title={t.jti}>{truncateJti(t.jti)}</code>
+                    <span className={`tag${live ? "" : " muted"}`}>
+                      {live ? "live" : "revoked"}
+                    </span>
+                    {t.subject ? (
+                      <span className="tag muted" title="label">
+                        {t.subject}
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="dim" style={{ marginTop: "0.25rem" }}>
+                    <span className="muted">scope: </span>
+                    {t.scopes.map((s, i) => (
+                      <span key={s}>
+                        <code>{s}</code>
+                        {i < t.scopes.length - 1 ? " " : null}
+                      </span>
+                    ))}
+                  </div>
+                  <div className="dim" style={{ marginTop: "0.25rem", fontSize: "0.82rem" }}>
+                    <span className="muted">expires </span>
+                    <code>{formatDate(t.expires_at)}</code>
+                  </div>
+                  {rowError ? (
+                    <div className="error" style={{ marginTop: "0.5rem" }}>
+                      {rowError.message}
+                    </div>
+                  ) : null}
+                  {isConfirming ? (
+                    <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+                      <p>
+                        Revoke <code>{truncateJti(t.jti)}</code>? This cannot be undone.
+                      </p>
+                      <div className="actions">
+                        <button
+                          type="button"
+                          onClick={() => void onConfirmRevoke(t.jti)}
+                          disabled={isRevoking}
+                          data-testid={`account-token-revoke-confirm-${t.jti}`}
+                        >
+                          {isRevoking ? "Revoking…" : "Revoke"}
+                        </button>
+                        <button
+                          type="button"
+                          className="secondary"
+                          onClick={() => setRevoke({ kind: "idle" })}
+                          disabled={isRevoking}
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
+                </div>
+                {!isConfirming && live ? (
+                  <button
+                    type="button"
+                    className="secondary"
+                    onClick={() => setRevoke({ kind: "confirming", jti: t.jti })}
+                    data-testid={`account-token-revoke-${t.jti}`}
+                  >
+                    Revoke
+                  </button>
+                ) : null}
+              </div>
+            );
+          })}
+          {list.nextCursor ? (
+            <div style={{ marginTop: "1rem" }}>
+              <button
+                type="button"
+                className="secondary"
+                disabled={loadingMore}
+                onClick={() => void loadMore()}
+                data-testid="account-tokens-load-more"
+              >
+                {loadingMore ? "Loading…" : "Load more"}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function truncateJti(jti: string): string {
+  if (jti.length <= 14) return jti;
+  return `${jti.slice(0, 8)}…${jti.slice(-4)}`;
+}
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return Number.isNaN(d.getTime()) ? iso : d.toLocaleString();
+}
+
+// ---------------------------------------------------------------------------
+// Linked Nostr keys
+// ---------------------------------------------------------------------------
+
+type PubkeyListState =
+  | { kind: "loading" }
+  | { kind: "ok"; pubkeys: AccountPubkey[] }
+  | { kind: "error"; message: string };
+
+type LinkView = { kind: "idle" } | { kind: "challenging"; challenge: PubkeyChallenge };
+
+type Nip07 = {
+  signEvent: (event: {
+    kind: number;
+    created_at: number;
+    tags: string[][];
+    content: string;
+  }) => Promise<SignedNostrEvent>;
+};
+
+function hasNip07(): Nip07 | null {
+  if (typeof window === "undefined") return null;
+  const nostr = (window as unknown as { nostr?: Nip07 }).nostr;
+  return nostr && typeof nostr.signEvent === "function" ? nostr : null;
+}
+
+function PubkeysSection({ csrf }: { csrf: string }) {
+  const [list, setList] = useState<PubkeyListState>({ kind: "loading" });
+  const [reload, setReload] = useState(0);
+  const [view, setView] = useState<LinkView>({ kind: "idle" });
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [eventJson, setEventJson] = useState("");
+  const [label, setLabel] = useState("");
+  const [password, setPassword] = useState("");
+  const [unlink, setUnlink] = useState<string | null>(null);
+  const [notice, setNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    void reload;
+    let cancelled = false;
+    setList({ kind: "loading" });
+    listAccountPubkeys()
+      .then((pubkeys) => {
+        if (cancelled) return;
+        setList({ kind: "ok", pubkeys });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setList({ kind: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reload]);
+
+  // Password step-up is required on the FIRST link. Show the field unless we
+  // already know this account holds a key; a failed list still shows it
+  // (server ignores the extra password on a subsequent link).
+  const firstLink = list.kind !== "ok" || list.pubkeys.length === 0;
+
+  async function onStartLink(): Promise<void> {
+    if (busy) return;
+    setErr(null);
+    setNotice(null);
+    setBusy(true);
+    try {
+      const challenge = await startPubkeyChallenge(csrf);
+      setView({ kind: "challenging", challenge });
+      setEventJson("");
+      setLabel("");
+      setPassword("");
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onSignWithExtension(): Promise<void> {
+    if (view.kind !== "challenging") return;
+    const nostr = hasNip07();
+    if (!nostr) {
+      setErr("No NIP-07 signer is available in this browser.");
+      return;
+    }
+    setErr(null);
+    setBusy(true);
+    try {
+      const tpl = view.challenge.event_template;
+      const signed = await nostr.signEvent({
+        kind: tpl.kind,
+        created_at: Math.floor(Date.now() / 1000),
+        tags: tpl.tags,
+        content: tpl.content,
+      });
+      setEventJson(JSON.stringify(signed, null, 2));
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onVerify(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    if (busy) return;
+    setErr(null);
+    setNotice(null);
+    let event: SignedNostrEvent;
+    try {
+      const parsed = JSON.parse(eventJson) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        setErr("Paste a signed NIP-01 event object.");
+        return;
+      }
+      event = parsed as SignedNostrEvent;
+    } catch {
+      setErr("Signed event is not valid JSON.");
+      return;
+    }
+    setBusy(true);
+    try {
+      const result = await verifyPubkeyLink(csrf, {
+        event,
+        ...(label.trim() ? { label: label.trim() } : {}),
+        ...(password ? { password } : {}),
+      });
+      setView({ kind: "idle" });
+      setEventJson("");
+      setLabel("");
+      setPassword("");
+      setNotice(
+        result.relinked
+          ? `Re-verified ${truncatePubkey(result.pubkey)}.`
+          : `Linked ${truncatePubkey(result.pubkey)}. A linked key grants nothing — it is an attribution label.`,
+      );
+      setReload((n) => n + 1);
+    } catch (e2) {
+      setErr(e2 instanceof Error ? e2.message : String(e2));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function onUnlink(pubkey: string): Promise<void> {
+    if (busy) return;
+    setErr(null);
+    setBusy(true);
+    try {
+      await unlinkAccountPubkey(csrf, pubkey);
+      setUnlink(null);
+      setReload((n) => n + 1);
+    } catch (e) {
+      setErr(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const nip07 = hasNip07();
+
+  return (
+    <section
+      className="settings-block"
+      aria-labelledby="account-pubkeys-heading"
+      data-testid="account-pubkeys"
+    >
+      <h2 id="account-pubkeys-heading">Nostr keys</h2>
+      <p className="muted">
+        A linked key is an attribution label. It does not log you in, mint a token, or widen a
+        scope. Unlink does not revoke tokens.
+      </p>
+
+      {notice ? (
+        <p className="muted" data-testid="account-pubkeys-notice">
+          {notice}
+        </p>
+      ) : null}
+
+      {view.kind === "challenging" ? (
+        <form onSubmit={(e) => void onVerify(e)} className="settings-form">
+          <p>
+            Sign this statement with a Nostr key you hold, then paste the signed event. A signer
+            that shows you the content will show you this sentence:
+          </p>
+          <pre
+            className="token-box"
+            data-testid="account-pubkey-statement"
+            style={{ whiteSpace: "pre-wrap" }}
+          >
+            <code>{view.challenge.event_template.content}</code>
+          </pre>
+          {nip07 ? (
+            <div className="actions">
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => void onSignWithExtension()}
+                data-testid="account-pubkey-nip07"
+              >
+                {busy ? "Waiting for signer…" : "Sign with browser extension"}
+              </button>
+            </div>
+          ) : (
+            <p className="muted">
+              No NIP-07 extension detected. Sign the event template elsewhere and paste the JSON
+              below.
+            </p>
+          )}
+          <label>
+            Signed event (JSON)
+            <textarea
+              value={eventJson}
+              onChange={(e) => setEventJson(e.target.value)}
+              rows={8}
+              style={{ width: "100%", fontFamily: "monospace", fontSize: "0.85rem" }}
+              data-testid="account-pubkey-event"
+            />
+          </label>
+          <label>
+            Label (optional)
+            <input
+              type="text"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="phone, signing device, …"
+              data-testid="account-pubkey-label"
+            />
+          </label>
+          {firstLink ? (
+            <label>
+              Current password (required to link your first key)
+              <input
+                type="password"
+                autoComplete="current-password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                data-testid="account-pubkey-password"
+              />
+            </label>
+          ) : null}
+          <div className="actions">
+            <button type="submit" disabled={busy} data-testid="account-pubkey-verify">
+              {busy ? "Verifying…" : "Link key"}
+            </button>
+            <button
+              type="button"
+              className="secondary"
+              disabled={busy}
+              onClick={() => {
+                setView({ kind: "idle" });
+                setErr(null);
+              }}
+              data-testid="account-pubkey-cancel"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      ) : (
+        <div className="actions">
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void onStartLink()}
+            data-testid="account-pubkey-link"
+          >
+            {busy ? "Starting…" : "Link a Nostr key"}
+          </button>
+        </div>
+      )}
+
+      {list.kind === "loading" ? (
+        <p className="muted">Loading keys…</p>
+      ) : list.kind === "error" ? (
+        <div className="error" data-testid="account-pubkeys-error">
+          {list.message}
+        </div>
+      ) : list.pubkeys.length === 0 ? (
+        <p className="muted" data-testid="account-pubkeys-empty">
+          No keys linked to this account.
+        </p>
+      ) : (
+        <div data-testid="account-pubkeys-list">
+          {list.pubkeys.map((k) => (
+            <div
+              key={k.pubkey}
+              className="vault-row"
+              data-testid={`account-pubkey-row-${k.pubkey}`}
+            >
+              <div className="body">
+                <div className="name">
+                  <code title={k.pubkey}>{truncatePubkey(k.pubkey)}</code>
+                  {k.label ? <span className="tag muted">{k.label}</span> : null}
+                </div>
+                <div className="dim" style={{ marginTop: "0.25rem", fontSize: "0.82rem" }}>
+                  <span className="muted">linked </span>
+                  <code>{formatDate(k.linked_at)}</code>
+                </div>
+                {unlink === k.pubkey ? (
+                  <div className="error-banner" style={{ marginTop: "0.5rem" }}>
+                    <p>
+                      Unlink <code>{truncatePubkey(k.pubkey)}</code>? Attribution proofs already
+                      written stay; tokens are not revoked.
+                    </p>
+                    <div className="actions">
+                      <button
+                        type="button"
+                        onClick={() => void onUnlink(k.pubkey)}
+                        disabled={busy}
+                        data-testid={`account-pubkey-unlink-confirm-${k.pubkey}`}
+                      >
+                        {busy ? "Unlinking…" : "Unlink"}
+                      </button>
+                      <button
+                        type="button"
+                        className="secondary"
+                        onClick={() => setUnlink(null)}
+                        disabled={busy}
+                      >
+                        Cancel
+                      </button>
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+              {unlink !== k.pubkey ? (
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => setUnlink(k.pubkey)}
+                  data-testid={`account-pubkey-unlink-${k.pubkey}`}
+                >
+                  Unlink
+                </button>
+              ) : null}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {err && (
+        <div className="error" data-testid="account-pubkeys-form-error">
+          {err}
+        </div>
+      )}
+    </section>
+  );
+}
+
+function truncatePubkey(pubkey: string): string {
+  if (pubkey.length <= 16) return pubkey;
+  return `${pubkey.slice(0, 8)}…${pubkey.slice(-4)}`;
 }

--- a/web/ui/src/routes/Home.test.tsx
+++ b/web/ui/src/routes/Home.test.tsx
@@ -98,12 +98,14 @@ describe("Administer group", () => {
     renderRoute();
 
     const administer = await screen.findByTestId("home-administer");
-    // These six sections should be present; /vaults should not.
+    // Hub-native sections; /vaults is module-owned and must not appear.
     for (const path of [
       "/connections",
       "/modules",
       "/users",
+      "/account",
       "/tokens",
+      "/grants",
       "/permissions",
       "/settings",
     ]) {

--- a/web/ui/src/routes/Home.tsx
+++ b/web/ui/src/routes/Home.tsx
@@ -74,12 +74,22 @@ const HUB_SECTIONS: readonly HubSection[] = [
   {
     to: "/connections",
     label: "Connections",
-    desc: "Wire a module event to another module's action.",
+    desc: "Wire a module event to another module's action (IFTTT).",
   },
   { to: "/modules", label: "Modules", desc: "Install, upgrade, and manage modules." },
   { to: "/users", label: "Users", desc: "Manage operators and invite members." },
-  { to: "/tokens", label: "Tokens", desc: "Mint and revoke access tokens." },
-  { to: "/permissions", label: "Permissions", desc: "OAuth consent grants per app." },
+  {
+    to: "/account",
+    label: "My account",
+    desc: "Your password, 2FA, API tokens, and linked Nostr keys.",
+  },
+  {
+    to: "/tokens",
+    label: "Tokens",
+    desc: "Operator registry — every CLI / OAuth / operator-mint on this hub.",
+  },
+  { to: "/grants", label: "Grants", desc: "Agent-connector approvals." },
+  { to: "/permissions", label: "Permissions", desc: "OAuth consent skip-list per app." },
   { to: "/settings", label: "Settings", desc: "Canonical URL, install channel, more." },
 ];
 

--- a/web/ui/src/routes/Tokens.tsx
+++ b/web/ui/src/routes/Tokens.tsx
@@ -19,7 +19,7 @@
  * before posting.
  */
 import { type FormEvent, useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import {
   type AdminTokenCreatedVia,
   type AdminTokenListing,
@@ -257,9 +257,11 @@ export function Tokens() {
       </div>
 
       <p className="muted">
-        The hub's token registry. Every CLI / OAuth / operator-mint writes a row here. Revoking
-        flips <code>revoked_at</code>; resource servers on{" "}
-        <code>@openparachute/scope-guard@^0.2.0</code> reject within ~60s of the next poll.
+        The operator registry. Every CLI / OAuth / operator-mint writes a row here. Your own tokens
+        — the ones a friend can mint without this page — live on{" "}
+        <Link to="/account">My account</Link>. Revoking flips <code>revoked_at</code>; resource
+        servers on <code>@openparachute/scope-guard@^0.2.0</code> reject within ~60s of the next
+        poll.
       </p>
 
       {mint.kind === "minted" ? (
@@ -482,7 +484,11 @@ function renderList({
   filtersActive,
 }: RenderListProps) {
   if (list.kind === "loading") {
-    return <p className="muted" data-loading="true">Loading…</p>;
+    return (
+      <p className="muted" data-loading="true">
+        Loading…
+      </p>
+    );
   }
   if (list.kind === "error") {
     return (


### PR DESCRIPTION
Merging this publishes `@openparachute/hub@0.7.18-rc.1` to npm `@rc` (and ghcr `:rc`). It is an **rc**, not stable.

**Merge-commit, do not squash.**

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What ships (on `next` after 0.7.17)

- #872 person-mint JWT `sub` is `users.id`; CAS; cookie+CSRF `/api/account/tokens`
- #874 Account SPA `/admin/account` — my-tokens + pubkey-link
- #875 CAS leftover + first-link 401 code
- #877 version+changelog 0.7.18-rc.1

NIP-98 / key-as-account is not this rc. 0.7.17 stable already published `@latest` via hub#876.

## After merge

I `parachute upgrade hub --channel rc` on this box (not bun-link) and record `/admin/account` from the live instance.

Do not suffix-drop 0.7.18 until it has lived on rc. Multiple rcs can land first.
