### PR TITLE
fix(hub): root /mcp OAuth account:vaults mints aud=account

### DIFF
--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -147,7 +147,9 @@ describe("requestable is NOT the same as advertised", () => {
     // The ordinary surface is advertised…
     expect(body.scopes_supported).toContain("vault:read");
     expect(body.scopes_supported).toContain("vault:admin");
-    // …account-wide authority is not.
+    // The account-MCP connection grant is legitimate at this door.
+    expect(body.scopes_supported).toContain("account:vaults");
+    // …account-wide REST authority (delete-vault / mint credentials) is not.
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_ADMIN_SCOPE);
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_WRITE_SCOPE);
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_READ_SCOPE);

--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -147,8 +147,9 @@ describe("requestable is NOT the same as advertised", () => {
     // The ordinary surface is advertised…
     expect(body.scopes_supported).toContain("vault:read");
     expect(body.scopes_supported).toContain("vault:admin");
-    // The account-MCP connection grant is legitimate at this door.
-    expect(body.scopes_supported).toContain("account:vaults");
+    // account:vaults is requestable at this door but not advertised here —
+    // catalog-copy would combine it with vault scopes, which authorize refuses.
+    expect(body.scopes_supported).not.toContain("account:vaults");
     // …account-wide REST authority (delete-vault / mint credentials) is not.
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_ADMIN_SCOPE);
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_WRITE_SCOPE);

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -7408,7 +7408,7 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
     }
   });
 
