### PR TITLE
release: hub 0.7.18-rc.2 — NIP-98 request auth + account-MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.2] - 2026-08-27
+
+**Key-as-account: NIP-98 request auth and the account-MCP door.** Two PRs
+on `next` after 0.7.18-rc.1. Version bump only; no new code in this
+commit. Merging this to `next` does not publish. The following next→main
+PR publishes `@rc`.
+
+- **NIP-98 request auth (#882).** `Authorization: Nostr <base64url event>`
+  (kind 27235) authenticates as a hub user. Linked pubkey maps to that
+  user. Opt-in auto-provision (`PARACHUTE_NOSTR_AUTO_PROVISION`, default
+  off) creates a key-only user that cannot become first-admin. Cookie
+  first-link is unchanged.
+
+- **Account-MCP door (#883).** `POST /account/mcp` is list-vaults /
+  create-vault / query-notes for that principal. NIP-98 coverage is
+  assignment. Bearer is the `account:vaults` connection grant (consent
+  binds to `account:self:vaults`, `aud=account`) or
+  `parachute:host:admin`. REST `account:self:read` does not open this
+  door. Descriptor advertises `account_mcp_endpoint`. No `vault_token` in
+  tool results.
+
+Leaves #880 and #881 open.
+
 ## [0.7.18-rc.1] - 2026-08-26
 
 **Person-mint principal is `users.id`; self-service Account tokens and pubkey

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ PR publishes `@rc`.
   create-vault / query-notes for that principal. NIP-98 coverage is
   assignment. Bearer is the `account:vaults` connection grant (consent
   binds to `account:self:vaults`, `aud=account`) or
-  `parachute:host:admin`. REST `account:self:read` does not open this
-  door. Descriptor advertises `account_mcp_endpoint`. No `vault_token` in
-  tool results.
+  `parachute:host:admin`. REST `account:self:read` / `:write` / `:admin`
+  do not open this door. Descriptor advertises `account_mcp_endpoint`.
+  No `vault_token` in tool results.
 
 Leaves #880 and #881 open.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.1",
+  "version": "0.7.18-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## What

Version bump only. `package.json` `0.7.18-rc.1` → `0.7.18-rc.2` + CHANGELOG. No code.

Captures [hub#882](https://github.com/ParachuteComputer/parachute-hub/pull/882) (NIP-98 request auth) and [hub#883](https://github.com/ParachuteComputer/parachute-hub/pull/883) (`/account/mcp`) which landed on `next` at the already-published 0.7.18-rc.1 version, so they never reached npm.

Merging this to `next` does **not** publish. The following `next` → `main` merge-commit publishes `@openparachute/hub@0.7.18-rc.2` `@rc`. `@latest` stays 0.7.17.

Leaves #880 and #881 open.

## Test

`release-check.sh` PASS vs `origin/main` (`0.7.18-rc.1` → `0.7.18-rc.2`). Lockfile WARN is version-only (deps untouched).