### PR TITLE
release: hub 0.7.18-rc.2 (next → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.2] - 2026-08-27
+
+**Key-as-account: NIP-98 request auth and the account-MCP door.** Two PRs
+on `next` after 0.7.18-rc.1. Version bump only; no new code in this
+commit. Merging this to `next` does not publish. The following next→main
+PR publishes `@rc`.
+
+- **NIP-98 request auth (#882).** `Authorization: Nostr <base64url event>`
+  (kind 27235) authenticates as a hub user. Linked pubkey maps to that
+  user. Opt-in auto-provision (`PARACHUTE_NOSTR_AUTO_PROVISION`, default
+  off) creates a key-only user that cannot become first-admin. Cookie
+  first-link is unchanged.
+
+- **Account-MCP door (#883).** `POST /account/mcp` is list-vaults /
+  create-vault / query-notes for that principal. NIP-98 coverage is
+  assignment. Bearer is the `account:vaults` connection grant (consent
+  binds to `account:self:vaults`, `aud=account`) or
+  `parachute:host:admin`. REST `account:self:read` / `:write` / `:admin`
+  do not open this door. Descriptor advertises `account_mcp_endpoint`.
+  No `vault_token` in tool results.
+
+Leaves #880 and #881 open.
+
 ## [0.7.18-rc.1] - 2026-08-26
 
 **Person-mint principal is `users.id`; self-service Account tokens and pubkey

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.1",
+  "version": "0.7.18-rc.2",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-api.test.ts
+++ b/src/__tests__/account-api.test.ts
@@ -151,6 +151,7 @@ describe("handleAccountCapabilities", () => {
       expect(body.issuer).toBe(ISSUER); // trailing slash trimmed
       expect(body.door).toBe("hub");
       expect(body.account_endpoint).toBe(`${ISSUER}/account`);
+      expect(body.account_mcp_endpoint).toBe(`${ISSUER}/account/mcp`);
       expect(body.auth).toEqual({ methods: ["password"], signin_path: "/login" });
       expect(body.vault_url_template).toContain("{name}");
       expect(body.vault_url_template).toBe(`${ISSUER}/vault/{name}`);

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -1,0 +1,949 @@
+import type { Database } from "bun:sqlite";
+/**
+ * Account-level MCP door (`/account/mcp`).
+ *
+ * Coverage:
+ *   - transport-parity (Accept 406 / CT 415 / parse 400 / notifications 202 /
+ *     GET 405 / DELETE 200 / initialize / ping / tools/list);
+ *   - auth: missing, wrong Bearer scope, NIP-98 linked user, auto-provision;
+ *   - coverage: Bearer/first-admin = all vaults; friend = assigned ∩ installed;
+ *     auto-provisioned = empty; read-role still lists + queries;
+ *   - create-vault: owner yes, friend no, no token in the tool result;
+ *   - query-notes: fan-out attribution + one-vault failure isolation +
+ *     vault_not_covered fail-closed;
+ *   - descriptor advertises account_mcp_endpoint (see account-api.test).
+ */
+import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { handleAccountCapabilities } from "../account-api.ts";
+import { accountMcpProtectedResource, handleAccountMcp } from "../account-mcp-http.ts";
+import { ACCOUNT_MCP_TOOLS } from "../account-mcp.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import { signAccessToken } from "../jwt-sign.ts";
+import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
+import { NostrReplayCache } from "../nostr-http-auth.ts";
+import { bindPubkeyFromHttpAuth } from "../pubkey-links.ts";
+import { upsertService } from "../services-manifest.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+import { createUser } from "../users.ts";
+
+const ISSUER = "http://127.0.0.1:1939";
+const MCP_URL = `${ISSUER}/account/mcp`;
+const BOTH_ACCEPT = "application/json, text/event-stream";
+const HOST_ADMIN_SCOPE = "parachute:host:admin";
+const ACCOUNT_WRITE_SCOPE = "account:self:write";
+const ACCOUNT_READ_SCOPE = "account:self:read";
+const ACCOUNT_VAULTS_SCOPE = "account:self:vaults";
+const ACCOUNT_VAULTS_UNNARROWED = "account:vaults";
+
+const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
+const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
+
+const OWNER_SECRET = hexToBytes("11".repeat(32));
+const OWNER_PUBKEY = bytesToHex(schnorr.getPublicKey(OWNER_SECRET));
+const FRIEND_SECRET = hexToBytes("22".repeat(32));
+const FRIEND_PUBKEY = bytesToHex(schnorr.getPublicKey(FRIEND_SECRET));
+const OTHER_SECRET = hexToBytes("33".repeat(32));
+const OTHER_PUBKEY = bytesToHex(schnorr.getPublicKey(OTHER_SECRET));
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+function signEvent(
+  secret: Uint8Array,
+  parts: { created_at?: number; kind?: number; tags?: string[][]; content?: string },
+): NostrEvent {
+  const unsigned = {
+    pubkey: bytesToHex(schnorr.getPublicKey(secret)),
+    created_at: parts.created_at ?? Math.floor(Date.now() / 1000),
+    kind: parts.kind ?? NOSTR_AUTH_KIND,
+    tags: parts.tags ?? [],
+    content: parts.content ?? "",
+  };
+  const id = nostrEventId(unsigned);
+  const sig = bytesToHex(schnorr.sign(hexToBytes(id), secret));
+  return { ...unsigned, id, sig };
+}
+
+function nostrHeader(event: NostrEvent): string {
+  return `Nostr ${Buffer.from(JSON.stringify(event), "utf8").toString("base64url")}`;
+}
+
+function rpc(
+  method: string,
+  params?: Record<string, unknown>,
+  id: number | string | null = 1,
+): unknown {
+  return { jsonrpc: "2.0", id, method, ...(params ? { params } : {}) };
+}
+
+function vaultCreateJson(name: string): string {
+  return JSON.stringify({
+    name,
+    token: `hubjwt.${name}.access`,
+    paths: {
+      vault_dir: `/home/test/.parachute/vault/${name}`,
+      vault_db: `/home/test/.parachute/vault/${name}/vault.db`,
+      vault_config: `/home/test/.parachute/vault/${name}/config.yaml`,
+    },
+    set_as_default: false,
+  });
+}
+
+interface Harness {
+  db: Database;
+  dir: string;
+  manifestPath: string;
+  ownerId: string;
+  friendId: string;
+  replay: NostrReplayCache;
+  cleanup: () => void;
+}
+
+async function makeHarness(vaultNames: string[] = ["beta", "personal"]): Promise<Harness> {
+  const dir = mkdtempSync(join(tmpdir(), "phub-account-mcp-"));
+  const db = openHubDb(hubDbPath(dir));
+  rotateSigningKey(db);
+  const manifestPath = join(dir, "services.json");
+  const paths = vaultNames.map((n) => `/vault/${n}`);
+  writeFileSync(
+    manifestPath,
+    JSON.stringify({
+      services: [
+        { name: "parachute-vault", port: 4101, paths, health: "/health", version: "0.4.2" },
+      ],
+    }),
+  );
+  const owner = await createUser(db, "owner", "correct-horse-battery-staple", {
+    passwordChanged: true,
+  });
+  const friend = await createUser(db, "alice", "correct-horse-battery-staple", {
+    allowMulti: true,
+    passwordChanged: true,
+    assignedVaults: ["beta"],
+  });
+  const now = new Date();
+  bindPubkeyFromHttpAuth(db, {
+    userId: owner.id,
+    pubkey: OWNER_PUBKEY,
+    proofEvent: "{}",
+    proofEventId: "a".repeat(64),
+    label: "test",
+    now,
+  });
+  bindPubkeyFromHttpAuth(db, {
+    userId: friend.id,
+    pubkey: FRIEND_PUBKEY,
+    proofEvent: "{}",
+    proofEventId: "b".repeat(64),
+    label: "test",
+    now,
+  });
+  return {
+    db,
+    dir,
+    manifestPath,
+    ownerId: owner.id,
+    friendId: friend.id,
+    replay: new NostrReplayCache(),
+    cleanup: () => {
+      db.close();
+      rmSync(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function bearer(h: Harness, scopes: string[], sub?: string): Promise<string> {
+  const minted = await signAccessToken(h.db, {
+    sub: sub ?? h.ownerId,
+    scopes,
+    audience: "account",
+    clientId: "parachute-hub-spa",
+    issuer: ISSUER,
+    ttlSeconds: 600,
+  });
+  return minted.token;
+}
+
+function mcpDeps(
+  h: Harness,
+  extra: {
+    fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+    runCommand?: (
+      cmd: readonly string[],
+    ) => Promise<{ exitCode: number; stdout: string; stderr: string }>;
+    autoProvisionEnv?: string;
+  } = {},
+) {
+  return {
+    db: h.db,
+    issuer: ISSUER,
+    manifestPath: h.manifestPath,
+    replay: h.replay,
+    ...(extra.fetchImpl ? { fetchImpl: extra.fetchImpl } : {}),
+    ...(extra.runCommand ? { runCommand: extra.runCommand } : {}),
+  };
+}
+
+function nostrReq(
+  secret: Uint8Array,
+  body: unknown,
+  extraHeaders: Record<string, string> = {},
+): Request {
+  const encoded = JSON.stringify(body);
+  const bytes = new TextEncoder().encode(encoded);
+  const event = signEvent(secret, {
+    content: `${Date.now()}-${Math.random()}`,
+    tags: [
+      ["u", MCP_URL],
+      ["method", "POST"],
+      ["payload", sha256Hex(bytes)],
+    ],
+  });
+  return new Request(MCP_URL, {
+    method: "POST",
+    headers: {
+      authorization: nostrHeader(event),
+      accept: BOTH_ACCEPT,
+      "content-type": "application/json",
+      ...extraHeaders,
+    },
+    body: encoded,
+  });
+}
+
+function bearerReq(token: string | null, body: unknown, init: RequestInit = {}): Request {
+  const headers = new Headers(init.headers);
+  if (!headers.has("accept")) headers.set("accept", BOTH_ACCEPT);
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  if (token) headers.set("authorization", `Bearer ${token}`);
+  return new Request(MCP_URL, {
+    method: "POST",
+    ...init,
+    headers,
+    body: JSON.stringify(body),
+  });
+}
+
+function parseTool(rpcBody: { result?: { content?: Array<{ text?: string }> } }): unknown {
+  const text = rpcBody.result?.content?.[0]?.text;
+  if (typeof text !== "string") throw new Error("missing tool text");
+  expect(text).not.toMatch(/vault_token|"token":|eyJ/);
+  return JSON.parse(text);
+}
+
+describe("account MCP — descriptor + PRM", () => {
+  test("capabilities descriptor advertises account_mcp_endpoint", async () => {
+    const h = await makeHarness();
+    try {
+      const res = handleAccountCapabilities(
+        new Request(`${ISSUER}/.well-known/parachute-account`),
+        {
+          db: h.db,
+          issuer: ISSUER,
+        },
+      );
+      const body = (await res.json()) as { account_mcp_endpoint: string };
+      expect(body.account_mcp_endpoint).toBe(MCP_URL);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("PRM names the account-MCP resource and account:vaults", async () => {
+    const res = accountMcpProtectedResource(ISSUER);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      resource: string;
+      authorization_servers: string[];
+      scopes_supported: string[];
+    };
+    expect(body.resource).toBe(MCP_URL);
+    expect(body.authorization_servers).toEqual([ISSUER]);
+    expect(body.scopes_supported).toEqual([ACCOUNT_VAULTS_UNNARROWED]);
+  });
+});
+
+describe("account MCP — transport", () => {
+  test("401 with no Authorization, RFC 9728 challenge", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(bearerReq(null, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain("resource_metadata=");
+      expect(challenge).toContain("/.well-known/oauth-protected-resource/account/mcp");
+      expect(res.headers.get("access-control-allow-origin")).toBe("*");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 Bearer without account-vaults or host:admin", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, ["vault:beta:read"]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(403);
+      const body = (await res.json()) as { error: string };
+      expect(body.error).toBe("insufficient_scope");
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain(`scope="${ACCOUNT_VAULTS_UNNARROWED}"`);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("403 Bearer account:self:read — REST read is not an MCP credential", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_READ_SCOPE]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(403);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain(`scope="${ACCOUNT_VAULTS_UNNARROWED}"`);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("401 Bearer account-vaults with a vault audience", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await signAccessToken(h.db, {
+        sub: h.ownerId,
+        scopes: [ACCOUNT_VAULTS_SCOPE],
+        audience: "vault.beta",
+        clientId: "parachute-hub-spa",
+        issuer: ISSUER,
+        ttlSeconds: 600,
+      });
+      const res = await handleAccountMcp(bearerReq(minted.token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(401);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("406 unless Accept lists both json and event-stream", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("ping"), { headers: { accept: "application/json" } }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(406);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("415 unless Content-Type is json", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("ping"), { headers: { "content-type": "text/plain" } }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(415);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET is 405 after auth; DELETE is 200", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const get = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "GET",
+          headers: { authorization: `Bearer ${token}` },
+        }),
+        mcpDeps(h),
+      );
+      expect(get.status).toBe(405);
+      const del = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${token}` },
+        }),
+        mcpDeps(h),
+      );
+      expect(del.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("notification-only POST is 202", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, { jsonrpc: "2.0", method: "notifications/initialized" }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(202);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("OPTIONS preflight is 204 with MCP headers", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(new Request(MCP_URL, { method: "OPTIONS" }), mcpDeps(h));
+      expect(res.status).toBe(204);
+      expect(res.headers.get("access-control-allow-headers")).toContain("Mcp-Protocol-Version");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — initialize + tools", () => {
+  test("Bearer account:self:vaults initializes and lists the three tools", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const init = await handleAccountMcp(
+        bearerReq(token, rpc("initialize", { protocolVersion: "2025-11-25" })),
+        mcpDeps(h),
+      );
+      expect(init.status).toBe(200);
+      const initBody = (await init.json()) as {
+        result: { serverInfo: { name: string }; protocolVersion: string };
+      };
+      expect(initBody.result.serverInfo.name).toBe("parachute-account");
+      expect(initBody.result.protocolVersion).toBe("2025-11-25");
+
+      const listed = await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h));
+      const listBody = (await listed.json()) as { result: { tools: Array<{ name: string }> } };
+      expect(listBody.result.tools.map((t) => t.name)).toEqual(
+        ACCOUNT_MCP_TOOLS.map((t) => t.name),
+      );
+      expect(listBody.result.tools.map((t) => t.name)).toEqual([
+        "list-vaults",
+        "create-vault",
+        "query-notes",
+      ]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 first-admin initializes", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(nostrReq(OWNER_SECRET, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — list-vaults coverage", () => {
+  test("Bearer host:admin lists every installed vault", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("all");
+      expect(payload.vaults.map((v) => v.name).sort()).toEqual(["beta", "personal"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 first-admin lists every installed vault", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(OWNER_SECRET, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("all");
+      expect(payload.vaults.map((v) => v.name).sort()).toEqual(["beta", "personal"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 friend lists only assigned vaults", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(FRIEND_SECRET, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("listed");
+      expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("auto-provisioned key lists nothing", async () => {
+    const h = await makeHarness();
+    const prev = process.env.PARACHUTE_NOSTR_AUTO_PROVISION;
+    process.env.PARACHUTE_NOSTR_AUTO_PROVISION = "1";
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(OTHER_SECRET, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        covered: string;
+        vaults: Array<{ name: string }>;
+      };
+      expect(payload.covered).toBe("listed");
+      expect(payload.vaults).toEqual([]);
+    } finally {
+      if (prev === undefined) process.env.PARACHUTE_NOSTR_AUTO_PROVISION = undefined;
+      else process.env.PARACHUTE_NOSTR_AUTO_PROVISION = prev;
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — create-vault", () => {
+  test("NIP-98 first-admin can create; result has no token", async () => {
+    const h = await makeHarness(["default"]);
+    try {
+      const runCommand = async () => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work"), stderr: "" };
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", { name: "create-vault", arguments: { name: "work" } }),
+        ),
+        mcpDeps(h, { runCommand }),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as Record<string, unknown>;
+      expect(payload.name).toBe("work");
+      expect(payload.url).toBe(`${ISSUER}/vault/work`);
+      expect(payload.vault_token).toBeUndefined();
+      expect(payload.token).toBeUndefined();
+      const raw = JSON.stringify(payload);
+      expect(raw).not.toContain("hubjwt");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 friend cannot create", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", { name: "create-vault", arguments: { name: "work" } }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("create_not_granted");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer account:self:vaults can create; still no token in the tool result", async () => {
+    const h = await makeHarness(["default"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const runCommand = async () => {
+        upsertService(
+          {
+            name: "parachute-vault",
+            port: 4101,
+            paths: ["/vault/default", "/vault/work"],
+            health: "/health",
+            version: "0.4.2",
+          },
+          h.manifestPath,
+        );
+        return { exitCode: 0, stdout: vaultCreateJson("work"), stderr: "" };
+      };
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "create-vault", arguments: { name: "work" } })),
+        mcpDeps(h, { runCommand }),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as Record<string, unknown>;
+      expect(payload.name).toBe("work");
+      expect(payload.vault_token).toBeUndefined();
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("existing name is vault_taken", async () => {
+    const h = await makeHarness(["work"]);
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "create-vault", arguments: { name: "work" } })),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("vault_taken");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — query-notes", () => {
+  test("fans out with per-vault attribution; one failure is isolated", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const fetchImpl = async (input: string | URL | Request) => {
+        const href =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : (input as Request).url;
+        if (href.includes("127.0.0.1:4101/vault/beta/")) {
+          return Response.json([{ id: "n-beta" }], { status: 200 });
+        }
+        throw new Error("personal is down");
+      };
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", { name: "query-notes", arguments: { search: "hello" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        vaults_queried: string[];
+        results: Array<{ vault: string; notes?: unknown; error?: string }>;
+      };
+      expect(payload.vaults_queried.sort()).toEqual(["beta", "personal"]);
+      const byVault = Object.fromEntries(payload.results.map((r) => [r.vault, r]));
+      expect(byVault.beta?.notes).toEqual([{ id: "n-beta" }]);
+      expect(byVault.personal?.error).toMatch(/personal is down/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend targeting an unassigned vault is vault_not_covered", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", { name: "query-notes", arguments: { vault: "personal" } }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("vault_not_covered");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend can query their assigned vault", async () => {
+    const h = await makeHarness();
+    try {
+      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", { name: "query-notes", arguments: { vault: "beta" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        vaults_queried: string[];
+      };
+      expect(payload.vaults_queried).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — NIP-98 bind", () => {
+  test("payload mismatch is 401", async () => {
+    const h = await makeHarness();
+    try {
+      const body = rpc("ping");
+      const encoded = JSON.stringify(body);
+      const event = signEvent(OWNER_SECRET, {
+        tags: [
+          ["u", MCP_URL],
+          ["method", "POST"],
+          ["payload", "0".repeat(64)],
+        ],
+      });
+      const res = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "POST",
+          headers: {
+            authorization: nostrHeader(event),
+            accept: BOTH_ACCEPT,
+            "content-type": "application/json",
+          },
+          body: encoded,
+        }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(401);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — extra pins", () => {
+  test("ping returns {}", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("ping")), mcpDeps(h));
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result: unknown };
+      expect(body.result).toEqual({});
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("invalid JSON is 400 parse error", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(
+        new Request(MCP_URL, {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${token}`,
+            accept: BOTH_ACCEPT,
+            "content-type": "application/json",
+          },
+          body: "{not json",
+        }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(400);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer host:admin with aud=hub (operator SPA mint) still opens", async () => {
+    const h = await makeHarness();
+    try {
+      const minted = await signAccessToken(h.db, {
+        sub: h.ownerId,
+        scopes: [HOST_ADMIN_SCOPE],
+        audience: "hub",
+        clientId: "parachute-hub-spa",
+        issuer: ISSUER,
+        ttlSeconds: 600,
+      });
+      const res = await handleAccountMcp(bearerReq(minted.token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer leftover un-narrowed account:vaults still opens as a blanket grant", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_UNNARROWED]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(200);
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { covered: string };
+      expect(payload.covered).toBe("all");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer account:self:write cannot open the door", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_WRITE_SCOPE]);
+      const res = await handleAccountMcp(bearerReq(token, rpc("initialize")), mcpDeps(h));
+      expect(res.status).toBe(403);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer narrowed account:self:vaults:beta lists only beta", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta"]);
+      const res = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { covered: string; vaults: Array<{ name: string }> };
+      expect(payload.covered).toBe("listed");
+      expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("NIP-98 read-role still lists and queries the assigned vault", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("44".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    try {
+      const reader = await createUser(h.db, "reader", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "c".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const listed = await handleAccountMcp(
+        nostrReq(readerSecret, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await listed.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vaults: Array<{ name: string }> };
+      expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
+      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const queried = await handleAccountMcp(
+        nostrReq(
+          readerSecret,
+          rpc("tools/call", { name: "query-notes", arguments: { vault: "beta" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(queried.status).toBe(200);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — hubFetch wiring", () => {
+  test("unauthed POST is 401 JSON with PRM challenge, not HTML", async () => {
+    const h = await makeHarness();
+    try {
+      const { hubFetch } = await import("../hub-server.ts");
+      const handler = hubFetch(h.dir, {
+        getDb: () => h.db,
+        manifestPath: h.manifestPath,
+        issuer: ISSUER,
+      });
+      const res = await handler(
+        new Request(MCP_URL, {
+          method: "POST",
+          headers: { accept: BOTH_ACCEPT, "content-type": "application/json" },
+          body: JSON.stringify(rpc("initialize")),
+        }),
+      );
+      expect(res.status).toBe(401);
+      expect(res.headers.get("content-type") ?? "").toContain("json");
+      expect(res.headers.get("www-authenticate") ?? "").toContain(
+        "/.well-known/oauth-protected-resource/account/mcp",
+      );
+      const text = await res.text();
+      expect(text.toLowerCase()).not.toContain("<html");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("GET PRM is public and advertises account:vaults", async () => {
+    const h = await makeHarness();
+    try {
+      const { hubFetch } = await import("../hub-server.ts");
+      const handler = hubFetch(h.dir, {
+        getDb: () => h.db,
+        manifestPath: h.manifestPath,
+        issuer: ISSUER,
+      });
+      const res = await handler(
+        new Request(`${ISSUER}/.well-known/oauth-protected-resource/account/mcp`),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { scopes_supported: string[]; resource: string };
+      expect(body.resource).toBe(MCP_URL);
+      expect(body.scopes_supported).toEqual([ACCOUNT_VAULTS_UNNARROWED]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/grants.test.ts
+++ b/src/__tests__/grants.test.ts
@@ -103,6 +103,51 @@ describe("grants module (#75)", () => {
     }
   });
 
+  test("isCoveredByGrant: account:vaults and account:self:vaults are equivalent", async () => {
+    const h = await harness();
+    try {
+      recordGrant(h.db, h.userId, h.clientId, ["account:self:vaults"]);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:vaults"])).toBe(true);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:self:vaults"])).toBe(true);
+      expect(
+        isCoveredByGrant(h.db, h.userId, h.clientId, ["account:vaults", "vault:work:read"]),
+      ).toBe(false);
+      expect(revokeGrant(h.db, h.userId, h.clientId)).toBe(true);
+      recordGrant(h.db, h.userId, h.clientId, ["account:vaults"]);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:self:vaults"])).toBe(true);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:vaults"])).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("isCoveredByGrantForClientName: same account:vaults equivalence", async () => {
+    const h = await harness();
+    try {
+      const named = registerClient(h.db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "mcp-reconnect",
+      });
+      recordGrant(h.db, h.userId, named.client.clientId, ["account:self:vaults"]);
+      expect(isCoveredByGrantForClientName(h.db, h.userId, "mcp-reconnect", ["account:vaults"])).toBe(
+        true,
+      );
+      expect(
+        isCoveredByGrantForClientName(h.db, h.userId, "mcp-reconnect", [
+          "account:vaults",
+          "vault:work:read",
+        ]),
+      ).toBe(false);
+      expect(revokeGrant(h.db, h.userId, named.client.clientId)).toBe(true);
+      recordGrant(h.db, h.userId, named.client.clientId, ["account:vaults"]);
+      expect(
+        isCoveredByGrantForClientName(h.db, h.userId, "mcp-reconnect", ["account:self:vaults"]),
+      ).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("isCoveredByGrant: empty request returns false (no auto-approve for empty)", async () => {
     const h = await harness();
     try {

--- a/src/__tests__/nostr-http-auth.test.ts
+++ b/src/__tests__/nostr-http-auth.test.ts
@@ -1,0 +1,349 @@
+/**
+ * NIP-98 request auth (hub#833 (c)).
+ *
+ * Watch-fail: these tests signed against an unpatched verify (no replay
+ * cache, no u/method bind) before the implementation landed.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { createHash } from "node:crypto";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import type { Database } from "bun:sqlite";
+import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
+import {
+  NIP98_MAX_SKEW_SECONDS,
+  NostrReplayCache,
+  authenticateNostrRequest,
+  extractNostrEvent,
+  verifyNostrHttpEvent,
+} from "../nostr-http-auth.ts";
+import { requireScope } from "../admin-auth.ts";
+import { createUser } from "../users.ts";
+import { bindPubkeyFromHttpAuth, findPubkeyLink } from "../pubkey-links.ts";
+import { issuePubkeyChallenge, linkPubkey } from "../pubkey-links.ts";
+
+const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
+const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
+const SECRET = hexToBytes("aa".repeat(32));
+const PUBKEY = bytesToHex(schnorr.getPublicKey(SECRET));
+
+function signEvent(parts: {
+  created_at?: number;
+  kind?: number;
+  tags?: string[][];
+  content?: string;
+}): NostrEvent {
+  const unsigned = {
+    pubkey: PUBKEY,
+    created_at: parts.created_at ?? Math.floor(Date.now() / 1000),
+    kind: parts.kind ?? NOSTR_AUTH_KIND,
+    tags: parts.tags ?? [],
+    content: parts.content ?? "",
+  };
+  const id = nostrEventId(unsigned);
+  const sig = bytesToHex(schnorr.sign(hexToBytes(id), SECRET));
+  return { ...unsigned, id, sig };
+}
+
+function nostrHeader(event: NostrEvent): string {
+  return `Nostr ${Buffer.from(JSON.stringify(event), "utf8").toString("base64url")}`;
+}
+
+function reqFor(
+  url: string,
+  method: string,
+  event: NostrEvent,
+  body?: string,
+): Request {
+  return new Request(url, {
+    method,
+    headers: {
+      authorization: nostrHeader(event),
+      ...(body !== undefined ? { "content-type": "application/json" } : {}),
+    },
+    ...(body !== undefined ? { body } : {}),
+  });
+}
+
+describe("extractNostrEvent", () => {
+  test("parses a base64url event", () => {
+    const event = signEvent({
+      tags: [
+        ["u", "http://127.0.0.1:1939/api/me"],
+        ["method", "GET"],
+      ],
+    });
+    const req = reqFor("http://127.0.0.1:1939/api/me", "GET", event);
+    expect(extractNostrEvent(req).id).toBe(event.id);
+  });
+
+  test("rejects Bearer", () => {
+    const req = new Request("http://127.0.0.1:1939/api/me", {
+      headers: { authorization: "Bearer abc" },
+    });
+    expect(() => extractNostrEvent(req)).toThrow(/Nostr/);
+  });
+});
+
+describe("verifyNostrHttpEvent", () => {
+  test("accepts a fresh GET with matching u and method", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const replay = new NostrReplayCache();
+    verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
+  });
+
+  test("rejects a replayed event id", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const replay = new NostrReplayCache();
+    verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
+    expect(() => verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay })).toThrow(
+      /already been used/,
+    );
+  });
+
+  test("rejects u mismatch", () => {
+    const event = signEvent({
+      tags: [
+        ["u", "http://evil.example/api/me"],
+        ["method", "GET"],
+      ],
+    });
+    expect(() =>
+      verifyNostrHttpEvent(
+        reqFor("http://127.0.0.1:1939/api/me", "GET", event),
+        event,
+        { replay: new NostrReplayCache() },
+      ),
+    ).toThrow(/u tag/);
+  });
+
+  test("rejects method mismatch", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "POST"]] });
+    expect(() =>
+      verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
+    ).toThrow(/method tag/);
+  });
+
+  test("rejects created_at outside the 60s window", () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({
+      created_at: Math.floor(Date.now() / 1000) - (NIP98_MAX_SKEW_SECONDS + 5),
+      tags: [["u", url], ["method", "GET"]],
+    });
+    expect(() =>
+      verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
+    ).toThrow(/60s window/);
+  });
+
+  test("requires payload sha256 hex when the body is non-empty", () => {
+    const url = "http://127.0.0.1:1939/api/account/tokens";
+    const body = '{"scope":"vault:work:read"}';
+    const hash = createHash("sha256").update(body, "utf8").digest("hex");
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "POST"],
+        ["payload", hash],
+      ],
+    });
+    const replay = new NostrReplayCache();
+    verifyNostrHttpEvent(reqFor(url, "POST", event, body), event, {
+      replay,
+      body: new TextEncoder().encode(body),
+    });
+
+    const bad = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "POST"],
+        ["payload", "00".repeat(32)],
+      ],
+    });
+    expect(() =>
+      verifyNostrHttpEvent(reqFor(url, "POST", bad, body), bad, {
+        replay: new NostrReplayCache(),
+        body: new TextEncoder().encode(body),
+      }),
+    ).toThrow(/payload tag/);
+  });
+});
+
+describe("authenticateNostrRequest", () => {
+  let db: Database;
+  let configDir: string;
+
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), "phub-nip98-"));
+    db = openHubDb(hubDbPath(configDir));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("unknown pubkey is 401 when auto-provision is off", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    await expect(
+      authenticateNostrRequest(db, reqFor(url, "GET", event), {
+        autoProvision: false,
+        replay: new NostrReplayCache(),
+      }),
+    ).rejects.toThrow(/not linked/);
+  });
+
+  test("linked pubkey authenticates as that user", async () => {
+    const owner = await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const friend = await createUser(db, "alice", "correct-horse-battery-staple", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["work"],
+    });
+    const now = new Date();
+    const { challenge } = issuePubkeyChallenge(db, friend.id, now);
+    const linked = linkPubkey(db, {
+      userId: friend.id,
+      pubkey: PUBKEY,
+      challenge,
+      proofEvent: JSON.stringify({ id: "0".repeat(64), pubkey: PUBKEY, kind: 27235, tags: [] }),
+      now,
+    });
+    expect(linked.ok).toBe(true);
+
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
+      autoProvision: false,
+      replay: new NostrReplayCache(),
+    });
+    expect(principal.userId).toBe(friend.id);
+    expect(principal.provisioned).toBe(false);
+    expect(principal.isHubAdmin).toBe(false);
+    expect(principal.scopes).toContain("vault:work:read");
+    expect(principal.scopes).toContain("vault:work:admin");
+    expect(owner.id).not.toBe(friend.id);
+  });
+
+  test("auto-provision creates a key-only user and binds the pubkey", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
+      autoProvision: true,
+      replay: new NostrReplayCache(),
+    });
+    expect(principal.provisioned).toBe(true);
+    expect(principal.isHubAdmin).toBe(false);
+    expect(principal.pubkey).toBe(PUBKEY);
+    expect(principal.scopes).toEqual([]);
+    const link = findPubkeyLink(db, PUBKEY);
+    expect(link?.userId).toBe(principal.userId);
+  });
+
+  test("auto-provision refuses when the hub has no owner yet", async () => {
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    await expect(
+      authenticateNostrRequest(db, reqFor(url, "GET", event), {
+        autoProvision: true,
+        replay: new NostrReplayCache(),
+      }),
+    ).rejects.toThrow(/existing hub owner/);
+  });
+
+  test("read-role assignment does not get write or admin scopes", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const friend = await createUser(db, "reader", "correct-horse-battery-staple", {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: ["shared"],
+      role: "read",
+    });
+    const now = new Date();
+    const { challenge } = issuePubkeyChallenge(db, friend.id, now);
+    expect(
+      linkPubkey(db, {
+        userId: friend.id,
+        pubkey: PUBKEY,
+        challenge,
+        proofEvent: JSON.stringify({ id: "0".repeat(64), pubkey: PUBKEY, kind: 27235, tags: [] }),
+        now,
+      }).ok,
+    ).toBe(true);
+    const url = "http://127.0.0.1:1939/api/me";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
+      autoProvision: false,
+      replay: new NostrReplayCache(),
+    });
+    expect(principal.scopes).toEqual(["vault:shared:read"]);
+  });
+
+  test("requireScope: provisioned key-user cannot take parachute:host:admin", async () => {
+    await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const url = "http://127.0.0.1:1939/api/users";
+    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    process.env.PARACHUTE_NOSTR_AUTO_PROVISION = "1";
+    try {
+      await expect(
+        requireScope(db, reqFor(url, "GET", event), "parachute:host:admin", "http://127.0.0.1:1939"),
+      ).rejects.toThrow(/parachute:host:admin/);
+    } finally {
+      delete process.env.PARACHUTE_NOSTR_AUTO_PROVISION;
+    }
+  });
+});
+
+describe("bindPubkeyFromHttpAuth", () => {
+  let db: Database;
+  let configDir: string;
+  beforeEach(() => {
+    configDir = mkdtempSync(join(tmpdir(), "phub-nip98-bind-"));
+    db = openHubDb(hubDbPath(configDir));
+  });
+  afterEach(() => {
+    db.close();
+    rmSync(configDir, { recursive: true, force: true });
+  });
+
+  test("refuses a pubkey already bound to another user", async () => {
+    const a = await createUser(db, "owner", "correct-horse-battery-staple", {
+      passwordChanged: true,
+    });
+    const b = await createUser(db, "bob", "correct-horse-battery-staple", {
+      allowMulti: true,
+      passwordChanged: true,
+    });
+    const ok = bindPubkeyFromHttpAuth(db, {
+      userId: a.id,
+      pubkey: PUBKEY,
+      proofEvent: "{}",
+      proofEventId: "1".repeat(64),
+    });
+    expect(ok.ok).toBe(true);
+    const taken = bindPubkeyFromHttpAuth(db, {
+      userId: b.id,
+      pubkey: PUBKEY,
+      proofEvent: "{}",
+      proofEventId: "2".repeat(64),
+    });
+    expect(taken).toEqual({ ok: false, reason: "pubkey_taken" });
+  });
+});

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -10517,6 +10517,60 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
     }
   });
 
+  test("owner requesting account:vaults is bound to account:self:vaults with aud=account", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:vaults",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ")).toContain("account:self:vaults");
+      expect(scope.split(" ")).not.toContain("account:vaults");
+      expect(aud).toBe("account");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("account:vaults cannot be combined with other scopes", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:vaults vault:work:read",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).toContain("error=invalid_scope");
+      expect(loc).not.toContain("code=");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("[9d] non-admin requesting account:self:write → also DROPPED", async () => {
     // Write is more capable than read, but it is still account-wide on a
     // self-host hub, so the same account-prefix cap must drop it.

--- a/src/__tests__/scope-registry.test.ts
+++ b/src/__tests__/scope-registry.test.ts
@@ -102,6 +102,8 @@ describe("loadDeclaredScopes", () => {
       expect(declared.has("vault:read")).toBe(true);
       expect(declared.has("scribe:transcribe")).toBe(true);
       expect(declared.has("hub:admin")).toBe(true);
+      expect(declared.has("account:vaults")).toBe(true);
+      expect(isKnownScope("account:self:vaults", declared)).toBe(true);
     } finally {
       cleanup();
     }

--- a/src/account-api.ts
+++ b/src/account-api.ts
@@ -253,14 +253,20 @@ export async function requireAnyScope(
 
 /** Scope set for admin-only `/account/*` mutations (delete / mint). */
 export const ACCOUNT_MUTATION_SCOPES = ADMIN_SCOPES;
+/** Scope set for a `/account/*` WRITE mutation (create, set-caps). */
+export const ACCOUNT_WRITE_SCOPES = WRITE_SCOPES;
 /** Scope set for a `/account/*` read (list / get-caps / bootstrap). */
 export const ACCOUNT_READ_SCOPES = READ_SCOPES;
 
-interface VaultMeta {
+export interface AccountVaultMeta {
   name: string;
   url: string;
   version: string;
+  /** Loopback port from services.json; used by account-MCP fan-out. */
+  port?: number;
 }
+
+type VaultMeta = AccountVaultMeta;
 
 /**
  * Enumerate every servable vault from services.json with its canonical URL +
@@ -269,7 +275,7 @@ interface VaultMeta {
  * name derivation, same `new URL(path, base)` URL build as `buildEntry`) so the
  * account list agrees with the well-known vaults[] fan-out and the create path.
  */
-function listVaultsWithMeta(manifestPath: string, issuer: string): VaultMeta[] {
+export function listVaultsWithMeta(manifestPath: string, issuer: string): VaultMeta[] {
   const base = issuer.replace(/\/$/, "");
   const out: VaultMeta[] = [];
   let manifest: ReturnType<typeof readManifestLenient>;
@@ -284,7 +290,7 @@ function listVaultsWithMeta(manifestPath: string, issuer: string): VaultMeta[] {
     for (const path of svc.paths) {
       const name = vaultInstanceNameFor(svc.name, path);
       const url = new URL(path, `${base}/`).toString();
-      out.push({ name, url, version: svc.version });
+      out.push({ name, url, version: svc.version, port: svc.port });
     }
   }
   return out;
@@ -315,6 +321,10 @@ function servicesBlock(meta: VaultMeta): Record<string, { url: string; version: 
  * public invite exists (`activePublicSignupPath`, invites.ts) — an operator-
  * shared link is otherwise the only way in, so the app must not render a
  * "create account" affordance when there is nowhere for it to go.
+ *
+ * `account_mcp_endpoint` is the hub's account-level MCP door (`/account/mcp`).
+ * Optional in door-contract; set once the surface exists so a client can
+ * discover it from the descriptor instead of guessing the path.
  */
 export function handleAccountCapabilities(
   req: Request,
@@ -337,6 +347,7 @@ export function handleAccountCapabilities(
     issuer,
     door: "hub",
     account_endpoint: `${issuer}/account`,
+    account_mcp_endpoint: `${issuer}/account/mcp`,
     auth: { methods: ["password"], signin_path: "/login" },
     ...(signupPath ? { signup_path: signupPath } : {}),
     vault_url_template: `${issuer}/vault/{name}`,

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -1,0 +1,449 @@
+/**
+ * `/account/mcp` — the hub's account-level MCP door.
+ *
+ * Transport framing is transcribed from the cloud identity worker's
+ * `account-mcp-http.ts` (itself transcribed from the vault door): Accept-both
+ * 406 / Content-Type 415 / parse-error 400 / notifications-202 / GET-405 /
+ * DELETE-200 / protocol-version. Keep them in lockstep; a divergence presents
+ * as an opaque connector failure.
+ *
+ * Auth runs BEFORE any JSON-RPC:
+ *   - `Authorization: Nostr <event>` → NIP-98 (hub#882). Any resolved hub
+ *     user opens the door; coverage is assignment, not account:self:*.
+ *   - `Authorization: Bearer <jwt>` → an account-vaults connection grant
+ *     (`account:self:vaults` / composed forms, `aud=account`) or
+ *     `parachute:host:admin` (operator bypass). REST `account:self:read`
+ *     does not open this door.
+ *
+ * Cookie sessions never open this door. Wildcard CORS is correct: nothing
+ * here is ambient-auth.
+ */
+import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULTS_UNNARROWED } from "@openparachute/door-contract";
+import type { AccountApiDeps } from "./account-api.ts";
+import {
+  ACCOUNT_MCP_TOOLS,
+  type AccountMcpPrincipal,
+  type AccountToolContext,
+  AccountToolError,
+  buildAccountConnectionGrant,
+} from "./account-mcp.ts";
+import {
+  AdminAuthError,
+  adminAuthErrorResponse,
+  extractBearerToken,
+  nostrAutoProvisionEnabled,
+} from "./admin-auth.ts";
+import { HOST_ADMIN_SCOPE } from "./admin-vaults.ts";
+import { SERVICES_MANIFEST_PATH } from "./config.ts";
+import { validateAccessToken } from "./jwt-sign.ts";
+import {
+  NostrHttpAuthError,
+  type NostrReplayCache,
+  authenticateNostrRequest,
+  isNostrAuthorization,
+} from "./nostr-http-auth.ts";
+import { isFirstAdmin } from "./users.ts";
+
+const LATEST_PROTOCOL_VERSION = "2025-11-25";
+const SUPPORTED_PROTOCOL_VERSIONS = [
+  LATEST_PROTOCOL_VERSION,
+  "2025-06-18",
+  "2025-03-26",
+  "2024-11-05",
+  "2024-10-07",
+];
+
+const PARSE_ERROR = -32700;
+const METHOD_NOT_FOUND = -32601;
+const INVALID_PARAMS = -32602;
+const INTERNAL_ERROR = -32603;
+
+type JsonRpcId = string | number | null;
+interface JsonRpcMessage {
+  jsonrpc?: string;
+  id?: JsonRpcId;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: unknown;
+  error?: unknown;
+}
+
+function result(id: JsonRpcId, value: unknown): JsonRpcMessage {
+  return { jsonrpc: "2.0", id, result: value };
+}
+function rpcError(id: JsonRpcId, code: number, message: string, data?: unknown): JsonRpcMessage {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: data === undefined ? { code, message } : { code, message, data },
+  };
+}
+function isJsonRpc(m: unknown): m is JsonRpcMessage {
+  return !!m && typeof m === "object" && (m as JsonRpcMessage).jsonrpc === "2.0";
+}
+function isRequest(m: JsonRpcMessage): boolean {
+  return typeof m.method === "string" && m.id !== undefined;
+}
+
+function withMcpCors(res: Response): Response {
+  res.headers.set("access-control-allow-origin", "*");
+  res.headers.set("access-control-expose-headers", "WWW-Authenticate");
+  return res;
+}
+
+function preflight(): Response {
+  return new Response(null, {
+    status: 204,
+    headers: {
+      "access-control-allow-origin": "*",
+      "access-control-allow-methods": "POST, DELETE, OPTIONS",
+      "access-control-allow-headers": "Authorization, Content-Type, Accept, Mcp-Protocol-Version",
+      "access-control-max-age": "86400",
+    },
+  });
+}
+
+function jsonRpcHttpError(status: number, code: number, message: string): Response {
+  return withMcpCors(
+    new Response(JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null }), {
+      status,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+export interface AccountMcpDeps extends AccountApiDeps {
+  replay?: NostrReplayCache;
+  fetchImpl?: AccountToolContext["fetchImpl"];
+  signToken?: AccountToolContext["signToken"];
+}
+
+function accountMcpResource(issuer: string): string {
+  return `${issuer.replace(/\/$/, "")}/account/mcp`;
+}
+
+function accountMcpChallenge(issuer: string): string {
+  const origin = issuer.replace(/\/$/, "");
+  return `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/account/mcp"`;
+}
+
+/** RFC 9728 PRM for `/account/mcp`. Public + wildcard CORS. */
+export function accountMcpProtectedResource(issuer: string): Response {
+  const origin = issuer.replace(/\/$/, "");
+  return withMcpCors(
+    new Response(
+      JSON.stringify({
+        resource: `${origin}/account/mcp`,
+        authorization_servers: [origin],
+        scopes_supported: [ACCOUNT_VAULTS_UNNARROWED],
+        bearer_methods_supported: ["header"],
+        resource_documentation: "https://parachute.computer",
+      }),
+      {
+        status: 200,
+        headers: {
+          "content-type": "application/json",
+          "cache-control": "no-store",
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        },
+      },
+    ),
+  );
+}
+
+function authFailure(
+  status: 401 | 403,
+  error: string,
+  message: string,
+  issuer: string,
+  scope?: string,
+): Response {
+  const challenge = [
+    accountMcpChallenge(issuer),
+    `error="${error}"`,
+    `error_description="${message.replace(/"/g, "'")}"`,
+  ];
+  if (status === 403 && scope) challenge.push(`scope="${scope}"`);
+  return withMcpCors(
+    new Response(JSON.stringify({ error, error_description: message }), {
+      status,
+      headers: {
+        "content-type": "application/json",
+        "cache-control": "no-store",
+        "WWW-Authenticate": challenge.join(", "),
+      },
+    }),
+  );
+}
+
+async function authenticateBearer(
+  db: Database,
+  req: Request,
+  expectedIssuer: string | readonly string[],
+): Promise<AccountMcpPrincipal> {
+  const token = extractBearerToken(req);
+  let validated: Awaited<ReturnType<typeof validateAccessToken>>;
+  try {
+    validated = await validateAccessToken(db, token, expectedIssuer);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    throw new AdminAuthError(401, `invalid token: ${msg}`);
+  }
+  const sub = typeof validated.payload.sub === "string" ? validated.payload.sub : null;
+  if (!sub) throw new AdminAuthError(401, "token missing required `sub` claim");
+  const scopeClaim = (validated.payload as { scope?: unknown }).scope;
+  const scopes =
+    typeof scopeClaim === "string" ? scopeClaim.split(/\s+/).filter((s) => s.length > 0) : [];
+  const grant = buildAccountConnectionGrant(scopes);
+  if (grant === null) {
+    throw new AdminAuthError(
+      403,
+      "the account MCP requires an account-vaults connection scope (account:vaults) or parachute:host:admin",
+      ACCOUNT_VAULTS_UNNARROWED,
+    );
+  }
+  const hostAdmin = scopes.includes(HOST_ADMIN_SCOPE);
+  if (!hostAdmin) {
+    const aud = typeof validated.payload.aud === "string" ? validated.payload.aud : undefined;
+    if (aud !== "account") {
+      throw new AdminAuthError(401, "token audience must be `account`");
+    }
+  }
+  const clientIdRaw = (validated.payload as { client_id?: unknown }).client_id;
+  const clientId = typeof clientIdRaw === "string" ? clientIdRaw : undefined;
+  return {
+    userId: sub,
+    scopes,
+    authKind: "bearer",
+    clientId,
+    isHubAdmin: isFirstAdmin(db, sub) || hostAdmin,
+    grant,
+  };
+}
+
+async function authenticate(
+  db: Database,
+  req: Request,
+  deps: AccountMcpDeps,
+  body: Uint8Array,
+): Promise<AccountMcpPrincipal> {
+  if (isNostrAuthorization(req)) {
+    const principal = await authenticateNostrRequest(db, req, {
+      autoProvision: nostrAutoProvisionEnabled(),
+      now: deps.now,
+      replay: deps.replay,
+      body,
+    });
+    return {
+      userId: principal.userId,
+      scopes: principal.scopes,
+      authKind: "nostr",
+      clientId: `nostr:${principal.pubkey}`,
+      isHubAdmin: principal.isHubAdmin,
+      grant: null,
+    };
+  }
+  return authenticateBearer(db, req, deps.knownIssuers ?? [deps.issuer]);
+}
+
+async function handleToolCall(
+  id: JsonRpcId,
+  params: Record<string, unknown> | undefined,
+  ctx: AccountToolContext,
+): Promise<JsonRpcMessage> {
+  const name = typeof params?.name === "string" ? params.name : "";
+  const args = (params?.arguments ?? {}) as Record<string, unknown>;
+  const tool = ACCOUNT_MCP_TOOLS.find((t) => t.name === name);
+  if (!tool) {
+    return result(id, {
+      content: [{ type: "text", text: `Unknown tool: ${name}` }],
+      isError: true,
+    });
+  }
+  try {
+    const out = await tool.execute(args, ctx);
+    return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+  } catch (err) {
+    if (err instanceof AccountToolError) {
+      return rpcError(id, INVALID_PARAMS, err.message, { error_type: err.errorType, ...err.extra });
+    }
+    const message = err instanceof Error ? err.message : "Unknown error";
+    return result(id, { content: [{ type: "text", text: `Error: ${message}` }], isError: true });
+  }
+}
+
+function instructions(): string {
+  return (
+    "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
+    "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
+    "and query-notes to search across them (omit `vault` to fan out, pass it to target one)."
+  );
+}
+
+async function handleOne(m: JsonRpcMessage, ctx: AccountToolContext): Promise<JsonRpcMessage> {
+  const { id = null, method, params } = m;
+  try {
+    switch (method) {
+      case "initialize": {
+        const requested = typeof params?.protocolVersion === "string" ? params.protocolVersion : "";
+        const protocolVersion = SUPPORTED_PROTOCOL_VERSIONS.includes(requested)
+          ? requested
+          : LATEST_PROTOCOL_VERSION;
+        return result(id, {
+          protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: { name: "parachute-account", version: "0.1.0" },
+          instructions: instructions(),
+        });
+      }
+      case "tools/list":
+        return result(id, {
+          tools: ACCOUNT_MCP_TOOLS.map((t) => ({
+            name: t.name,
+            description: t.description,
+            inputSchema: t.inputSchema,
+          })),
+        });
+      case "tools/call":
+        return await handleToolCall(id, params, ctx);
+      case "ping":
+        return result(id, {});
+      default:
+        return rpcError(id, METHOD_NOT_FOUND, `Method not found: ${method}`);
+    }
+  } catch (err) {
+    return rpcError(id, INTERNAL_ERROR, err instanceof Error ? err.message : "Internal error");
+  }
+}
+
+function translateAuthError(err: unknown, issuer: string): Response {
+  if (err instanceof NostrHttpAuthError) {
+    return authFailure(err.status === 403 ? 403 : 401, "invalid_token", err.message, issuer);
+  }
+  if (err instanceof AdminAuthError) {
+    const res = adminAuthErrorResponse(err);
+    const challenge = res.headers.get("www-authenticate") ?? accountMcpChallenge(issuer);
+    const withMeta = challenge.includes("resource_metadata=")
+      ? challenge
+      : `${accountMcpChallenge(issuer)}, ${challenge}`;
+    const headers = new Headers(res.headers);
+    headers.set("www-authenticate", withMeta);
+    headers.set("access-control-allow-origin", "*");
+    headers.set("access-control-expose-headers", "WWW-Authenticate");
+    return new Response(res.body, { status: res.status, headers });
+  }
+  const message = err instanceof Error ? err.message : "unauthorized";
+  return authFailure(401, "invalid_token", message, issuer);
+}
+
+/**
+ * Handle a request at `/account/mcp`. Auth first, then Streamable-HTTP
+ * JSON-response mode. `app.all` equivalent: every method is owned so the
+ * path never falls through to the `/account/` HTML home.
+ */
+export async function handleAccountMcp(req: Request, deps: AccountMcpDeps): Promise<Response> {
+  if (req.method === "OPTIONS") return preflight();
+
+  let body = new Uint8Array();
+  if (req.method !== "GET" && req.method !== "HEAD" && req.method !== "DELETE") {
+    body = new Uint8Array(await req.arrayBuffer());
+  }
+
+  let principal: AccountMcpPrincipal;
+  try {
+    principal = await authenticate(deps.db, req, deps, body);
+  } catch (err) {
+    return translateAuthError(err, deps.issuer);
+  }
+
+  if (req.method === "DELETE") return withMcpCors(new Response(null, { status: 200 }));
+  if (req.method !== "POST") {
+    return withMcpCors(
+      new Response(
+        JSON.stringify({
+          jsonrpc: "2.0",
+          error: { code: -32000, message: "Method not allowed." },
+          id: null,
+        }),
+        {
+          status: 405,
+          headers: { Allow: "POST, DELETE, OPTIONS", "Content-Type": "application/json" },
+        },
+      ),
+    );
+  }
+
+  const accept = req.headers.get("accept") ?? "";
+  if (!accept.includes("application/json") || !accept.includes("text/event-stream")) {
+    return jsonRpcHttpError(
+      406,
+      -32000,
+      "Not Acceptable: Client must accept both application/json and text/event-stream",
+    );
+  }
+  const ct = req.headers.get("content-type") ?? "";
+  if (!ct.includes("application/json")) {
+    return jsonRpcHttpError(
+      415,
+      -32000,
+      "Unsupported Media Type: Content-Type must be application/json",
+    );
+  }
+
+  let raw: unknown;
+  try {
+    raw = JSON.parse(new TextDecoder().decode(body));
+  } catch {
+    return jsonRpcHttpError(400, PARSE_ERROR, "Parse error: Invalid JSON");
+  }
+
+  const rawMessages = Array.isArray(raw) ? raw : [raw];
+  const messages: JsonRpcMessage[] = [];
+  for (const m of rawMessages) {
+    if (!isJsonRpc(m))
+      return jsonRpcHttpError(400, PARSE_ERROR, "Parse error: Invalid JSON-RPC message");
+    messages.push(m);
+  }
+
+  const isInit = messages.some((m) => m.method === "initialize");
+  if (!isInit) {
+    const pv = req.headers.get("mcp-protocol-version");
+    if (pv !== null && !SUPPORTED_PROTOCOL_VERSIONS.includes(pv)) {
+      return jsonRpcHttpError(
+        400,
+        -32000,
+        `Bad Request: Unsupported protocol version: ${pv} (supported versions: ${SUPPORTED_PROTOCOL_VERSIONS.join(", ")})`,
+      );
+    }
+  }
+
+  const requests = messages.filter(isRequest);
+  if (requests.length === 0) {
+    return withMcpCors(new Response(null, { status: 202 }));
+  }
+
+  const ctx: AccountToolContext = {
+    db: deps.db,
+    issuer: deps.issuer,
+    manifestPath: deps.manifestPath ?? SERVICES_MANIFEST_PATH,
+    principal,
+    ...(deps.now !== undefined ? { now: deps.now } : {}),
+    ...(deps.runCommand !== undefined ? { runCommand: deps.runCommand } : {}),
+    ...(deps.fetchImpl !== undefined ? { fetchImpl: deps.fetchImpl } : {}),
+    ...(deps.signToken !== undefined ? { signToken: deps.signToken } : {}),
+  };
+  const responses: JsonRpcMessage[] = [];
+  for (const m of requests) responses.push(await handleOne(m, ctx));
+
+  const payload = responses.length === 1 ? responses[0] : responses;
+  return withMcpCors(
+    new Response(JSON.stringify(payload), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }),
+  );
+}
+
+export { accountMcpResource };

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -1,0 +1,407 @@
+/**
+ * Account-level MCP tools for the self-host hub — the payload behind
+ * `/account/mcp`.
+ *
+ * Cloud's twin lives in the identity worker (`account-mcp.ts`). Same three
+ * tools (list-vaults, create-vault, query-notes), same "no vault_token in
+ * model context" rule. Coverage is hub-shaped, not D1-ownership-shaped:
+ *
+ *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
+ *     (legacy blanket / narrowed) or composed `account:self:vaults:*:<verb>`,
+ *     plus `parachute:host:admin` as the operator bypass. REST `account:self:read`
+ *     does NOT open this door — that scope lists vaults and usage, not notes.
+ *   - NIP-98 is the Buzz path. First-admin → every vault + create. Anyone
+ *     else → `user_vaults` ∩ services.json (fail-closed; read verb required).
+ *     Auto-provisioned key-only users have no rows → empty list, no create.
+ *
+ * query-notes fans out through a 60s `vault:<name>:read` mint, the same
+ * authority `account-usage.ts` already uses for the friend home tiles. A
+ * failed vault becomes that vault's `{ vault, error }` — never a whole-call
+ * failure.
+ */
+import type { Database } from "bun:sqlite";
+import {
+  ACCOUNT_VAULTS_UNNARROWED,
+  COMPOSED_VERB_RANK,
+  type ComposedVaultVerb,
+  accountVaultsGrant,
+  composedAccountGrant,
+} from "@openparachute/door-contract";
+import { type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
+import { HOST_ADMIN_SCOPE, provisionVault } from "./admin-vaults.ts";
+import { signAccessToken } from "./jwt-sign.ts";
+import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
+
+/** Hub account sentinel — account ≡ box. */
+export const HUB_ACCOUNT_ID = "self";
+
+/** Per-vault timeout for the query-notes fan-out. */
+export const FANOUT_TIMEOUT_MS = 10_000;
+
+/** Per-vault `limit` ceiling on a fan-out query. */
+export const MAX_NOTES_LIMIT = 100;
+
+const ACCOUNT_MCP_CLIENT_ID = "parachute-account";
+const FANOUT_TOKEN_TTL_SECONDS = 60;
+
+export type AccountMcpAuthKind = "bearer" | "nostr";
+
+export interface AccountConnectionGrant {
+  wildcard: ComposedVaultVerb | null;
+  vaults: Map<string, ComposedVaultVerb>;
+  create: boolean;
+}
+
+export interface AccountMcpPrincipal {
+  userId: string;
+  scopes: string[];
+  authKind: AccountMcpAuthKind;
+  clientId: string | undefined;
+  /** First-admin, or a Bearer that already carries host:admin. */
+  isHubAdmin: boolean;
+  /** Present on Bearer (null only for NIP-98). host:admin is a synthetic wildcard. */
+  grant: AccountConnectionGrant | null;
+}
+
+export class AccountToolError extends Error {
+  constructor(
+    public readonly errorType: string,
+    message: string,
+    public readonly extra?: Record<string, unknown>,
+  ) {
+    super(message);
+    this.name = "AccountToolError";
+  }
+}
+
+export interface Coverage {
+  covered: "all" | "listed";
+  vaults: AccountVaultMeta[];
+  names: string[];
+  create: boolean;
+}
+
+export interface AccountToolContext {
+  db: Database;
+  issuer: string;
+  manifestPath: string;
+  principal: AccountMcpPrincipal;
+  now?: () => Date;
+  runCommand?: (cmd: readonly string[]) => Promise<{
+    exitCode: number;
+    stdout: string;
+    stderr: string;
+  }>;
+  fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+  signToken?: typeof signAccessToken;
+}
+
+export interface AccountMcpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  execute(args: Record<string, unknown>, ctx: AccountToolContext): Promise<unknown>;
+}
+
+function raiseVaultVerb(
+  map: Map<string, ComposedVaultVerb>,
+  name: string,
+  verb: ComposedVaultVerb,
+): void {
+  const cur = map.get(name);
+  if (!cur || COMPOSED_VERB_RANK[verb] > COMPOSED_VERB_RANK[cur]) map.set(name, verb);
+}
+
+/**
+ * Unify legacy Wave A `account:<id>:vaults` with the composed grammar.
+ * Returns null when the set confers nothing that opens this door.
+ */
+export function buildAccountConnectionGrant(
+  scopes: readonly string[],
+  accountId: string = HUB_ACCOUNT_ID,
+): AccountConnectionGrant | null {
+  const composed = composedAccountGrant(scopes, accountId);
+  let wildcard = composed.wildcard;
+  const vaults = new Map(composed.vaults);
+  let create = composed.create;
+  if (scopes.includes(ACCOUNT_VAULTS_UNNARROWED)) {
+    create = true;
+    if (wildcard === null) wildcard = "read";
+  }
+  const legacy = accountVaultsGrant(scopes, accountId);
+  if (legacy !== null) {
+    create = true;
+    if ("blanket" in legacy) {
+      if (wildcard === null) wildcard = "read";
+    } else {
+      for (const name of legacy.vaults) raiseVaultVerb(vaults, name, "read");
+    }
+  }
+  if (scopes.includes(HOST_ADMIN_SCOPE)) {
+    return { wildcard: "admin", vaults, create: true };
+  }
+  const opensDoor = wildcard !== null || vaults.size > 0 || create;
+  return opensDoor ? { wildcard, vaults, create } : null;
+}
+
+function canCreate(principal: AccountMcpPrincipal): boolean {
+  if (principal.authKind === "nostr") return principal.isHubAdmin;
+  return principal.grant?.create === true;
+}
+
+function assignedReadable(
+  db: Database,
+  userId: string,
+  installed: AccountVaultMeta[],
+): AccountVaultMeta[] {
+  const user = getUserById(db, userId);
+  const assigned = new Set(user?.assignedVaults ?? []);
+  return installed.filter((v) => {
+    if (!assigned.has(v.name)) return false;
+    const verbs = vaultVerbsForUserVault(db, userId, v.name);
+    return verbs?.includes("read");
+  });
+}
+
+/**
+ * Live coverage. NIP-98 is assignment. Bearer is the connection grant ∩
+ * currently installed vaults (and ∩ assignment when the subject is not
+ * first-admin). host:admin is unrestricted.
+ */
+export function resolveCoverage(
+  db: Database,
+  principal: AccountMcpPrincipal,
+  installed: AccountVaultMeta[],
+): Coverage {
+  if (principal.authKind === "nostr") {
+    if (principal.isHubAdmin || isFirstAdmin(db, principal.userId)) {
+      return {
+        covered: "all",
+        vaults: installed,
+        names: installed.map((v) => v.name),
+        create: true,
+      };
+    }
+    const vaults = assignedReadable(db, principal.userId, installed);
+    return { covered: "listed", vaults, names: vaults.map((v) => v.name), create: false };
+  }
+
+  const grant = principal.grant;
+  const create = grant?.create === true;
+  const owned =
+    principal.isHubAdmin || isFirstAdmin(db, principal.userId)
+      ? installed
+      : assignedReadable(db, principal.userId, installed);
+
+  if (!grant || grant.wildcard !== null) {
+    const covered = grant?.wildcard !== null || principal.isHubAdmin ? "all" : "listed";
+    return { covered, vaults: owned, names: owned.map((v) => v.name), create };
+  }
+  const vaults = owned.filter((v) => grant.vaults.has(v.name));
+  return { covered: "listed", vaults, names: vaults.map((v) => v.name), create };
+}
+
+function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
+  return listVaultsWithMeta(ctx.manifestPath, ctx.issuer);
+}
+
+const listVaultsTool: AccountMcpTool = {
+  name: "list-vaults",
+  description:
+    "List the vaults this connection can reach. Returns each vault's name, URL, and version, " +
+    "plus whether the grant covers ALL of the hub's vaults or a specific listed subset.",
+  inputSchema: { type: "object", properties: {}, additionalProperties: false },
+  async execute(_args, ctx) {
+    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+    return {
+      covered: coverage.covered,
+      vaults: coverage.vaults.map((v) => ({ name: v.name, url: v.url, version: v.version })),
+    };
+  },
+};
+
+const createVaultTool: AccountMcpTool = {
+  name: "create-vault",
+  description:
+    "Create a new vault on this hub. Returns the new vault's name and URL. " +
+    "Does not return a vault token — mint one out of band if you need a credential.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      name: {
+        type: "string",
+        description: "The vault name (lowercase letters, numbers, hyphens, and underscores).",
+      },
+    },
+    required: ["name"],
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    if (!canCreate(ctx.principal)) {
+      throw new AccountToolError(
+        "create_not_granted",
+        "This connection was not granted permission to create vaults.",
+      );
+    }
+    const rawName = typeof args.name === "string" ? args.name : "";
+    const provisioned = await provisionVault(rawName, {
+      issuer: ctx.issuer,
+      manifestPath: ctx.manifestPath,
+      ...(ctx.runCommand ? { runCommand: ctx.runCommand } : {}),
+    });
+    if (!provisioned.ok) {
+      const message = provisioned.message;
+      if (provisioned.status === 400 && /reserved/i.test(message)) {
+        throw new AccountToolError("reserved", "That name is reserved. Please choose another.");
+      }
+      if (provisioned.status === 400) {
+        throw new AccountToolError(
+          "invalid_name",
+          "Use lowercase letters, numbers, hyphens, and underscores.",
+        );
+      }
+      throw new AccountToolError("server_error", message);
+    }
+    if (!provisioned.created) {
+      throw new AccountToolError("vault_taken", "That vault name is already taken.");
+    }
+    return { name: provisioned.entry.name, url: provisioned.entry.url };
+  },
+};
+
+type VaultQueryEntry = { vault: string; notes: unknown } | { vault: string; error: string };
+
+function buildNotesQuery(args: Record<string, unknown>): string {
+  const p = new URLSearchParams();
+  if (typeof args.search === "string" && args.search.length > 0) p.set("search", args.search);
+  const rawTags = Array.isArray(args.tag)
+    ? args.tag
+    : typeof args.tag === "string"
+      ? [args.tag]
+      : [];
+  for (const t of rawTags) if (typeof t === "string" && t.length > 0) p.append("tag", t);
+  if (args.metadata && typeof args.metadata === "object")
+    p.set("metadata", JSON.stringify(args.metadata));
+  const rawLimit =
+    typeof args.limit === "number"
+      ? args.limit
+      : typeof args.limit === "string"
+        ? Number.parseInt(args.limit, 10)
+        : undefined;
+  if (rawLimit !== undefined && Number.isFinite(rawLimit)) {
+    const clamped = Math.min(Math.max(1, Math.floor(rawLimit)), MAX_NOTES_LIMIT);
+    p.set("limit", String(clamped));
+  }
+  return p.toString();
+}
+
+async function queryOneVault(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  args: Record<string, unknown>,
+): Promise<VaultQueryEntry> {
+  const sign = ctx.signToken ?? signAccessToken;
+  const fetchImpl = ctx.fetchImpl ?? fetch;
+  const qs = buildNotesQuery(args);
+  const minted = await sign(ctx.db, {
+    sub: ctx.principal.userId,
+    scopes: [`vault:${vault.name}:read`],
+    audience: `vault.${vault.name}`,
+    clientId: ACCOUNT_MCP_CLIENT_ID,
+    issuer: ctx.issuer,
+    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    vaultScope: [vault.name],
+    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
+  });
+  const origin =
+    typeof vault.port === "number" && vault.port > 0
+      ? `http://127.0.0.1:${vault.port}`
+      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
+  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}/api/notes${qs ? `?${qs}` : ""}`;
+  const res = await fetchImpl(url, {
+    headers: { authorization: `Bearer ${minted.token}`, accept: "application/json" },
+    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    let detail = `vault responded ${res.status}`;
+    try {
+      const body = (await res.json()) as Record<string, unknown>;
+      if (typeof body.error === "string") detail = body.error;
+    } catch {
+      // Non-JSON error body — keep the status-only detail.
+    }
+    return { vault: vault.name, error: detail };
+  }
+  const notes = await res.json();
+  return { vault: vault.name, notes };
+}
+
+async function fanOut(
+  ctx: AccountToolContext,
+  targets: AccountVaultMeta[],
+  args: Record<string, unknown>,
+): Promise<VaultQueryEntry[]> {
+  const settled = await Promise.allSettled(targets.map((v) => queryOneVault(ctx, v, args)));
+  return settled.map((s, i) =>
+    s.status === "fulfilled"
+      ? s.value
+      : {
+          vault: targets[i]!.name,
+          error: s.reason instanceof Error ? s.reason.message : "query failed",
+        },
+  );
+}
+
+const queryNotesTool: AccountMcpTool = {
+  name: "query-notes",
+  description:
+    "Search notes across the vaults this connection can reach. Omit `vault` to fan the query out " +
+    "(results are grouped per vault, not ranked across vaults); pass `vault` to target one. " +
+    "Supports keyword `search`, `tag` and `metadata` filters, and `limit`.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      vault: {
+        type: "string",
+        description:
+          "Target a single vault by name. Must be one of the reachable vaults. Omit to query all.",
+      },
+      search: { type: "string", description: "Full-text keyword query." },
+      tag: {
+        type: ["string", "array"],
+        items: { type: "string" },
+        description: "Restrict to notes carrying this tag (or any of these tags).",
+      },
+      metadata: {
+        type: "object",
+        description: 'Structured metadata filters, e.g. {"status":{"eq":"open"}}.',
+      },
+      limit: { type: "number", description: "Maximum notes per vault (default 50)." },
+    },
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+    let targets = coverage.vaults;
+    if (typeof args.vault === "string" && args.vault.length > 0) {
+      const wanted = args.vault.toLowerCase();
+      const hit = coverage.vaults.find((v) => v.name === wanted);
+      if (!hit) {
+        throw new AccountToolError(
+          "vault_not_covered",
+          `Vault "${args.vault}" is not among the vaults this connection can reach.`,
+        );
+      }
+      targets = [hit];
+    }
+    const results = await fanOut(ctx, targets, args);
+    return { vaults_queried: targets.map((v) => v.name), results };
+  },
+};
+
+/** Order is stable so `tools/list` is deterministic. */
+export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
+  listVaultsTool,
+  createVaultTool,
+  queryNotesTool,
+];

--- a/src/admin-auth.ts
+++ b/src/admin-auth.ts
@@ -15,6 +15,10 @@
  */
 import type { Database } from "bun:sqlite";
 import { validateAccessToken } from "./jwt-sign.ts";
+import {
+  authenticateNostrRequest,
+  isNostrAuthorization,
+} from "./nostr-http-auth.ts";
 
 export interface AdminAuthContext {
   /** JWT `sub` — the hub user id. */
@@ -92,12 +96,55 @@ export function extractBearerToken(req: Request): string {
  * hub minted ever reach the `iss` check; never pass a raw request Host, only a
  * `buildHubBoundOrigins`-derived set.
  */
+export function nostrAutoProvisionEnabled(): boolean {
+  const v = process.env.PARACHUTE_NOSTR_AUTO_PROVISION;
+  return v === "1" || v === "true" || v === "yes";
+}
+
 export async function requireScope(
   db: Database,
   req: Request,
   requiredScope: string,
   expectedIssuer: string | readonly string[],
 ): Promise<AdminAuthContext> {
+  if (isNostrAuthorization(req)) {
+    let body = new Uint8Array();
+    if (req.method !== "GET" && req.method !== "HEAD") {
+      body = new Uint8Array(await req.clone().arrayBuffer());
+    }
+    try {
+      const principal = await authenticateNostrRequest(db, req, {
+        autoProvision: nostrAutoProvisionEnabled(),
+        body,
+      });
+      if (principal.isHubAdmin) {
+        return {
+          sub: principal.userId,
+          scopes: [requiredScope],
+          clientId: `nostr:${principal.pubkey}`,
+          audience: undefined,
+        };
+      }
+      if (!principal.scopes.includes(requiredScope)) {
+        throw new AdminAuthError(
+          403,
+          `token missing required scope: ${requiredScope}`,
+          requiredScope,
+        );
+      }
+      return {
+        sub: principal.userId,
+        scopes: principal.scopes,
+        clientId: `nostr:${principal.pubkey}`,
+        audience: undefined,
+      };
+    } catch (err) {
+      if (err instanceof AdminAuthError) throw err;
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new AdminAuthError(401, msg);
+    }
+  }
+
   const token = extractBearerToken(req);
 
   let validated: Awaited<ReturnType<typeof validateAccessToken>>;

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -26,7 +26,32 @@
  */
 
 import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
 import { vaultScopeName } from "./scope-explanations.ts";
+
+const HUB_ACCOUNT_VAULTS_BOUND = accountVaultsScope("self");
+
+/**
+ * `account:vaults` (PRM request form) and `account:self:vaults` (consent-bound
+ * mint form) are the same grant. Skip-consent used to exact-match, so an MCP
+ * client that re-requests the advertised un-narrowed string after a bound
+ * mint would re-consent every time (hub#883 review nit).
+ */
+function accountVaultsEquivalents(scope: string): readonly string[] {
+  if (scope === ACCOUNT_VAULTS_UNNARROWED) return [scope, HUB_ACCOUNT_VAULTS_BOUND];
+  if (scope === HUB_ACCOUNT_VAULTS_BOUND) return [scope, ACCOUNT_VAULTS_UNNARROWED];
+  return [scope];
+}
+
+function requestedCoveredByGranted(
+  granted: ReadonlySet<string>,
+  requested: readonly string[],
+): boolean {
+  for (const s of requested) {
+    if (!accountVaultsEquivalents(s).some((eq) => granted.has(eq))) return false;
+  }
+  return true;
+}
 
 export interface Grant {
   userId: string;
@@ -112,10 +137,7 @@ export function isCoveredByGrant(
   const grant = findGrant(db, userId, clientId);
   if (!grant) return false;
   const granted = new Set(grant.scopes);
-  for (const s of requestedScopes) {
-    if (!granted.has(s)) return false;
-  }
-  return true;
+  return requestedCoveredByGranted(granted, requestedScopes);
 }
 
 /**
@@ -183,10 +205,7 @@ export function isCoveredByGrantForClientName(
   const grant = findGrantByClientName(db, userId, clientName);
   if (!grant) return false;
   const granted = new Set(grant.scopes);
-  for (const s of requestedScopes) {
-    if (!granted.has(s)) return false;
-  }
-  return true;
+  return requestedCoveredByGranted(granted, requestedScopes);
 }
 
 const VAULT_SCOPE_PREFIX_RE = /^vault:([^:]+):/;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -53,9 +53,9 @@
  *   /.well-known/parachute-account             → account-door capabilities descriptor (public, H2)
  *   /.well-known/oauth-authorization-server    → RFC 8414 metadata (issuer, endpoints)
  *   /.well-known/oauth-protected-resource/mcp  → RFC 9728 PRM for root /mcp,
- *                                                FORWARDED from the vault daemon
- *                                                (not built locally like the
- *                                                hub-issued PRM)
+ *                                                built locally (hub#789)
+ *   /.well-known/oauth-protected-resource/account/mcp → RFC 9728 PRM for
+ *                                                the account-MCP door
  *   /.well-known/oauth-protected-resource/vault/<name>[/mcp] → RFC 9728 per-vault PRM, forwarded from vault daemon
  *
  *   # OAuth issuer.
@@ -76,6 +76,9 @@
  *   # account:self:write (create/configure), account:self:admin (delete/mint),
  *   # or parachute:host:admin (all mutations); +:read (reads).
  *   /account                      (GET)        → account bootstrap {id,email,door} (Bearer only)
+ *   /account/mcp                  (POST/DELETE/OPTIONS) → account-level MCP
+ *                                                (NIP-98 or account:self:* /
+ *                                                host:admin Bearer)
  *   /account/vaults               (GET/POST)   → list / create vault (create returns vault_token)
  *   /account/vaults/<name>        (DELETE)     → teardown (wraps /vaults/<name> cascade)
  *   /account/vaults/<name>/token  (POST)       → per-vault scoped token mint
@@ -240,6 +243,7 @@ import {
   handleAccountSetVaultCaps,
   requireAnyScope,
 } from "./account-api.ts";
+import { accountMcpProtectedResource, handleAccountMcp } from "./account-mcp-http.ts";
 import { type AccountSessionDeps, handleAccountSession } from "./account-session.ts";
 import { handleAccountSetupGet, handleAccountSetupPost } from "./account-setup.ts";
 import { handleAccountToken } from "./account-token.ts";
@@ -3033,6 +3037,27 @@ export function hubFetch(
         return new Response(res.body, { status: res.status, headers: merged });
       }
 
+      // /.well-known/oauth-protected-resource/account/mcp — RFC 9728 PRM
+      // for the account-MCP door. Hub-authored (the resource is a hub
+      // path). Public + wildcard CORS so a spec-following client can walk
+      // a 401 challenge here without a cookie.
+      if (pathname === "/.well-known/oauth-protected-resource/account/mcp") {
+        const corsHeaders = {
+          "access-control-allow-origin": "*",
+          "access-control-allow-methods": "GET, OPTIONS",
+        };
+        if (req.method === "OPTIONS") {
+          return new Response(null, { status: 204, headers: corsHeaders });
+        }
+        if (req.method !== "GET") {
+          return new Response("method not allowed", {
+            status: 405,
+            headers: { allow: "GET, OPTIONS", ...corsHeaders },
+          });
+        }
+        return accountMcpProtectedResource(oauthDeps(req).issuer);
+      }
+
       // /.well-known/oauth-protected-resource/vault/<name>[/mcp] — the
       // path-insertion PRM for a per-vault resource. The vault daemon owns this
       // document because it authors the vault-specific resource URL and scopes;
@@ -4128,6 +4153,15 @@ export function hubFetch(
       // account:self:write (or its stronger admin scope); delete/mint remain
       // admin-only; reads also accept account:self:read. See `account-api.ts`.
       // ====================================================================
+      if (pathname === "/account/mcp") {
+        if (!getDb) return dbNotConfigured();
+        return handleAccountMcp(req, {
+          db: getDb(),
+          issuer: oauthDeps(req).issuer,
+          knownIssuers: oauthDeps(req).hubBoundOrigins(),
+          manifestPath,
+        });
+      }
       if (pathname === "/account/vaults") {
         if (!getDb) return dbNotConfigured();
         const accountDeps: AccountApiDeps = {

--- a/src/nostr-event.ts
+++ b/src/nostr-event.ts
@@ -52,9 +52,11 @@ import { schnorr } from "@noble/curves/secp256k1.js";
  * tags rather than inventing a hub-private kind, so a generic NIP-98 signer
  * can produce our event with one extra tag.
  *
- * We do NOT implement NIP-98 as a request-authentication scheme: NIP-98's own
- * replay defense is a ±60s `created_at` window, which is weak. The hub issues
- * a single-use challenge instead and requires it in a `challenge` tag.
+ * Linkage (cookie ceremony) still uses a single-use `challenge` tag because
+ * NIP-98's ±60s `created_at` window is too weak to bind a durable proof.
+ * Request authentication is a separate path: `nostr-http-auth.ts` verifies
+ * kind 27235 against this request's `u`/`method`/`payload` and rejects a
+ * replayed event id for twice the clock-skew window.
  */
 export const NOSTR_AUTH_KIND = 27235;
 

--- a/src/nostr-http-auth.ts
+++ b/src/nostr-http-auth.ts
@@ -1,0 +1,349 @@
+/**
+ * NIP-98 HTTP request authentication (hub#833 (c)).
+ *
+ * A request carrying `Authorization: Nostr <base64url(json event)>` proves
+ * the caller holds the private key for `event.pubkey`. That pubkey maps to a
+ * hub user via `user_pubkeys`. Unknown keys may create a key-only user when
+ * `autoProvision` is on — the Buzz-shaped onboarding: agents already have
+ * keys; they do not get hub passwords.
+ *
+ * Replay: NIP-98's ±60s `created_at` window is not enough (the linkage
+ * ceremony already refused to rely on it). This module also rejects an
+ * event id it has seen until well after that window closes.
+ *
+ * The cookie + password first-link path in `api-account-pubkeys.ts` is
+ * unchanged. This path never asks for a password: the signature *is* the
+ * possession proof.
+ */
+import { createHash, randomBytes } from "node:crypto";
+import type { Database } from "bun:sqlite";
+import {
+  NOSTR_AUTH_KIND,
+  type NostrEvent,
+  parseNostrEvent,
+  tagValue,
+  verifyNostrEvent,
+} from "./nostr-event.ts";
+import { bindPubkeyFromHttpAuth, findPubkeyLink } from "./pubkey-links.ts";
+import {
+  createUser,
+  getFirstAdminId,
+  getUserById,
+  isFirstAdmin,
+  vaultVerbsForUserVault,
+} from "./users.ts";
+
+/** NIP-98 clock skew, seconds. Spec window. */
+export const NIP98_MAX_SKEW_SECONDS = 60;
+
+/**
+ * How long a used event id stays rejected. Must be ≥ 2× the skew window so
+ * an event still inside ±60s cannot be replayed after eviction.
+ */
+export const NIP98_REPLAY_TTL_MS = 2 * NIP98_MAX_SKEW_SECONDS * 1000 + 1000;
+
+export type NostrHttpAuthFailure =
+  | "missing_authorization"
+  | "malformed_authorization"
+  | "invalid_event"
+  | "bad_signature"
+  | "wrong_kind"
+  | "expired"
+  | "replayed"
+  | "url_mismatch"
+  | "method_mismatch"
+  | "payload_mismatch"
+  | "unknown_pubkey"
+  | "pubkey_taken";
+
+export class NostrHttpAuthError extends Error {
+  override name = "NostrHttpAuthError";
+  constructor(
+    public readonly status: number,
+    public readonly code: NostrHttpAuthFailure,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export class NostrReplayCache {
+  private readonly seen = new Map<string, number>();
+  constructor(private readonly ttlMs: number = NIP98_REPLAY_TTL_MS) {}
+
+  /**
+   * Returns true if this id was already consumed and is still inside TTL.
+   * Records the id on first sight.
+   */
+  consume(id: string, nowMs: number): boolean {
+    this.gc(nowMs);
+    const exp = this.seen.get(id);
+    if (exp !== undefined && exp > nowMs) return true;
+    this.seen.set(id, nowMs + this.ttlMs);
+    return false;
+  }
+
+  private gc(nowMs: number): void {
+    for (const [id, exp] of this.seen) {
+      if (exp <= nowMs) this.seen.delete(id);
+    }
+  }
+}
+
+const defaultReplay = new NostrReplayCache();
+
+export function extractNostrEvent(req: Request): NostrEvent {
+  const header = req.headers.get("authorization");
+  if (!header) {
+    throw new NostrHttpAuthError(401, "missing_authorization", "missing Authorization header");
+  }
+  const match = header.match(/^Nostr\s+(\S+)$/i);
+  if (!match || !match[1]) {
+    throw new NostrHttpAuthError(
+      401,
+      "malformed_authorization",
+      "Authorization header must be 'Nostr <base64 event>'",
+    );
+  }
+  let json: string;
+  try {
+    json = Buffer.from(match[1], "base64url").toString("utf8");
+  } catch {
+    throw new NostrHttpAuthError(401, "malformed_authorization", "Nostr token is not base64url");
+  }
+  let raw: unknown;
+  try {
+    raw = JSON.parse(json);
+  } catch {
+    throw new NostrHttpAuthError(401, "malformed_authorization", "Nostr token is not JSON");
+  }
+  const parsed = parseNostrEvent(raw);
+  if (!parsed.ok) {
+    throw new NostrHttpAuthError(401, "invalid_event", `Nostr event rejected: ${parsed.reason}`);
+  }
+  return parsed.event;
+}
+
+export function requestAbsoluteUrl(req: Request): string {
+  return req.url;
+}
+
+function sha256Hex(bytes: Uint8Array): string {
+  return createHash("sha256").update(bytes).digest("hex");
+}
+
+/**
+ * Verify the event is a NIP-98 auth event for *this* request. Does not
+ * resolve a hub user.
+ */
+export function verifyNostrHttpEvent(
+  req: Request,
+  event: NostrEvent,
+  opts: {
+    now?: () => Date;
+    replay?: NostrReplayCache;
+    /** Raw body bytes; required when the request has a body. */
+    body?: Uint8Array;
+  } = {},
+): void {
+  const now = opts.now?.() ?? new Date();
+  const replay = opts.replay ?? defaultReplay;
+
+  const verified = verifyNostrEvent(event);
+  if (!verified.ok) {
+    throw new NostrHttpAuthError(
+      401,
+      "bad_signature",
+      verified.reason === "id_mismatch"
+        ? "Nostr event id does not match payload"
+        : "Nostr event signature is invalid",
+    );
+  }
+  if (event.kind !== NOSTR_AUTH_KIND) {
+    throw new NostrHttpAuthError(401, "wrong_kind", `Nostr event kind must be ${NOSTR_AUTH_KIND}`);
+  }
+
+  const createdAtMs = event.created_at * 1000;
+  const skewMs = NIP98_MAX_SKEW_SECONDS * 1000;
+  if (Math.abs(now.getTime() - createdAtMs) > skewMs) {
+    throw new NostrHttpAuthError(401, "expired", "Nostr event created_at is outside the 60s window");
+  }
+
+  if (replay.consume(event.id, now.getTime())) {
+    throw new NostrHttpAuthError(401, "replayed", "Nostr event id has already been used");
+  }
+
+  const u = tagValue(event, "u");
+  const expectedUrl = requestAbsoluteUrl(req);
+  if (u !== expectedUrl) {
+    throw new NostrHttpAuthError(401, "url_mismatch", "Nostr event u tag must equal this request URL");
+  }
+  const method = tagValue(event, "method");
+  if (!method || method.toUpperCase() !== req.method.toUpperCase()) {
+    throw new NostrHttpAuthError(
+      401,
+      "method_mismatch",
+      "Nostr event method tag must equal this request method",
+    );
+  }
+
+  const body = opts.body ?? new Uint8Array();
+  const payload = tagValue(event, "payload");
+  if (body.byteLength === 0) {
+    if (payload) {
+      throw new NostrHttpAuthError(
+        401,
+        "payload_mismatch",
+        "Nostr event payload tag must be absent when the body is empty",
+      );
+    }
+  } else {
+    const expected = sha256Hex(body);
+    if (payload !== expected) {
+      throw new NostrHttpAuthError(
+        401,
+        "payload_mismatch",
+        "Nostr event payload tag must be sha256 hex of the request body",
+      );
+    }
+  }
+}
+
+export interface NostrPrincipal {
+  userId: string;
+  username: string;
+  pubkey: string;
+  /** True when this request created the hub user. */
+  provisioned: boolean;
+  /**
+   * Hub-admin unrestricted sentinel is first-admin only. Key-native users
+   * never become first-admin by auto-provision (the owner row already exists).
+   */
+  isHubAdmin: boolean;
+  /** `vault:<name>:<verb>` for assigned vaults. Empty for first-admin. */
+  scopes: string[];
+}
+
+function usernameForPubkey(pubkey: string): string {
+  // validateUsername: [a-z0-9_-] 2–32. Hex is in charset.
+  return `n${pubkey.slice(0, 31)}`;
+}
+
+/**
+ * Map a verified pubkey to a hub user. Existing `user_pubkeys` row wins.
+ * When `autoProvision` is true and the key is unknown, create a key-only
+ * user (random unusable password, password_changed=1, key already bound).
+ */
+export async function resolveNostrPrincipal(
+  db: Database,
+  event: NostrEvent,
+  opts: { autoProvision: boolean; now?: () => Date },
+): Promise<NostrPrincipal> {
+  const nowFn = opts.now ?? (() => new Date());
+  const now = nowFn();
+  const existing = findPubkeyLink(db, event.pubkey);
+  if (existing) {
+    const user = getUserById(db, existing.userId);
+    if (!user) {
+      throw new NostrHttpAuthError(401, "unknown_pubkey", "linked user no longer exists");
+    }
+    return principalFromUser(db, user.id, user.username, event.pubkey, false);
+  }
+  if (!opts.autoProvision) {
+    throw new NostrHttpAuthError(
+      401,
+      "unknown_pubkey",
+      "Nostr pubkey is not linked to a hub user",
+    );
+  }
+  if (getFirstAdminId(db) === null) {
+    throw new NostrHttpAuthError(
+      401,
+      "unknown_pubkey",
+      "Nostr auto-provision requires an existing hub owner",
+    );
+  }
+
+  const password = randomBytes(32).toString("base64url");
+  let username = usernameForPubkey(event.pubkey);
+  let user;
+  try {
+    user = await createUser(db, username, password, {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: [],
+      now: nowFn,
+    });
+  } catch (err) {
+    if (err instanceof Error && err.name === "UsernameTakenError") {
+      username = `n${event.pubkey.slice(1, 32)}`;
+      user = await createUser(db, username, password, {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: [],
+        now: nowFn,
+      });
+    } else {
+      throw err;
+    }
+  }
+
+  const bound = bindPubkeyFromHttpAuth(db, {
+    userId: user.id,
+    pubkey: event.pubkey,
+    proofEvent: JSON.stringify(event),
+    proofEventId: event.id,
+    label: "nip98",
+    now,
+  });
+  if (!bound.ok) {
+    throw new NostrHttpAuthError(401, "pubkey_taken", "Nostr pubkey is already bound to another user");
+  }
+  return principalFromUser(db, user.id, user.username, event.pubkey, true);
+}
+
+function principalFromUser(
+  db: Database,
+  userId: string,
+  username: string,
+  pubkey: string,
+  provisioned: boolean,
+): NostrPrincipal {
+  const admin = isFirstAdmin(db, userId);
+  const user = getUserById(db, userId);
+  const scopes: string[] = [];
+  if (!admin && user) {
+    for (const name of user.assignedVaults) {
+      const verbs = vaultVerbsForUserVault(db, userId, name) ?? [];
+      for (const verb of verbs) scopes.push(`vault:${name}:${verb}`);
+    }
+  }
+  return { userId, username, pubkey, provisioned, isHubAdmin: admin, scopes };
+}
+
+export async function authenticateNostrRequest(
+  db: Database,
+  req: Request,
+  opts: {
+    autoProvision: boolean;
+    now?: () => Date;
+    replay?: NostrReplayCache;
+    body?: Uint8Array;
+  },
+): Promise<NostrPrincipal> {
+  const event = extractNostrEvent(req);
+  verifyNostrHttpEvent(req, event, {
+    now: opts.now,
+    replay: opts.replay,
+    body: opts.body,
+  });
+  return resolveNostrPrincipal(db, event, {
+    autoProvision: opts.autoProvision,
+    now: opts.now,
+  });
+}
+
+export function isNostrAuthorization(req: Request): boolean {
+  const header = req.headers.get("authorization");
+  return !!header && /^Nostr\s+/i.test(header);
+}

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -22,6 +22,7 @@
  * on presentation.
  */
 import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
 import { AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { recordLoginUnlock } from "./admin-lock.ts";
 import { renderTotpChallenge } from "./admin-login-ui.ts";
@@ -1237,6 +1238,14 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // Per RFC 6749 §4.1.2.1, errors that aren't redirect-uri-related are
   // delivered by redirect with `error=invalid_scope`.
   const requestedScopes = parsed.scope.split(" ").filter((s) => s.length > 0);
+  if (accountVaultsCombinedWithOtherScopes(requestedScopes)) {
+    return oauthErrorRedirect(
+      parsed.redirectUri,
+      "invalid_scope",
+      "account:vaults cannot be combined with other scopes",
+      parsed.state,
+    );
+  }
   const blocked = findNonRequestableScopes(requestedScopes);
   if (blocked.length > 0) {
     return oauthErrorRedirect(
@@ -1494,6 +1503,20 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
  *     skip-consent flow can never replay an un-held admin verb because it was
  *     never recorded.
  */
+function bindAccountVaultsScopes(scopes: readonly string[]): string[] {
+  return scopes.map((s) => (s === ACCOUNT_VAULTS_UNNARROWED ? accountVaultsScope("self") : s));
+}
+
+function isAccountVaultsConnectionScope(scope: string): boolean {
+  return scope === ACCOUNT_VAULTS_UNNARROWED || scope === accountVaultsScope("self");
+}
+
+function accountVaultsCombinedWithOtherScopes(scopes: readonly string[]): boolean {
+  const has = scopes.some(isAccountVaultsConnectionScope);
+  if (!has) return false;
+  return scopes.some((s) => !isAccountVaultsConnectionScope(s));
+}
+
 function capScopesToUserAuthority(
   db: Database,
   userId: string,
@@ -1574,6 +1597,7 @@ export function grantableExtraScopes(
     ACCOUNT_SELF_READ_SCOPE,
     ACCOUNT_SELF_WRITE_SCOPE,
     ACCOUNT_SELF_ADMIN_SCOPE,
+    ACCOUNT_VAULTS_UNNARROWED,
   ];
 
   // Compare both naming shapes in one canonical key space. When an admin's
@@ -1643,7 +1667,19 @@ function issueAuthCodeRedirect(
   // the final named shapes. Owner (isFirstAdmin) bypasses — holds admin
   // everywhere by construction.
   const userIsAdmin = isFirstAdmin(db, userId);
-  const cappedScopes = capScopesToUserAuthority(db, userId, scopes, { userIsAdmin });
+  // RFC 9728 walk: PRM advertises un-narrowed `account:vaults`; the token
+  // must carry the id-bound blanket `account:self:vaults`. Bind here at the
+  // single mint choke-point so skip-consent and form-consent cannot diverge.
+  const boundScopes = bindAccountVaultsScopes(scopes);
+  if (accountVaultsCombinedWithOtherScopes(boundScopes)) {
+    return oauthErrorRedirect(
+      params.redirectUri,
+      "invalid_scope",
+      "account:vaults cannot be combined with other scopes",
+      params.state,
+    );
+  }
+  const cappedScopes = capScopesToUserAuthority(db, userId, boundScopes, { userIsAdmin });
   // Dedup HERE, after the cap, at the single mint choke-point every path funnels
   // through — so the auth-code row, the JWT `scope` claim, the refresh row, the
   // token response, and the recorded grant all carry the same set.

--- a/src/pubkey-links.ts
+++ b/src/pubkey-links.ts
@@ -24,11 +24,11 @@
  *
  * ## What a linked key does and does not grant
  *
- * **It grants nothing.** A linked key cannot authenticate a request, mint a
- * token, read a vault, or widen a scope. Nothing in the hub's authorization
- * path reads `user_pubkeys`. Phase 1 makes *who did this* checkable; who may
- * do what is Jon's ACL design (seams S1/S1b in the doc) and is deliberately
- * untouched here.
+ * On the **cookie + password** path a linked key still grants nothing — it is
+ * an attribution label (phase 1). On the **NIP-98 HTTP auth** path
+ * (`nostr-http-auth.ts`, hub#833 (c)) the same table is the principal map:
+ * a request signed by `pubkey` authenticates as `user_id`. Unlink drops
+ * future NIP-98 logins for that key; it does not erase `attribution_proofs`.
  *
  * ## Replay protection
  *
@@ -349,6 +349,105 @@ export function findPubkeyLink(db: Database, pubkey: string): LinkedPubkey | nul
     .query<LinkRow, [string]>("SELECT * FROM user_pubkeys WHERE pubkey = ?")
     .get(pubkey);
   return row ? rowToLink(row) : null;
+}
+
+export type BindPubkeyFromHttpAuthResult =
+  | { ok: true; link: LinkedPubkey; relinked: boolean }
+  | { ok: false; reason: "pubkey_taken" | "too_many_pubkeys" };
+
+/**
+ * Bind `pubkey` to `userId` using a NIP-98 HTTP-auth event as the proof.
+ * No challenge-response: the signed request *is* the possession proof.
+ * The cookie ceremony (`linkPubkey`) stays challenge-gated.
+ *
+ * Caller MUST have verified the event (id + BIP-340 + `u`/`method` bind)
+ * before calling. This function performs no cryptography.
+ */
+export function bindPubkeyFromHttpAuth(
+  db: Database,
+  opts: {
+    userId: string;
+    pubkey: string;
+    proofEvent: string;
+    proofEventId: string;
+    label?: string | null;
+    now?: Date;
+  },
+): BindPubkeyFromHttpAuthResult {
+  const now = opts.now ?? new Date();
+  const stamp = now.toISOString();
+  const label = opts.label ?? null;
+  const run = db.transaction((): BindPubkeyFromHttpAuthResult => {
+    const existing = db
+      .query<LinkRow, [string]>("SELECT * FROM user_pubkeys WHERE pubkey = ?")
+      .get(opts.pubkey);
+    if (existing && existing.user_id !== opts.userId) {
+      return { ok: false, reason: "pubkey_taken" };
+    }
+    if (!existing) {
+      const count = (
+        db
+          .query<{ n: number }, [string]>(
+            "SELECT COUNT(*) AS n FROM user_pubkeys WHERE user_id = ?",
+          )
+          .get(opts.userId) ?? { n: 0 }
+      ).n;
+      if (count >= MAX_PUBKEYS_PER_USER) return { ok: false, reason: "too_many_pubkeys" };
+      db.prepare(
+        `INSERT INTO user_pubkeys
+           (pubkey, user_id, label, proof_event, proof_event_id, linked_at, last_verified_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      ).run(opts.pubkey, opts.userId, label, opts.proofEvent, opts.proofEventId, stamp, stamp);
+      retainAttributionProof(db, {
+        subject: opts.userId,
+        pubkey: opts.pubkey,
+        label,
+        proofEvent: opts.proofEvent,
+        proofEventId: opts.proofEventId,
+        linkedAt: stamp,
+        lastVerifiedAt: stamp,
+      });
+      return {
+        ok: true,
+        relinked: false,
+        link: {
+          pubkey: opts.pubkey,
+          userId: opts.userId,
+          label,
+          proofEventId: opts.proofEventId,
+          linkedAt: stamp,
+          lastVerifiedAt: stamp,
+        },
+      };
+    }
+    db.prepare(
+      `UPDATE user_pubkeys
+         SET label = ?, proof_event = ?, proof_event_id = ?, last_verified_at = ?
+       WHERE pubkey = ? AND user_id = ?`,
+    ).run(label, opts.proofEvent, opts.proofEventId, stamp, opts.pubkey, opts.userId);
+    retainAttributionProof(db, {
+      subject: opts.userId,
+      pubkey: opts.pubkey,
+      label,
+      proofEvent: opts.proofEvent,
+      proofEventId: opts.proofEventId,
+      linkedAt: existing.linked_at,
+      lastVerifiedAt: stamp,
+    });
+    return {
+      ok: true,
+      relinked: true,
+      link: {
+        pubkey: opts.pubkey,
+        userId: opts.userId,
+        label,
+        proofEventId: opts.proofEventId,
+        linkedAt: existing.linked_at,
+        lastVerifiedAt: stamp,
+      },
+    };
+  });
+  return run();
 }
 
 /**

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -193,6 +193,16 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
     level: "read",
     risk: "low",
   },
+  // Account-MCP connection grant (hub#883). PRM advertises the un-narrowed
+  // `account:vaults`; consent binds it to `account:self:vaults`. Elevated
+  // because the grant includes create-vault plus cross-vault query-notes —
+  // not the REST `account:self:read` list/usage surface.
+  "account:vaults": {
+    label:
+      "Connect across your vaults — list them, search their notes, and create new vaults. Does not delete vaults or mint long-lived access tokens.",
+    level: "write",
+    risk: "elevated",
+  },
 };
 
 /** Account scope strings (Parachute App campaign, Phase 2). Exported so the


### PR DESCRIPTION
Merging this publishes `@openparachute/hub@0.7.18-rc.2` to npm `@rc` (and ghcr `:rc`). It is an **rc**, not stable. `@latest` stays 0.7.17.

**Merge-commit, do not squash.** Squash would split `next` from `main`.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What ships (on `next` after 0.7.18-rc.1)

- #882 NIP-98 request auth (`Authorization: Nostr <event>`)
- #883 `/account/mcp` door (list/query/create vaults for that key)
- #884 version+changelog 0.7.18-rc.2

Leaves #880 and #881 open. Auto-provision still defaults **off**. Do not suffix-drop 0.7.18; multiple rcs can land first.

## After merge

`parachute upgrade hub --channel rc` on this box (not bun-link). Then smoke NIP-98 + `/account/mcp` on the live instance.