### PR TITLE
release: hub 0.7.18-rc.3 — NIP-98 /mcp dispatch + grant-by-pubkey

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.3] - 2026-08-27
+
+**NIP-98 at `/mcp` plus grant-by-pubkey.** Two PRs on `next` after
+0.7.18-rc.2. Version bump only; no new code in this commit. Merging
+this to `next` does not publish. The following next→main PR publishes
+`@rc`.
+
+- **NIP-98 at `/mcp` (#888).** `Authorization: Nostr` at root `/mcp` was
+  proxied to the vault daemon (401 "API key required"). Intercept and
+  hand to `handleAccountMcp` — same door as `/account/mcp`. Vault-audience
+  Bearer and API keys still proxy. `narrowRootMcpScopes` stays vault-only.
+
+- **Grant vault access by pubkey (#889).** Account-MCP tools
+  `grant-access` / `revoke-access` / `list-access`. Grant-first creates a
+  key-only user when the key is unknown (auto-provision stays off). One
+  `user_vaults` upsert; other vaults of the target are not wiped. Operator
+  `parachute auth link-pubkey --user <name> <hex>` binds without the SPA
+  ceremony.
+
+Leaves #880 and #881 open. Auto-provision still defaults off. Do not
+suffix-drop 0.7.18.
+
 ## [0.7.18-rc.2] - 2026-08-27
 
 **Key-as-account: NIP-98 request auth and the account-MCP door.** Two PRs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.2",
+  "version": "0.7.18-rc.3",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## What

Version bump only. `package.json` `0.7.18-rc.2` → `0.7.18-rc.3` + CHANGELOG. No code.

Also merges `main` into `next` (the #885 merge commit next did not have). Same shape as #886. **Merge-commit this PR, do not squash** — squash would drop that merge commit and leave `next` behind `main` again.

Captures [hub#888](https://github.com/ParachuteComputer/parachute-hub/pull/888) (NIP-98 at `/mcp` → account-MCP) and [hub#889](https://github.com/ParachuteComputer/parachute-hub/pull/889) (grant-by-pubkey). Both landed on `next` at the already-published 0.7.18-rc.2 version, so they never reached npm.

Merging this to `next` does **not** publish. The following `next` → `main` merge-commit publishes `@openparachute/hub@0.7.18-rc.3` `@rc`. `@latest` stays 0.7.17.

Leaves #880 and #881 open. Auto-provision still defaults off. Do not suffix-drop 0.7.18.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

`release-check.sh` PASS vs `origin/main` (`0.7.18-rc.2` → `0.7.18-rc.3`). Lockfile WARN is version-only (deps untouched).
