### PR TITLE
fix(hub#883): treat account:vaults and account:self:vaults as one grant

### DIFF
--- a/src/__tests__/grants.test.ts
+++ b/src/__tests__/grants.test.ts
@@ -103,6 +103,22 @@ describe("grants module (#75)", () => {
     }
   });
 
+  test("isCoveredByGrant: account:vaults and account:self:vaults are equivalent", async () => {
+    const h = await harness();
+    try {
+      recordGrant(h.db, h.userId, h.clientId, ["account:self:vaults"]);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:vaults"])).toBe(true);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:self:vaults"])).toBe(true);
+      expect(
+        isCoveredByGrant(h.db, h.userId, h.clientId, ["account:vaults", "vault:work:read"]),
+      ).toBe(false);
+      recordGrant(h.db, h.userId, h.clientId, ["account:vaults"]);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:self:vaults"])).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("isCoveredByGrant: empty request returns false (no auto-approve for empty)", async () => {
     const h = await harness();
     try {

--- a/src/__tests__/grants.test.ts
+++ b/src/__tests__/grants.test.ts
@@ -112,8 +112,37 @@ describe("grants module (#75)", () => {
       expect(
         isCoveredByGrant(h.db, h.userId, h.clientId, ["account:vaults", "vault:work:read"]),
       ).toBe(false);
+      expect(revokeGrant(h.db, h.userId, h.clientId)).toBe(true);
       recordGrant(h.db, h.userId, h.clientId, ["account:vaults"]);
       expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:self:vaults"])).toBe(true);
+      expect(isCoveredByGrant(h.db, h.userId, h.clientId, ["account:vaults"])).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("isCoveredByGrantForClientName: same account:vaults equivalence", async () => {
+    const h = await harness();
+    try {
+      const named = registerClient(h.db, {
+        redirectUris: ["https://app.example/cb"],
+        clientName: "mcp-reconnect",
+      });
+      recordGrant(h.db, h.userId, named.client.clientId, ["account:self:vaults"]);
+      expect(isCoveredByGrantForClientName(h.db, h.userId, "mcp-reconnect", ["account:vaults"])).toBe(
+        true,
+      );
+      expect(
+        isCoveredByGrantForClientName(h.db, h.userId, "mcp-reconnect", [
+          "account:vaults",
+          "vault:work:read",
+        ]),
+      ).toBe(false);
+      expect(revokeGrant(h.db, h.userId, named.client.clientId)).toBe(true);
+      recordGrant(h.db, h.userId, named.client.clientId, ["account:vaults"]);
+      expect(
+        isCoveredByGrantForClientName(h.db, h.userId, "mcp-reconnect", ["account:self:vaults"]),
+      ).toBe(true);
     } finally {
       h.cleanup();
     }

--- a/src/grants.ts
+++ b/src/grants.ts
@@ -26,7 +26,32 @@
  */
 
 import type { Database } from "bun:sqlite";
+import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
 import { vaultScopeName } from "./scope-explanations.ts";
+
+const HUB_ACCOUNT_VAULTS_BOUND = accountVaultsScope("self");
+
+/**
+ * `account:vaults` (PRM request form) and `account:self:vaults` (consent-bound
+ * mint form) are the same grant. Skip-consent used to exact-match, so an MCP
+ * client that re-requests the advertised un-narrowed string after a bound
+ * mint would re-consent every time (hub#883 review nit).
+ */
+function accountVaultsEquivalents(scope: string): readonly string[] {
+  if (scope === ACCOUNT_VAULTS_UNNARROWED) return [scope, HUB_ACCOUNT_VAULTS_BOUND];
+  if (scope === HUB_ACCOUNT_VAULTS_BOUND) return [scope, ACCOUNT_VAULTS_UNNARROWED];
+  return [scope];
+}
+
+function requestedCoveredByGranted(
+  granted: ReadonlySet<string>,
+  requested: readonly string[],
+): boolean {
+  for (const s of requested) {
+    if (!accountVaultsEquivalents(s).some((eq) => granted.has(eq))) return false;
+  }
+  return true;
+}
 
 export interface Grant {
   userId: string;
@@ -112,10 +137,7 @@ export function isCoveredByGrant(
   const grant = findGrant(db, userId, clientId);
   if (!grant) return false;
   const granted = new Set(grant.scopes);
-  for (const s of requestedScopes) {
-    if (!granted.has(s)) return false;
-  }
-  return true;
+  return requestedCoveredByGranted(granted, requestedScopes);
 }
 
 /**
@@ -183,10 +205,7 @@ export function isCoveredByGrantForClientName(
   const grant = findGrantByClientName(db, userId, clientName);
   if (!grant) return false;
   const granted = new Set(grant.scopes);
-  for (const s of requestedScopes) {
-    if (!granted.has(s)) return false;
-  }
-  return true;
+  return requestedCoveredByGranted(granted, requestedScopes);
 }
 
 const VAULT_SCOPE_PREFIX_RE = /^vault:([^:]+):/;


### PR DESCRIPTION
## What

Skip-consent used exact string match. Consent mints `account:self:vaults`; the PRM advertises `account:vaults`. An MCP reconnect that re-requests the advertised form re-consented every time (hub#883 review nit).

`isCoveredByGrant` / `isCoveredByGrantForClientName` now treat those two strings as the same grant. A mix with a vault verb is still not covered.

No version bump. Rides the next rc after 0.7.18-rc.2.

## Test

`bun test src/__tests__/grants.test.ts` 31/0. `tsc --noEmit` 0.