### PR TITLE
feat(hub): account-MCP create-note({vault}) with per-call write check

### DIFF
--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -596,8 +596,9 @@ describe("account MCP — create-vault", () => {
         ),
         mcpDeps(h),
       );
-      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
-      expect(body.error?.data?.error_type).toBe("create_not_granted");
+      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-vault/);
     } finally {
       h.cleanup();
     }
@@ -801,9 +802,96 @@ describe("account MCP — create-note", () => {
           return Response.json({}, { status: 201 });
         } }),
       );
-      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
-      expect(body.error?.data?.error_type).toBe("write_not_granted");
+      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
       expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("first-admin Bearer named beta:read cannot create-note on beta", async () => {
+    const h = await makeHarness();
+    let fetched = 0;
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta:read"], h.ownerId);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
+        ),
+        mcpDeps(h, { fetchImpl: async () => {
+          fetched += 1;
+          return Response.json({}, { status: 201 });
+        } }),
+      );
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend Bearer named beta:read cannot create-note even with write assignment", async () => {
+    const h = await makeHarness();
+    let fetched = 0;
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta:read"], h.friendId);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
+        ),
+        mcpDeps(h, { fetchImpl: async () => {
+          fetched += 1;
+          return Response.json({}, { status: 201 });
+        } }),
+      );
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend NIP-98 write-role can create-note on the assigned vault", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: string[] = [];
+      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(String(input), init);
+        const parts = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").split(".");
+        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+          scope?: string;
+        };
+        seen.push(payload.scope ?? "");
+        return Response.json({ id: "n-friend" }, { status: 201 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "beta", content: "from friend" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const out = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string; note: { id: string } };
+      expect(out.vault).toBe("beta");
+      expect(out.note.id).toBe("n-friend");
+      expect(seen).toEqual(["vault:beta:write"]);
     } finally {
       h.cleanup();
     }
@@ -1256,8 +1344,9 @@ describe("account MCP — grant-access", () => {
         ),
         mcpDeps(h),
       );
-      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
-      expect(body.error?.data?.error_type).toBe("grant_not_permitted");
+      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();
     }
@@ -1504,9 +1593,9 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await personal.json()) as { error?: { data?: { error_type?: string } } }).error?.data
-          ?.error_type,
-      ).toBe("grant_not_permitted");
+        ((await personal.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
+          .result?.content?.[0]?.text,
+      ).toMatch(/Unknown tool: grant-access/);
       const beta = await handleAccountMcp(
         bearerReq(
           token,
@@ -1518,9 +1607,9 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await beta.json()) as { error?: { data?: { error_type?: string } } }).error?.data
-          ?.error_type,
-      ).toBe("grant_not_permitted");
+        ((await beta.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
+          .result?.content?.[0]?.text,
+      ).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();
     }
