### PR TITLE
feat(hub): grant vault access by Nostr pubkey on account-MCP

### DIFF
--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -1068,8 +1068,10 @@ describe("account MCP — grant-access", () => {
       );
       const payload = parseTool(
         (await ok.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string };
+      ) as { vault: string; user_id: string };
       expect(payload.vault).toBe("beta");
+      expect(vaultVerbsForUserVault(h.db, payload.user_id, "beta")).toEqual(["read"]);
+      expect(vaultVerbsForUserVault(h.db, payload.user_id, "personal")).toBeNull();
 
       const denied = await handleAccountMcp(
         nostrReq(
@@ -1337,9 +1339,129 @@ describe("account MCP — grant-access", () => {
       );
       const payload = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { created_user: boolean; vault: string };
+      ) as { created_user: boolean; vault: string; user_id: string };
       expect(payload.created_user).toBe(true);
       expect(payload.vault).toBe("personal");
+      expect(vaultVerbsForUserVault(h.db, payload.user_id, "personal")).toEqual([
+        "read",
+        "write",
+        "admin",
+      ]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("first-admin Bearer named beta:read cannot grant personal or beta", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta:read"]);
+      const personal = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "personal", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await personal.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("grant_not_permitted");
+      const beta = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await beta.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("grant_not_permitted");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("first-admin Bearer account:self:vaults (coverage wildcard) can grant personal", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "personal", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string; created_user: boolean };
+      expect(payload.vault).toBe("personal");
+      expect(payload.created_user).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend Bearer named beta:read cannot grant even with write assignment", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta:read"], h.friendId);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await res.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("grant_not_permitted");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("username collision on both n-prefixes refuses rather than granting the wrong user", async () => {
+    const h = await makeHarness();
+    try {
+      await createUser(h.db, `n${OTHER_PUBKEY.slice(0, 31)}`, "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+      });
+      await createUser(h.db, `n${OTHER_PUBKEY.slice(1, 32)}`, "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+      });
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await res.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("username_taken");
+      expect(findPubkeyLink(h.db, OTHER_PUBKEY)).toBeNull();
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -11,6 +11,9 @@ import type { Database } from "bun:sqlite";
  *   - create-vault: owner yes, friend no, no token in the tool result;
  *   - query-notes: fan-out attribution + one-vault failure isolation +
  *     vault_not_covered fail-closed;
+ *   - grant-access: grant-first creates a key-only user; one-row upsert;
+ *     friend write can grant their vault, read cannot; owner unrestricted
+ *     is a no-op; revoke leaves the user; list-access is pubkey-shaped;
  *   - descriptor advertises account_mcp_endpoint (see account-api.test).
  */
 import { describe, expect, test } from "bun:test";
@@ -26,10 +29,10 @@ import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { signAccessToken } from "../jwt-sign.ts";
 import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
 import { NostrReplayCache } from "../nostr-http-auth.ts";
-import { bindPubkeyFromHttpAuth } from "../pubkey-links.ts";
+import { bindPubkeyFromHttpAuth, findPubkeyLink } from "../pubkey-links.ts";
 import { upsertService } from "../services-manifest.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
-import { createUser } from "../users.ts";
+import { createUser, getUserById, vaultVerbsForUserVault } from "../users.ts";
 
 const ISSUER = "http://127.0.0.1:1939";
 const MCP_URL = `${ISSUER}/account/mcp`;
@@ -410,7 +413,7 @@ describe("account MCP — transport", () => {
 });
 
 describe("account MCP — initialize + tools", () => {
-  test("Bearer account:self:vaults initializes and lists the three tools", async () => {
+  test("Bearer account:self:vaults initializes and lists the account-MCP tools", async () => {
     const h = await makeHarness();
     try {
       const token = await bearer(h, [ACCOUNT_VAULTS_SCOPE]);
@@ -434,6 +437,9 @@ describe("account MCP — initialize + tools", () => {
         "list-vaults",
         "create-vault",
         "query-notes",
+        "grant-access",
+        "revoke-access",
+        "list-access",
       ]);
     } finally {
       h.cleanup();
@@ -942,6 +948,398 @@ describe("account MCP — hubFetch wiring", () => {
       const body = (await res.json()) as { scopes_supported: string[]; resource: string };
       expect(body.resource).toBe(MCP_URL);
       expect(body.scopes_supported).toEqual([ACCOUNT_VAULTS_UNNARROWED]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — grant-access", () => {
+  test("NIP-98 owner grant-first: unknown pubkey becomes a key-only user and can list the vault", async () => {
+    const h = await makeHarness();
+    try {
+      const granted = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await granted.json()) as { result: { content: Array<{ text: string }> } },
+      ) as {
+        pubkey: string;
+        vault: string;
+        role: string;
+        created_user: boolean;
+        unrestricted: boolean;
+        user_id: string;
+      };
+      expect(payload.pubkey).toBe(OTHER_PUBKEY);
+      expect(payload.vault).toBe("beta");
+      expect(payload.role).toBe("write");
+      expect(payload.created_user).toBe(true);
+      expect(payload.unrestricted).toBe(false);
+      const link = findPubkeyLink(h.db, OTHER_PUBKEY);
+      expect(link?.userId).toBe(payload.user_id);
+      expect(vaultVerbsForUserVault(h.db, payload.user_id, "beta")).toEqual([
+        "read",
+        "write",
+        "admin",
+      ]);
+      expect(vaultVerbsForUserVault(h.db, payload.user_id, "personal")).toBeNull();
+
+      const listed = await handleAccountMcp(
+        nostrReq(OTHER_SECRET, rpc("tools/call", { name: "list-vaults", arguments: {} })),
+        mcpDeps(h),
+      );
+      const coverage = parseTool(
+        (await listed.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { covered: string; vaults: Array<{ name: string }> };
+      expect(coverage.covered).toBe("listed");
+      expect(coverage.vaults.map((v) => v.name)).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("second grant upserts role and does not wipe other vaults", async () => {
+    const h = await makeHarness();
+    try {
+      await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "personal", role: "read" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const second = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "read" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await second.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { created_user: boolean; user_id: string };
+      expect(payload.created_user).toBe(false);
+      expect(vaultVerbsForUserVault(h.db, payload.user_id, "beta")).toEqual(["read"]);
+      expect(getUserById(h.db, payload.user_id)?.assignedVaults.sort()).toEqual([
+        "beta",
+        "personal",
+      ]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend with write on beta can grant beta, not personal", async () => {
+    const h = await makeHarness();
+    try {
+      const ok = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "read" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await ok.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string };
+      expect(payload.vault).toBe("beta");
+
+      const denied = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "personal", role: "read" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await denied.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("grant_not_permitted");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("read-role assignee cannot grant", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("44".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    try {
+      const reader = await createUser(h.db, "reader", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "c".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const res = await handleAccountMcp(
+        nostrReq(
+          readerSecret,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "read" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("grant_not_permitted");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("granting the owner pubkey is unrestricted and writes no user_vaults row", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OWNER_PUBKEY, vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { unrestricted: boolean; user_id: string };
+      expect(payload.unrestricted).toBe(true);
+      expect(payload.user_id).toBe(h.ownerId);
+      expect(getUserById(h.db, h.ownerId)?.assignedVaults).toEqual([]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("invalid pubkey / missing vault / unknown vault / npub", async () => {
+    const h = await makeHarness();
+    try {
+      const npub = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: "npub1qqqqqqq", vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await npub.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("invalid_pubkey");
+
+      const missing = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await missing.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("invalid_vault");
+
+      const unknown = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "ghost", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await unknown.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("vault_not_installed");
+
+      const badRole = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "admin" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await badRole.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("invalid_role");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("revoke drops the row, leaves the user, refuses the owner", async () => {
+    const h = await makeHarness();
+    try {
+      const granted = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const g = parseTool(
+        (await granted.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { user_id: string };
+
+      const revoked = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "revoke-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const r = parseTool(
+        (await revoked.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { revoked: boolean };
+      expect(r.revoked).toBe(true);
+      expect(getUserById(h.db, g.user_id)).not.toBeNull();
+      expect(vaultVerbsForUserVault(h.db, g.user_id, "beta")).toBeNull();
+      expect(findPubkeyLink(h.db, OTHER_PUBKEY)?.userId).toBe(g.user_id);
+
+      const ownerRevoke = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "revoke-access",
+            arguments: { pubkey: OWNER_PUBKEY, vault: "beta" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      expect(
+        ((await ownerRevoke.json()) as { error?: { data?: { error_type?: string } } }).error?.data
+          ?.error_type,
+      ).toBe("target_is_hub_admin");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("list-access is pubkey-shaped; friend sees only vaults they can admin", async () => {
+    const h = await makeHarness();
+    try {
+      await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "personal", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "beta", role: "read" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+
+      const ownerList = await handleAccountMcp(
+        nostrReq(OWNER_SECRET, rpc("tools/call", { name: "list-access", arguments: {} })),
+        mcpDeps(h),
+      );
+      const ownerRows = parseTool(
+        (await ownerList.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { access: Array<{ pubkey: string; vault: string; role: string }> };
+      expect(
+        ownerRows.access
+          .filter((a) => a.pubkey === OTHER_PUBKEY)
+          .map((a) => a.vault)
+          .sort(),
+      ).toEqual(["beta", "personal"]);
+
+      const friendList = await handleAccountMcp(
+        nostrReq(FRIEND_SECRET, rpc("tools/call", { name: "list-access", arguments: {} })),
+        mcpDeps(h),
+      );
+      const friendRows = parseTool(
+        (await friendList.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { access: Array<{ pubkey: string; vault: string }> };
+      expect(friendRows.access.every((a) => a.vault === "beta")).toBe(true);
+      expect(friendRows.access.some((a) => a.pubkey === OTHER_PUBKEY)).toBe(true);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("Bearer host:admin can grant", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", {
+            name: "grant-access",
+            arguments: { pubkey: OTHER_PUBKEY, vault: "personal", role: "write" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const payload = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { created_user: boolean; vault: string };
+      expect(payload.created_user).toBe(true);
+      expect(payload.vault).toBe("personal");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/auth.test.ts
+++ b/src/__tests__/auth.test.ts
@@ -268,6 +268,7 @@ describe("authHelp", () => {
   test("lists every blessed subcommand", () => {
     expect(h).toContain("parachute auth set-password");
     expect(h).toContain("parachute auth list-users");
+    expect(h).toContain("parachute auth link-pubkey");
     expect(h).toContain("parachute auth 2fa");
     expect(h).toContain("parachute auth rotate-key");
     expect(h).toContain("parachute auth reap-clients");
@@ -2442,5 +2443,95 @@ describe("parachute auth revoke-token", () => {
   test("authHelp lists revoke-token alongside mint-token", () => {
     expect(authHelp()).toContain("revoke-token");
     expect(authHelp()).toContain("revoke-token <jti>");
+  });
+});
+
+describe("parachute auth link-pubkey", () => {
+  const OWNER_PUB = "11".repeat(32);
+  const OTHER_PUB = "22".repeat(32);
+
+  test("binds a hex pubkey to --user owner", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = { dbPath: tmp.dbPath, isInteractive: () => false };
+      await captureOutput(() =>
+        auth(["set-password", "--username", "owner", "--password", "pw"], deps),
+      );
+      const { code, stdout, stderr } = await captureOutput(() =>
+        auth(["link-pubkey", "--user", "owner", OWNER_PUB], deps),
+      );
+      expect(stderr).toBe("");
+      expect(code).toBe(0);
+      expect(stdout).toContain("Linked pubkey");
+      expect(stdout).toContain(OWNER_PUB);
+      expect(stdout).toContain("owner");
+      const db = openHubDb(tmp.dbPath);
+      try {
+        const { findPubkeyLink } = await import("../pubkey-links.ts");
+        const link = findPubkeyLink(db, OWNER_PUB);
+        expect(link).not.toBeNull();
+        const users = listUsers(db);
+        expect(link?.userId).toBe(users[0]?.id);
+      } finally {
+        db.close();
+      }
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("refuses npub and mixed-case hex", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = { dbPath: tmp.dbPath, isInteractive: () => false };
+      await captureOutput(() =>
+        auth(["set-password", "--username", "owner", "--password", "pw"], deps),
+      );
+      const npub = await captureOutput(() =>
+        auth(["link-pubkey", "--user", "owner", "npub1qqqqqqq"], deps),
+      );
+      expect(npub.code).toBe(1);
+      expect(npub.stderr).toContain("lowercase-hex");
+      const mixed = await captureOutput(() =>
+        auth(["link-pubkey", "--user", "owner", "AA".repeat(32)], deps),
+      );
+      expect(mixed.code).toBe(1);
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("refuses a pubkey already bound to another user", async () => {
+    const tmp = makeTmp();
+    try {
+      const deps: AuthDeps = { dbPath: tmp.dbPath, isInteractive: () => false };
+      await captureOutput(() =>
+        auth(["set-password", "--username", "owner", "--password", "pw"], deps),
+      );
+      const db = openHubDb(tmp.dbPath);
+      await createUser(db, "alice", "alice-strong-passphrase", { allowMulti: true });
+      db.close();
+      await captureOutput(() => auth(["link-pubkey", "--user", "owner", OTHER_PUB], deps));
+      const taken = await captureOutput(() =>
+        auth(["link-pubkey", "--user", "alice", OTHER_PUB], deps),
+      );
+      expect(taken.code).toBe(1);
+      expect(taken.stderr).toContain("already bound");
+    } finally {
+      tmp.cleanup();
+    }
+  });
+
+  test("requires --user", async () => {
+    const tmp = makeTmp();
+    try {
+      const { code, stderr } = await captureOutput(() =>
+        auth(["link-pubkey", OWNER_PUB], { dbPath: tmp.dbPath }),
+      );
+      expect(code).toBe(1);
+      expect(stderr).toContain("--user is required");
+    } finally {
+      tmp.cleanup();
+    }
   });
 });

--- a/src/__tests__/users.test.ts
+++ b/src/__tests__/users.test.ts
@@ -22,9 +22,11 @@ import {
   isSeedAdminUsername,
   listUnlinkableUsernames,
   listUsers,
+  removeUserVault,
   resetUserPassword,
   setPassword,
   setUserVaults,
+  upsertUserVault,
   userCount,
   validateEmail,
   validatePassword,
@@ -846,6 +848,77 @@ describe("setUserVaults (multi-user Phase 2 PR 2)", () => {
         .query<{ n: number }, [string]>("SELECT COUNT(*) AS n FROM user_vaults WHERE user_id = ?")
         .get(u.id);
       expect(after?.n).toBe(0);
+    } finally {
+      cleanup();
+    }
+  });
+});
+
+describe("upsertUserVault / removeUserVault", () => {
+  test("returns false when user does not exist", () => {
+    const { db, cleanup } = makeDb();
+    try {
+      expect(upsertUserVault(db, "no-such-id", "beta", "write")).toBe(false);
+      expect(removeUserVault(db, "no-such-id", "beta")).toBe(false);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("inserts one vault without wiping others", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase", {
+        allowMulti: true,
+        assignedVaults: ["personal"],
+      });
+      expect(upsertUserVault(db, u.id, "beta", "read")).toBe(true);
+      const fresh = getUserById(db, u.id);
+      expect(new Set(fresh?.assignedVaults)).toEqual(new Set(["personal", "beta"]));
+      expect(vaultVerbsForUserVault(db, u.id, "beta")).toEqual(["read"]);
+      expect(vaultVerbsForUserVault(db, u.id, "personal")).toEqual(["read", "write", "admin"]);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("ON CONFLICT updates role and preserves created_at", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase", {
+        allowMulti: true,
+        assignedVaults: ["beta"],
+        now: () => new Date(1000),
+      });
+      const before = db
+        .query<{ created_at: string }, [string, string]>(
+          "SELECT created_at FROM user_vaults WHERE user_id = ? AND vault_name = ?",
+        )
+        .get(u.id, "beta");
+      expect(upsertUserVault(db, u.id, "beta", "read", () => new Date(2000))).toBe(true);
+      const after = db
+        .query<{ created_at: string; role: string }, [string, string]>(
+          "SELECT created_at, role FROM user_vaults WHERE user_id = ? AND vault_name = ?",
+        )
+        .get(u.id, "beta");
+      expect(after?.role).toBe("read");
+      expect(after?.created_at).toBe(before?.created_at);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("removeUserVault drops one row and leaves the rest", async () => {
+    const { db, cleanup } = makeDb();
+    try {
+      const u = await createUser(db, "alice", "alice-strong-passphrase", {
+        allowMulti: true,
+        assignedVaults: ["a", "b"],
+      });
+      expect(removeUserVault(db, u.id, "a")).toBe(true);
+      expect(removeUserVault(db, u.id, "a")).toBe(false);
+      const fresh = getUserById(db, u.id);
+      expect(fresh?.assignedVaults).toEqual(["b"]);
     } finally {
       cleanup();
     }

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -278,7 +278,9 @@ function instructions(): string {
   return (
     "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
     "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
-    "and query-notes to search across them (omit `vault` to fan out, pass it to target one)."
+    "and query-notes to search across them (omit `vault` to fan out, pass it to target one). " +
+    "grant-access / revoke-access / list-access give a Nostr pubkey a vault (role read|write) " +
+    "if you can admin that vault."
   );
 }
 

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -3,8 +3,10 @@
  * `/account/mcp`.
  *
  * Cloud's twin lives in the identity worker (`account-mcp.ts`). Same three
- * tools (list-vaults, create-vault, query-notes), same "no vault_token in
- * model context" rule. Coverage is hub-shaped, not D1-ownership-shaped:
+ * coverage tools (list-vaults, create-vault, query-notes), same "no vault_token
+ * in model context" rule. Hub adds grant-access / revoke-access / list-access
+ * (pubkey → one `user_vaults` row). Those three are hub-only: cloud grants are
+ * D1-ownership shaped, not `user_vaults`. Coverage is hub-shaped:
  *
  *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
  *     (legacy blanket / narrowed) or composed `account:self:vaults:*:<verb>`,
@@ -29,6 +31,7 @@ import {
 } from "@openparachute/door-contract";
 import { type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
 import { HOST_ADMIN_SCOPE, provisionVault } from "./admin-vaults.ts";
+import { GrantError, grantAccess, listAccess, revokeAccess } from "./grant-access.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
 
@@ -399,9 +402,111 @@ const queryNotesTool: AccountMcpTool = {
   },
 };
 
+function installedNameSet(ctx: AccountToolContext): Set<string> {
+  return new Set(installedVaults(ctx).map((v) => v.name));
+}
+
+function throwGrant(err: unknown): never {
+  if (err instanceof GrantError) throw new AccountToolError(err.errorType, err.message);
+  throw err;
+}
+
+const grantAccessTool: AccountMcpTool = {
+  name: "grant-access",
+  description:
+    "Give a Nostr pubkey access to one vault. Creates a key-only hub user if the " +
+    "pubkey is not yet linked. Writes one user_vaults row — does not replace the " +
+    "target's other vaults. Role is read or write and cannot be granted unless you " +
+    "can admin that vault.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      pubkey: {
+        type: "string",
+        description: "64-character lowercase-hex x-only Nostr public key.",
+      },
+      vault: { type: "string", description: "Installed vault name." },
+      role: {
+        type: "string",
+        enum: ["read", "write"],
+        description: 'Access role. "write" is full vault authority (read/write/admin).',
+      },
+    },
+    required: ["pubkey", "vault", "role"],
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    try {
+      return await grantAccess(
+        ctx.db,
+        ctx.principal,
+        args,
+        installedNameSet(ctx),
+        ctx.now ?? (() => new Date()),
+      );
+    } catch (err) {
+      throwGrant(err);
+    }
+  },
+};
+
+const revokeAccessTool: AccountMcpTool = {
+  name: "revoke-access",
+  description:
+    "Remove one vault grant from a Nostr pubkey. Leaves the hub user and any other " +
+    "vaults in place. Refuses the hub owner (unrestricted by construction).",
+  inputSchema: {
+    type: "object",
+    properties: {
+      pubkey: {
+        type: "string",
+        description: "64-character lowercase-hex x-only Nostr public key.",
+      },
+      vault: { type: "string", description: "Installed vault name." },
+    },
+    required: ["pubkey", "vault"],
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    try {
+      return revokeAccess(ctx.db, ctx.principal, args, installedNameSet(ctx));
+    } catch (err) {
+      throwGrant(err);
+    }
+  },
+};
+
+const listAccessTool: AccountMcpTool = {
+  name: "list-access",
+  description:
+    "List pubkey → vault grants this connection can admin. Omit `vault` for every " +
+    "such grant; pass it to filter to one vault. Password-only users without a " +
+    "linked key are not included.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      vault: {
+        type: "string",
+        description: "Restrict to one installed vault. Omit to list every vault you can admin.",
+      },
+    },
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    try {
+      return listAccess(ctx.db, ctx.principal, args, installedNameSet(ctx));
+    } catch (err) {
+      throwGrant(err);
+    }
+  },
+};
+
 /** Order is stable so `tools/list` is deterministic. */
 export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
   listVaultsTool,
   createVaultTool,
   queryNotesTool,
+  grantAccessTool,
+  revokeAccessTool,
+  listAccessTool,
 ];

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -56,6 +56,7 @@ import {
   issueOperatorToken,
   useOperatorTokenWithAutoRotate,
 } from "../operator-token.ts";
+import { bindPubkeyFromHttpAuth, findPubkeyLink, isPubkeyHex } from "../pubkey-links.ts";
 import { isNonRequestableScope } from "../scope-explanations.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import { generateTotpSecret, otpauthUrlFor, verifyTotpCode } from "../totp.ts";
@@ -101,6 +102,7 @@ const HUB_LOCAL_SUBCOMMANDS = new Set([
   "2fa",
   "set-password",
   "list-users",
+  "link-pubkey",
   "rotate-operator",
   "mint-token",
   "revoke-token",
@@ -119,6 +121,10 @@ Usage:
   parachute auth set-password [--username <name>] [--password <pw>] [--allow-multi]
                                        Create or update the hub user's password
   parachute auth list-users            Show registered hub accounts
+  parachute auth link-pubkey --user <name> <pubkey>
+                                       Bind a Nostr pubkey to an existing hub
+                                       user (operator-attested; no SPA ceremony).
+                                       pubkey is 64-char lowercase hex.
   parachute auth 2fa [status]          Show hub-login 2FA (TOTP) status
   parachute auth 2fa enroll [--username <name>]
                                        Enroll TOTP for hub login (prints the
@@ -1643,6 +1649,106 @@ async function run2fa(args: readonly string[], deps: AuthDeps): Promise<number> 
   }
 }
 
+interface LinkPubkeyFlags {
+  user?: string;
+  pubkey?: string;
+  error?: string;
+}
+
+function parseLinkPubkeyFlags(args: readonly string[]): LinkPubkeyFlags {
+  let user: string | undefined;
+  const rest: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    const a = args[i];
+    if (a === "--user") {
+      const v = args[++i];
+      if (!v) return { error: "--user requires a value" };
+      user = v;
+    } else if (a?.startsWith("--user=")) {
+      user = a.slice("--user=".length);
+      if (!user) return { error: "--user requires a value" };
+    } else if (a === "--username") {
+      const v = args[++i];
+      if (!v) return { error: "--username requires a value" };
+      user = v;
+    } else if (a?.startsWith("--username=")) {
+      user = a.slice("--username=".length);
+      if (!user) return { error: "--username requires a value" };
+    } else if (a !== undefined) {
+      rest.push(a);
+    }
+  }
+  if (rest.length === 0) return { user, error: "missing pubkey argument" };
+  if (rest.length > 1) return { user, error: `unexpected argument "${rest[1]}"` };
+  return { user, pubkey: rest[0] };
+}
+
+/**
+ * `parachute auth link-pubkey --user owner <hex>` — operator bind.
+ *
+ * On-box privilege: the operator asserts this key belongs to this hub user.
+ * No NIP-07 ceremony, no possession proof. That is the point — agents cannot
+ * click the Account SPA, and the 5-minute challenge expires unconsumed.
+ */
+function runLinkPubkey(args: readonly string[], deps: AuthDeps): number {
+  const flags = parseLinkPubkeyFlags(args);
+  if (flags.error) {
+    console.error(`parachute auth link-pubkey: ${flags.error}`);
+    console.error("usage: parachute auth link-pubkey --user <username|id> <pubkey-hex>");
+    return 1;
+  }
+  if (!flags.user) {
+    console.error("parachute auth link-pubkey: --user is required");
+    console.error("usage: parachute auth link-pubkey --user <username|id> <pubkey-hex>");
+    return 1;
+  }
+  const pubkey = flags.pubkey ?? "";
+  if (pubkey.startsWith("npub") || !isPubkeyHex(pubkey)) {
+    console.error(
+      "parachute auth link-pubkey: pubkey must be a 64-character lowercase-hex x-only key (not npub)",
+    );
+    return 1;
+  }
+  const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
+  try {
+    const target = resolveUser(db, flags.user);
+    if (!target) {
+      console.error(`parachute auth link-pubkey: no hub user "${flags.user}"`);
+      return 1;
+    }
+    const existing = findPubkeyLink(db, pubkey);
+    if (existing && existing.userId !== target.id) {
+      console.error("parachute auth link-pubkey: that pubkey is already bound to another user");
+      return 1;
+    }
+    const bound = bindPubkeyFromHttpAuth(db, {
+      userId: target.id,
+      pubkey,
+      proofEvent: JSON.stringify({ source: "operator" }),
+      proofEventId: "0".repeat(64),
+      label: "operator",
+    });
+    if (!bound.ok) {
+      if (bound.reason === "too_many_pubkeys") {
+        console.error(
+          "parachute auth link-pubkey: this user already has the maximum number of linked keys",
+        );
+        return 1;
+      }
+      console.error("parachute auth link-pubkey: that pubkey is already bound to another user");
+      return 1;
+    }
+    console.log(
+      bound.relinked
+        ? `Relinked pubkey ${pubkey} to "${target.username}" (${target.id}).`
+        : `Linked pubkey ${pubkey} to "${target.username}" (${target.id}).`,
+    );
+    return 0;
+  } finally {
+    db.close();
+  }
+}
+
 function runListUsers(deps: AuthDeps): number {
   const db = deps.dbPath ? openHubDb(deps.dbPath) : openHubDb();
   try {
@@ -1712,6 +1818,15 @@ export async function auth(args: readonly string[], deps: AuthDeps | Runner = {}
     }
     if (sub === "list-users") {
       return runListUsers(normalized);
+    }
+    if (sub === "link-pubkey") {
+      try {
+        return runLinkPubkey(args.slice(1), normalized);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`parachute auth link-pubkey: ${msg}`);
+        return 1;
+      }
     }
     if (sub === "rotate-operator") {
       try {

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -56,7 +56,7 @@ import {
   issueOperatorToken,
   useOperatorTokenWithAutoRotate,
 } from "../operator-token.ts";
-import { bindPubkeyFromHttpAuth, findPubkeyLink, isPubkeyHex } from "../pubkey-links.ts";
+import { bindPubkeyOperatorAttested, findPubkeyLink, isPubkeyHex } from "../pubkey-links.ts";
 import { isNonRequestableScope } from "../scope-explanations.ts";
 import { rotateSigningKey } from "../signing-keys.ts";
 import { generateTotpSecret, otpauthUrlFor, verifyTotpCode } from "../totp.ts";
@@ -1721,11 +1721,9 @@ function runLinkPubkey(args: readonly string[], deps: AuthDeps): number {
       console.error("parachute auth link-pubkey: that pubkey is already bound to another user");
       return 1;
     }
-    const bound = bindPubkeyFromHttpAuth(db, {
+    const bound = bindPubkeyOperatorAttested(db, {
       userId: target.id,
       pubkey,
-      proofEvent: JSON.stringify({ source: "operator" }),
-      proofEventId: "0".repeat(64),
       label: "operator",
     });
     if (!bound.ok) {

--- a/src/grant-access.ts
+++ b/src/grant-access.ts
@@ -6,11 +6,14 @@
  * hub user when the pubkey is unknown. Auto-provision stays off: grant-first
  * is how an unlinked key becomes a user.
  *
- * Grant is an admin verb on the vault. First-admin / host:admin can grant any
- * installed vault. Anyone else needs `vaultVerbsForUserVault` to include
- * `admin` (today: `user_vaults.role = 'write'`). Role on the grant is `read`
- * or `write` and cannot exceed what the stored role model allows the caller
- * to hold — a read-only assignee cannot grant.
+ * Grant is an admin verb on the vault. NIP-98 first-admin and Bearer
+ * `parachute:host:admin` (wildcard `admin`) can grant any installed vault.
+ * A Bearer connection still has to cover the vault: a named subset cannot
+ * grant outside it, and a named composed verb must satisfy `admin`. Legacy
+ * `account:vaults` / `account:self:vaults` are coverage wildcards (verb
+ * `read`) — they do not cap the verb; first-admin or a write assignee does.
+ * Anyone else needs `vaultVerbsForUserVault` to include `admin` (today:
+ * `user_vaults.role = 'write'`). A read-only assignee cannot grant.
  *
  * First-admin is unrestricted by empty `user_vaults`, not by rows. Granting
  * to the owner's pubkey is a no-op success (`unrestricted: true`); we never
@@ -22,11 +25,13 @@
  */
 import type { Database } from "bun:sqlite";
 import { randomBytes } from "node:crypto";
-import { bindPubkeyFromHttpAuth, findPubkeyLink, isPubkeyHex } from "./pubkey-links.ts";
+import { composedVerbSatisfies, isComposedVaultVerb } from "@openparachute/door-contract";
+import { bindPubkeyOperatorAttested, findPubkeyLink, isPubkeyHex } from "./pubkey-links.ts";
 import {
   UsernameTakenError,
   createUser,
-  getUserByUsername,
+  deleteUser,
+  getFirstAdminId,
   isFirstAdmin,
   removeUserVault,
   upsertUserVault,
@@ -50,7 +55,10 @@ export interface GrantCaller {
   userId: string;
   isHubAdmin: boolean;
   authKind: "bearer" | "nostr";
-  grant: { wildcard: string | null; vaults: { has(name: string): boolean } } | null;
+  grant: {
+    wildcard: string | null;
+    vaults: { has(name: string): boolean; get(name: string): string | undefined };
+  } | null;
 }
 
 export interface GrantResult {
@@ -115,25 +123,45 @@ export function parseGrantVault(raw: unknown): string {
   return raw.trim().toLowerCase();
 }
 
+function bearerCoversVaultForGrant(
+  grant: NonNullable<GrantCaller["grant"]>,
+  vaultName: string,
+): boolean {
+  // host:admin synthesizes wildcard admin — unrestricted.
+  if (grant.wildcard === "admin") return true;
+  if (grant.wildcard !== null) {
+    // Legacy/composed coverage wildcard (`account:vaults`, `account:self:vaults`,
+    // `account:self:vaults:*:<verb>`). This is coverage, not a per-vault verb
+    // cap — assignment (or first-admin) still has to allow the grant.
+    return true;
+  }
+  const named = grant.vaults.get(vaultName);
+  if (named === undefined) return false;
+  return isComposedVaultVerb(named) && composedVerbSatisfies(named, "admin");
+}
+
 /**
  * True when the caller may grant/revoke/list this vault.
  *
- * Hub admin (first-admin or host:admin token) is unrestricted across
- * installed vaults. Everyone else needs the `admin` verb on the vault
- * (`role = 'write'` today). A Bearer connection that names a vault subset
- * cannot grant outside that subset.
+ * NIP-98 first-admin is unrestricted across installed vaults. Bearer
+ * `parachute:host:admin` (wildcard `admin`) is too. A Bearer that names a
+ * vault subset cannot grant outside it; a named composed verb must satisfy
+ * `admin`. Everyone else needs the `admin` verb on the vault
+ * (`role = 'write'` today).
  */
 export function callerCanAdminVault(db: Database, caller: GrantCaller, vaultName: string): boolean {
-  if (caller.isHubAdmin || isFirstAdmin(db, caller.userId)) return true;
-  const verbs = vaultVerbsForUserVault(db, caller.userId, vaultName);
-  if (!verbs?.includes("admin")) return false;
   if (caller.authKind === "bearer") {
     const grant = caller.grant;
     if (!grant) return false;
-    if (grant.wildcard !== null) return true;
-    return grant.vaults.has(vaultName);
+    if (!bearerCoversVaultForGrant(grant, vaultName)) return false;
+    if (grant.wildcard === "admin") return true;
+    if (isFirstAdmin(db, caller.userId)) return true;
+    const verbs = vaultVerbsForUserVault(db, caller.userId, vaultName);
+    return verbs?.includes("admin") === true;
   }
-  return true;
+  if (caller.isHubAdmin || isFirstAdmin(db, caller.userId)) return true;
+  const verbs = vaultVerbsForUserVault(db, caller.userId, vaultName);
+  return verbs?.includes("admin") === true;
 }
 
 async function ensureUserForPubkey(
@@ -148,6 +176,13 @@ async function ensureUserForPubkey(
       username: lookupUsername(db, existing.userId),
       created: false,
     };
+  }
+
+  if (getFirstAdminId(db) === null) {
+    throw new GrantError(
+      "no_hub_owner",
+      "Grant-first cannot create the hub owner. Create an owner first.",
+    );
   }
 
   const password = randomBytes(32).toString("base64url");
@@ -180,10 +215,10 @@ async function ensureUserForPubkey(
               created: false,
             };
           }
-          const taken = getUserByUsername(db, usernameForPubkey(pubkey));
-          if (taken) {
-            return { userId: taken.id, username: taken.username, created: false };
-          }
+          throw new GrantError(
+            "username_taken",
+            "Could not allocate a hub username for that pubkey.",
+          );
         }
         throw err2;
       }
@@ -192,16 +227,15 @@ async function ensureUserForPubkey(
     }
   }
 
-  const bound = bindPubkeyFromHttpAuth(db, {
+  const bound = bindPubkeyOperatorAttested(db, {
     userId: user.id,
     pubkey,
-    proofEvent: JSON.stringify({ source: "grant-access" }),
-    proofEventId: "0".repeat(64),
     label: "grant",
     now: now(),
   });
   if (!bound.ok) {
     const raced = findPubkeyLink(db, pubkey);
+    deleteUser(db, user.id);
     if (raced) {
       return { userId: raced.userId, username: lookupUsername(db, raced.userId), created: false };
     }

--- a/src/grant-access.ts
+++ b/src/grant-access.ts
@@ -1,0 +1,343 @@
+/**
+ * Grant / revoke / list vault access by Nostr pubkey.
+ *
+ * This is the hub-shaped "this key, this vault, this role" loop. It writes
+ * one `user_vaults` row at a time (never replace-all) and creates a key-only
+ * hub user when the pubkey is unknown. Auto-provision stays off: grant-first
+ * is how an unlinked key becomes a user.
+ *
+ * Grant is an admin verb on the vault. First-admin / host:admin can grant any
+ * installed vault. Anyone else needs `vaultVerbsForUserVault` to include
+ * `admin` (today: `user_vaults.role = 'write'`). Role on the grant is `read`
+ * or `write` and cannot exceed what the stored role model allows the caller
+ * to hold — a read-only assignee cannot grant.
+ *
+ * First-admin is unrestricted by empty `user_vaults`, not by rows. Granting
+ * to the owner's pubkey is a no-op success (`unrestricted: true`); we never
+ * insert a row that would collapse that sentinel. Revoking the owner is
+ * refused.
+ *
+ * Cloud's account-MCP twin is identity-worker shaped and does not grow these
+ * tools. Hub-only on purpose.
+ */
+import type { Database } from "bun:sqlite";
+import { randomBytes } from "node:crypto";
+import { bindPubkeyFromHttpAuth, findPubkeyLink, isPubkeyHex } from "./pubkey-links.ts";
+import {
+  UsernameTakenError,
+  createUser,
+  getUserByUsername,
+  isFirstAdmin,
+  removeUserVault,
+  upsertUserVault,
+  vaultVerbsForUserVault,
+} from "./users.ts";
+
+export const GRANTABLE_ROLES = ["read", "write"] as const;
+export type GrantableRole = (typeof GRANTABLE_ROLES)[number];
+
+export class GrantError extends Error {
+  constructor(
+    public readonly errorType: string,
+    message: string,
+  ) {
+    super(message);
+    this.name = "GrantError";
+  }
+}
+
+export interface GrantCaller {
+  userId: string;
+  isHubAdmin: boolean;
+  authKind: "bearer" | "nostr";
+  grant: { wildcard: string | null; vaults: { has(name: string): boolean } } | null;
+}
+
+export interface GrantResult {
+  pubkey: string;
+  vault: string;
+  role: GrantableRole;
+  user_id: string;
+  username: string;
+  created_user: boolean;
+  unrestricted: boolean;
+}
+
+export interface RevokeResult {
+  pubkey: string;
+  vault: string;
+  revoked: boolean;
+}
+
+export interface AccessRow {
+  pubkey: string;
+  vault: string;
+  role: string;
+  user_id: string;
+  username: string;
+}
+
+function usernameForPubkey(pubkey: string): string {
+  return `n${pubkey.slice(0, 31)}`;
+}
+
+export function parseGrantPubkey(raw: unknown): string {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new GrantError("invalid_pubkey", "pubkey is required.");
+  }
+  if (raw.startsWith("npub")) {
+    throw new GrantError(
+      "invalid_pubkey",
+      "pubkey must be a 64-character lowercase-hex x-only key, not an npub.",
+    );
+  }
+  if (!isPubkeyHex(raw)) {
+    throw new GrantError(
+      "invalid_pubkey",
+      "pubkey must be a 64-character lowercase-hex x-only public key.",
+    );
+  }
+  return raw;
+}
+
+export function parseGrantRole(raw: unknown): GrantableRole {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new GrantError("invalid_role", "role is required (read or write).");
+  }
+  if ((GRANTABLE_ROLES as readonly string[]).includes(raw)) return raw as GrantableRole;
+  throw new GrantError("invalid_role", 'role must be "read" or "write".');
+}
+
+export function parseGrantVault(raw: unknown): string {
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new GrantError("invalid_vault", "vault is required.");
+  }
+  return raw.trim().toLowerCase();
+}
+
+/**
+ * True when the caller may grant/revoke/list this vault.
+ *
+ * Hub admin (first-admin or host:admin token) is unrestricted across
+ * installed vaults. Everyone else needs the `admin` verb on the vault
+ * (`role = 'write'` today). A Bearer connection that names a vault subset
+ * cannot grant outside that subset.
+ */
+export function callerCanAdminVault(db: Database, caller: GrantCaller, vaultName: string): boolean {
+  if (caller.isHubAdmin || isFirstAdmin(db, caller.userId)) return true;
+  const verbs = vaultVerbsForUserVault(db, caller.userId, vaultName);
+  if (!verbs?.includes("admin")) return false;
+  if (caller.authKind === "bearer") {
+    const grant = caller.grant;
+    if (!grant) return false;
+    if (grant.wildcard !== null) return true;
+    return grant.vaults.has(vaultName);
+  }
+  return true;
+}
+
+async function ensureUserForPubkey(
+  db: Database,
+  pubkey: string,
+  now: () => Date,
+): Promise<{ userId: string; username: string; created: boolean }> {
+  const existing = findPubkeyLink(db, pubkey);
+  if (existing) {
+    return {
+      userId: existing.userId,
+      username: lookupUsername(db, existing.userId),
+      created: false,
+    };
+  }
+
+  const password = randomBytes(32).toString("base64url");
+  let username = usernameForPubkey(pubkey);
+  let user: Awaited<ReturnType<typeof createUser>>;
+  try {
+    user = await createUser(db, username, password, {
+      allowMulti: true,
+      passwordChanged: true,
+      assignedVaults: [],
+      now,
+    });
+  } catch (err) {
+    if (err instanceof UsernameTakenError) {
+      username = `n${pubkey.slice(1, 32)}`;
+      try {
+        user = await createUser(db, username, password, {
+          allowMulti: true,
+          passwordChanged: true,
+          assignedVaults: [],
+          now,
+        });
+      } catch (err2) {
+        if (err2 instanceof UsernameTakenError) {
+          const raced = findPubkeyLink(db, pubkey);
+          if (raced) {
+            return {
+              userId: raced.userId,
+              username: lookupUsername(db, raced.userId),
+              created: false,
+            };
+          }
+          const taken = getUserByUsername(db, usernameForPubkey(pubkey));
+          if (taken) {
+            return { userId: taken.id, username: taken.username, created: false };
+          }
+        }
+        throw err2;
+      }
+    } else {
+      throw err;
+    }
+  }
+
+  const bound = bindPubkeyFromHttpAuth(db, {
+    userId: user.id,
+    pubkey,
+    proofEvent: JSON.stringify({ source: "grant-access" }),
+    proofEventId: "0".repeat(64),
+    label: "grant",
+    now: now(),
+  });
+  if (!bound.ok) {
+    const raced = findPubkeyLink(db, pubkey);
+    if (raced) {
+      return { userId: raced.userId, username: lookupUsername(db, raced.userId), created: false };
+    }
+    throw new GrantError("pubkey_taken", "That pubkey is already bound to another user.");
+  }
+  return { userId: user.id, username: user.username, created: true };
+}
+
+function lookupUsername(db: Database, userId: string): string {
+  const row = db
+    .query<{ username: string }, [string]>("SELECT username FROM users WHERE id = ?")
+    .get(userId);
+  return row?.username ?? userId;
+}
+
+export async function grantAccess(
+  db: Database,
+  caller: GrantCaller,
+  args: { pubkey: unknown; vault: unknown; role: unknown },
+  installed: ReadonlySet<string>,
+  now: () => Date = () => new Date(),
+): Promise<GrantResult> {
+  const pubkey = parseGrantPubkey(args.pubkey);
+  const vault = parseGrantVault(args.vault);
+  const role = parseGrantRole(args.role);
+  if (!installed.has(vault)) {
+    throw new GrantError("vault_not_installed", `Vault "${vault}" is not installed on this hub.`);
+  }
+  if (!callerCanAdminVault(db, caller, vault)) {
+    throw new GrantError("grant_not_permitted", `You cannot grant access to vault "${vault}".`);
+  }
+
+  const target = await ensureUserForPubkey(db, pubkey, now);
+  if (isFirstAdmin(db, target.userId)) {
+    return {
+      pubkey,
+      vault,
+      role,
+      user_id: target.userId,
+      username: target.username,
+      created_user: target.created,
+      unrestricted: true,
+    };
+  }
+
+  const ok = upsertUserVault(db, target.userId, vault, role, now);
+  if (!ok) {
+    throw new GrantError("server_error", "Failed to write the vault grant.");
+  }
+  return {
+    pubkey,
+    vault,
+    role,
+    user_id: target.userId,
+    username: target.username,
+    created_user: target.created,
+    unrestricted: false,
+  };
+}
+
+export function revokeAccess(
+  db: Database,
+  caller: GrantCaller,
+  args: { pubkey: unknown; vault: unknown },
+  installed: ReadonlySet<string>,
+): RevokeResult {
+  const pubkey = parseGrantPubkey(args.pubkey);
+  const vault = parseGrantVault(args.vault);
+  if (!installed.has(vault)) {
+    throw new GrantError("vault_not_installed", `Vault "${vault}" is not installed on this hub.`);
+  }
+  if (!callerCanAdminVault(db, caller, vault)) {
+    throw new GrantError("grant_not_permitted", `You cannot revoke access to vault "${vault}".`);
+  }
+  const link = findPubkeyLink(db, pubkey);
+  if (!link) {
+    throw new GrantError("unknown_pubkey", "No hub user is linked to that pubkey.");
+  }
+  if (isFirstAdmin(db, link.userId)) {
+    throw new GrantError(
+      "target_is_hub_admin",
+      "The hub owner is unrestricted; vault grants on that account cannot be revoked this way.",
+    );
+  }
+  const revoked = removeUserVault(db, link.userId, vault);
+  return { pubkey, vault, revoked };
+}
+
+export function listAccess(
+  db: Database,
+  caller: GrantCaller,
+  args: { vault?: unknown },
+  installed: ReadonlySet<string>,
+): { access: AccessRow[] } {
+  let vaultFilter: string | null = null;
+  if (args.vault !== undefined && args.vault !== null && args.vault !== "") {
+    vaultFilter = parseGrantVault(args.vault);
+    if (!installed.has(vaultFilter)) {
+      throw new GrantError(
+        "vault_not_installed",
+        `Vault "${vaultFilter}" is not installed on this hub.`,
+      );
+    }
+    if (!callerCanAdminVault(db, caller, vaultFilter)) {
+      throw new GrantError(
+        "grant_not_permitted",
+        `You cannot list access for vault "${vaultFilter}".`,
+      );
+    }
+  }
+
+  const rows = db
+    .query<
+      { pubkey: string; vault_name: string; role: string; user_id: string; username: string },
+      []
+    >(
+      `SELECT up.pubkey, uv.vault_name, uv.role, u.id AS user_id, u.username
+       FROM user_vaults uv
+       JOIN users u ON u.id = uv.user_id
+       JOIN user_pubkeys up ON up.user_id = uv.user_id
+       ORDER BY uv.vault_name ASC, up.pubkey ASC`,
+    )
+    .all();
+
+  const access: AccessRow[] = [];
+  for (const r of rows) {
+    if (!installed.has(r.vault_name)) continue;
+    if (vaultFilter && r.vault_name !== vaultFilter) continue;
+    if (!callerCanAdminVault(db, caller, r.vault_name)) continue;
+    access.push({
+      pubkey: r.pubkey,
+      vault: r.vault_name,
+      role: r.role,
+      user_id: r.user_id,
+      username: r.username,
+    });
+  }
+  return { access };
+}

--- a/src/grant-access.ts
+++ b/src/grant-access.ts
@@ -220,7 +220,7 @@ function lookupUsername(db: Database, userId: string): string {
 export async function grantAccess(
   db: Database,
   caller: GrantCaller,
-  args: { pubkey: unknown; vault: unknown; role: unknown },
+  args: Record<string, unknown>,
   installed: ReadonlySet<string>,
   now: () => Date = () => new Date(),
 ): Promise<GrantResult> {
@@ -265,7 +265,7 @@ export async function grantAccess(
 export function revokeAccess(
   db: Database,
   caller: GrantCaller,
-  args: { pubkey: unknown; vault: unknown },
+  args: Record<string, unknown>,
   installed: ReadonlySet<string>,
 ): RevokeResult {
   const pubkey = parseGrantPubkey(args.pubkey);
@@ -293,7 +293,7 @@ export function revokeAccess(
 export function listAccess(
   db: Database,
   caller: GrantCaller,
-  args: { vault?: unknown },
+  args: Record<string, unknown>,
   installed: ReadonlySet<string>,
 ): { access: AccessRow[] } {
   let vaultFilter: string | null = null;

--- a/src/pubkey-links.ts
+++ b/src/pubkey-links.ts
@@ -363,6 +363,79 @@ export type BindPubkeyFromHttpAuthResult =
   | { ok: false; reason: "pubkey_taken" | "too_many_pubkeys" };
 
 /**
+ * Operator-attested bind: the hub asserts this key belongs to this user.
+ * No NIP-01 event is stored — `proof_event` is empty and nothing is written
+ * to `attribution_proofs`. Possession proofs stay in the ceremony / NIP-98
+ * paths. Same uniqueness + per-user cap as `bindPubkeyFromHttpAuth`.
+ */
+export function bindPubkeyOperatorAttested(
+  db: Database,
+  opts: {
+    userId: string;
+    pubkey: string;
+    label?: string | null;
+    now?: Date;
+  },
+): BindPubkeyFromHttpAuthResult {
+  const now = opts.now ?? new Date();
+  const stamp = now.toISOString();
+  const label = opts.label ?? "operator";
+  const run = db.transaction((): BindPubkeyFromHttpAuthResult => {
+    const existing = db
+      .query<LinkRow, [string]>("SELECT * FROM user_pubkeys WHERE pubkey = ?")
+      .get(opts.pubkey);
+    if (existing && existing.user_id !== opts.userId) {
+      return { ok: false, reason: "pubkey_taken" };
+    }
+    if (!existing) {
+      const count = (
+        db
+          .query<{ n: number }, [string]>(
+            "SELECT COUNT(*) AS n FROM user_pubkeys WHERE user_id = ?",
+          )
+          .get(opts.userId) ?? { n: 0 }
+      ).n;
+      if (count >= MAX_PUBKEYS_PER_USER) return { ok: false, reason: "too_many_pubkeys" };
+      db.prepare(
+        `INSERT INTO user_pubkeys
+           (pubkey, user_id, label, proof_event, proof_event_id, linked_at, last_verified_at)
+         VALUES (?, ?, ?, '', '', ?, ?)`,
+      ).run(opts.pubkey, opts.userId, label, stamp, stamp);
+      return {
+        ok: true,
+        relinked: false,
+        link: {
+          pubkey: opts.pubkey,
+          userId: opts.userId,
+          label,
+          proofEventId: "",
+          linkedAt: stamp,
+          lastVerifiedAt: stamp,
+        },
+      };
+    }
+    db.prepare(
+      `UPDATE user_pubkeys
+         SET label = ?, last_verified_at = ?
+       WHERE pubkey = ? AND user_id = ?`,
+    ).run(label, stamp, opts.pubkey, opts.userId);
+    return {
+      ok: true,
+      relinked: true,
+      link: {
+        pubkey: opts.pubkey,
+        userId: opts.userId,
+        label,
+        proofEventId: existing.proof_event_id,
+        linkedAt: existing.linked_at,
+        lastVerifiedAt: stamp,
+      },
+    };
+  });
+  return run();
+}
+
+/**
  * Bind `pubkey` to `userId` using a NIP-98 HTTP-auth event as the proof.
  * No challenge-response: the signed request *is* the possession proof.
  * The cookie ceremony (`linkPubkey`) stays challenge-gated.

--- a/src/pubkey-links.ts
+++ b/src/pubkey-links.ts
@@ -58,6 +58,13 @@ export const PUBKEY_CHALLENGE_TTL_MS = 5 * 60 * 1000;
  */
 export const MAX_PUBKEYS_PER_USER = 10;
 
+/** 32-byte x-only secp256k1 key, lowercase hex. Reject mixed case — don't normalize. */
+export const PUBKEY_HEX_RE = /^[0-9a-f]{64}$/;
+
+export function isPubkeyHex(value: string): boolean {
+  return PUBKEY_HEX_RE.test(value);
+}
+
 /** A verified pubkey→user link. `proofEvent` is fetched separately (it's bulky). */
 export interface LinkedPubkey {
   pubkey: string;

--- a/src/users.ts
+++ b/src/users.ts
@@ -516,6 +516,61 @@ export function setUserVaults(
 }
 
 /**
+ * Upsert one `user_vaults` row. Does not touch the user's other vaults —
+ * unlike `setUserVaults`, which is replace-all. Grant-by-pubkey uses this
+ * so adding access to vault B cannot wipe vault A.
+ *
+ * ON CONFLICT updates `role` and preserves the original `created_at`.
+ * Returns `false` when the user id does not exist.
+ */
+export function upsertUserVault(
+  db: Database,
+  userId: string,
+  vaultName: string,
+  role: string,
+  now: () => Date = () => new Date(),
+): boolean {
+  const exists = db
+    .query<{ id: string }, [string]>("SELECT id FROM users WHERE id = ?")
+    .get(userId);
+  if (!exists) return false;
+  const stamp = now().toISOString();
+  db.transaction(() => {
+    db.prepare(
+      `INSERT INTO user_vaults (user_id, vault_name, role, created_at)
+       VALUES (?, ?, ?, ?)
+       ON CONFLICT(user_id, vault_name) DO UPDATE SET role = excluded.role`,
+    ).run(userId, vaultName, role, stamp);
+    db.prepare("UPDATE users SET updated_at = ? WHERE id = ?").run(stamp, userId);
+  })();
+  return true;
+}
+
+/**
+ * Drop one `user_vaults` row. Leaves the user (and any other vaults) in place.
+ * Returns `true` when a row was deleted.
+ */
+export function removeUserVault(
+  db: Database,
+  userId: string,
+  vaultName: string,
+  now: () => Date = () => new Date(),
+): boolean {
+  const stamp = now().toISOString();
+  let removed = false;
+  db.transaction(() => {
+    const res = db
+      .prepare("DELETE FROM user_vaults WHERE user_id = ? AND vault_name = ?")
+      .run(userId, vaultName);
+    removed = Number(res.changes) > 0;
+    if (removed) {
+      db.prepare("UPDATE users SET updated_at = ? WHERE id = ?").run(stamp, userId);
+    }
+  })();
+  return removed;
+}
+
+/**
  * Vault-delete cascade step (B1, 2026-06-09 hub-module-boundary): drop every
  * `user_vaults` assignment row for the deleted vault, across all users.
  * Exact `=` comparison on `vault_name` — no pattern matching. Returns the

--- a/src/users.ts
+++ b/src/users.ts
@@ -182,7 +182,7 @@ function readVaultsForUser(db: Database, userId: string): string[] {
  *   - `write` (today's default)     → `["read", "write", "admin"]`
  *   - `read` (forward-compat)       → `["read"]` — a *deliberate* read-only
  *     assignment stays read-only even under the any-assigned-user-gets-admin
- *     policy. Not created by any flow today.
+ *     policy. `grant-access` on `/account/mcp` can create these rows.
  *   - anything else (unknown role)  → `[]` — fail closed. An unrecognised
  *     role grants no minting authority rather than silently defaulting to
  *     write. (Defense-in-depth: a hand-edited / future row with a role this


### PR DESCRIPTION
## Why

Aaron's starting point: one agent that owns the hub grants access by public key. `grant-access pubkey=… vault=… role=read|write`. If the caller holds that permission, the row exists. A new agent adds `/mcp` (NIP-98 after hub#888) or `/account/mcp` and `list-vaults` is empty until someone who can grant, grants.

Today's grant is `PATCH /api/users/:id/vaults`: hub user id, replace-all, always `role=write`, admin API. Invite flow is a password link. Neither is "this pubkey, this vault, this role."

## What

On `/account/mcp` (and therefore on NIP-98 `/mcp` after hub#888):

- `grant-access` `{ pubkey, vault, role }` — create a key-only user if needed, link the pubkey, upsert **one** `user_vaults` row. Does not wipe their other vaults. Role is `read` | `write`.
- `revoke-access` `{ pubkey, vault }` — drop that one row; leave the user.
- `list-access` `{ vault? }` → pubkey, vault, role.

Grant is an admin verb on the vault (`user_vaults.role = 'write'` today maps to read+write+admin). First-admin / `parachute:host:admin` can grant any installed vault. Read-only assignees cannot. Role cannot exceed that: `admin` is not a stored role in this slice.

The hub owner is unrestricted by empty `user_vaults`. Granting to the owner's pubkey is a no-op success (`unrestricted: true`); revoke of the owner is refused.

Also: `parachute auth link-pubkey --user <name> <hex>` binds an existing hub user without the Account SPA ceremony (the one that expired unconsumed on this box).

Auto-provision stays **off**. Grant-first still creates the user.

Not in this slice: retargeting `/mcp` OAuth scopes, NIP-OA inheritance, npub decoding, Desktop notes pane, channel-attached vaults. Cloud's account-MCP twin stays at the three coverage tools — grant is hub `user_vaults` shaped.

## Tests

- New MCP pins in `account-mcp.test.ts`: grant-first then the new key can `list-vaults`; upsert does not wipe; friend write can grant their vault not others; read-role cannot grant; owner unrestricted; revoke leaves the user; list-access is pubkey-shaped; Bearer host:admin can grant.
- `upsertUserVault` / `removeUserVault` in `users.test.ts`.
- `parachute auth link-pubkey` in `auth.test.ts`.
- `bunx tsc --noEmit` 0 at `6c2061e`.
- `bun test ./src` at `6c2061e`: **4752 pass / 1 skip / 1 fail**. The fail is `surface-command.test.ts` "a command-minted write token pushes; revoke then blocks the next push" timing out at 5s — file not in this diff, same pre-existing fail as hub#888. Not this change.

Not bun-linked. Not live `:1939`. Changelog with the next rc bump.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`, thread `1039ce8c`.
