### PR TITLE
fix(hub): NIP-98 at /mcp routes to account-MCP, not the vault daemon

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -7386,6 +7386,28 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
     }
   });
 
+  test("NIP-98 POST /mcp with no getDb is 503 service_unavailable, daemon never reached", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const url = "http://hub.example.com/mcp";
+      const secret = hexToBytes("aa".repeat(32));
+      const res = await fetcher(
+        nostrMcpReq(secret, url, { jsonrpc: "2.0", id: 1, method: "initialize" }),
+      );
+      expect(res.status).toBe(503);
+      const body = (await res.json()) as { error?: string; error_description?: string };
+      expect(body.error).toBe("service_unavailable");
+      expect(body.error_description).toBe("hub db not configured");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
   test("Bearer POST /mcp still proxies to the daemon (NIP-98 intercept is scheme-only)", async () => {
     const h = makeHarness();
     const upstream = startRecordingUpstream();

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from "bun:test";
+import { createHash } from "node:crypto";
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
+import { schnorr } from "@noble/curves/secp256k1.js";
 import { _resetBootstrapTokenForTests, generateBootstrapToken } from "../bootstrap-token.ts";
 import { buildCsrfCookie, generateCsrfToken } from "../csrf.ts";
 import { HUB_SVC, hubPortPath } from "../hub-control.ts";
@@ -19,9 +21,11 @@ import {
 } from "../hub-server.ts";
 import { defaultRootModeFor, setNotesRedirectDisabled, setRootMode } from "../hub-settings.ts";
 import { signAccessToken } from "../jwt-sign.ts";
+import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
 import { clearNotesRedirectLogState } from "../notes-redirect.ts";
 import { mintOperatorToken } from "../operator-token.ts";
 import { pidPath } from "../process-state.ts";
+import { bindPubkeyFromHttpAuth } from "../pubkey-links.ts";
 import { type ServiceEntry, writeManifest } from "../services-manifest.ts";
 import { buildSessionCookie, createSession } from "../sessions.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
@@ -7304,6 +7308,148 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
       expect(body).not.toContain("PARACHUTE-APP-SHELL");
     } finally {
       db.close();
+      h.cleanup();
+    }
+  });
+
+  // NIP-98 at root /mcp is hub-user auth the vault daemon does not speak.
+  // Intercept that scheme and hand it to handleAccountMcp. Vault-audience
+  // Bearer still proxies. Does not reopen narrowRootMcpScopes.
+  const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
+  const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
+  const BOTH_ACCEPT = "application/json, text/event-stream";
+
+  function signNostrEvent(
+    secret: Uint8Array,
+    parts: { created_at?: number; tags?: string[][]; content?: string },
+  ): NostrEvent {
+    const unsigned = {
+      pubkey: bytesToHex(schnorr.getPublicKey(secret)),
+      created_at: parts.created_at ?? Math.floor(Date.now() / 1000),
+      kind: NOSTR_AUTH_KIND,
+      tags: parts.tags ?? [],
+      content: parts.content ?? "",
+    };
+    const id = nostrEventId(unsigned);
+    const sig = bytesToHex(schnorr.sign(hexToBytes(id), secret));
+    return { ...unsigned, id, sig };
+  }
+
+  function nostrMcpReq(secret: Uint8Array, url: string, body: unknown): Request {
+    const encoded = JSON.stringify(body);
+    const bytes = new TextEncoder().encode(encoded);
+    const event = signNostrEvent(secret, {
+      content: `${Date.now()}-${Math.random()}`,
+      tags: [
+        ["u", url],
+        ["method", "POST"],
+        ["payload", createHash("sha256").update(bytes).digest("hex")],
+      ],
+    });
+    return new Request(url, {
+      method: "POST",
+      headers: {
+        authorization: `Nostr ${Buffer.from(JSON.stringify(event), "utf8").toString("base64url")}`,
+        accept: BOTH_ACCEPT,
+        "content-type": "application/json",
+        host: new URL(url).host,
+      },
+      body: encoded,
+    });
+  }
+
+  test("NIP-98 POST /mcp does not reach the daemon — same 401 shape as /account/mcp", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      await createUser(db, "owner", "pw", { passwordChanged: true });
+      const fetcher = hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath });
+      const url = "http://hub.example.com/mcp";
+      const secret = hexToBytes("99".repeat(32));
+      const res = await fetcher(
+        nostrMcpReq(secret, url, { jsonrpc: "2.0", id: 1, method: "initialize" }),
+      );
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error?: string; error_description?: string };
+      expect(body.error).toBe("invalid_token");
+      expect(body.error_description).toBe("Nostr pubkey is not linked to a hub user");
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain("resource_metadata=");
+      expect(challenge).toContain("/.well-known/oauth-protected-resource/account/mcp");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      db.close();
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("Bearer POST /mcp still proxies to the daemon (NIP-98 intercept is scheme-only)", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      const fetcher = hubFetch(h.dir, { manifestPath: h.manifestPath });
+      const res = await fetcher(
+        new Request("http://hub.example.com/mcp", {
+          method: "POST",
+          headers: {
+            authorization: "Bearer not-a-vault-token",
+            "content-type": "application/json",
+            host: "hub.example.com",
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+        }),
+      );
+      expect(res.status).toBe(200);
+      expect(upstream.requests()).toHaveLength(1);
+      expect(upstream.requests()[0]?.pathname).toBe("/mcp");
+    } finally {
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("linked NIP-98 POST /mcp initialize is answered by account-MCP, daemon never reached", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      const owner = await createUser(db, "owner", "pw", { passwordChanged: true });
+      const secret = hexToBytes("11".repeat(32));
+      const pubkey = bytesToHex(schnorr.getPublicKey(secret));
+      const bound = bindPubkeyFromHttpAuth(db, {
+        userId: owner.id,
+        pubkey,
+        proofEvent: "{}",
+        proofEventId: "c".repeat(64),
+        label: "test",
+      });
+      expect(bound.ok).toBe(true);
+      const fetcher = hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath });
+      const url = "http://hub.example.com/mcp";
+      const res = await fetcher(
+        nostrMcpReq(secret, url, {
+          jsonrpc: "2.0",
+          id: 1,
+          method: "initialize",
+          params: {
+            protocolVersion: "2025-11-25",
+            capabilities: {},
+            clientInfo: { name: "t", version: "0" },
+          },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
+      expect(body.result?.serverInfo?.name).toBe("parachute-account");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      db.close();
+      upstream.stop();
       h.cleanup();
     }
   });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -187,10 +187,13 @@
  *
  *   # Root MCP surface (hub-owned protocol namespace, dispatched BEFORE the
  *   # per-vault proxy and generic service mounts so no module can claim it
- *   # via services.json paths). Vault-agnostic — the TOKEN's audience names
- *   # the target vault, re-validated by the daemon; no "which vault" in the
- *   # URL. Same daemon resolution + loopback-cloak as /vault/admin above.
- *   /mcp, /mcp/*                                → proxy to the vault module's daemon
+ *   # via services.json paths). Vault-audience Bearer / API key still proxy
+ *   # to the vault daemon (token names the vault). NIP-98
+ *   # (`Authorization: Nostr`) is hub-user auth the daemon does not speak,
+ *   # so that scheme routes to handleAccountMcp — same door as /account/mcp.
+ *   # OAuth authorize / narrowRootMcpScopes are untouched.
+ *   /mcp, /mcp/*                                → NIP-98 → account-MCP;
+ *                                                otherwise proxy to the vault daemon
  *
  *   # Per-vault content proxy (user-facing vault data: Notes PWA, MCP, etc.).
  *   /vault/<name>/*                            → proxy to the vault backend
@@ -344,6 +347,7 @@ import {
   type ModuleManifest,
   readModuleManifest as defaultReadModuleManifest,
 } from "./module-manifest.ts";
+import { isNostrAuthorization } from "./nostr-http-auth.ts";
 import { isLegacyNotesPath, logNotesRedirect, maybeRedirectNotes } from "./notes-redirect.ts";
 import {
   authorizationServerMetadata,
@@ -4347,13 +4351,15 @@ export function hubFetch(
       // vault daemon has served since 0.7.3. Hub-owned protocol namespace,
       // dispatched here (BEFORE the /vault/ per-vault proxy and the generic
       // service mounts) so no service can claim it via services.json paths.
-      // There's no "which vault" question at this layer — the TOKEN's
-      // audience names the target vault, re-validated by the daemon itself
-      // — so we forward via `proxyToVaultDaemon` unconditionally, the same
-      // resolution + loopback-cloak as `/vault/admin`. The response is
-      // returned RAW (no `decorateWithChrome`): this is a JSON-RPC protocol
-      // surface, not an HTML page, so chrome injection would be wrong even
-      // when it no-ops on non-HTML bodies.
+      //
+      // Two auth models share this URL; they are NOT merged into one OAuth
+      // resource. Vault-audience Bearer / API key still proxy to the daemon
+      // (the TOKEN names the vault). NIP-98 never goes through OAuth
+      // authorize — it is a signed event per request — and the daemon does
+      // not speak it (401 "API key required"). Intercept that scheme and
+      // hand the request to handleAccountMcp, the same handler /account/mcp
+      // uses. narrowRootMcpScopes and the root-/mcp authorize branch stay
+      // vault-only; folding account:vaults into them is a separate decision.
       if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
         // Same per-request force-change-password gate as the twins above —
         // a pre-rotation signed-in user can't reach vault data through here
@@ -4361,6 +4367,15 @@ export function hubFetch(
         if (getDb) {
           const gate = forceChangePasswordGate(getDb(), req);
           if (gate) return gate;
+        }
+        if (isNostrAuthorization(req)) {
+          if (!getDb) return dbNotConfigured();
+          return handleAccountMcp(req, {
+            db: getDb(),
+            issuer: oauthDeps(req).issuer,
+            knownIssuers: oauthDeps(req).hubBoundOrigins(),
+            manifestPath,
+          });
         }
         const proxied = await proxyToVaultDaemon(req, manifestPath, deps?.supervisor, peerAddr);
         if (proxied) return proxied;

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -4360,6 +4360,8 @@ export function hubFetch(
       // hand the request to handleAccountMcp, the same handler /account/mcp
       // uses. narrowRootMcpScopes and the root-/mcp authorize branch stay
       // vault-only; folding account:vaults into them is a separate decision.
+      // Hub-only until Cloud's twin (parachute-cloud#273) matches this scheme
+      // split — door-contract 0.6.0 already ratifies a unified /mcp gateway.
       if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
         // Same per-request force-change-password gate as the twins above —
         // a pre-rotation signed-in user can't reach vault data through here


### PR DESCRIPTION
## Why

An agent that adds `<hub>/mcp` and signs with its nsec (NIP-98) currently hits `proxyToVaultDaemon`. The vault daemon does not speak NIP-98 — live probe on this box (hub 0.7.18-rc.2) returned `401 API key required`. That is the gap in Aaron's "add /mcp, identity is the key" story.

This does **not** merge `/mcp` and `/account/mcp` into one OAuth resource. `narrowRootMcpScopes` and the root-`/mcp` authorize branch stay vault-only. Folding `account:vaults` into that consent surface is a separate named decision.

## What

In the `/mcp` dispatch branch, `Authorization: Nostr …` routes to `handleAccountMcp` (same handler `/account/mcp` uses). Vault-audience Bearer and API keys still proxy.

Throwaway unlinked NIP-98 at `/mcp` now gets the same 401 shape as `/account/mcp` (`invalid_token` / "Nostr pubkey is not linked to a hub user", PRM challenge pointing at `/account/mcp`), and the daemon is never reached. Linked NIP-98 `initialize` is answered by account-MCP (`serverInfo.name = parachute-account`).

## Tests

- New hubFetch pins in `hub-server.test.ts` (watched fail without the intercept: NIP-98 got daemon 200 / `API key` path; then pass with it).
- `bun run typecheck` 0 at `db84952`.
- `bun test ./src` at `db84952`: **4734 pass / 1 skip / 1 fail**. The fail is `surface-command.test.ts` "a command-minted write token pushes; revoke then blocks the next push" timing out at 5s — file not in this diff, reproduced in isolation on this box. Not this change.

Not bun-linked. Not live `:1939`. Changelog with the next rc bump.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`, thread `1039ce8c`.