@@ -1565,9 +1654,9 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await res.json()) as { error?: { data?: { error_type?: string } } }).error?.data
-          ?.error_type,
-      ).toBe("grant_not_permitted");
+        ((await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
+          .result?.content?.[0]?.text,
+      ).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -437,6 +437,7 @@ describe("account MCP — initialize + tools", () => {
         "list-vaults",
         "create-vault",
         "query-notes",
+        "create-note",
         "grant-access",
         "revoke-access",
         "list-access",
@@ -722,6 +723,142 @@ describe("account MCP — query-notes", () => {
         vaults_queried: string[];
       };
       expect(payload.vaults_queried).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — create-note", () => {
+  test("owner posts to the named vault with a write-audience mint", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: Array<{ url: string; method: string; scope: string }> = [];
+      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(String(input), init);
+        const auth = req.headers.get("authorization") ?? "";
+        const parts = auth.replace(/^Bearer\s+/i, "").split(".");
+        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+          scope?: string;
+        };
+        seen.push({ url: req.url, method: req.method, scope: payload.scope ?? "" });
+        return Response.json({ id: "n1", path: "Log/hello" }, { status: 201 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "beta", path: "Log/hello", content: "hi" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const out = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string; note: { id: string } };
+      expect(out.vault).toBe("beta");
+      expect(out.note.id).toBe("n1");
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.url).toContain("/vault/beta/api/notes");
+      expect(seen[0]?.method).toBe("POST");
+      expect(seen[0]?.scope).toBe("vault:beta:write");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("read-role cannot create-note — write_not_granted, fetch never called", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("44".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    let fetched = 0;
+    try {
+      const reader = await createUser(h.db, "reader", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "d".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const res = await handleAccountMcp(
+        nostrReq(
+          readerSecret,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "beta", content: "nope" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl: async () => {
+          fetched += 1;
+          return Response.json({}, { status: 201 });
+        } }),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("write_not_granted");
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unassigned vault is vault_not_covered", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "personal", content: "nope" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("vault_not_covered");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("tools/list hides create-note and grant tools from a read-role caller", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("55".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    try {
+      const reader = await createUser(h.db, "reader2", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "e".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const listed = await handleAccountMcp(
+        nostrReq(readerSecret, rpc("tools/list")),
+        mcpDeps(h),
+      );
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toEqual(["list-vaults", "query-notes"]);
+      expect(names).not.toContain("create-note");
+      expect(names).not.toContain("grant-access");
+      expect(names).not.toContain("create-vault");
     } finally {
       h.cleanup();
     }

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -27,6 +27,7 @@ import {
   type AccountToolContext,
   AccountToolError,
   buildAccountConnectionGrant,
+  toolsForPrincipal,
 } from "./account-mcp.ts";
 import {
   AdminAuthError,
@@ -278,9 +279,10 @@ function instructions(): string {
   return (
     "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
     "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
-    "and query-notes to search across them (omit `vault` to fan out, pass it to target one). " +
+    "query-notes to search across them (omit `vault` to fan out, pass it to target one), " +
+    "and create-note to write in one vault (`vault` is required). " +
     "grant-access / revoke-access / list-access give a Nostr pubkey a vault (role read|write) " +
-    "if you can admin that vault."
+    "if you can admin that vault. tools/list hides tools you cannot call."
   );
 }
 
@@ -302,7 +304,7 @@ async function handleOne(m: JsonRpcMessage, ctx: AccountToolContext): Promise<Js
       }
       case "tools/list":
         return result(id, {
-          tools: ACCOUNT_MCP_TOOLS.map((t) => ({
+          tools: toolsForPrincipal(ctx).map((t) => ({
             name: t.name,
             description: t.description,
             inputSchema: t.inputSchema,

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -22,7 +22,6 @@ import type { Database } from "bun:sqlite";
 import { ACCOUNT_VAULTS_UNNARROWED } from "@openparachute/door-contract";
 import type { AccountApiDeps } from "./account-api.ts";
 import {
-  ACCOUNT_MCP_TOOLS,
   type AccountMcpPrincipal,
   type AccountToolContext,
   AccountToolError,
@@ -256,7 +255,7 @@ async function handleToolCall(
 ): Promise<JsonRpcMessage> {
   const name = typeof params?.name === "string" ? params.name : "";
   const args = (params?.arguments ?? {}) as Record<string, unknown>;
-  const tool = ACCOUNT_MCP_TOOLS.find((t) => t.name === name);
+  const tool = toolsForPrincipal(ctx).find((t) => t.name === name);
   if (!tool) {
     return result(id, {
       content: [{ type: "text", text: `Unknown tool: ${name}` }],

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -2,10 +2,11 @@
  * Account-level MCP tools for the self-host hub — the payload behind
  * `/account/mcp`.
  *
- * Cloud's twin lives in the identity worker (`account-mcp.ts`). Same three
- * coverage tools (list-vaults, create-vault, query-notes), same "no vault_token
- * in model context" rule. Hub adds grant-access / revoke-access / list-access
- * (pubkey → one `user_vaults` row). Those three are hub-only: cloud grants are
+ * Cloud's twin lives in the identity worker (`account-mcp.ts`). Coverage tools
+ * (list-vaults, create-vault, query-notes) plus hub-only grant-access /
+ * revoke-access / list-access (pubkey → one `user_vaults` row). create-note is
+ * the first cross-vault write tool: `vault` is required, write is checked
+ * per call, a 60s `vault:<name>:write` mint fans to REST. Cloud grants are
  * D1-ownership shaped, not `user_vaults`. Coverage is hub-shaped:
  *
  *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
@@ -28,10 +29,11 @@ import {
   type ComposedVaultVerb,
   accountVaultsGrant,
   composedAccountGrant,
+  composedVerbSatisfies,
 } from "@openparachute/door-contract";
 import { type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
 import { HOST_ADMIN_SCOPE, provisionVault } from "./admin-vaults.ts";
-import { GrantError, grantAccess, listAccess, revokeAccess } from "./grant-access.ts";
+import { GrantError, callerCanAdminVault, grantAccess, listAccess, revokeAccess } from "./grant-access.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
 
@@ -206,6 +208,33 @@ export function resolveCoverage(
 
 function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
   return listVaultsWithMeta(ctx.manifestPath, ctx.issuer);
+}
+
+function isUnrestricted(db: Database, principal: AccountMcpPrincipal): boolean {
+  return principal.isHubAdmin || isFirstAdmin(db, principal.userId);
+}
+
+/**
+ * Per-call write check. Opening the account door (list/query) is not write.
+ * First-admin / host:admin are unrestricted. Everyone else needs the `write`
+ * verb on that vault's `user_vaults` row. A Bearer named subset that does not
+ * include the vault cannot write it even if assignment would allow.
+ */
+export function canWriteVault(
+  db: Database,
+  principal: AccountMcpPrincipal,
+  vaultName: string,
+): boolean {
+  if (isUnrestricted(db, principal)) return true;
+  if (principal.authKind === "bearer" && principal.grant) {
+    if (principal.grant.wildcard === "admin") return true;
+    if (principal.grant.wildcard === null && !principal.grant.vaults.has(vaultName)) {
+      return false;
+    }
+    const named = principal.grant.vaults.get(vaultName);
+    if (named !== undefined && !composedVerbSatisfies(named, "write")) return false;
+  }
+  return vaultVerbsForUserVault(db, principal.userId, vaultName)?.includes("write") === true;
 }
 
 const listVaultsTool: AccountMcpTool = {
@@ -402,6 +431,110 @@ const queryNotesTool: AccountMcpTool = {
   },
 };
 
+function noteWriteBody(args: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (typeof args.content === "string") body.content = args.content;
+  if (typeof args.path === "string") body.path = args.path;
+  if (Array.isArray(args.tags)) body.tags = args.tags;
+  if (args.metadata && typeof args.metadata === "object") body.metadata = args.metadata;
+  if (typeof args.if_exists === "string") body.if_exists = args.if_exists;
+  return body;
+}
+
+async function postNoteToVault(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const sign = ctx.signToken ?? signAccessToken;
+  const fetchImpl = ctx.fetchImpl ?? fetch;
+  const minted = await sign(ctx.db, {
+    sub: ctx.principal.userId,
+    scopes: [`vault:${vault.name}:write`],
+    audience: `vault.${vault.name}`,
+    clientId: ACCOUNT_MCP_CLIENT_ID,
+    issuer: ctx.issuer,
+    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    vaultScope: [vault.name],
+    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
+  });
+  const origin =
+    typeof vault.port === "number" && vault.port > 0
+      ? `http://127.0.0.1:${vault.port}`
+      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
+  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}/api/notes`;
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${minted.token}`,
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    let detail = `vault responded ${res.status}`;
+    try {
+      const errBody = (await res.json()) as Record<string, unknown>;
+      if (typeof errBody.error === "string") detail = errBody.error;
+    } catch {
+      // Non-JSON error body — keep the status-only detail.
+    }
+    throw new AccountToolError("vault_error", detail, { status: res.status, vault: vault.name });
+  }
+  return res.json();
+}
+
+const createNoteTool: AccountMcpTool = {
+  name: "create-note",
+  description:
+    "Create a note in one vault this connection can write. `vault` is required — this " +
+    "door does not invent a target. Does not return a vault token.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      vault: {
+        type: "string",
+        description: "Target vault by name. Must be a reachable vault this connection can write.",
+      },
+      content: { type: "string", description: "Note body (markdown)." },
+      path: { type: "string", description: "Note path (e.g. 'Log/hello')." },
+      tags: { type: "array", items: { type: "string" }, description: "Tags to apply." },
+      metadata: { type: "object", description: "Metadata fields to set." },
+      if_exists: {
+        type: "string",
+        enum: ["error", "ignore", "update", "replace"],
+        description: "What to do when `path` already names a note. Default error.",
+      },
+    },
+    required: ["vault"],
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    if (typeof args.vault !== "string" || args.vault.length === 0) {
+      throw new AccountToolError("invalid_vault", "vault is required.");
+    }
+    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+    const wanted = args.vault.toLowerCase();
+    const hit = coverage.vaults.find((v) => v.name === wanted);
+    if (!hit) {
+      throw new AccountToolError(
+        "vault_not_covered",
+        `Vault "${args.vault}" is not among the vaults this connection can reach.`,
+      );
+    }
+    if (!canWriteVault(ctx.db, ctx.principal, hit.name)) {
+      throw new AccountToolError(
+        "write_not_granted",
+        `This connection cannot write vault "${hit.name}".`,
+      );
+    }
+    const note = await postNoteToVault(ctx, hit, noteWriteBody(args));
+    return { vault: hit.name, note };
+  },
+};
+
 function installedNameSet(ctx: AccountToolContext): Set<string> {
   return new Set(installedVaults(ctx).map((v) => v.name));
 }
@@ -506,7 +639,31 @@ export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
   listVaultsTool,
   createVaultTool,
   queryNotesTool,
+  createNoteTool,
   grantAccessTool,
   revokeAccessTool,
   listAccessTool,
 ];
+
+/**
+ * Catalog filtered by what this principal can actually call. Admin-shaped
+ * tools (grant/revoke/list-access) and write tools are invisible below the
+ * verb, not just refused. Same pattern as the vault door.
+ */
+export function toolsForPrincipal(ctx: AccountToolContext): readonly AccountMcpTool[] {
+  const installed = installedVaults(ctx);
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installed);
+  const canWrite = coverage.vaults.some((v) => canWriteVault(ctx.db, ctx.principal, v.name));
+  const canAdmin = coverage.vaults.some((v) =>
+    callerCanAdminVault(ctx.db, ctx.principal, v.name),
+  );
+  const create = canCreate(ctx.principal);
+  return ACCOUNT_MCP_TOOLS.filter((t) => {
+    if (t.name === "create-vault") return create;
+    if (t.name === "create-note") return canWrite;
+    if (t.name === "grant-access" || t.name === "revoke-access" || t.name === "list-access") {
+      return canAdmin;
+    }
+    return true;
+  });
+}

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -225,15 +225,21 @@ export function canWriteVault(
   principal: AccountMcpPrincipal,
   vaultName: string,
 ): boolean {
-  if (isUnrestricted(db, principal)) return true;
-  if (principal.authKind === "bearer" && principal.grant) {
-    if (principal.grant.wildcard === "admin") return true;
-    if (principal.grant.wildcard === null && !principal.grant.vaults.has(vaultName)) {
-      return false;
-    }
-    const named = principal.grant.vaults.get(vaultName);
+  // Bearer coverage / named-verb BEFORE unrestricted — same order as
+  // callerCanAdminVault. A first-admin token named `…:beta:read` must not
+  // mint `vault:beta:write`. Coverage wildcards (`account:vaults`) are not
+  // a verb cap; first-admin still writes after the named-verb check.
+  if (principal.authKind === "bearer") {
+    const grant = principal.grant;
+    if (!grant) return false;
+    if (grant.wildcard === null && !grant.vaults.has(vaultName)) return false;
+    const named = grant.vaults.get(vaultName);
     if (named !== undefined && !composedVerbSatisfies(named, "write")) return false;
+    if (grant.wildcard === "admin") return true;
+    if (isUnrestricted(db, principal)) return true;
+    return vaultVerbsForUserVault(db, principal.userId, vaultName)?.includes("write") === true;
   }
+  if (isUnrestricted(db, principal)) return true;
   return vaultVerbsForUserVault(db, principal.userId, vaultName)?.includes("write") === true;
 }
 


### PR DESCRIPTION
## What

Option B first slice: account-MCP grows `create-note({vault, path, content, …})`. `vault` is required — this door does not invent a target. Write is checked **per call** (first-admin / `host:admin` unrestricted; otherwise `user_vaults` write). A 60s `vault:<name>:write` mint POSTs to that vault's REST `/api/notes`. No `vault_token` in the tool result.

`tools/list` hides tools the caller cannot use: read-role sees `list-vaults` + `query-notes` only. Grant tools and `create-vault` stay invisible below admin/create.

Does not replace the per-vault MCP door. Does not add `update-note` / `delete-note` yet.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

`bun run typecheck` 0 at `7aae7ac`. `bun test src/__tests__/account-mcp.test.ts` 51/51 including owner write-mint, read-role `write_not_granted` (fetch never called), unassigned `vault_not_covered`, tools/list filter.

## Independent of

[hub#892](https://github.com/ParachuteComputer/parachute-hub/pull/892) (root `/mcp` OAuth `account:vaults`). Can merge in either order.
