### PR TITLE
feat(hub#833): account-MCP door for key-native users

### DIFF
--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -151,6 +151,7 @@ describe("handleAccountCapabilities", () => {
       expect(body.issuer).toBe(ISSUER); // trailing slash trimmed
       expect(body.door).toBe("hub");
       expect(body.account_endpoint).toBe(`${ISSUER}/account`);
+      expect(body.account_mcp_endpoint).toBe(`${ISSUER}/account/mcp`);
       expect(body.auth).toEqual({ methods: ["password"], signin_path: "/login" });
       expect(body.vault_url_template).toContain("{name}");
       expect(body.vault_url_template).toBe(`${ISSUER}/vault/{name}`);

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -35,9 +35,10 @@ const ISSUER = "http://127.0.0.1:1939";
 const MCP_URL = `${ISSUER}/account/mcp`;
 const BOTH_ACCEPT = "application/json, text/event-stream";
 const HOST_ADMIN_SCOPE = "parachute:host:admin";
-const ACCOUNT_ADMIN_SCOPE = "account:self:admin";
 const ACCOUNT_WRITE_SCOPE = "account:self:write";
 const ACCOUNT_READ_SCOPE = "account:self:read";
+const ACCOUNT_VAULTS_SCOPE = "account:self:vaults";
+const ACCOUNT_VAULTS_UNNARROWED = "account:vaults";
 
 const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
 const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
@@ -232,6 +233,7 @@ function bearerReq(token: string | null, body: unknown, init: RequestInit = {}):
 function parseTool(rpcBody: { result?: { content?: Array<{ text?: string }> } }): unknown {
   const text = rpcBody.result?.content?.[0]?.text;
   if (typeof text !== "string") throw new Error("missing tool text");
+  expect(text).not.toMatch(/vault_token|"token":|eyJ/);
   return JSON.parse(text);
 }
 
@@ -253,7 +255,7 @@ describe("account MCP — descriptor + PRM", () => {
     }
   });
 
-  test("PRM names the account-MCP resource and account:self:read", async () => {
+  test("PRM names the account-MCP resource and account:vaults", async () => {
     const res = accountMcpProtectedResource(ISSUER);
     expect(res.status).toBe(200);
     const body = (await res.json()) as {
@@ -263,7 +265,7 @@ describe("account MCP — descriptor + PRM", () => {
     };
     expect(body.resource).toBe(MCP_URL);
     expect(body.authorization_servers).toEqual([ISSUER]);
-    expect(body.scopes_supported).toEqual([ACCOUNT_READ_SCOPE]);
+    expect(body.scopes_supported).toEqual([ACCOUNT_VAULTS_UNNARROWED]);
   });
 });
 
@@ -282,7 +284,7 @@ describe("account MCP — transport", () => {
     }
   });
 
-  test("403 Bearer without account:self:* or host:admin", async () => {
+  test("403 Bearer without account-vaults or host:admin", async () => {
     const h = await makeHarness();
     try {
       const token = await bearer(h, ["vault:beta:read"]);
@@ -291,7 +293,38 @@ describe("account MCP — transport", () => {
       const body = (await res.json()) as { error: string };
       expect(body.error).toBe("insufficient_scope");
       const challenge = res.headers.get("www-authenticate") ?? "";
-      expect(challenge).toContain(`scope="${ACCOUNT_READ_SCOPE}"`);
+      expect(challenge).toContain(`scope="${ACCOUNT_VAULTS_UNNARROWED}"`);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 Bearer account:self:read — REST read is not an MCP credential", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(403);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain(`scope="${ACCOUNT_VAULTS_UNNARROWED}"`);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("401 Bearer account-vaults with a vault audience", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await signAccessToken(h.db, {
+        sub: h.ownerId,
+        scopes: [ACCOUNT_VAULTS_SCOPE],
+        audience: "vault.beta",
+        clientId: "parachute-hub-spa",
+        issuer: ISSUER,
+        ttlSeconds: 600,
+      });
+      const res = await handleAccountMcp(bearerReq(minted.token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(401);
     } finally {
       h.cleanup();
     }
@@ -300,7 +333,7 @@ describe("account MCP — transport", () => {
   test("406 unless Accept lists both json and event-stream", async () => {
     const h = await makeHarness();
     try {
-      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
       const res = await handleAccountMcp(
         bearerReq(token, rpc("ping"), { headers: { accept: "application/json" } }),
         mcpDeps(h),
@@ -314,7 +347,7 @@ describe("account MCP — transport", () => {
   test("415 unless Content-Type is json", async () => {
     const h = await makeHarness();
     try {
-      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
       const res = await handleAccountMcp(
         bearerReq(token, rpc("ping"), { headers: { "content-type": "text/plain" } }),
         mcpDeps(h),
@@ -328,7 +361,7 @@ describe("account MCP — transport", () => {
   test("GET is 405 after auth; DELETE is 200", async () => {
     const h = await makeHarness();
     try {
-      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
       const get = await handleAccountMcp(
         new Request(MCP_URL, {
           method: "GET",
@@ -353,7 +386,7 @@ describe("account MCP — transport", () => {
   test("notification-only POST is 202", async () => {
     const h = await makeHarness();
     try {
-      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
       const res = await handleAccountMcp(
         bearerReq(token, { jsonrpc: "2.0", method: "notifications/initialized" }),
         mcpDeps(h),
@@ -377,10 +410,10 @@ describe("account MCP — transport", () => {
 });
 
 describe("account MCP — initialize + tools", () => {
-  test("Bearer account:self:read initializes and lists the three tools", async () => {
+  test("Bearer account:self:vaults initializes and lists the three tools", async () => {
     const h = await makeHarness();
     try {
-      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
       const init = await handleAccountMcp(
         bearerReq(token, rpc("initialize", { protocolVersion: "2025-11-25" })),
         mcpDeps(h),
@@ -563,10 +596,10 @@ describe("account MCP — create-vault", () => {
     }
   });
 
-  test("Bearer account:self:write can create; still no token in the tool result", async () => {
+  test("Bearer account:self:vaults can create; still no token in the tool result", async () => {
     const h = await makeHarness(["default"]);
     try {
-      const token = await bearer(h, [ACCOUNT_WRITE_SCOPE]);
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
       const runCommand = async () => {
         upsertService(
           {
@@ -597,7 +630,7 @@ describe("account MCP — create-vault", () => {
   test("existing name is vault_taken", async () => {
     const h = await makeHarness(["work"]);
     try {
-      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
       const res = await handleAccountMcp(
         bearerReq(token, rpc("tools/call", { name: "create-vault", arguments: { name: "work" } })),
         mcpDeps(h),
@@ -715,6 +748,164 @@ describe("account MCP — NIP-98 bind", () => {
         mcpDeps(h),
       );
       expect(res.status).toBe(401);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — extra pins", () => {
+  test("ping returns {}", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("ping")), mcpDeps(h));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result: unknown };
+      expect(body.result).toEqual({});
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("invalid JSON is 400 parse error", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            accept: BOTH_ACCEPT,
+            "content-type": "application/json",
+          },
+          body: "{not json",
+        }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(400);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer account:self:write cannot open the door", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_WRITE_SCOPE]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(403);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer narrowed account:self:vaults:beta lists only beta", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta"]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { covered: string; vaults: Array<{ name: string }> };
+      expect(payload.covered).toBe("listed");
+      expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 read-role still lists and queries the assigned vault", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("44".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    try {
+      const reader = await createUser(h.db, "reader", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "c".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const listed = await handleAccountMcp(
+        nostrReq(readerSecret, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await listed.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vaults: Array<{ name: string }> };
+      expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
+      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const queried = await handleAccountMcp(
+        nostrReq(
+          readerSecret,
+          rpc("tools/call", { name: "query-notes", arguments: { vault: "beta" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(queried.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — hubFetch wiring", () => {
+  test("unauthed POST is 401 JSON with PRM challenge, not HTML", async () => {
+    const h = await makeHarness();
+    try {
+      const { hubFetch } = await import("../hub-server.ts");
+      const handler = hubFetch(h.dir, {
+        getDb: () => h.db,
+        manifestPath: h.manifestPath,
+        issuer: ISSUER,
+      });
+      const res = await handler(
+        new Request(MCP_URL, {
+          method: "POST",
+          headers: { accept: BOTH_ACCEPT, "content-type": "application/json" },
+          body: JSON.stringify(rpc("initialize")),
+        }),
+      );
+      expect(res.status).toBe(401);
+      expect(res.headers.get("content-type") ?? "").toContain("json");
+      expect(res.headers.get("www-authenticate") ?? "").toContain(
+        "/.well-known/oauth-protected-resource/account/mcp",
+      );
+      const text = await res.text();
+      expect(text.toLowerCase()).not.toContain("<html");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET PRM is public and advertises account:vaults", async () => {
+    const h = await makeHarness();
+    try {
+      const { hubFetch } = await import("../hub-server.ts");
+      const handler = hubFetch(h.dir, {
+        getDb: () => h.db,
+        manifestPath: h.manifestPath,
+        issuer: ISSUER,
+      });
+      const res = await handler(
+        new Request(`${ISSUER}/.well-known/oauth-protected-resource/account/mcp`),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { scopes_supported: string[]; resource: string };
+      expect(body.resource).toBe(MCP_URL);
+      expect(body.scopes_supported).toEqual([ACCOUNT_VAULTS_UNNARROWED]);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -655,7 +655,7 @@ describe("account MCP — query-notes", () => {
             : input instanceof URL
               ? input.href
               : (input as Request).url;
-        if (href.includes("/vault/beta/")) {
+        if (href.includes("127.0.0.1:4101/vault/beta/")) {
           return Response.json([{ id: "n-beta" }], { status: 200 });
         }
         throw new Error("personal is down");
@@ -785,6 +785,42 @@ describe("account MCP — extra pins", () => {
         mcpDeps(h),
       );
       expect(res.status).toBe(400);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer host:admin with aud=hub (operator SPA mint) still opens", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await signAccessToken(h.db, {
+        sub: h.ownerId,
+        scopes: [HOST_ADMIN_SCOPE],
+        audience: "hub",
+        clientId: "parachute-hub-spa",
+        issuer: ISSUER,
+        ttlSeconds: 600,
+      });
+      const res = await handleAccountMcp(bearerReq(minted.token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer leftover un-narrowed account:vaults still opens as a blanket grant", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_UNNARROWED]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { covered: string };
+      expect(payload.covered).toBe("all");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -1,0 +1,722 @@
+import type { Database } from "bun:sqlite";
+/**
+ * Account-level MCP door (`/account/mcp`).
+ *
+ * Coverage:
+ *   - transport-parity (Accept 406 / CT 415 / parse 400 / notifications 202 /
+ *     GET 405 / DELETE 200 / initialize / ping / tools/list);
+ *   - auth: missing, wrong Bearer scope, NIP-98 linked user, auto-provision;
+ *   - coverage: Bearer/first-admin = all vaults; friend = assigned ∩ installed;
+ *     auto-provisioned = empty; read-role still lists + queries;
+ *   - create-vault: owner yes, friend no, no token in the tool result;
+ *   - query-notes: fan-out attribution + one-vault failure isolation +
+ *     vault_not_covered fail-closed;
+ *   - descriptor advertises account_mcp_endpoint (see account-api.test).
+ */
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { handleAccountCapabilities } from "../account-api.ts";
+import { accountMcpProtectedResource, handleAccountMcp } from "../account-mcp-http.ts";
+import { ACCOUNT_MCP_TOOLS } from "../account-mcp.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
+import { NostrReplayCache } from "../nostr-http-auth.ts";
+import { bindPubkeyFromHttpAuth } from "../pubkey-links.ts";
+import { upsertService } from "../services-manifest.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+const MCP_URL = `${ISSUER}/account/mcp`;
+const BOTH_ACCEPT = "application/json, text/event-stream";
+const HOST_ADMIN_SCOPE = "parachute:host:admin";
+const ACCOUNT_ADMIN_SCOPE = "account:self:admin";
+const ACCOUNT_WRITE_SCOPE = "account:self:write";
+const ACCOUNT_READ_SCOPE = "account:self:read";
+
+const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
+const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
+
+const OWNER_SECRET = hexToBytes("11".repeat(32));
+const OWNER_PUBKEY = bytesToHex(schnorr.getPublicKey(OWNER_SECRET));
+const FRIEND_SECRET = hexToBytes("22".repeat(32));
+const FRIEND_PUBKEY = bytesToHex(schnorr.getPublicKey(FRIEND_SECRET));
+const OTHER_SECRET = hexToBytes("33".repeat(32));
+const OTHER_PUBKEY = bytesToHex(schnorr.getPublicKey(OTHER_SECRET));
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function signEvent(
+  secret: Uint8Array,
+  parts: { created_at?: number; kind?: number; tags?: string[][]; content?: string },
+): NostrEvent {
+  const unsigned = {
+    pubkey: bytesToHex(schnorr.getPublicKey(secret)),
+    created_at: parts.created_at ?? Math.floor(Date.now() / 1000),
+    kind: parts.kind ?? NOSTR_AUTH_KIND,
+    tags: parts.tags ?? [],
+    content: parts.content ?? "",
+  };
+  const id = nostrEventId(unsigned);
+  const sig = bytesToHex(schnorr.sign(hexToBytes(id), secret));
+  return { ...unsigned, id, sig };
+}
+
+function nostrHeader(event: NostrEvent): string {
+  return `Nostr ${Buffer.from(JSON.stringify(event), "utf8").toString("base64url")}`;
+}
+
+function rpc(
+  method: string,
+  params?: Record<string, unknown>,
+  id: number | string | null = 1,
+): unknown {
+  return { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) };
+}
+
+function vaultCreateJson(name: string): string {
+  return JSON.stringify({
+    name,
+    token: `hubjwt.${name}.access`,
+    paths: {
+      vault_dir: `/home/test/.parachute/vault/${name}`,
+      vault_db: `/home/test/.parachute/vault/${name}/vault.db`,
+      vault_config: `/home/test/.parachute/vault/${name}/config.yaml`,
+    },
+    set_as_default: false,
+  });
+}
+
+interface Harness {
+  db: Database;
+  dir: string;
+  manifestPath: string;
+  ownerId: string;
+  friendId: string;
+  replay: NostrReplayCache;
+  cleanup: () => void;
+}
+
+async function makeHarness(vaultNames: string[] = ["beta", "personal"]): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-mcp-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const manifestPath = join(dir, "services.json");
+  const paths = vaultNames.map((n) => `/vault/${n}`);
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      services: [
+        { name: "parachute-vault", port: 4101, paths, health: "/health", version: "0.4.2" },
+      ],
+    }),
+  );
+  const owner = await createUser(db, "owner", "correct-horse-battery-staple", {
+    passwordChanged: true,
+  });
+  const friend = await createUser(db, "alice", "correct-horse-battery-staple", {
+    allowMulti: true,
+    passwordChanged: true,
+    assignedVaults: ["beta"],
+  });
+  const now = new Date();
+  bindPubkeyFromHttpAuth(db, {
+    userId: owner.id,
+    pubkey: OWNER_PUBKEY,
+    proofEvent: "{}",
+    proofEventId: "a".repeat(64),
+    label: "test",
+    now,
+  });
+  bindPubkeyFromHttpAuth(db, {
+    userId: friend.id,
+    pubkey: FRIEND_PUBKEY,
+    proofEvent: "{}",
+    proofEventId: "b".repeat(64),
+    label: "test",
+    now,
+  });
+  return {
+    db,
+    dir,
+    manifestPath,
+    ownerId: owner.id,
+    friendId: friend.id,
+    replay: new NostrReplayCache(),
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function bearer(h: Harness, scopes: string[], sub?: string): Promise<string> {
+  const minted = await signAccessToken(h.db, {
+    sub: sub ?? h.ownerId,
+    scopes,
+    audience: "account",
+    clientId: "parachute-hub-spa",
+    issuer: ISSUER,
+    ttlSeconds: 600,
+  });
+  return minted.token;
+}
+
+function mcpDeps(
+  h: Harness,
+  extra: {
+    fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+    runCommand?: (
+      cmd: readonly string[],
+    ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+    autoProvisionEnv?: string;
+  } = {},
+) {
+  return {
+    db: h.db,
+    issuer: ISSUER,
+    manifestPath: h.manifestPath,
+    replay: h.replay,
+    ...(extra.fetchImpl ? { fetchImpl: extra.fetchImpl } : {}),
+    ...(extra.runCommand ? { runCommand: extra.runCommand } : {}),
+  };
+}
+
+function nostrReq(
+  secret: Uint8Array,
+  body: unknown,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  const encoded = JSON.stringify(body);
+  const bytes = new TextEncoder().encode(encoded);
+  const event = signEvent(secret, {
+    content: `${Date.now()}-${Math.random()}`,
+    tags: [
+      ["u", MCP_URL],
+      ["method", "POST"],
+      ["payload", sha256Hex(bytes)],
+    ],
+  });
+  return new Request(MCP_URL, {
+    method: "POST",
+    headers: {
+      authorization: nostrHeader(event),
+      accept: BOTH_ACCEPT,
+      "content-type": "application/json",
+      ...extraHeaders,
+    },
+    body: encoded,
+  });
+}
+
+function bearerReq(token: string | null, body: unknown, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers);
+  if (!headers.has("accept")) headers.set("accept", BOTH_ACCEPT);
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return new Request(MCP_URL, {
+    method: "POST",
+    ...init,
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function parseTool(rpcBody: { result?: { content?: Array<{ text?: string }> } }): unknown {
+  const text = rpcBody.result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error("missing tool text");
+  return JSON.parse(text);
+}
+
+describe("account MCP — descriptor + PRM", () => {
+  test("capabilities descriptor advertises account_mcp_endpoint", async () => {
+    const h = await makeHarness();
+    try {
+      const res = handleAccountCapabilities(
+        new Request(`${ISSUER}/.well-known/parachute-account`),
+        {
+          db: h.db,
+          issuer: ISSUER,
+        },
+      );
+      const body = (await res.json()) as { account_mcp_endpoint: string };
+      expect(body.account_mcp_endpoint).toBe(MCP_URL);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PRM names the account-MCP resource and account:self:read", async () => {
+    const res = accountMcpProtectedResource(ISSUER);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      resource: string;
+      authorization_servers: string[];
+      scopes_supported: string[];
+    };
+    expect(body.resource).toBe(MCP_URL);
+    expect(body.authorization_servers).toEqual([ISSUER]);
+    expect(body.scopes_supported).toEqual([ACCOUNT_READ_SCOPE]);
+  });
+});
+
+describe("account MCP — transport", () => {
+  test("401 with no Authorization, RFC 9728 challenge", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(bearerReq(null, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain("resource_metadata=");
+      expect(challenge).toContain("/.well-known/oauth-protected-resource/account/mcp");
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 Bearer without account:self:* or host:admin", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, ["vault:beta:read"]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("insufficient_scope");
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain(`scope="${ACCOUNT_READ_SCOPE}"`);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("406 unless Accept lists both json and event-stream", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("ping"), { headers: { accept: "application/json" } }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(406);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("415 unless Content-Type is json", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("ping"), { headers: { "content-type": "text/plain" } }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(415);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET is 405 after auth; DELETE is 200", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const get = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "GET",
+          headers: { authorization: `Bearer ${token}` },
+        }),
+        mcpDeps(h),
+      );
+      expect(get.status).toBe(405);
+      const del = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${token}` },
+        }),
+        mcpDeps(h),
+      );
+      expect(del.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("notification-only POST is 202", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, { jsonrpc: "2.0", method: "notifications/initialized" }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(202);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight is 204 with MCP headers", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(new Request(MCP_URL, { method: "OPTIONS" }), mcpDeps(h));
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-headers")).toContain("Mcp-Protocol-Version");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — initialize + tools", () => {
+  test("Bearer account:self:read initializes and lists the three tools", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const init = await handleAccountMcp(
+        bearerReq(token, rpc("initialize", { protocolVersion: "2025-11-25" })),
+        mcpDeps(h),
+      );
+      expect(init.status).toBe(200);
+      const initBody = (await init.json()) as {
+        result: { serverInfo: { name: string }; protocolVersion: string };
+      };
+      expect(initBody.result.serverInfo.name).toBe("parachute-account");
+      expect(initBody.result.protocolVersion).toBe("2025-11-25");
+
+      const listed = await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h));
+      const listBody = (await listed.json()) as { result: { tools: Array<{ name: string }> } };
+      expect(listBody.result.tools.map((t) => t.name)).toEqual(
+        ACCOUNT_MCP_TOOLS.map((t) => t.name),
+      );
+      expect(listBody.result.tools.map((t) => t.name)).toEqual([
+        "list-vaults",
+        "create-vault",
+        "query-notes",
+      ]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 first-admin initializes", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(nostrReq(OWNER_SECRET, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — list-vaults coverage", () => {
+  test("Bearer host:admin lists every installed vault", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("all");
+      expect(payload.vaults.map((v) => v.name).sort()).toEqual(["beta", "personal"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 first-admin lists every installed vault", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(OWNER_SECRET, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("all");
+      expect(payload.vaults.map((v) => v.name).sort()).toEqual(["beta", "personal"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 friend lists only assigned vaults", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(FRIEND_SECRET, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("listed");
+      expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("auto-provisioned key lists nothing", async () => {
+    const h = await makeHarness();
+    const prev = process.env.PARACHUTE_NOSTR_AUTO_PROVISION;
+    process.env.PARACHUTE_NOSTR_AUTO_PROVISION = "1";
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(OTHER_SECRET, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("listed");
+      expect(payload.vaults).toEqual([]);
+    } finally {
+      if (prev === undefined) process.env.PARACHUTE_NOSTR_AUTO_PROVISION = undefined;
+      else process.env.PARACHUTE_NOSTR_AUTO_PROVISION = prev;
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — create-vault", () => {
+  test("NIP-98 first-admin can create; result has no token", async () => {
+    const h = await makeHarness(["default"]);
+    try {
+      const runCommand = async () => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work"), stderr: "" };
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", { name: "create-vault", arguments: { name: "work" } }),
+        ),
+        mcpDeps(h, { runCommand }),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as Record<string, unknown>;
+      expect(payload.name).toBe("work");
+      expect(payload.url).toBe(`${ISSUER}/vault/work`);
+      expect(payload.vault_token).toBeUndefined();
+      expect(payload.token).toBeUndefined();
+      const raw = JSON.stringify(payload);
+      expect(raw).not.toContain("hubjwt");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 friend cannot create", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", { name: "create-vault", arguments: { name: "work" } }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("create_not_granted");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer account:self:write can create; still no token in the tool result", async () => {
+    const h = await makeHarness(["default"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_WRITE_SCOPE]);
+      const runCommand = async () => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work"), stderr: "" };
+      };
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "create-vault", arguments: { name: "work" } })),
+        mcpDeps(h, { runCommand }),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as Record<string, unknown>;
+      expect(payload.name).toBe("work");
+      expect(payload.vault_token).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("existing name is vault_taken", async () => {
+    const h = await makeHarness(["work"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_ADMIN_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "create-vault", arguments: { name: "work" } })),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("vault_taken");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — query-notes", () => {
+  test("fans out with per-vault attribution; one failure is isolated", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const fetchImpl = async (input: string | URL | Request) => {
+        const href =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : (input as Request).url;
+        if (href.includes("/vault/beta/")) {
+          return Response.json([{ id: "n-beta" }], { status: 200 });
+        }
+        throw new Error("personal is down");
+      };
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", { name: "query-notes", arguments: { search: "hello" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        vaults_queried: string[];
+        results: Array<{ vault: string; notes?: unknown; error?: string }>;
+      };
+      expect(payload.vaults_queried.sort()).toEqual(["beta", "personal"]);
+      const byVault = Object.fromEntries(payload.results.map((r) => [r.vault, r]));
+      expect(byVault.beta?.notes).toEqual([{ id: "n-beta" }]);
+      expect(byVault.personal?.error).toMatch(/personal is down/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend targeting an unassigned vault is vault_not_covered", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", { name: "query-notes", arguments: { vault: "personal" } }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("vault_not_covered");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend can query their assigned vault", async () => {
+    const h = await makeHarness();
+    try {
+      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", { name: "query-notes", arguments: { vault: "beta" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        vaults_queried: string[];
+      };
+      expect(payload.vaults_queried).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — NIP-98 bind", () => {
+  test("payload mismatch is 401", async () => {
+    const h = await makeHarness();
+    try {
+      const body = rpc("ping");
+      const encoded = JSON.stringify(body);
+      const event = signEvent(OWNER_SECRET, {
+        tags: [
+          ["u", MCP_URL],
+          ["method", "POST"],
+          ["payload", "0".repeat(64)],
+        ],
+      });
+      const res = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "POST",
+          headers: {
+            authorization: nostrHeader(event),
+            accept: BOTH_ACCEPT,
+            "content-type": "application/json",
+          },
+          body: encoded,
+        }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(401);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -10517,6 +10517,60 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
     }
   });
 
+  test("owner requesting account:vaults is bound to account:self:vaults with aud=account", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:vaults",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ")).toContain("account:self:vaults");
+      expect(scope.split(" ")).not.toContain("account:vaults");
+      expect(aud).toBe("account");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("account:vaults cannot be combined with other scopes", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:vaults vault:work:read",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).toContain("error=invalid_scope");
+      expect(loc).not.toContain("code=");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("[9d] non-admin requesting account:self:write → also DROPPED", async () => {
     // Write is more capable than read, but it is still account-wide on a
     // self-host hub, so the same account-prefix cap must drop it.

--- a/src/__tests__/scope-registry.test.ts
+++ b/src/__tests__/scope-registry.test.ts
@@ -102,6 +102,8 @@ describe("loadDeclaredScopes", () => {
       expect(declared.has("vault:read")).toBe(true);
       expect(declared.has("scribe:transcribe")).toBe(true);
       expect(declared.has("hub:admin")).toBe(true);
+      expect(declared.has("account:vaults")).toBe(true);
+      expect(isKnownScope("account:self:vaults", declared)).toBe(true);
     } finally {
       cleanup();
     }

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -253,14 +253,18 @@ export async function requireAnyScope(
 
 /** Scope set for admin-only `/account/*` mutations (delete / mint). */
 export const ACCOUNT_MUTATION_SCOPES = ADMIN_SCOPES;
+/** Scope set for a `/account/*` WRITE mutation (create, set-caps). */
+export const ACCOUNT_WRITE_SCOPES = WRITE_SCOPES;
 /** Scope set for a `/account/*` read (list / get-caps / bootstrap). */
 export const ACCOUNT_READ_SCOPES = READ_SCOPES;
 
-interface VaultMeta {
+export interface AccountVaultMeta {
   name: string;
   url: string;
   version: string;
 }
+
+type VaultMeta = AccountVaultMeta;
 
 /**
  * Enumerate every servable vault from services.json with its canonical URL +
@@ -269,7 +273,7 @@ interface VaultMeta {
  * name derivation, same `new URL(path, base)` URL build as `buildEntry`) so the
  * account list agrees with the well-known vaults[] fan-out and the create path.
  */
-function listVaultsWithMeta(manifestPath: string, issuer: string): VaultMeta[] {
+export function listVaultsWithMeta(manifestPath: string, issuer: string): VaultMeta[] {
   const base = issuer.replace(/\/$/, "");
   const out: VaultMeta[] = [];
   let manifest: ReturnType<typeof readManifestLenient>;
@@ -315,6 +319,10 @@ function servicesBlock(meta: VaultMeta): Record<string, { url: string; version: 
  * public invite exists (`activePublicSignupPath`, invites.ts) — an operator-
  * shared link is otherwise the only way in, so the app must not render a
  * "create account" affordance when there is nowhere for it to go.
+ *
+ * `account_mcp_endpoint` is the hub's account-level MCP door (`/account/mcp`).
+ * Optional in door-contract; set once the surface exists so a client can
+ * discover it from the descriptor instead of guessing the path.
  */
 export function handleAccountCapabilities(
   req: Request,
@@ -337,6 +345,7 @@ export function handleAccountCapabilities(
     issuer,
     door: "hub",
     account_endpoint: `${issuer}/account`,
+    account_mcp_endpoint: `${issuer}/account/mcp`,
     auth: { methods: ["password"], signin_path: "/login" },
     ...(signupPath ? { signup_path: signupPath } : {}),
     vault_url_template: `${issuer}/vault/{name}`,

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -262,6 +262,8 @@ export interface AccountVaultMeta {
   name: string;
   url: string;
   version: string;
+  /** Loopback port from services.json; used by account-MCP fan-out. */
+  port?: number;
 }
 
 type VaultMeta = AccountVaultMeta;
@@ -288,7 +290,7 @@ export function listVaultsWithMeta(manifestPath: string, issuer: string): VaultM
     for (const path of svc.paths) {
       const name = vaultInstanceNameFor(svc.name, path);
       const url = new URL(path, `${base}/`).toString();
-      out.push({ name, url, version: svc.version });
+      out.push({ name, url, version: svc.version, port: svc.port });
     }
   }
   return out;

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -10,20 +10,23 @@
  * Auth runs BEFORE any JSON-RPC:
  *   - `Authorization: Nostr <event>` → NIP-98 (hub#882). Any resolved hub
  *     user opens the door; coverage is assignment, not account:self:*.
- *   - `Authorization: Bearer <jwt>` → `account:self:*` or
- *     `parachute:host:admin` (the REST account-door ladder). The box, not a
- *     friend vault token.
+ *   - `Authorization: Bearer <jwt>` → an account-vaults connection grant
+ *     (`account:self:vaults` / composed forms, `aud=account`) or
+ *     `parachute:host:admin` (operator bypass). REST `account:self:read`
+ *     does not open this door.
  *
  * Cookie sessions never open this door. Wildcard CORS is correct: nothing
  * here is ambient-auth.
  */
 import type { Database } from "bun:sqlite";
-import { ACCOUNT_READ_SCOPES, type AccountApiDeps } from "./account-api.ts";
+import { ACCOUNT_VAULTS_UNNARROWED } from "@openparachute/door-contract";
+import type { AccountApiDeps } from "./account-api.ts";
 import {
   ACCOUNT_MCP_TOOLS,
   type AccountMcpPrincipal,
   type AccountToolContext,
   AccountToolError,
+  buildAccountConnectionGrant,
 } from "./account-mcp.ts";
 import {
   AdminAuthError,
@@ -40,7 +43,6 @@ import {
   authenticateNostrRequest,
   isNostrAuthorization,
 } from "./nostr-http-auth.ts";
-import { ACCOUNT_SELF_READ_SCOPE } from "./scope-explanations.ts";
 import { isFirstAdmin } from "./users.ts";
 
 const LATEST_PROTOCOL_VERSION = "2025-11-25";
@@ -134,7 +136,7 @@ export function accountMcpProtectedResource(issuer: string): Response {
       JSON.stringify({
         resource: `${origin}/account/mcp`,
         authorization_servers: [origin],
-        scopes_supported: [ACCOUNT_SELF_READ_SCOPE],
+        scopes_supported: [ACCOUNT_VAULTS_UNNARROWED],
         bearer_methods_supported: ["header"],
         resource_documentation: "https://parachute.computer",
       }),
@@ -194,12 +196,20 @@ async function authenticateBearer(
   const scopeClaim = (validated.payload as { scope?: unknown }).scope;
   const scopes =
     typeof scopeClaim === "string" ? scopeClaim.split(/\s+/).filter((s) => s.length > 0) : [];
-  if (!ACCOUNT_READ_SCOPES.some((s) => scopes.includes(s))) {
+  const grant = buildAccountConnectionGrant(scopes);
+  if (grant === null) {
     throw new AdminAuthError(
       403,
-      `token missing one of required scopes: ${ACCOUNT_READ_SCOPES.join(", ")}`,
-      ACCOUNT_SELF_READ_SCOPE,
+      "the account MCP requires an account-vaults connection scope (account:vaults) or parachute:host:admin",
+      ACCOUNT_VAULTS_UNNARROWED,
     );
+  }
+  const hostAdmin = scopes.includes(HOST_ADMIN_SCOPE);
+  if (!hostAdmin) {
+    const aud = typeof validated.payload.aud === "string" ? validated.payload.aud : undefined;
+    if (aud !== "account") {
+      throw new AdminAuthError(401, "token audience must be `account`");
+    }
   }
   const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
   const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
@@ -208,7 +218,8 @@ async function authenticateBearer(
     scopes,
     authKind: "bearer",
     clientId,
-    isHubAdmin: isFirstAdmin(db, sub) || scopes.includes(HOST_ADMIN_SCOPE),
+    isHubAdmin: isFirstAdmin(db, sub) || hostAdmin,
+    grant,
   };
 }
 
@@ -231,6 +242,7 @@ async function authenticate(
       authKind: "nostr",
       clientId: `nostr:${principal.pubkey}`,
       isHubAdmin: principal.isHubAdmin,
+      grant: null,
     };
   }
   return authenticateBearer(db, req, deps.knownIssuers ?? [deps.issuer]);

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -1,0 +1,437 @@
+/**
+ * `/account/mcp` — the hub's account-level MCP door.
+ *
+ * Transport framing is transcribed from the cloud identity worker's
+ * `account-mcp-http.ts` (itself transcribed from the vault door): Accept-both
+ * 406 / Content-Type 415 / parse-error 400 / notifications-202 / GET-405 /
+ * DELETE-200 / protocol-version. Keep them in lockstep; a divergence presents
+ * as an opaque connector failure.
+ *
+ * Auth runs BEFORE any JSON-RPC:
+ *   - `Authorization: Nostr <event>` → NIP-98 (hub#882). Any resolved hub
+ *     user opens the door; coverage is assignment, not account:self:*.
+ *   - `Authorization: Bearer <jwt>` → `account:self:*` or
+ *     `parachute:host:admin` (the REST account-door ladder). The box, not a
+ *     friend vault token.
+ *
+ * Cookie sessions never open this door. Wildcard CORS is correct: nothing
+ * here is ambient-auth.
+ */
+import type { Database } from "bun:sqlite";
+import { ACCOUNT_READ_SCOPES, type AccountApiDeps } from "./account-api.ts";
+import {
+  ACCOUNT_MCP_TOOLS,
+  type AccountMcpPrincipal,
+  type AccountToolContext,
+  AccountToolError,
+} from "./account-mcp.ts";
+import {
+  AdminAuthError,
+  adminAuthErrorResponse,
+  extractBearerToken,
+  nostrAutoProvisionEnabled,
+} from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { validateAccessToken } from "./jwt-sign.ts";
+import {
+  NostrHttpAuthError,
+  type NostrReplayCache,
+  authenticateNostrRequest,
+  isNostrAuthorization,
+} from "./nostr-http-auth.ts";
+import { ACCOUNT_SELF_READ_SCOPE } from "./scope-explanations.ts";
+import { isFirstAdmin } from "./users.ts";
+
+const LATEST_PROTOCOL_VERSION = "2025-11-25";
+const SUPPORTED_PROTOCOL_VERSIONS = [
+  LATEST_PROTOCOL_VERSION,
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+  "2024-10-07",
+];
+
+const PARSE_ERROR = -32700;
+const METHOD_NOT_FOUND = -32601;
+const INVALID_PARAMS = -32602;
+const INTERNAL_ERROR = -32603;
+
+type JsonRpcId = string | number | null;
+interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: JsonRpcId;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: unknown;
+  error?: unknown;
+}
+
+function result(id: JsonRpcId, value: unknown): JsonRpcMessage {
+  return { jsonrpc: "2.0", id, result: value };
+}
+function rpcError(id: JsonRpcId, code: number, message: string, data?: unknown): JsonRpcMessage {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: data === undefined ? { code, message } : { code, message, data },
+  };
+}
+function isJsonRpc(m: unknown): m is JsonRpcMessage {
+  return !!m && typeof m === "object" && (m as JsonRpcMessage).jsonrpc === "2.0";
+}
+function isRequest(m: JsonRpcMessage): boolean {
+  return typeof m.method === "string" && m.id !== undefined;
+}
+
+function withMcpCors(res: Response): Response {
+  res.headers.set("access-control-allow-origin", "*");
+  res.headers.set("access-control-expose-headers", "WWW-Authenticate");
+  return res;
+}
+
+function preflight(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "POST, DELETE, OPTIONS",
+      "access-control-allow-headers": "Authorization, Content-Type, Accept, Mcp-Protocol-Version",
+      "access-control-max-age": "86400",
+    },
+  });
+}
+
+function jsonRpcHttpError(status: number, code: number, message: string): Response {
+  return withMcpCors(
+    new Response(JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null }), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+export interface AccountMcpDeps extends AccountApiDeps {
+  replay?: NostrReplayCache;
+  fetchImpl?: AccountToolContext["fetchImpl"];
+  signToken?: AccountToolContext["signToken"];
+}
+
+function accountMcpResource(issuer: string): string {
+  return `${issuer.replace(/\/$/, "")}/account/mcp`;
+}
+
+function accountMcpChallenge(issuer: string): string {
+  const origin = issuer.replace(/\/$/, "");
+  return `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/account/mcp"`;
+}
+
+/** RFC 9728 PRM for `/account/mcp`. Public + wildcard CORS. */
+export function accountMcpProtectedResource(issuer: string): Response {
+  const origin = issuer.replace(/\/$/, "");
+  return withMcpCors(
+    new Response(
+      JSON.stringify({
+        resource: `${origin}/account/mcp`,
+        authorization_servers: [origin],
+        scopes_supported: [ACCOUNT_SELF_READ_SCOPE],
+        bearer_methods_supported: ["header"],
+        resource_documentation: "https://parachute.computer",
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        },
+      },
+    ),
+  );
+}
+
+function authFailure(
+  status: 401 | 403,
+  error: string,
+  message: string,
+  issuer: string,
+  scope?: string,
+): Response {
+  const challenge = [
+    accountMcpChallenge(issuer),
+    `error="${error}"`,
+    `error_description="${message.replace(/"/g, "'")}"`,
+  ];
+  if (status === 403 && scope) challenge.push(`scope="${scope}"`);
+  return withMcpCors(
+    new Response(JSON.stringify({ error, error_description: message }), {
+      status,
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "no-store",
+        "WWW-Authenticate": challenge.join(", "),
+      },
+    }),
+  );
+}
+
+async function authenticateBearer(
+  db: Database,
+  req: Request,
+  expectedIssuer: string | readonly string[],
+): Promise<AccountMcpPrincipal> {
+  const token = extractBearerToken(req);
+  let validated: Awaited<ReturnType<typeof validateAccessToken>>;
+  try {
+    validated = await validateAccessToken(db, token, expectedIssuer);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new AdminAuthError(401, `invalid token: ${msg}`);
+  }
+  const sub = typeof validated.payload.sub === "string" ? validated.payload.sub : null;
+  if (!sub) throw new AdminAuthError(401, "token missing required `sub` claim");
+  const scopeClaim = (validated.payload as { scope?: unknown }).scope;
+  const scopes =
+    typeof scopeClaim === "string" ? scopeClaim.split(/\s+/).filter((s) => s.length > 0) : [];
+  if (!ACCOUNT_READ_SCOPES.some((s) => scopes.includes(s))) {
+    throw new AdminAuthError(
+      403,
+      `token missing one of required scopes: ${ACCOUNT_READ_SCOPES.join(", ")}`,
+      ACCOUNT_SELF_READ_SCOPE,
+    );
+  }
+  const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
+  const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
+  return {
+    userId: sub,
+    scopes,
+    authKind: "bearer",
+    clientId,
+    isHubAdmin: isFirstAdmin(db, sub) || scopes.includes(HOST_ADMIN_SCOPE),
+  };
+}
+
+async function authenticate(
+  db: Database,
+  req: Request,
+  deps: AccountMcpDeps,
+  body: Uint8Array,
+): Promise<AccountMcpPrincipal> {
+  if (isNostrAuthorization(req)) {
+    const principal = await authenticateNostrRequest(db, req, {
+      autoProvision: nostrAutoProvisionEnabled(),
+      now: deps.now,
+      replay: deps.replay,
+      body,
+    });
+    return {
+      userId: principal.userId,
+      scopes: principal.scopes,
+      authKind: "nostr",
+      clientId: `nostr:${principal.pubkey}`,
+      isHubAdmin: principal.isHubAdmin,
+    };
+  }
+  return authenticateBearer(db, req, deps.knownIssuers ?? [deps.issuer]);
+}
+
+async function handleToolCall(
+  id: JsonRpcId,
+  params: Record<string, unknown> | undefined,
+  ctx: AccountToolContext,
+): Promise<JsonRpcMessage> {
+  const name = typeof params?.name === "string" ? params.name : "";
+  const args = (params?.arguments ?? {}) as Record<string, unknown>;
+  const tool = ACCOUNT_MCP_TOOLS.find((t) => t.name === name);
+  if (!tool) {
+    return result(id, {
+      content: [{ type: "text", text: `Unknown tool: ${name}` }],
+      isError: true,
+    });
+  }
+  try {
+    const out = await tool.execute(args, ctx);
+    return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+  } catch (err) {
+    if (err instanceof AccountToolError) {
+      return rpcError(id, INVALID_PARAMS, err.message, { error_type: err.errorType, ...err.extra });
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return result(id, { content: [{ type: "text", text: `Error: ${message}` }], isError: true });
+  }
+}
+
+function instructions(): string {
+  return (
+    "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
+    "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
+    "and query-notes to search across them (omit `vault` to fan out, pass it to target one)."
+  );
+}
+
+async function handleOne(m: JsonRpcMessage, ctx: AccountToolContext): Promise<JsonRpcMessage> {
+  const { id = null, method, params } = m;
+  try {
+    switch (method) {
+      case "initialize": {
+        const requested = typeof params?.protocolVersion === "string" ? params.protocolVersion : "";
+        const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+          ? requested
+          : LATEST_PROTOCOL_VERSION;
+        return result(id, {
+          protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: { name: "parachute-account", version: "0.1.0" },
+          instructions: instructions(),
+        });
+      }
+      case "tools/list":
+        return result(id, {
+          tools: ACCOUNT_MCP_TOOLS.map((t) => ({
+            name: t.name,
+            description: t.description,
+            inputSchema: t.inputSchema,
+          })),
+        });
+      case "tools/call":
+        return await handleToolCall(id, params, ctx);
+      case "ping":
+        return result(id, {});
+      default:
+        return rpcError(id, METHOD_NOT_FOUND, `Method not found: ${method}`);
+    }
+  } catch (err) {
+    return rpcError(id, INTERNAL_ERROR, err instanceof Error ? err.message : "Internal error");
+  }
+}
+
+function translateAuthError(err: unknown, issuer: string): Response {
+  if (err instanceof NostrHttpAuthError) {
+    return authFailure(err.status === 403 ? 403 : 401, "invalid_token", err.message, issuer);
+  }
+  if (err instanceof AdminAuthError) {
+    const res = adminAuthErrorResponse(err);
+    const challenge = res.headers.get("www-authenticate") ?? accountMcpChallenge(issuer);
+    const withMeta = challenge.includes("resource_metadata=")
+      ? challenge
+      : `${accountMcpChallenge(issuer)}, ${challenge}`;
+    const headers = new Headers(res.headers);
+    headers.set("www-authenticate", withMeta);
+    headers.set("access-control-allow-origin", "*");
+    headers.set("access-control-expose-headers", "WWW-Authenticate");
+    return new Response(res.body, { status: res.status, headers });
+  }
+  const message = err instanceof Error ? err.message : "unauthorized";
+  return authFailure(401, "invalid_token", message, issuer);
+}
+
+/**
+ * Handle a request at `/account/mcp`. Auth first, then Streamable-HTTP
+ * JSON-response mode. `app.all` equivalent: every method is owned so the
+ * path never falls through to the `/account/` HTML home.
+ */
+export async function handleAccountMcp(req: Request, deps: AccountMcpDeps): Promise<Response> {
+  if (req.method === "OPTIONS") return preflight();
+
+  let body = new Uint8Array();
+  if (req.method !== "GET" && req.method !== "HEAD" && req.method !== "DELETE") {
+    body = new Uint8Array(await req.arrayBuffer());
+  }
+
+  let principal: AccountMcpPrincipal;
+  try {
+    principal = await authenticate(deps.db, req, deps, body);
+  } catch (err) {
+    return translateAuthError(err, deps.issuer);
+  }
+
+  if (req.method === "DELETE") return withMcpCors(new Response(null, { status: 200 }));
+  if (req.method !== "POST") {
+    return withMcpCors(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Method not allowed." },
+          id: null,
+        }),
+        {
+          status: 405,
+          headers: { Allow: "POST, DELETE, OPTIONS", "Content-Type": "application/json" },
+        },
+      ),
+    );
+  }
+
+  const accept = req.headers.get("accept") ?? "";
+  if (!accept.includes("application/json") || !accept.includes("text/event-stream")) {
+    return jsonRpcHttpError(
+      406,
+      -32000,
+      "Not Acceptable: Client must accept both application/json and text/event-stream",
+    );
+  }
+  const ct = req.headers.get("content-type") ?? "";
+  if (!ct.includes("application/json")) {
+    return jsonRpcHttpError(
+      415,
+      -32000,
+      "Unsupported Media Type: Content-Type must be application/json",
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(new TextDecoder().decode(body));
+  } catch {
+    return jsonRpcHttpError(400, PARSE_ERROR, "Parse error: Invalid JSON");
+  }
+
+  const rawMessages = Array.isArray(raw) ? raw : [raw];
+  const messages: JsonRpcMessage[] = [];
+  for (const m of rawMessages) {
+    if (!isJsonRpc(m))
+      return jsonRpcHttpError(400, PARSE_ERROR, "Parse error: Invalid JSON-RPC message");
+    messages.push(m);
+  }
+
+  const isInit = messages.some((m) => m.method === "initialize");
+  if (!isInit) {
+    const pv = req.headers.get("mcp-protocol-version");
+    if (pv !== null && !SUPPORTED_PROTOCOL_VERSIONS.includes(pv)) {
+      return jsonRpcHttpError(
+        400,
+        -32000,
+        `Bad Request: Unsupported protocol version: ${pv} (supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")})`,
+      );
+    }
+  }
+
+  const requests = messages.filter(isRequest);
+  if (requests.length === 0) {
+    return withMcpCors(new Response(null, { status: 202 }));
+  }
+
+  const ctx: AccountToolContext = {
+    db: deps.db,
+    issuer: deps.issuer,
+    manifestPath: deps.manifestPath ?? SERVICES_MANIFEST_PATH,
+    principal,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+    ...(deps.runCommand !== undefined ? { runCommand: deps.runCommand } : {}),
+    ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+    ...(deps.signToken !== undefined ? { signToken: deps.signToken } : {}),
+  };
+  const responses: JsonRpcMessage[] = [];
+  for (const m of requests) responses.push(await handleOne(m, ctx));
+
+  const payload = responses.length === 1 ? responses[0] : responses;
+  return withMcpCors(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+export { accountMcpResource };

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -21,6 +21,7 @@
  */
 import type { Database } from "bun:sqlite";
 import {
+  ACCOUNT_VAULTS_UNNARROWED,
   COMPOSED_VERB_RANK,
   type ComposedVaultVerb,
   accountVaultsGrant,
@@ -123,6 +124,10 @@ export function buildAccountConnectionGrant(
   let wildcard = composed.wildcard;
   const vaults = new Map(composed.vaults);
   let create = composed.create;
+  if (scopes.includes(ACCOUNT_VAULTS_UNNARROWED)) {
+    create = true;
+    if (wildcard === null) wildcard = "read";
+  }
   const legacy = accountVaultsGrant(scopes, accountId);
   if (legacy !== null) {
     create = true;

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -6,9 +6,10 @@
  * tools (list-vaults, create-vault, query-notes), same "no vault_token in
  * model context" rule. Coverage is hub-shaped, not D1-ownership-shaped:
  *
- *   - Bearer `account:self:*` / `parachute:host:admin` is the box (operator ≡
- *     account ≡ box). Coverage is every services.json vault; create follows
- *     the REST write-scope ladder.
+ *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
+ *     (legacy blanket / narrowed) or composed `account:self:vaults:*:<verb>`,
+ *     plus `parachute:host:admin` as the operator bypass. REST `account:self:read`
+ *     does NOT open this door — that scope lists vaults and usage, not notes.
  *   - NIP-98 is the Buzz path. First-admin → every vault + create. Anyone
  *     else → `user_vaults` ∩ services.json (fail-closed; read verb required).
  *     Auto-provisioned key-only users have no rows → empty list, no create.
@@ -19,10 +20,19 @@
  * failure.
  */
 import type { Database } from "bun:sqlite";
-import { ACCOUNT_WRITE_SCOPES, type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
-import { provisionVault } from "./admin-vaults.ts";
+import {
+  COMPOSED_VERB_RANK,
+  type ComposedVaultVerb,
+  accountVaultsGrant,
+  composedAccountGrant,
+} from "@openparachute/door-contract";
+import { type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
+import { HOST_ADMIN_SCOPE, provisionVault } from "./admin-vaults.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
+
+/** Hub account sentinel — account ≡ box. */
+export const HUB_ACCOUNT_ID = "self";
 
 /** Per-vault timeout for the query-notes fan-out. */
 export const FANOUT_TIMEOUT_MS = 10_000;
@@ -35,6 +45,12 @@ const FANOUT_TOKEN_TTL_SECONDS = 60;
 
 export type AccountMcpAuthKind = "bearer" | "nostr";
 
+export interface AccountConnectionGrant {
+  wildcard: ComposedVaultVerb | null;
+  vaults: Map<string, ComposedVaultVerb>;
+  create: boolean;
+}
+
 export interface AccountMcpPrincipal {
   userId: string;
   scopes: string[];
@@ -42,6 +58,8 @@ export interface AccountMcpPrincipal {
   clientId: string | undefined;
   /** First-admin, or a Bearer that already carries host:admin. */
   isHubAdmin: boolean;
+  /** Present on Bearer (null only for NIP-98). host:admin is a synthetic wildcard. */
+  grant: AccountConnectionGrant | null;
 }
 
 export class AccountToolError extends Error {
@@ -84,41 +102,97 @@ export interface AccountMcpTool {
   execute(args: Record<string, unknown>, ctx: AccountToolContext): Promise<unknown>;
 }
 
-function hasWriteScope(scopes: readonly string[]): boolean {
-  return ACCOUNT_WRITE_SCOPES.some((s) => scopes.includes(s));
+function raiseVaultVerb(
+  map: Map<string, ComposedVaultVerb>,
+  name: string,
+  verb: ComposedVaultVerb,
+): void {
+  const cur = map.get(name);
+  if (!cur || COMPOSED_VERB_RANK[verb] > COMPOSED_VERB_RANK[cur]) map.set(name, verb);
+}
+
+/**
+ * Unify legacy Wave A `account:<id>:vaults` with the composed grammar.
+ * Returns null when the set confers nothing that opens this door.
+ */
+export function buildAccountConnectionGrant(
+  scopes: readonly string[],
+  accountId: string = HUB_ACCOUNT_ID,
+): AccountConnectionGrant | null {
+  const composed = composedAccountGrant(scopes, accountId);
+  let wildcard = composed.wildcard;
+  const vaults = new Map(composed.vaults);
+  let create = composed.create;
+  const legacy = accountVaultsGrant(scopes, accountId);
+  if (legacy !== null) {
+    create = true;
+    if ("blanket" in legacy) {
+      if (wildcard === null) wildcard = "read";
+    } else {
+      for (const name of legacy.vaults) raiseVaultVerb(vaults, name, "read");
+    }
+  }
+  if (scopes.includes(HOST_ADMIN_SCOPE)) {
+    return { wildcard: "admin", vaults, create: true };
+  }
+  const opensDoor = wildcard !== null || vaults.size > 0 || create;
+  return opensDoor ? { wildcard, vaults, create } : null;
 }
 
 function canCreate(principal: AccountMcpPrincipal): boolean {
   if (principal.authKind === "nostr") return principal.isHubAdmin;
-  return hasWriteScope(principal.scopes);
+  return principal.grant?.create === true;
+}
+
+function assignedReadable(
+  db: Database,
+  userId: string,
+  installed: AccountVaultMeta[],
+): AccountVaultMeta[] {
+  const user = getUserById(db, userId);
+  const assigned = new Set(user?.assignedVaults ?? []);
+  return installed.filter((v) => {
+    if (!assigned.has(v.name)) return false;
+    const verbs = vaultVerbsForUserVault(db, userId, v.name);
+    return verbs?.includes("read");
+  });
 }
 
 /**
- * Live coverage for this principal. Bearer account-door tokens see the box
- * (every services.json vault). NIP-98 sees assignment: first-admin is
- * unrestricted; everyone else is `user_vaults` intersected with currently
- * installed vaults. A name for a since-removed vault silently drops.
+ * Live coverage. NIP-98 is assignment. Bearer is the connection grant ∩
+ * currently installed vaults (and ∩ assignment when the subject is not
+ * first-admin). host:admin is unrestricted.
  */
 export function resolveCoverage(
   db: Database,
   principal: AccountMcpPrincipal,
   installed: AccountVaultMeta[],
 ): Coverage {
-  const create = canCreate(principal);
-  if (
-    principal.authKind === "bearer" ||
-    principal.isHubAdmin ||
-    isFirstAdmin(db, principal.userId)
-  ) {
-    return { covered: "all", vaults: installed, names: installed.map((v) => v.name), create };
+  if (principal.authKind === "nostr") {
+    if (principal.isHubAdmin || isFirstAdmin(db, principal.userId)) {
+      return {
+        covered: "all",
+        vaults: installed,
+        names: installed.map((v) => v.name),
+        create: true,
+      };
+    }
+    const vaults = assignedReadable(db, principal.userId, installed);
+    return { covered: "listed", vaults, names: vaults.map((v) => v.name), create: false };
   }
-  const user = getUserById(db, principal.userId);
-  const assigned = new Set(user?.assignedVaults ?? []);
-  const vaults = installed.filter((v) => {
-    if (!assigned.has(v.name)) return false;
-    const verbs = vaultVerbsForUserVault(db, principal.userId, v.name);
-    return verbs?.includes("read");
-  });
+
+  const grant = principal.grant;
+  const create = grant?.create === true;
+  const owned =
+    principal.isHubAdmin || isFirstAdmin(db, principal.userId)
+      ? installed
+      : assignedReadable(db, principal.userId, installed);
+
+  if (!grant || grant.wildcard !== null) {
+    const covered = grant?.wildcard !== null || principal.isHubAdmin ? "all" : "listed";
+    return { covered, vaults: owned, names: owned.map((v) => v.name), create };
+  }
+  const vaults = owned.filter((v) => grant.vaults.has(v.name));
   return { covered: "listed", vaults, names: vaults.map((v) => v.name), create };
 }
 
@@ -228,13 +302,17 @@ async function queryOneVault(
     sub: ctx.principal.userId,
     scopes: [`vault:${vault.name}:read`],
     audience: `vault.${vault.name}`,
-    clientId: ctx.principal.clientId ?? ACCOUNT_MCP_CLIENT_ID,
+    clientId: ACCOUNT_MCP_CLIENT_ID,
     issuer: ctx.issuer,
     ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
     vaultScope: [vault.name],
     ...(ctx.now !== undefined ? { now: ctx.now } : {}),
   });
-  const url = `${vault.url.replace(/\/$/, "")}/api/notes${qs ? `?${qs}` : ""}`;
+  const origin =
+    typeof vault.port === "number" && vault.port > 0
+      ? `http://127.0.0.1:${vault.port}`
+      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
+  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}/api/notes${qs ? `?${qs}` : ""}`;
   const res = await fetchImpl(url, {
     headers: { authorization: `Bearer ${minted.token}`, accept: "application/json" },
     signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -1,0 +1,324 @@
+/**
+ * Account-level MCP tools for the self-host hub — the payload behind
+ * `/account/mcp`.
+ *
+ * Cloud's twin lives in the identity worker (`account-mcp.ts`). Same three
+ * tools (list-vaults, create-vault, query-notes), same "no vault_token in
+ * model context" rule. Coverage is hub-shaped, not D1-ownership-shaped:
+ *
+ *   - Bearer `account:self:*` / `parachute:host:admin` is the box (operator ≡
+ *     account ≡ box). Coverage is every services.json vault; create follows
+ *     the REST write-scope ladder.
+ *   - NIP-98 is the Buzz path. First-admin → every vault + create. Anyone
+ *     else → `user_vaults` ∩ services.json (fail-closed; read verb required).
+ *     Auto-provisioned key-only users have no rows → empty list, no create.
+ *
+ * query-notes fans out through a 60s `vault:<name>:read` mint, the same
+ * authority `account-usage.ts` already uses for the friend home tiles. A
+ * failed vault becomes that vault's `{ vault, error }` — never a whole-call
+ * failure.
+ */
+import type { Database } from "bun:sqlite";
+import { ACCOUNT_WRITE_SCOPES, type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
+import { provisionVault } from "./admin-vaults.ts";
+import { signAccessToken } from "./jwt-sign.ts";
+import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
+
+/** Per-vault timeout for the query-notes fan-out. */
+export const FANOUT_TIMEOUT_MS = 10_000;
+
+/** Per-vault `limit` ceiling on a fan-out query. */
+export const MAX_NOTES_LIMIT = 100;
+
+const ACCOUNT_MCP_CLIENT_ID = "parachute-account";
+const FANOUT_TOKEN_TTL_SECONDS = 60;
+
+export type AccountMcpAuthKind = "bearer" | "nostr";
+
+export interface AccountMcpPrincipal {
+  userId: string;
+  scopes: string[];
+  authKind: AccountMcpAuthKind;
+  clientId: string | undefined;
+  /** First-admin, or a Bearer that already carries host:admin. */
+  isHubAdmin: boolean;
+}
+
+export class AccountToolError extends Error {
+  constructor(
+    public readonly errorType: string,
+    message: string,
+    public readonly extra?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "AccountToolError";
+  }
+}
+
+export interface Coverage {
+  covered: "all" | "listed";
+  vaults: AccountVaultMeta[];
+  names: string[];
+  create: boolean;
+}
+
+export interface AccountToolContext {
+  db: Database;
+  issuer: string;
+  manifestPath: string;
+  principal: AccountMcpPrincipal;
+  now?: () => Date;
+  runCommand?: (cmd: readonly string[]) => Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }>;
+  fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+  signToken?: typeof signAccessToken;
+}
+
+export interface AccountMcpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute(args: Record<string, unknown>, ctx: AccountToolContext): Promise<unknown>;
+}
+
+function hasWriteScope(scopes: readonly string[]): boolean {
+  return ACCOUNT_WRITE_SCOPES.some((s) => scopes.includes(s));
+}
+
+function canCreate(principal: AccountMcpPrincipal): boolean {
+  if (principal.authKind === "nostr") return principal.isHubAdmin;
+  return hasWriteScope(principal.scopes);
+}
+
+/**
+ * Live coverage for this principal. Bearer account-door tokens see the box
+ * (every services.json vault). NIP-98 sees assignment: first-admin is
+ * unrestricted; everyone else is `user_vaults` intersected with currently
+ * installed vaults. A name for a since-removed vault silently drops.
+ */
+export function resolveCoverage(
+  db: Database,
+  principal: AccountMcpPrincipal,
+  installed: AccountVaultMeta[],
+): Coverage {
+  const create = canCreate(principal);
+  if (
+    principal.authKind === "bearer" ||
+    principal.isHubAdmin ||
+    isFirstAdmin(db, principal.userId)
+  ) {
+    return { covered: "all", vaults: installed, names: installed.map((v) => v.name), create };
+  }
+  const user = getUserById(db, principal.userId);
+  const assigned = new Set(user?.assignedVaults ?? []);
+  const vaults = installed.filter((v) => {
+    if (!assigned.has(v.name)) return false;
+    const verbs = vaultVerbsForUserVault(db, principal.userId, v.name);
+    return verbs?.includes("read");
+  });
+  return { covered: "listed", vaults, names: vaults.map((v) => v.name), create };
+}
+
+function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
+  return listVaultsWithMeta(ctx.manifestPath, ctx.issuer);
+}
+
+const listVaultsTool: AccountMcpTool = {
+  name: "list-vaults",
+  description:
+    "List the vaults this connection can reach. Returns each vault's name, URL, and version, " +
+    "plus whether the grant covers ALL of the hub's vaults or a specific listed subset.",
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  async execute(_args, ctx) {
+    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+    return {
+      covered: coverage.covered,
+      vaults: coverage.vaults.map((v) => ({ name: v.name, url: v.url, version: v.version })),
+    };
+  },
+};
+
+const createVaultTool: AccountMcpTool = {
+  name: "create-vault",
+  description:
+    "Create a new vault on this hub. Returns the new vault's name and URL. " +
+    "Does not return a vault token — mint one out of band if you need a credential.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "The vault name (lowercase letters, numbers, hyphens, and underscores).",
+      },
+    },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    if (!canCreate(ctx.principal)) {
+      throw new AccountToolError(
+        "create_not_granted",
+        "This connection was not granted permission to create vaults.",
+      );
+    }
+    const rawName = typeof args.name === "string" ? args.name : "";
+    const provisioned = await provisionVault(rawName, {
+      issuer: ctx.issuer,
+      manifestPath: ctx.manifestPath,
+      ...(ctx.runCommand ? { runCommand: ctx.runCommand } : {}),
+    });
+    if (!provisioned.ok) {
+      const message = provisioned.message;
+      if (provisioned.status === 400 && /reserved/i.test(message)) {
+        throw new AccountToolError("reserved", "That name is reserved. Please choose another.");
+      }
+      if (provisioned.status === 400) {
+        throw new AccountToolError(
+          "invalid_name",
+          "Use lowercase letters, numbers, hyphens, and underscores.",
+        );
+      }
+      throw new AccountToolError("server_error", message);
+    }
+    if (!provisioned.created) {
+      throw new AccountToolError("vault_taken", "That vault name is already taken.");
+    }
+    return { name: provisioned.entry.name, url: provisioned.entry.url };
+  },
+};
+
+type VaultQueryEntry = { vault: string; notes: unknown } | { vault: string; error: string };
+
+function buildNotesQuery(args: Record<string, unknown>): string {
+  const p = new URLSearchParams();
+  if (typeof args.search === "string" && args.search.length > 0) p.set("search", args.search);
+  const rawTags = Array.isArray(args.tag)
+    ? args.tag
+    : typeof args.tag === "string"
+      ? [args.tag]
+      : [];
+  for (const t of rawTags) if (typeof t === "string" && t.length > 0) p.append("tag", t);
+  if (args.metadata && typeof args.metadata === "object")
+    p.set("metadata", JSON.stringify(args.metadata));
+  const rawLimit =
+    typeof args.limit === "number"
+      ? args.limit
+      : typeof args.limit === "string"
+        ? Number.parseInt(args.limit, 10)
+        : undefined;
+  if (rawLimit !== undefined && Number.isFinite(rawLimit)) {
+    const clamped = Math.min(Math.max(1, Math.floor(rawLimit)), MAX_NOTES_LIMIT);
+    p.set("limit", String(clamped));
+  }
+  return p.toString();
+}
+
+async function queryOneVault(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  args: Record<string, unknown>,
+): Promise<VaultQueryEntry> {
+  const sign = ctx.signToken ?? signAccessToken;
+  const fetchImpl = ctx.fetchImpl ?? fetch;
+  const qs = buildNotesQuery(args);
+  const minted = await sign(ctx.db, {
+    sub: ctx.principal.userId,
+    scopes: [`vault:${vault.name}:read`],
+    audience: `vault.${vault.name}`,
+    clientId: ctx.principal.clientId ?? ACCOUNT_MCP_CLIENT_ID,
+    issuer: ctx.issuer,
+    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    vaultScope: [vault.name],
+    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
+  });
+  const url = `${vault.url.replace(/\/$/, "")}/api/notes${qs ? `?${qs}` : ""}`;
+  const res = await fetchImpl(url, {
+    headers: { authorization: `Bearer ${minted.token}`, accept: "application/json" },
+    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    let detail = `vault responded ${res.status}`;
+    try {
+      const body = (await res.json()) as Record<string, unknown>;
+      if (typeof body.error === "string") detail = body.error;
+    } catch {
+      // Non-JSON error body — keep the status-only detail.
+    }
+    return { vault: vault.name, error: detail };
+  }
+  const notes = await res.json();
+  return { vault: vault.name, notes };
+}
+
+async function fanOut(
+  ctx: AccountToolContext,
+  targets: AccountVaultMeta[],
+  args: Record<string, unknown>,
+): Promise<VaultQueryEntry[]> {
+  const settled = await Promise.allSettled(targets.map((v) => queryOneVault(ctx, v, args)));
+  return settled.map((s, i) =>
+    s.status === "fulfilled"
+      ? s.value
+      : {
+          vault: targets[i]!.name,
+          error: s.reason instanceof Error ? s.reason.message : "query failed",
+        },
+  );
+}
+
+const queryNotesTool: AccountMcpTool = {
+  name: "query-notes",
+  description:
+    "Search notes across the vaults this connection can reach. Omit `vault` to fan the query out " +
+    "(results are grouped per vault, not ranked across vaults); pass `vault` to target one. " +
+    "Supports keyword `search`, `tag` and `metadata` filters, and `limit`.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      vault: {
+        type: "string",
+        description:
+          "Target a single vault by name. Must be one of the reachable vaults. Omit to query all.",
+      },
+      search: { type: "string", description: "Full-text keyword query." },
+      tag: {
+        type: ["string", "array"],
+        items: { type: "string" },
+        description: "Restrict to notes carrying this tag (or any of these tags).",
+      },
+      metadata: {
+        type: "object",
+        description: 'Structured metadata filters, e.g. {"status":{"eq":"open"}}.',
+      },
+      limit: { type: "number", description: "Maximum notes per vault (default 50)." },
+    },
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+    let targets = coverage.vaults;
+    if (typeof args.vault === "string" && args.vault.length > 0) {
+      const wanted = args.vault.toLowerCase();
+      const hit = coverage.vaults.find((v) => v.name === wanted);
+      if (!hit) {
+        throw new AccountToolError(
+          "vault_not_covered",
+          `Vault "${args.vault}" is not among the vaults this connection can reach.`,
+        );
+      }
+      targets = [hit];
+    }
+    const results = await fanOut(ctx, targets, args);
+    return { vaults_queried: targets.map((v) => v.name), results };
+  },
+};
+
+/** Order is stable so `tools/list` is deterministic. */
+export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
+  listVaultsTool,
+  createVaultTool,
+  queryNotesTool,
+];

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -53,9 +53,9 @@
  *   /.well-known/parachute-account             → account-door capabilities descriptor (public, H2)
  *   /.well-known/oauth-authorization-server    → RFC 8414 metadata (issuer, endpoints)
  *   /.well-known/oauth-protected-resource/mcp  → RFC 9728 PRM for root /mcp,
- *                                                FORWARDED from the vault daemon
- *                                                (not built locally like the
- *                                                hub-issued PRM)
+ *                                                built locally (hub#789)
+ *   /.well-known/oauth-protected-resource/account/mcp → RFC 9728 PRM for
+ *                                                the account-MCP door
  *   /.well-known/oauth-protected-resource/vault/<name>[/mcp] → RFC 9728 per-vault PRM, forwarded from vault daemon
  *
  *   # OAuth issuer.
@@ -76,6 +76,9 @@
  *   # account:self:write (create/configure), account:self:admin (delete/mint),
  *   # or parachute:host:admin (all mutations); +:read (reads).
  *   /account                      (GET)        → account bootstrap {id,email,door} (Bearer only)
+ *   /account/mcp                  (POST/DELETE/OPTIONS) → account-level MCP
+ *                                                (NIP-98 or account:self:* /
+ *                                                host:admin Bearer)
  *   /account/vaults               (GET/POST)   → list / create vault (create returns vault_token)
  *   /account/vaults/<name>        (DELETE)     → teardown (wraps /vaults/<name> cascade)
  *   /account/vaults/<name>/token  (POST)       → per-vault scoped token mint
@@ -240,6 +243,7 @@ import {
   handleAccountSetVaultCaps,
   requireAnyScope,
 } from "./account-api.ts";
+import { accountMcpProtectedResource, handleAccountMcp } from "./account-mcp-http.ts";
 import { type AccountSessionDeps, handleAccountSession } from "./account-session.ts";
 import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
 import { handleAccountToken } from "./account-token.ts";
@@ -3033,6 +3037,27 @@ export function hubFetch(
         return new Response(res.body, { status: res.status, headers: merged });
       }
 
+      // /.well-known/oauth-protected-resource/account/mcp — RFC 9728 PRM
+      // for the account-MCP door. Hub-authored (the resource is a hub
+      // path). Public + wildcard CORS so a spec-following client can walk
+      // a 401 challenge here without a cookie.
+      if (pathname === "/.well-known/oauth-protected-resource/account/mcp") {
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        if (req.method !== "GET") {
+          return new Response("method not allowed", {
+            status: 405,
+            headers: { allow: "GET, OPTIONS", ...corsHeaders },
+          });
+        }
+        return accountMcpProtectedResource(oauthDeps(req).issuer);
+      }
+
       // /.well-known/oauth-protected-resource/vault/<name>[/mcp] — the
       // path-insertion PRM for a per-vault resource. The vault daemon owns this
       // document because it authors the vault-specific resource URL and scopes;
@@ -4128,6 +4153,15 @@ export function hubFetch(
       // account:self:write (or its stronger admin scope); delete/mint remain
       // admin-only; reads also accept account:self:read. See `account-api.ts`.
       // ====================================================================
+      if (pathname === "/account/mcp") {
+        if (!getDb) return dbNotConfigured();
+        return handleAccountMcp(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
+          manifestPath,
+        });
+      }
       if (pathname === "/account/vaults") {
         if (!getDb) return dbNotConfigured();
         const accountDeps: AccountApiDeps = {

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -22,6 +22,7 @@
  * on presentation.
  */
 import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
 import { AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { recordLoginUnlock } from "./admin-lock.ts";
 import { renderTotpChallenge } from "./admin-login-ui.ts";
@@ -1237,6 +1238,14 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // Per RFC 6749 §4.1.2.1, errors that aren't redirect-uri-related are
   // delivered by redirect with `error=invalid_scope`.
   const requestedScopes = parsed.scope.split(" ").filter((s) => s.length > 0);
+  if (accountVaultsCombinedWithOtherScopes(requestedScopes)) {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "invalid_scope",
+      "account:vaults cannot be combined with other scopes",
+      parsed.state,
+    );
+  }
   const blocked = findNonRequestableScopes(requestedScopes);
   if (blocked.length > 0) {
     return oauthErrorRedirect(
@@ -1494,6 +1503,20 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
  *     skip-consent flow can never replay an un-held admin verb because it was
  *     never recorded.
  */
+function bindAccountVaultsScopes(scopes: readonly string[]): string[] {
+  return scopes.map((s) => (s === ACCOUNT_VAULTS_UNNARROWED ? accountVaultsScope("self") : s));
+}
+
+function isAccountVaultsConnectionScope(scope: string): boolean {
+  return scope === ACCOUNT_VAULTS_UNNARROWED || scope === accountVaultsScope("self");
+}
+
+function accountVaultsCombinedWithOtherScopes(scopes: readonly string[]): boolean {
+  const has = scopes.some(isAccountVaultsConnectionScope);
+  if (!has) return false;
+  return scopes.some((s) => !isAccountVaultsConnectionScope(s));
+}
+
 function capScopesToUserAuthority(
   db: Database,
   userId: string,
@@ -1574,6 +1597,7 @@ export function grantableExtraScopes(
     ACCOUNT_SELF_READ_SCOPE,
     ACCOUNT_SELF_WRITE_SCOPE,
     ACCOUNT_SELF_ADMIN_SCOPE,
+    ACCOUNT_VAULTS_UNNARROWED,
   ];
 
   // Compare both naming shapes in one canonical key space. When an admin's
@@ -1643,7 +1667,19 @@ function issueAuthCodeRedirect(
   // the final named shapes. Owner (isFirstAdmin) bypasses — holds admin
   // everywhere by construction.
   const userIsAdmin = isFirstAdmin(db, userId);
-  const cappedScopes = capScopesToUserAuthority(db, userId, scopes, { userIsAdmin });
+  // RFC 9728 walk: PRM advertises un-narrowed `account:vaults`; the token
+  // must carry the id-bound blanket `account:self:vaults`. Bind here at the
+  // single mint choke-point so skip-consent and form-consent cannot diverge.
+  const boundScopes = bindAccountVaultsScopes(scopes);
+  if (accountVaultsCombinedWithOtherScopes(boundScopes)) {
+    return oauthErrorRedirect(
+      params.redirectUri,
+      "invalid_scope",
+      "account:vaults cannot be combined with other scopes",
+      params.state,
+    );
+  }
+  const cappedScopes = capScopesToUserAuthority(db, userId, boundScopes, { userIsAdmin });
   // Dedup HERE, after the cap, at the single mint choke-point every path funnels
   // through — so the auth-code row, the JWT `scope` claim, the refresh row, the
   // token response, and the recorded grant all carry the same set.

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -193,6 +193,16 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
     level: "read",
     risk: "low",
   },
+  // Account-MCP connection grant (hub#883). PRM advertises the un-narrowed
+  // `account:vaults`; consent binds it to `account:self:vaults`. Elevated
+  // because the grant includes create-vault plus cross-vault query-notes —
+  // not the REST `account:self:read` list/usage surface.
+  "account:vaults": {
+    label:
+      "Connect across your vaults — list them, search their notes, and create new vaults. Does not delete vaults or mint long-lived access tokens.",
+    level: "write",
+    risk: "elevated",
+  },
 };
 
 /** Account scope strings (Parachute App campaign, Phase 2). Exported so the


### PR DESCRIPTION
## What

The Buzz-shaped door a key-native user actually talks to: `POST /account/mcp`.

A Buzz agent already has an nsec; hub#882 made that key a hub user. This slice is the MCP session that lists the vaults *that key* can use, queries across them, and (for the hub owner) creates one.

## Auth

- `Authorization: Nostr <event>` (hub#882) — any resolved hub user opens the door. Coverage is assignment: first-admin → every services.json vault + create; friend → `user_vaults` ∩ installed (read verb required); auto-provisioned → empty list, no create.
- `Authorization: Bearer` — an account-vaults connection grant (`account:vaults` request form, bound at consent to `account:self:vaults`, `aud=account`) or `parachute:host:admin` (operator bypass). REST `account:self:read` / `:write` / `:admin` do **not** open this door.

Cookie sessions never open it. Wildcard CORS: nothing here is ambient-auth.

## Tools

Same three as cloud's account-MCP:

- `list-vaults`
- `create-vault` (no `vault_token` in the result)
- `query-notes` (loopback fan-out via a 60s `vault:<name>:read` mint, `client_id=parachute-account`, per-vault attribution)

Transport framing matches the cloud twin. Descriptor sets `account_mcp_endpoint`. RFC 9728 PRM at `/.well-known/oauth-protected-resource/account/mcp` advertises `account:vaults`.

## Not in this slice

- bun-link / live `:1939`
- version bump
- channel-vault binding (NIP-OA 39002 → `user_vaults`)
- Account SPA rewrite (#880)
- multiple hub admins (#881)

## Test

`bun test src/__tests__/account-mcp.test.ts src/__tests__/account-api.test.ts src/__tests__/oauth-handlers.test.ts src/__tests__/scope-registry.test.ts` — green at `a83e078`. `tsc --noEmit` 0.