-  test("Bearer POST /mcp still proxies to the daemon (NIP-98 intercept is scheme-only)", async () => {
+  test("non-JWT Bearer POST /mcp still proxies to the daemon", async () => {
     const h = makeHarness();
     const upstream = startRecordingUpstream();
     try {
@@ -7463,6 +7463,59 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
             capabilities: {},
             clientInfo: { name: "t", version: "0" },
           },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
+      expect(body.result?.serverInfo?.name).toBe("parachute-account");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      db.close();
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("aud=account Bearer POST /mcp initialize is answered by account-MCP, daemon never reached", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      rotateSigningKey(db);
+      const owner = await createUser(db, "owner", "pw", { passwordChanged: true });
+      const minted = await signAccessToken(db, {
+        sub: owner.id,
+        scopes: ["account:self:vaults"],
+        audience: "account",
+        clientId: "parachute-hub-spa",
+        issuer: "http://hub.example.com",
+        ttlSeconds: 600,
+      });
+      const fetcher = hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        issuer: "http://hub.example.com",
+      });
+      const res = await fetcher(
+        new Request("http://hub.example.com/mcp", {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${minted.token}`,
+            accept: BOTH_ACCEPT,
+            "content-type": "application/json",
+            host: "hub.example.com",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              clientInfo: { name: "t", version: "0" },
+            },
+          }),
         }),
       );
       expect(res.status).toBe(200);

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -345,9 +345,11 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
     expect(body.scopes_supported as string[]).not.toContain("parachute:host:admin");
   });
 
-  test("shares the bare PRM's requestable-scope filter, narrowed further to vault-only", async () => {
+  test("shares the bare PRM's requestable-scope filter, plus account:vaults at this door", async () => {
     // Both documents start from one registry and requestable-scope filter; the
-    // root document applies its additional vault-only door constraint.
+    // root document keeps vault scopes and adds the account-MCP connection
+    // grant (stripped from the generic catalog so a notes client doesn't
+    // over-request it).
     const root = (await call().json()) as Record<string, unknown>;
     const bare = (await protectedResourceMetadata({
       issuer: ISSUER,
@@ -355,7 +357,7 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
       loadServicesManifest: fixtureLoadServicesManifest,
     }).json()) as Record<string, unknown>;
     expect([...(root.scopes_supported as string[])].sort()).toEqual(
-      [...(bare.scopes_supported as string[])].sort(),
+      [...(bare.scopes_supported as string[]), "account:vaults"].sort(),
     );
   });
 
@@ -10114,6 +10116,104 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
       expect(html).toContain("vault:jon:read");
       expect(html).not.toContain("scribe:");
       expect(html).not.toContain('name="vault_pick"');
+    });
+
+    test("resource=<origin>/mcp + account:vaults is a legitimate grant, not empty", async () => {
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { challenge } = makePkce();
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: "account:vaults",
+              resource: `${ISSUER}/mcp`,
+            }),
+            {
+              headers: {
+                cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+              },
+            },
+          ),
+          RESOURCE_DEPS,
+        );
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        expect(html).toContain("account:vaults");
+        expect(html).toContain("Let this app see which vaults you have");
+        expect(html).not.toContain("Pick a vault");
+        expect(html).not.toContain("scribe:");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("resource=<origin>/mcp + account:vaults mints aud=account (not invalid_target)", async () => {
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { verifier, challenge } = makePkce();
+        const consentRes = await handleAuthorizePost(
+          db,
+          new Request(`${ISSUER}/oauth/authorize`, {
+            method: "POST",
+            body: new URLSearchParams({
+              __action: "consent",
+              __csrf: TEST_CSRF,
+              approve: "yes",
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              scope: "account:vaults",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              resource: `${ISSUER}/mcp`,
+            }),
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            },
+          }),
+          RESOURCE_DEPS,
+        );
+        expect(consentRes.status).toBe(302);
+        const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+        expect(code).toBeTruthy();
+
+        const tokenRes = await handleToken(
+          db,
+          new Request(`${ISSUER}/oauth/token`, {
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "authorization_code",
+              code: code ?? "",
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              code_verifier: verifier,
+            }),
+            headers: { "content-type": "application/x-www-form-urlencoded" },
+          }),
+          RESOURCE_DEPS,
+        );
+        expect(tokenRes.status).toBe(200);
+        const tok = (await tokenRes.json()) as { access_token: string; scope: string };
+        expect(tok.scope.split(" ")).toContain("account:self:vaults");
+        expect(tok.scope.split(" ")).not.toContain("account:vaults");
+        const { payload } = await validateAccessToken(db, tok.access_token, ISSUER);
+        expect(payload.aud).toBe("account");
+      } finally {
+        cleanup();
+      }
     });
   });
 });

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -345,11 +345,10 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
     expect(body.scopes_supported as string[]).not.toContain("parachute:host:admin");
   });
 
-  test("shares the bare PRM's requestable-scope filter, plus account:vaults at this door", async () => {
+  test("shares the bare PRM's requestable-scope filter, narrowed further to vault-only", async () => {
     // Both documents start from one registry and requestable-scope filter; the
-    // root document keeps vault scopes and adds the account-MCP connection
-    // grant (stripped from the generic catalog so a notes client doesn't
-    // over-request it).
+    // root document applies its additional vault-only advertisement. account:vaults
+    // is requestable at this door but not advertised (catalog-copy combine).
     const root = (await call().json()) as Record<string, unknown>;
     const bare = (await protectedResourceMetadata({
       issuer: ISSUER,
@@ -357,8 +356,9 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
       loadServicesManifest: fixtureLoadServicesManifest,
     }).json()) as Record<string, unknown>;
     expect([...(root.scopes_supported as string[])].sort()).toEqual(
-      [...(bare.scopes_supported as string[]), "account:vaults"].sort(),
+      [...(bare.scopes_supported as string[])].sort(),
     );
+    expect(root.scopes_supported as string[]).not.toContain("account:vaults");
   });
 
   test("narrows the bare PRM's requestable catalog to vault scopes at the root door", async () => {
@@ -10211,6 +10211,48 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
         expect(tok.scope.split(" ")).not.toContain("account:vaults");
         const { payload } = await validateAccessToken(db, tok.access_token, ISSUER);
         expect(payload.aud).toBe("account");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("catalog-copy of the root PRM still reaches the vault picker (not invalid_scope)", async () => {
+      const prm = (await rootMcpProtectedResourceMetadata(RESOURCE_DEPS).json()) as {
+        scopes_supported: string[];
+      };
+      expect(prm.scopes_supported).not.toContain("account:vaults");
+      const html = await consentFor(`${ISSUER}/mcp`);
+      expect(html).toContain("Pick a vault");
+      expect(html).not.toContain("error=invalid_scope");
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { challenge } = makePkce();
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: prm.scopes_supported.join(" "),
+              resource: `${ISSUER}/mcp`,
+            }),
+            {
+              headers: {
+                cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+              },
+            },
+          ),
+          RESOURCE_DEPS,
+        );
+        expect(res.status).toBe(200);
+        const copied = await res.text();
+        expect(copied).toContain("Pick a vault");
       } finally {
         cleanup();
       }

--- a/src/__tests__/resource-binding.test.ts
+++ b/src/__tests__/resource-binding.test.ts
@@ -4,6 +4,7 @@ import {
   narrowResourceVaultScopes,
   narrowRootMcpScopes,
   resolveResourceVault,
+  resolveRootMcpTokenAudience,
 } from "../resource-binding.ts";
 
 const ORIGIN = "https://hub.example";
@@ -195,6 +196,25 @@ describe("narrowRootMcpScopes", () => {
     ).toEqual(["vault:read", "vault:write", "vault:admin"]);
   });
 
+  test("keeps account:vaults — the other legitimate root-/mcp resource", () => {
+    expect(narrowRootMcpScopes(["account:vaults"])).toEqual(["account:vaults"]);
+    expect(narrowRootMcpScopes(["account:self:vaults"])).toEqual(["account:self:vaults"]);
+    expect(narrowRootMcpScopes(["account:vaults", "scribe:admin", "hub:admin"])).toEqual([
+      "account:vaults",
+    ]);
+  });
+
+  test("keeps vault scopes and account:vaults together (combine check refuses later)", () => {
+    expect(narrowRootMcpScopes(["vault:read", "account:vaults", "scribe:admin"])).toEqual([
+      "vault:read",
+      "account:vaults",
+    ]);
+  });
+
+  test("drops named account:self:vaults:<vault> — not the connection grant", () => {
+    expect(narrowRootMcpScopes(["account:self:vaults:beta:read", "hub:admin"])).toEqual([]);
+  });
+
   test("does NOT name the vault scopes — there is no vault in the resource", () => {
     // The picker supplies the name; `vault:<name>:<verb>` is minted downstream.
     // Naming them here would require inventing a vault the client never asked
@@ -214,5 +234,22 @@ describe("narrowRootMcpScopes", () => {
   test("is idempotent", () => {
     const once = narrowRootMcpScopes(["vault:read", "hub:admin"]);
     expect(narrowRootMcpScopes(once)).toEqual(once);
+    const account = narrowRootMcpScopes(["account:vaults", "hub:admin"]);
+    expect(narrowRootMcpScopes(account)).toEqual(account);
+  });
+});
+
+describe("resolveRootMcpTokenAudience", () => {
+  test("vault-named grants keep fallbackAudience", () => {
+    expect(resolveRootMcpTokenAudience(new Set(["beta"]), "vault.beta")).toBe("vault.beta");
+  });
+
+  test("account-vaults-only grant (no named vault) mints aud=account", () => {
+    expect(resolveRootMcpTokenAudience(new Set(), "account")).toBe("account");
+  });
+
+  test("empty/foreign grant is null — token handler rejects invalid_target", () => {
+    expect(resolveRootMcpTokenAudience(new Set(), "hub")).toBeNull();
+    expect(resolveRootMcpTokenAudience(new Set(), "scribe")).toBeNull();
   });
 });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -189,11 +189,12 @@
  *   # per-vault proxy and generic service mounts so no module can claim it
  *   # via services.json paths). Vault-audience Bearer / API key still proxy
  *   # to the vault daemon (token names the vault). NIP-98
- *   # (`Authorization: Nostr`) is hub-user auth the daemon does not speak,
- *   # so that scheme routes to handleAccountMcp — same door as /account/mcp.
- *   # OAuth authorize / narrowRootMcpScopes are untouched.
- *   /mcp, /mcp/*                                → NIP-98 → account-MCP;
- *                                                otherwise proxy to the vault daemon
+ *   # (`Authorization: Nostr`) and Bearer `aud=account` are hub-user auth
+ *   # the daemon does not speak, so those route to handleAccountMcp — same
+ *   # door as /account/mcp. Vault-audience Bearer / API key still proxy.
+ *   /mcp, /mcp/*                                → NIP-98 or aud=account →
+ *                                                account-MCP; otherwise proxy
+ *                                                to the vault daemon
  *
  *   # Per-vault content proxy (user-facing vault data: Notes PWA, MCP, etc.).
  *   /vault/<name>/*                            → proxy to the vault backend
@@ -4379,8 +4380,9 @@ export function hubFetch(
       // the OAuth twin of that path: minting happens at /oauth/token after
       // narrowRootMcpScopes kept `account:vaults`. Intercept both and hand
       // the request to handleAccountMcp, the same handler /account/mcp uses.
-      // Hub-only until Cloud's twin (parachute-cloud#273) matches this scheme
-      // split — door-contract 0.6.0 already ratifies a unified /mcp gateway.
+      // Hub-only until Cloud's OAuth twin (parachute-cloud#274) matches this
+      // scheme split. #273 is NIP-98 only. door-contract 0.6.0 already
+      // ratifies a unified /mcp gateway.
       if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
         // Same per-request force-change-password gate as the twins above —
         // a pre-rotation signed-in user can't reach vault data through here

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -233,6 +233,7 @@ import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { decodeJwt } from "jose";
 import pkg from "../package.json" with { type: "json" };
 import {
   ACCOUNT_MUTATION_SCOPES,
@@ -1766,6 +1767,24 @@ function dbNotConfigured(): Response {
     { error: "service_unavailable", error_description: "hub db not configured" },
     { status: 503 },
   );
+}
+
+/**
+ * Routing peek only — not auth. A well-formed JWT with `aud=account` is
+ * handed to account-MCP; anything else (malformed, vault audience, API key)
+ * stays on the daemon-proxy path which does its own auth.
+ */
+function peekBearerAudience(req: Request): string | undefined {
+  const header = req.headers.get("authorization");
+  if (!header) return undefined;
+  const match = header.match(/^Bearer\s+(\S+)/i);
+  if (!match?.[1]) return undefined;
+  try {
+    const payload = decodeJwt(match[1]);
+    return typeof payload.aud === "string" ? payload.aud : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // Canonical 404 body for root `/mcp` + its PRM well-known when
@@ -4356,10 +4375,10 @@ export function hubFetch(
       // resource. Vault-audience Bearer / API key still proxy to the daemon
       // (the TOKEN names the vault). NIP-98 never goes through OAuth
       // authorize — it is a signed event per request — and the daemon does
-      // not speak it (401 "API key required"). Intercept that scheme and
-      // hand the request to handleAccountMcp, the same handler /account/mcp
-      // uses. narrowRootMcpScopes and the root-/mcp authorize branch stay
-      // vault-only; folding account:vaults into them is a separate decision.
+      // not speak it (401 "API key required"). An `aud=account` Bearer is
+      // the OAuth twin of that path: minting happens at /oauth/token after
+      // narrowRootMcpScopes kept `account:vaults`. Intercept both and hand
+      // the request to handleAccountMcp, the same handler /account/mcp uses.
       // Hub-only until Cloud's twin (parachute-cloud#273) matches this scheme
       // split — door-contract 0.6.0 already ratifies a unified /mcp gateway.
       if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
@@ -4370,7 +4389,8 @@ export function hubFetch(
           const gate = forceChangePasswordGate(getDb(), req);
           if (gate) return gate;
         }
-        if (isNostrAuthorization(req)) {
+        const accountMcp = isNostrAuthorization(req) || peekBearerAudience(req) === "account";
+        if (accountMcp) {
           if (!getDb) return dbNotConfigured();
           return handleAccountMcp(req, {
             db: getDb(),

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -87,6 +87,7 @@ import {
   narrowResourceVaultScopes,
   narrowRootMcpScopes,
   resolveResourceVault,
+  resolveRootMcpTokenAudience,
 } from "./resource-binding.ts";
 import {
   ACCOUNT_SELF_ADMIN_SCOPE,
@@ -506,29 +507,32 @@ function advertisedScopes(declared: ReadonlySet<string>, manifest: ServicesManif
  *
  *   - **Hub-level scopes now have an explicit door boundary.** The root PRM
  *     starts from hub's authoritative requestable/module-installed catalog,
- *     then filters to vault scopes because root `/mcp` only accepts
- *     vault-audience tokens. This keeps the root advertisement honest while
- *     the bare PRM continues to describe the full hub resource.
+ *     then keeps vault scopes plus `account:vaults`. `scribe:*` / `agent:send`
+ *     / `hub:admin` stay dropped — advertising a scope this authorize branch
+ *     drops would mislead a spec-following client. `account:self:admin` and
+ *     friends stay out of the catalog (opt-in by intent, not by copy).
  *
- * Both documents start from `advertisedScopes`: one scope registry, filtered
- * by one rule (requestable ∧ module-installed). The root document then applies
- * `narrowRootMcpScopes` because the root door only ever mints vault-audience
- * tokens; advertising a non-vault scope that this authorize branch drops would
- * mislead a spec-following client into requesting something the door cannot
- * accept.
+ * Both documents start from `advertisedScopes`. The root document then applies
+ * `narrowRootMcpScopes` and appends `account:vaults` (stripped from the
+ * generic catalog so a notes client doesn't over-request it, but legitimate
+ * at this door).
  */
 export function rootMcpProtectedResourceMetadata(deps: OAuthDeps): Response {
   const iss = deps.issuer;
   const declared = (deps.loadDeclaredScopes ?? loadDeclaredScopes)();
+  const vaultScopes = narrowRootMcpScopes(
+    advertisedScopes(declared, (deps.loadServicesManifest ?? readServicesManifest)()),
+  );
+  const scopes_supported = vaultScopes.includes(ACCOUNT_VAULTS_UNNARROWED)
+    ? vaultScopes
+    : [...vaultScopes, ACCOUNT_VAULTS_UNNARROWED];
   return jsonResponse({
     // The resource is the root MCP endpoint, not the origin — that's what
     // distinguishes this document from the bare PRM, and what the client
     // matches against the endpoint it got the 401 from.
     resource: `${iss}/mcp`,
     authorization_servers: [iss],
-    scopes_supported: narrowRootMcpScopes(
-      advertisedScopes(declared, (deps.loadServicesManifest ?? readServicesManifest)()),
-    ),
+    scopes_supported,
     bearer_methods_supported: ["header"],
     resource_documentation: "https://parachute.computer",
   });
@@ -641,10 +645,10 @@ function invalidTargetResponse(resource: string): Response {
  *     vault's scope explicitly — and inferAudience's first-scope-wins scan
  *     can't tell which one the CALLER wants THIS token bound to; an explicit
  *     `resource` disambiguates).
- *   - names the vault-agnostic root door → allowed as long as at least one
- *     named vault scope is present (root tokens are vault tokens whose
- *     target the resource server derives from the token itself); audience
- *     stays `fallbackAudience` (unchanged — root doesn't rename anything).
+ *   - names the vault-agnostic root door → vault-named grants stay on
+ *     `fallbackAudience` (`vault.<name>`); an account-vaults-only grant
+ *     (no named vault, `inferAudience` → `"account"`) mints `aud=account`.
+ *     Empty/foreign grants still reject.
  *   - resolves to neither (off-origin, malformed, non-MCP path, or a vault
  *     name not in `grantedVaultNames`) → reject.
  */
@@ -663,10 +667,9 @@ function resolveTokenResourceAudience(
     return { audience: `vault.${boundVault}` };
   }
   if (isRootMcpResource(requestResource, boundOrigins)) {
-    if (grantedVaultNames.size === 0) {
-      return { errorResponse: invalidTargetResponse(requestResource) };
-    }
-    return { audience: fallbackAudience };
+    const audience = resolveRootMcpTokenAudience(grantedVaultNames, fallbackAudience);
+    if (audience === null) return { errorResponse: invalidTargetResponse(requestResource) };
+    return { audience };
   }
   return { errorResponse: invalidTargetResponse(requestResource) };
 }
@@ -1086,12 +1089,11 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // the URL) so the two never diverge. Re-entry after login re-narrows
   // idempotently (no foreign scopes left to drop).
   //
-  // The ROOT `/mcp` door takes the same treatment minus the naming. It is a
-  // vault door too (vault derives the target from the token), so foreign
-  // scopes are just as unusable in the token it mints — but the resource
-  // carries no vault name, so there is nothing to narrow the vault scopes TO
-  // and the consent picker still supplies that. Without this branch the root
-  // door was the one place the whole-hub catalog still reached consent.
+  // The ROOT `/mcp` door takes the same treatment minus the naming. Vault
+  // grants still pick a vault at consent; `account:vaults` is the other
+  // legitimate root resource and mints `aud=account` (no picker). Foreign
+  // scopes are unusable in either token. Without this branch the root door
+  // was the one place the whole-hub catalog still reached consent.
   //
   // No resource, or one that isn't an MCP resource we front (off-origin,
   // malformed, non-vault path) → neither branch fires and the flow is

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -507,32 +507,29 @@ function advertisedScopes(declared: ReadonlySet<string>, manifest: ServicesManif
  *
  *   - **Hub-level scopes now have an explicit door boundary.** The root PRM
  *     starts from hub's authoritative requestable/module-installed catalog,
- *     then keeps vault scopes plus `account:vaults`. `scribe:*` / `agent:send`
- *     / `hub:admin` stay dropped — advertising a scope this authorize branch
- *     drops would mislead a spec-following client. `account:self:admin` and
- *     friends stay out of the catalog (opt-in by intent, not by copy).
+ *     then filters to vault scopes. `account:vaults` is requestable at this
+ *     door (`narrowRootMcpScopes` keeps it) but is NOT advertised here: a
+ *     spec-following client copies the whole catalog, and combining
+ *     `account:vaults` with vault scopes is refused. Advertise it on
+ *     `/account/mcp`'s PRM; request it explicitly at root `/mcp`.
+ *     `scribe:*` / `agent:send` / `hub:admin` stay dropped.
  *
  * Both documents start from `advertisedScopes`. The root document then applies
- * `narrowRootMcpScopes` and appends `account:vaults` (stripped from the
- * generic catalog so a notes client doesn't over-request it, but legitimate
- * at this door).
+ * `narrowRootMcpScopes`, which still drops `account:vaults` out of this
+ * advertisement because `advertisedScopes` already stripped `account:*`.
  */
 export function rootMcpProtectedResourceMetadata(deps: OAuthDeps): Response {
   const iss = deps.issuer;
   const declared = (deps.loadDeclaredScopes ?? loadDeclaredScopes)();
-  const vaultScopes = narrowRootMcpScopes(
-    advertisedScopes(declared, (deps.loadServicesManifest ?? readServicesManifest)()),
-  );
-  const scopes_supported = vaultScopes.includes(ACCOUNT_VAULTS_UNNARROWED)
-    ? vaultScopes
-    : [...vaultScopes, ACCOUNT_VAULTS_UNNARROWED];
   return jsonResponse({
     // The resource is the root MCP endpoint, not the origin — that's what
     // distinguishes this document from the bare PRM, and what the client
     // matches against the endpoint it got the 401 from.
     resource: `${iss}/mcp`,
     authorization_servers: [iss],
-    scopes_supported,
+    scopes_supported: narrowRootMcpScopes(
+      advertisedScopes(declared, (deps.loadServicesManifest ?? readServicesManifest)()),
+    ),
     bearer_methods_supported: ["header"],
     resource_documentation: "https://parachute.computer",
   });

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -27,6 +27,7 @@
  *
  * Source of truth for scope shape: `docs/contracts/oauth-scopes.md`.
  */
+import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
 
 import { VAULT_VERBS } from "./jwt-audience.ts";
 
@@ -198,40 +199,56 @@ export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: 
 }
 
 /**
- * The root-`/mcp` counterpart of `narrowResourceVaultScopes`: drop every
- * non-vault scope, and change nothing else.
+ * The root-`/mcp` counterpart of `narrowResourceVaultScopes`: keep vault
+ * scopes and the account-MCP connection grant (`account:vaults` /
+ * `account:self:vaults`), drop everything else.
  *
- * Root `/mcp` is a vault door — whichever vault the token names. So the same
- * argument that drops `scribe:*` / `agent:send` / `hub:admin` from a per-vault
- * consent applies verbatim here: the flow ends in a token stamped
- * `aud=vault.<picked>`, in which those scopes are unusable, and carrying them
- * only inflates the consent surface. Before this branch existed a `resource`
- * naming root `/mcp` fell through `resolveResourceVault` to null, the whole
- * binding path no-op'd, and the root door alone kept showing the entire hub
- * scope catalog — the exact "scary consent" this module was written to kill,
- * surviving at one of the two MCP doors.
+ * Root `/mcp` is two token shapes at one URL, branched on what arrives:
+ * vault-audience Bearer still names one vault; `account:vaults` mints
+ * `aud=account` and is answered by account-MCP. The same argument that drops
+ * `scribe:*` / `agent:send` / `hub:admin` from a per-vault consent applies
+ * verbatim: those scopes are unusable in either token this door mints, and
+ * carrying them only inflates the consent surface.
  *
- * What this deliberately does NOT do is name the scopes. Unnamed
- * `vault:<verb>` is left exactly as requested, because there is no vault in
- * the resource to name it after; the consent picker supplies the name and the
- * existing rewrite turns it into `vault:<picked>:<verb>` before the code is
- * issued (`docs/contracts/oauth-scopes.md`, "Parser rules"). That is also why
- * the root PRM advertises the bare `vault:read` / `vault:write` /
- * `vault:admin` shapes: at the root door the bare shape is the correct thing
- * for a client to *request*, even though it is never the shape that ships in
- * the minted token.
+ * `account:vaults` cannot be combined with other scopes (authorize already
+ * refuses that). This filter still keeps both if a client asked for both —
+ * the combine check, not this function, is the refusal. Named
+ * `account:self:vaults:<vault>` forms are NOT the connection grant and are
+ * dropped here.
  *
- * Already-named `vault:<name>:<verb>` rides through untouched, same as the
- * per-vault path — a client that named a vault is not second-guessed here.
+ * What this deliberately does NOT do is name vault scopes. Unnamed
+ * `vault:<verb>` is left exactly as requested; the consent picker supplies
+ * the name. Already-named `vault:<name>:<verb>` rides through untouched.
  *
  * A request that carries ONLY foreign scopes narrows to the empty list. The
- * root authorize handler refuses that case with `invalid_scope` rather than
- * reaching a zero-scope consent screen; the per-vault path deliberately keeps
- * its empty narrowed list and renders consent, because that existing behavior
- * is part of its contract.
+ * root authorize handler refuses that case with `invalid_scope`.
  *
  * Idempotent: a second pass has nothing left to drop.
  */
+export function isAccountVaultsRootScope(scope: string): boolean {
+  return scope === ACCOUNT_VAULTS_UNNARROWED || scope === accountVaultsScope("self");
+}
+
 export function narrowRootMcpScopes(scopes: readonly string[]): string[] {
-  return scopes.filter((s) => s.split(":")[0] === "vault");
+  return scopes.filter((s) => s.split(":")[0] === "vault" || isAccountVaultsRootScope(s));
+}
+
+/**
+ * Audience for a token minted against root `/mcp`.
+ *
+ * Vault-named grants stay on `fallbackAudience` (`inferAudience` →
+ * `vault.<name>`). An account-vaults-only grant has no named vault and
+ * `inferAudience` already returns `"account"` — accept that instead of
+ * rejecting an empty vault-name set.
+ *
+ * Returns `null` when the grant is neither (foreign-only / empty) — the
+ * token handler turns that into `invalid_target`.
+ */
+export function resolveRootMcpTokenAudience(
+  grantedVaultNames: ReadonlySet<string>,
+  fallbackAudience: string,
+): string | null {
+  if (grantedVaultNames.size > 0) return fallbackAudience;
+  if (fallbackAudience === "account") return "account";
+  return null;
 }

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -199,7 +199,7 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
   // not the REST `account:self:read` list/usage surface.
   "account:vaults": {
     label:
-      "Connect across your vaults — list them, search their notes, and create new vaults. Does not delete vaults or mint long-lived access tokens.",
+      "Let this app see which vaults you have and manage access to them — list them, search their notes, create vaults, and grant access by public key. Does not delete vaults or mint long-lived access tokens.",
     level: "write",
     risk: "elevated",
   },


### PR DESCRIPTION
## What

Root `/mcp` already routes **NIP-98** to account-MCP (#888). This is the OAuth twin: a client that adds `parachute.<host>/mcp` and requests `account:vaults` now gets `aud=account` instead of `invalid_target`, and `Bearer` with that audience is answered by account-MCP (same handler as `/account/mcp`).

Vault-audience Bearer and API keys still proxy to the daemon. `scribe:*` / `agent:send` / `hub:admin` still drop. Combining `account:vaults` with other scopes is still refused. Named `account:self:vaults:<vault>` is not the connection grant and still drops.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

`bun run typecheck` 0 at `25bc3c3`. Focused: resource-binding + account-scope-consent 48/48; hub-server aud=account intercept 2/2; oauth-handlers root `/mcp` + PRM 15/15 including the two new E2E tests (`account:vaults` at `resource=<origin>/mcp` consents without a picker and mints `aud=account`). Feature PR — no version bump.

## Not this PR

Option B (cross-vault `create-note({vault, …})`) is independent and follows.
