### PR TITLE
feat(hub#833): NIP-98 request auth as a hub user principal

### DIFF
--- a/src/__tests__/nostr-http-auth.test.ts
+++ b/src/__tests__/nostr-http-auth.test.ts
@@ -1,0 +1,308 @@
+/**
+ * NIP-98 request auth (hub#833 (c)).
+ *
+ * Watch-fail: these tests signed against an unpatched verify (no replay
+ * cache, no u/method bind) before the implementation landed.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import type { Database } from "bun:sqlite";
+import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
+import {
+  NIP98_MAX_SKEW_SECONDS,
+  NostrReplayCache,
+  authenticateNostrRequest,
+  extractNostrEvent,
+  verifyNostrHttpEvent,
+} from "../nostr-http-auth.ts";
+import { requireScope } from "../admin-auth.ts";
+import { createUser } from "../users.ts";
+import { bindPubkeyFromHttpAuth, findPubkeyLink } from "../pubkey-links.ts";
+import { issuePubkeyChallenge, linkPubkey } from "../pubkey-links.ts";
+
+const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
+const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
+const SECRET = hexToBytes("aa".repeat(32));
+const PUBKEY = bytesToHex(schnorr.getPublicKey(SECRET));
+
+function signEvent(parts: {
+  created_at?: number;
+  kind?: number;
+  tags?: string[][];
+  content?: string;
+}): NostrEvent {
+  const unsigned = {
+    pubkey: PUBKEY,
+    created_at: parts.created_at ?? Math.floor(Date.now() / 1000),
+    kind: parts.kind ?? NOSTR_AUTH_KIND,
+    tags: parts.tags ?? [],
+    content: parts.content ?? "",
+  };
+  const id = nostrEventId(unsigned);
+  const sig = bytesToHex(schnorr.sign(hexToBytes(id), SECRET));
+  return { ...unsigned, id, sig };
+}
+
+function nostrHeader(event: NostrEvent): string {
+  return `Nostr ${Buffer.from(JSON.stringify(event), "utf8").toString("base64url")}`;
+}
+
+function reqFor(
+  url: string,
+  method: string,
+  event: NostrEvent,
+  body?: string,
+): Request {
+  return new Request(url, {
+    method,
+    headers: {
+      authorization: nostrHeader(event),
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body } : {}),
+  });
+}
+
+describe("extractNostrEvent", () => {
+  test("parses a base64url event", () => {
+    const event = signEvent({
+      tags: [
+        ["u", "http://127.0.0.1:1939/api/me"],
+        ["method", "GET"],
+      ],
+    });
+    const req = reqFor("http://127.0.0.1:1939/api/me", "GET", event);
+    expect(extractNostrEvent(req).id).toBe(event.id);
+  });
+
+  test("rejects Bearer", () => {
+    const req = new Request("http://127.0.0.1:1939/api/me", {
+      headers: { authorization: "Bearer abc" },
+    });
+    expect(() => extractNostrEvent(req)).toThrow(/Nostr/);
+  });
+});
+
+describe("verifyNostrHttpEvent", () => {
+  test("accepts a fresh GET with matching u and method", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const replay = new NostrReplayCache();
+    verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
+  });
+
+  test("rejects a replayed event id", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const replay = new NostrReplayCache();
+    verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
+    expect(() => verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay })).toThrow(
+      /already been used/,
+    );
+  });
+
+  test("rejects u mismatch", () => {
+    const event = signEvent({
+      tags: [
+        ["u", "http://evil.example/api/me"],
+        ["method", "GET"],
+      ],
+    });
+    expect(() =>
+      verifyNostrHttpEvent(
+        reqFor("http://127.0.0.1:1939/api/me", "GET", event),
+        event,
+        { replay: new NostrReplayCache() },
+      ),
+    ).toThrow(/u tag/);
+  });
+
+  test("rejects method mismatch", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "POST"]] });
+    expect(() =>
+      verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
+    ).toThrow(/method tag/);
+  });
+
+  test("rejects created_at outside the 60s window", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({
+      created_at: Math.floor(Date.now() / 1000) - (NIP98_MAX_SKEW_SECONDS + 5),
+      tags: [["u", url], ["method", "GET"]],
+    });
+    expect(() =>
+      verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
+    ).toThrow(/60s window/);
+  });
+
+  test("requires payload sha256 hex when the body is non-empty", () => {
+    const url = "http://127.0.0.1:1939/api/account/tokens";
+    const body = '{"scope":"vault:work:read"}';
+    const hash = createHash("sha256").update(body, "utf8").digest("hex");
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "POST"],
+        ["payload", hash],
+      ],
+    });
+    const replay = new NostrReplayCache();
+    verifyNostrHttpEvent(reqFor(url, "POST", event, body), event, {
+      replay,
+      body: new TextEncoder().encode(body),
+    });
+
+    const bad = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "POST"],
+        ["payload", "00".repeat(32)],
+      ],
+    });
+    expect(() =>
+      verifyNostrHttpEvent(reqFor(url, "POST", bad, body), bad, {
+        replay: new NostrReplayCache(),
+        body: new TextEncoder().encode(body),
+      }),
+    ).toThrow(/payload tag/);
+  });
+});
+
+describe("authenticateNostrRequest", () => {
+  let db: Database;
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), "phub-nip98-"));
+    db = openHubDb(hubDbPath(configDir));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("unknown pubkey is 401 when auto-provision is off", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    await expect(
+      authenticateNostrRequest(db, reqFor(url, "GET", event), {
+        autoProvision: false,
+        replay: new NostrReplayCache(),
+      }),
+    ).rejects.toThrow(/not linked/);
+  });
+
+  test("linked pubkey authenticates as that user", async () => {
+    const owner = await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const friend = await createUser(db, "alice", "correct-horse-battery-staple", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["work"],
+    });
+    const now = new Date();
+    const { challenge } = issuePubkeyChallenge(db, friend.id, now);
+    const linked = linkPubkey(db, {
+      userId: friend.id,
+      pubkey: PUBKEY,
+      challenge,
+      proofEvent: JSON.stringify({ id: "0".repeat(64), pubkey: PUBKEY, kind: 27235, tags: [] }),
+      now,
+    });
+    expect(linked.ok).toBe(true);
+
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
+      autoProvision: false,
+      replay: new NostrReplayCache(),
+    });
+    expect(principal.userId).toBe(friend.id);
+    expect(principal.provisioned).toBe(false);
+    expect(principal.isHubAdmin).toBe(false);
+    expect(principal.scopes).toContain("vault:work:read");
+    expect(principal.scopes).toContain("vault:work:admin");
+    expect(owner.id).not.toBe(friend.id);
+  });
+
+  test("auto-provision creates a key-only user and binds the pubkey", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
+      autoProvision: true,
+      replay: new NostrReplayCache(),
+    });
+    expect(principal.provisioned).toBe(true);
+    expect(principal.isHubAdmin).toBe(false);
+    expect(principal.pubkey).toBe(PUBKEY);
+    expect(principal.scopes).toEqual([]);
+    const link = findPubkeyLink(db, PUBKEY);
+    expect(link?.userId).toBe(principal.userId);
+  });
+
+  test("requireScope: provisioned key-user cannot take parachute:host:admin", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const url = "http://127.0.0.1:1939/api/users";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    process.env.PARACHUTE_NOSTR_AUTO_PROVISION = "1";
+    try {
+      await expect(
+        requireScope(db, reqFor(url, "GET", event), "parachute:host:admin", "http://127.0.0.1:1939"),
+      ).rejects.toThrow(/parachute:host:admin/);
+    } finally {
+      delete process.env.PARACHUTE_NOSTR_AUTO_PROVISION;
+    }
+  });
+});
+
+describe("bindPubkeyFromHttpAuth", () => {
+  let db: Database;
+  let configDir: string;
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), "phub-nip98-bind-"));
+    db = openHubDb(hubDbPath(configDir));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("refuses a pubkey already bound to another user", async () => {
+    const a = await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const b = await createUser(db, "bob", "correct-horse-battery-staple", {
+      allowMulti: true,
+      passwordChanged: true,
+    });
+    const ok = bindPubkeyFromHttpAuth(db, {
+      userId: a.id,
+      pubkey: PUBKEY,
+      proofEvent: "{}",
+      proofEventId: "1".repeat(64),
+    });
+    expect(ok.ok).toBe(true);
+    const taken = bindPubkeyFromHttpAuth(db, {
+      userId: b.id,
+      pubkey: PUBKEY,
+      proofEvent: "{}",
+      proofEventId: "2".repeat(64),
+    });
+    expect(taken).toEqual({ ok: false, reason: "pubkey_taken" });
+  });
+});

--- a/src/__tests__/nostr-http-auth.test.ts
+++ b/src/__tests__/nostr-http-auth.test.ts
@@ -253,6 +253,47 @@ describe("authenticateNostrRequest", () => {
     expect(link?.userId).toBe(principal.userId);
   });
 
+  test("auto-provision refuses when the hub has no owner yet", async () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    await expect(
+      authenticateNostrRequest(db, reqFor(url, "GET", event), {
+        autoProvision: true,
+        replay: new NostrReplayCache(),
+      }),
+    ).rejects.toThrow(/existing hub owner/);
+  });
+
+  test("read-role assignment does not get write or admin scopes", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const friend = await createUser(db, "reader", "correct-horse-battery-staple", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["shared"],
+      role: "read",
+    });
+    const now = new Date();
+    const { challenge } = issuePubkeyChallenge(db, friend.id, now);
+    expect(
+      linkPubkey(db, {
+        userId: friend.id,
+        pubkey: PUBKEY,
+        challenge,
+        proofEvent: JSON.stringify({ id: "0".repeat(64), pubkey: PUBKEY, kind: 27235, tags: [] }),
+        now,
+      }).ok,
+    ).toBe(true);
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
+      autoProvision: false,
+      replay: new NostrReplayCache(),
+    });
+    expect(principal.scopes).toEqual(["vault:shared:read"]);
+  });
+
   test("requireScope: provisioned key-user cannot take parachute:host:admin", async () => {
     await createUser(db, "owner", "correct-horse-battery-staple", {
       passwordChanged: true,

--- a/src/admin-auth.ts
+++ b/src/admin-auth.ts
@@ -15,6 +15,10 @@
  */
 import type { Database } from "bun:sqlite";
 import { validateAccessToken } from "./jwt-sign.ts";
+import {
+  authenticateNostrRequest,
+  isNostrAuthorization,
+} from "./nostr-http-auth.ts";
 
 export interface AdminAuthContext {
   /** JWT `sub` — the hub user id. */
@@ -92,12 +96,55 @@ export function extractBearerToken(req: Request): string {
  * hub minted ever reach the `iss` check; never pass a raw request Host, only a
  * `buildHubBoundOrigins`-derived set.
  */
+export function nostrAutoProvisionEnabled(): boolean {
+  const v = process.env.PARACHUTE_NOSTR_AUTO_PROVISION;
+  return v === "1" || v === "true" || v === "yes";
+}
+
 export async function requireScope(
   db: Database,
   req: Request,
   requiredScope: string,
   expectedIssuer: string | readonly string[],
 ): Promise<AdminAuthContext> {
+  if (isNostrAuthorization(req)) {
+    let body = new Uint8Array();
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      body = new Uint8Array(await req.clone().arrayBuffer());
+    }
+    try {
+      const principal = await authenticateNostrRequest(db, req, {
+        autoProvision: nostrAutoProvisionEnabled(),
+        body,
+      });
+      if (principal.isHubAdmin) {
+        return {
+          sub: principal.userId,
+          scopes: [requiredScope],
+          clientId: `nostr:${principal.pubkey}`,
+          audience: undefined,
+        };
+      }
+      if (!principal.scopes.includes(requiredScope)) {
+        throw new AdminAuthError(
+          403,
+          `token missing required scope: ${requiredScope}`,
+          requiredScope,
+        );
+      }
+      return {
+        sub: principal.userId,
+        scopes: principal.scopes,
+        clientId: `nostr:${principal.pubkey}`,
+        audience: undefined,
+      };
+    } catch (err) {
+      if (err instanceof AdminAuthError) throw err;
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new AdminAuthError(401, msg);
+    }
+  }
+
   const token = extractBearerToken(req);
 
   let validated: Awaited<ReturnType<typeof validateAccessToken>>;

--- a/src/nostr-event.ts
+++ b/src/nostr-event.ts
@@ -52,9 +52,11 @@ import { schnorr } from "@noble/curves/secp256k1.js";
  * tags rather than inventing a hub-private kind, so a generic NIP-98 signer
  * can produce our event with one extra tag.
  *
- * We do NOT implement NIP-98 as a request-authentication scheme: NIP-98's own
- * replay defense is a ±60s `created_at` window, which is weak. The hub issues
- * a single-use challenge instead and requires it in a `challenge` tag.
+ * Linkage (cookie ceremony) still uses a single-use `challenge` tag because
+ * NIP-98's ±60s `created_at` window is too weak to bind a durable proof.
+ * Request authentication is a separate path: `nostr-http-auth.ts` verifies
+ * kind 27235 against this request's `u`/`method`/`payload` and rejects a
+ * replayed event id for twice the clock-skew window.
  */
 export const NOSTR_AUTH_KIND = 27235;
 

--- a/src/nostr-http-auth.ts
+++ b/src/nostr-http-auth.ts
@@ -1,0 +1,336 @@
+/**
+ * NIP-98 HTTP request authentication (hub#833 (c)).
+ *
+ * A request carrying `Authorization: Nostr <base64url(json event)>` proves
+ * the caller holds the private key for `event.pubkey`. That pubkey maps to a
+ * hub user via `user_pubkeys`. Unknown keys may create a key-only user when
+ * `autoProvision` is on — the Buzz-shaped onboarding: agents already have
+ * keys; they do not get hub passwords.
+ *
+ * Replay: NIP-98's ±60s `created_at` window is not enough (the linkage
+ * ceremony already refused to rely on it). This module also rejects an
+ * event id it has seen until well after that window closes.
+ *
+ * The cookie + password first-link path in `api-account-pubkeys.ts` is
+ * unchanged. This path never asks for a password: the signature *is* the
+ * possession proof.
+ */
+import { createHash, randomBytes } from "node:crypto";
+import type { Database } from "bun:sqlite";
+import {
+  NOSTR_AUTH_KIND,
+  type NostrEvent,
+  parseNostrEvent,
+  tagValue,
+  verifyNostrEvent,
+} from "./nostr-event.ts";
+import { bindPubkeyFromHttpAuth, findPubkeyLink } from "./pubkey-links.ts";
+import { createUser, getUserById, isFirstAdmin, vaultVerbsForRole } from "./users.ts";
+
+/** NIP-98 clock skew, seconds. Spec window. */
+export const NIP98_MAX_SKEW_SECONDS = 60;
+
+/**
+ * How long a used event id stays rejected. Must be ≥ 2× the skew window so
+ * an event still inside ±60s cannot be replayed after eviction.
+ */
+export const NIP98_REPLAY_TTL_MS = 2 * NIP98_MAX_SKEW_SECONDS * 1000;
+
+export type NostrHttpAuthFailure =
+  | "missing_authorization"
+  | "malformed_authorization"
+  | "invalid_event"
+  | "bad_signature"
+  | "wrong_kind"
+  | "expired"
+  | "replayed"
+  | "url_mismatch"
+  | "method_mismatch"
+  | "payload_mismatch"
+  | "unknown_pubkey"
+  | "pubkey_taken";
+
+export class NostrHttpAuthError extends Error {
+  override name = "NostrHttpAuthError";
+  constructor(
+    public readonly status: number,
+    public readonly code: NostrHttpAuthFailure,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export class NostrReplayCache {
+  private readonly seen = new Map<string, number>();
+  constructor(private readonly ttlMs: number = NIP98_REPLAY_TTL_MS) {}
+
+  /**
+   * Returns true if this id was already consumed and is still inside TTL.
+   * Records the id on first sight.
+   */
+  consume(id: string, nowMs: number): boolean {
+    this.gc(nowMs);
+    const exp = this.seen.get(id);
+    if (exp !== undefined && exp > nowMs) return true;
+    this.seen.set(id, nowMs + this.ttlMs);
+    return false;
+  }
+
+  private gc(nowMs: number): void {
+    for (const [id, exp] of this.seen) {
+      if (exp <= nowMs) this.seen.delete(id);
+    }
+  }
+}
+
+const defaultReplay = new NostrReplayCache();
+
+export function extractNostrEvent(req: Request): NostrEvent {
+  const header = req.headers.get("authorization");
+  if (!header) {
+    throw new NostrHttpAuthError(401, "missing_authorization", "missing Authorization header");
+  }
+  const match = header.match(/^Nostr\s+(\S+)$/i);
+  if (!match || !match[1]) {
+    throw new NostrHttpAuthError(
+      401,
+      "malformed_authorization",
+      "Authorization header must be 'Nostr <base64 event>'",
+    );
+  }
+  let json: string;
+  try {
+    json = Buffer.from(match[1], "base64url").toString("utf8");
+  } catch {
+    throw new NostrHttpAuthError(401, "malformed_authorization", "Nostr token is not base64url");
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new NostrHttpAuthError(401, "malformed_authorization", "Nostr token is not JSON");
+  }
+  const parsed = parseNostrEvent(raw);
+  if (!parsed.ok) {
+    throw new NostrHttpAuthError(401, "invalid_event", `Nostr event rejected: ${parsed.reason}`);
+  }
+  return parsed.event;
+}
+
+export function requestAbsoluteUrl(req: Request): string {
+  return req.url;
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Verify the event is a NIP-98 auth event for *this* request. Does not
+ * resolve a hub user.
+ */
+export function verifyNostrHttpEvent(
+  req: Request,
+  event: NostrEvent,
+  opts: {
+    now?: () => Date;
+    replay?: NostrReplayCache;
+    /** Raw body bytes; required when the request has a body. */
+    body?: Uint8Array;
+  } = {},
+): void {
+  const now = opts.now?.() ?? new Date();
+  const replay = opts.replay ?? defaultReplay;
+
+  const verified = verifyNostrEvent(event);
+  if (!verified.ok) {
+    throw new NostrHttpAuthError(
+      401,
+      "bad_signature",
+      verified.reason === "id_mismatch"
+        ? "Nostr event id does not match payload"
+        : "Nostr event signature is invalid",
+    );
+  }
+  if (event.kind !== NOSTR_AUTH_KIND) {
+    throw new NostrHttpAuthError(401, "wrong_kind", `Nostr event kind must be ${NOSTR_AUTH_KIND}`);
+  }
+
+  const createdAtMs = event.created_at * 1000;
+  const skewMs = NIP98_MAX_SKEW_SECONDS * 1000;
+  if (Math.abs(now.getTime() - createdAtMs) > skewMs) {
+    throw new NostrHttpAuthError(401, "expired", "Nostr event created_at is outside the 60s window");
+  }
+
+  if (replay.consume(event.id, now.getTime())) {
+    throw new NostrHttpAuthError(401, "replayed", "Nostr event id has already been used");
+  }
+
+  const u = tagValue(event, "u");
+  const expectedUrl = requestAbsoluteUrl(req);
+  if (u !== expectedUrl) {
+    throw new NostrHttpAuthError(401, "url_mismatch", "Nostr event u tag must equal this request URL");
+  }
+  const method = tagValue(event, "method");
+  if (!method || method.toUpperCase() !== req.method.toUpperCase()) {
+    throw new NostrHttpAuthError(
+      401,
+      "method_mismatch",
+      "Nostr event method tag must equal this request method",
+    );
+  }
+
+  const body = opts.body ?? new Uint8Array();
+  const payload = tagValue(event, "payload");
+  if (body.byteLength === 0) {
+    if (payload) {
+      throw new NostrHttpAuthError(
+        401,
+        "payload_mismatch",
+        "Nostr event payload tag must be absent when the body is empty",
+      );
+    }
+  } else {
+    const expected = sha256Hex(body);
+    if (payload !== expected) {
+      throw new NostrHttpAuthError(
+        401,
+        "payload_mismatch",
+        "Nostr event payload tag must be sha256 hex of the request body",
+      );
+    }
+  }
+}
+
+export interface NostrPrincipal {
+  userId: string;
+  username: string;
+  pubkey: string;
+  /** True when this request created the hub user. */
+  provisioned: boolean;
+  /**
+   * Hub-admin unrestricted sentinel is first-admin only. Key-native users
+   * never become first-admin by auto-provision (the owner row already exists).
+   */
+  isHubAdmin: boolean;
+  /** `vault:<name>:<verb>` for assigned vaults. Empty for first-admin. */
+  scopes: string[];
+}
+
+function usernameForPubkey(pubkey: string): string {
+  // validateUsername: [a-z0-9_-] 2–32. Hex is in charset.
+  return `n${pubkey.slice(0, 31)}`;
+}
+
+/**
+ * Map a verified pubkey to a hub user. Existing `user_pubkeys` row wins.
+ * When `autoProvision` is true and the key is unknown, create a key-only
+ * user (random unusable password, password_changed=1, key already bound).
+ */
+export async function resolveNostrPrincipal(
+  db: Database,
+  event: NostrEvent,
+  opts: { autoProvision: boolean; now?: () => Date },
+): Promise<NostrPrincipal> {
+  const nowFn = opts.now ?? (() => new Date());
+  const now = nowFn();
+  const existing = findPubkeyLink(db, event.pubkey);
+  if (existing) {
+    const user = getUserById(db, existing.userId);
+    if (!user) {
+      throw new NostrHttpAuthError(401, "unknown_pubkey", "linked user no longer exists");
+    }
+    return principalFromUser(db, user.id, user.username, event.pubkey, false);
+  }
+  if (!opts.autoProvision) {
+    throw new NostrHttpAuthError(
+      401,
+      "unknown_pubkey",
+      "Nostr pubkey is not linked to a hub user",
+    );
+  }
+
+  const password = randomBytes(32).toString("base64url");
+  let username = usernameForPubkey(event.pubkey);
+  let user;
+  try {
+    user = await createUser(db, username, password, {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: [],
+      now: nowFn,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "UsernameTakenError") {
+      username = `n${event.pubkey.slice(1, 32)}`;
+      user = await createUser(db, username, password, {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: [],
+        now: nowFn,
+      });
+    } else {
+      throw err;
+    }
+  }
+
+  const bound = bindPubkeyFromHttpAuth(db, {
+    userId: user.id,
+    pubkey: event.pubkey,
+    proofEvent: JSON.stringify(event),
+    proofEventId: event.id,
+    label: "nip98",
+    now,
+  });
+  if (!bound.ok) {
+    throw new NostrHttpAuthError(401, "pubkey_taken", "Nostr pubkey is already bound to another user");
+  }
+  return principalFromUser(db, user.id, user.username, event.pubkey, true);
+}
+
+function principalFromUser(
+  db: Database,
+  userId: string,
+  username: string,
+  pubkey: string,
+  provisioned: boolean,
+): NostrPrincipal {
+  const admin = isFirstAdmin(db, userId);
+  const user = getUserById(db, userId);
+  const scopes: string[] = [];
+  if (!admin && user) {
+    const verbs = vaultVerbsForRole("write");
+    for (const name of user.assignedVaults) {
+      for (const verb of verbs) scopes.push(`vault:${name}:${verb}`);
+    }
+  }
+  return { userId, username, pubkey, provisioned, isHubAdmin: admin, scopes };
+}
+
+export async function authenticateNostrRequest(
+  db: Database,
+  req: Request,
+  opts: {
+    autoProvision: boolean;
+    now?: () => Date;
+    replay?: NostrReplayCache;
+    body?: Uint8Array;
+  },
+): Promise<NostrPrincipal> {
+  const event = extractNostrEvent(req);
+  verifyNostrHttpEvent(req, event, {
+    now: opts.now,
+    replay: opts.replay,
+    body: opts.body,
+  });
+  return resolveNostrPrincipal(db, event, {
+    autoProvision: opts.autoProvision,
+    now: opts.now,
+  });
+}
+
+export function isNostrAuthorization(req: Request): boolean {
+  const header = req.headers.get("authorization");
+  return !!header && /^Nostr\s+/i.test(header);
+}

--- a/src/nostr-http-auth.ts
+++ b/src/nostr-http-auth.ts
@@ -25,7 +25,13 @@ import {
   verifyNostrEvent,
 } from "./nostr-event.ts";
 import { bindPubkeyFromHttpAuth, findPubkeyLink } from "./pubkey-links.ts";
-import { createUser, getUserById, isFirstAdmin, vaultVerbsForRole } from "./users.ts";
+import {
+  createUser,
+  getFirstAdminId,
+  getUserById,
+  isFirstAdmin,
+  vaultVerbsForUserVault,
+} from "./users.ts";
 
 /** NIP-98 clock skew, seconds. Spec window. */
 export const NIP98_MAX_SKEW_SECONDS = 60;
@@ -34,7 +40,7 @@ export const NIP98_MAX_SKEW_SECONDS = 60;
  * How long a used event id stays rejected. Must be ≥ 2× the skew window so
  * an event still inside ±60s cannot be replayed after eviction.
  */
-export const NIP98_REPLAY_TTL_MS = 2 * NIP98_MAX_SKEW_SECONDS * 1000;
+export const NIP98_REPLAY_TTL_MS = 2 * NIP98_MAX_SKEW_SECONDS * 1000 + 1000;
 
 export type NostrHttpAuthFailure =
   | "missing_authorization"
@@ -250,6 +256,13 @@ export async function resolveNostrPrincipal(
       "Nostr pubkey is not linked to a hub user",
     );
   }
+  if (getFirstAdminId(db) === null) {
+    throw new NostrHttpAuthError(
+      401,
+      "unknown_pubkey",
+      "Nostr auto-provision requires an existing hub owner",
+    );
+  }
 
   const password = randomBytes(32).toString("base64url");
   let username = usernameForPubkey(event.pubkey);
@@ -300,8 +313,8 @@ function principalFromUser(
   const user = getUserById(db, userId);
   const scopes: string[] = [];
   if (!admin && user) {
-    const verbs = vaultVerbsForRole("write");
     for (const name of user.assignedVaults) {
+      const verbs = vaultVerbsForUserVault(db, userId, name) ?? [];
       for (const verb of verbs) scopes.push(`vault:${name}:${verb}`);
     }
   }

--- a/src/pubkey-links.ts
+++ b/src/pubkey-links.ts
@@ -24,11 +24,11 @@
  *
  * ## What a linked key does and does not grant
  *
- * **It grants nothing.** A linked key cannot authenticate a request, mint a
- * token, read a vault, or widen a scope. Nothing in the hub's authorization
- * path reads `user_pubkeys`. Phase 1 makes *who did this* checkable; who may
- * do what is Jon's ACL design (seams S1/S1b in the doc) and is deliberately
- * untouched here.
+ * On the **cookie + password** path a linked key still grants nothing — it is
+ * an attribution label (phase 1). On the **NIP-98 HTTP auth** path
+ * (`nostr-http-auth.ts`, hub#833 (c)) the same table is the principal map:
+ * a request signed by `pubkey` authenticates as `user_id`. Unlink drops
+ * future NIP-98 logins for that key; it does not erase `attribution_proofs`.
  *
  * ## Replay protection
  *
@@ -349,6 +349,105 @@ export function findPubkeyLink(db: Database, pubkey: string): LinkedPubkey | nul
     .query<LinkRow, [string]>("SELECT * FROM user_pubkeys WHERE pubkey = ?")
     .get(pubkey);
   return row ? rowToLink(row) : null;
+}
+
+export type BindPubkeyFromHttpAuthResult =
+  | { ok: true; link: LinkedPubkey; relinked: boolean }
+  | { ok: false; reason: "pubkey_taken" | "too_many_pubkeys" };
+
+/**
+ * Bind `pubkey` to `userId` using a NIP-98 HTTP-auth event as the proof.
+ * No challenge-response: the signed request *is* the possession proof.
+ * The cookie ceremony (`linkPubkey`) stays challenge-gated.
+ *
+ * Caller MUST have verified the event (id + BIP-340 + `u`/`method` bind)
+ * before calling. This function performs no cryptography.
+ */
+export function bindPubkeyFromHttpAuth(
+  db: Database,
+  opts: {
+    userId: string;
+    pubkey: string;
+    proofEvent: string;
+    proofEventId: string;
+    label?: string | null;
+    now?: Date;
+  },
+): BindPubkeyFromHttpAuthResult {
+  const now = opts.now ?? new Date();
+  const stamp = now.toISOString();
+  const label = opts.label ?? null;
+  const run = db.transaction((): BindPubkeyFromHttpAuthResult => {
+    const existing = db
+      .query<LinkRow, [string]>("SELECT * FROM user_pubkeys WHERE pubkey = ?")
+      .get(opts.pubkey);
+    if (existing && existing.user_id !== opts.userId) {
+      return { ok: false, reason: "pubkey_taken" };
+    }
+    if (!existing) {
+      const count = (
+        db
+          .query<{ n: number }, [string]>(
+            "SELECT COUNT(*) AS n FROM user_pubkeys WHERE user_id = ?",
+          )
+          .get(opts.userId) ?? { n: 0 }
+      ).n;
+      if (count >= MAX_PUBKEYS_PER_USER) return { ok: false, reason: "too_many_pubkeys" };
+      db.prepare(
+        `INSERT INTO user_pubkeys
+           (pubkey, user_id, label, proof_event, proof_event_id, linked_at, last_verified_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(opts.pubkey, opts.userId, label, opts.proofEvent, opts.proofEventId, stamp, stamp);
+      retainAttributionProof(db, {
+        subject: opts.userId,
+        pubkey: opts.pubkey,
+        label,
+        proofEvent: opts.proofEvent,
+        proofEventId: opts.proofEventId,
+        linkedAt: stamp,
+        lastVerifiedAt: stamp,
+      });
+      return {
+        ok: true,
+        relinked: false,
+        link: {
+          pubkey: opts.pubkey,
+          userId: opts.userId,
+          label,
+          proofEventId: opts.proofEventId,
+          linkedAt: stamp,
+          lastVerifiedAt: stamp,
+        },
+      };
+    }
+    db.prepare(
+      `UPDATE user_pubkeys
+         SET label = ?, proof_event = ?, proof_event_id = ?, last_verified_at = ?
+       WHERE pubkey = ? AND user_id = ?`,
+    ).run(label, opts.proofEvent, opts.proofEventId, stamp, opts.pubkey, opts.userId);
+    retainAttributionProof(db, {
+      subject: opts.userId,
+      pubkey: opts.pubkey,
+      label,
+      proofEvent: opts.proofEvent,
+      proofEventId: opts.proofEventId,
+      linkedAt: existing.linked_at,
+      lastVerifiedAt: stamp,
+    });
+    return {
+      ok: true,
+      relinked: true,
+      link: {
+        pubkey: opts.pubkey,
+        userId: opts.userId,
+        label,
+        proofEventId: opts.proofEventId,
+        linkedAt: existing.linked_at,
+        lastVerifiedAt: stamp,
+      },
+    };
+  });
+  return run();
 }
 
 /**


### PR DESCRIPTION
hub#833 **(c)**: `Authorization: Nostr <base64url event>` authenticates as a hub user. Buzz-shaped path — humans and agents already hold keys.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What this PR does

- Kind 27235, `u` = this request URL, `method` = this method, `payload` = sha256 hex of body when present.
- Replay cache 2×60s+1s on event id, on top of the 60s window.
- Linked pubkey → that `users.id`. Vault scopes from `vaultVerbsForUserVault` (read-role stays read). `parachute:host:admin` remains first-admin only.
- `PARACHUTE_NOSTR_AUTO_PROVISION=1` creates a key-only user with **no vaults**. Refuses if the hub has no owner yet (cannot become first-admin). Default **off**.
- Cookie first-link unchanged.

## What this PR does not do

- Account-MCP on the hub. Channel-vault binding. Account SPA rewrite. Multiple hub admins.
- `/api/me` is still cookie-only — NIP-98 is wired through `requireScope` (admin APIs). Next slice: a door a Buzz agent can actually call (account-MCP).
- Live `:1939`. Not bun-linked.

## Verification

- `bun test ./src/__tests__/nostr-http-auth.test.ts` — **15 pass / 0 fail** (includes empty-table auto-provision refuse + read-role).
- `bun run typecheck` — 0 errors
- Did **not** run `bun test ./src` on this live operator box (hub#840)

Fold: review NO-SHIP on first-admin-via-empty-table + hardcoded write verbs.