### PR TITLE
release: hub 0.7.18-rc.4 (next → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.4] - 2026-08-27
+
+**Account-MCP at root `/mcp` (OAuth) plus create-note.** Two PRs on
+`next` after 0.7.18-rc.3. Version bump only; no new code in this
+commit. Merging this to `next` does not publish. The following next→main
+PR publishes `@rc`.
+
+- **Root `/mcp` OAuth `account:vaults` (#892).** Explicit
+  `resource=<origin>/mcp` + `scope=account:vaults` mints `aud=account`.
+  Bearer with that audience is answered by account-MCP (NIP-98 twin of
+  #888). Vault-audience Bearer still proxies. Combine-with-other-scopes
+  still refused. Root PRM does **not** advertise `account:vaults`
+  (catalog-copy would mix it with vault scopes); it stays requestable.
+  Cloud follow-up: parachute-cloud#274.
+
+- **Account-MCP `create-note({vault, …})` (#893).** Option B first slice.
+  `vault` is required. Write is checked per call (named Bearer `:read`
+  cannot mint write, including first-admin). 60s `vault:<name>:write`
+  mint POSTs to REST. `tools/list` and `tools/call` share the filtered
+  catalog; hidden tools are `Unknown tool`.
+
+Leaves #880 and #881 open. Auto-provision still defaults off. Do not
+suffix-drop 0.7.18.
+
 ## [0.7.18-rc.3] - 2026-08-27
 
 **NIP-98 at `/mcp` plus grant-by-pubkey.** Two PRs on `next` after

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.3",
+  "version": "0.7.18-rc.4",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -437,6 +437,7 @@ describe("account MCP — initialize + tools", () => {
         "list-vaults",
         "create-vault",
         "query-notes",
+        "create-note",
         "grant-access",
         "revoke-access",
         "list-access",
@@ -595,8 +596,9 @@ describe("account MCP — create-vault", () => {
         ),
         mcpDeps(h),
       );
-      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
-      expect(body.error?.data?.error_type).toBe("create_not_granted");
+      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-vault/);
     } finally {
       h.cleanup();
     }
@@ -722,6 +724,229 @@ describe("account MCP — query-notes", () => {
         vaults_queried: string[];
       };
       expect(payload.vaults_queried).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — create-note", () => {
+  test("owner posts to the named vault with a write-audience mint", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: Array<{ url: string; method: string; scope: string }> = [];
+      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(String(input), init);
+        const auth = req.headers.get("authorization") ?? "";
+        const parts = auth.replace(/^Bearer\s+/i, "").split(".");
+        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+          scope?: string;
+        };
+        seen.push({ url: req.url, method: req.method, scope: payload.scope ?? "" });
+        return Response.json({ id: "n1", path: "Log/hello" }, { status: 201 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "beta", path: "Log/hello", content: "hi" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const out = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string; note: { id: string } };
+      expect(out.vault).toBe("beta");
+      expect(out.note.id).toBe("n1");
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.url).toContain("/vault/beta/api/notes");
+      expect(seen[0]?.method).toBe("POST");
+      expect(seen[0]?.scope).toBe("vault:beta:write");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("read-role cannot create-note — write_not_granted, fetch never called", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("44".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    let fetched = 0;
+    try {
+      const reader = await createUser(h.db, "reader", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "d".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const res = await handleAccountMcp(
+        nostrReq(
+          readerSecret,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "beta", content: "nope" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl: async () => {
+          fetched += 1;
+          return Response.json({}, { status: 201 });
+        } }),
+      );
+      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("first-admin Bearer named beta:read cannot create-note on beta", async () => {
+    const h = await makeHarness();
+    let fetched = 0;
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta:read"], h.ownerId);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
+        ),
+        mcpDeps(h, { fetchImpl: async () => {
+          fetched += 1;
+          return Response.json({}, { status: 201 });
+        } }),
+      );
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend Bearer named beta:read cannot create-note even with write assignment", async () => {
+    const h = await makeHarness();
+    let fetched = 0;
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta:read"], h.friendId);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
+        ),
+        mcpDeps(h, { fetchImpl: async () => {
+          fetched += 1;
+          return Response.json({}, { status: 201 });
+        } }),
+      );
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend NIP-98 write-role can create-note on the assigned vault", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: string[] = [];
+      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(String(input), init);
+        const parts = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").split(".");
+        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+          scope?: string;
+        };
+        seen.push(payload.scope ?? "");
+        return Response.json({ id: "n-friend" }, { status: 201 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "beta", content: "from friend" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const out = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string; note: { id: string } };
+      expect(out.vault).toBe("beta");
+      expect(out.note.id).toBe("n-friend");
+      expect(seen).toEqual(["vault:beta:write"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unassigned vault is vault_not_covered", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "create-note",
+            arguments: { vault: "personal", content: "nope" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("vault_not_covered");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("tools/list hides create-note and grant tools from a read-role caller", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("55".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    try {
+      const reader = await createUser(h.db, "reader2", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "e".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const listed = await handleAccountMcp(
+        nostrReq(readerSecret, rpc("tools/list")),
+        mcpDeps(h),
+      );
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toEqual(["list-vaults", "query-notes"]);
+      expect(names).not.toContain("create-note");
+      expect(names).not.toContain("grant-access");
+      expect(names).not.toContain("create-vault");
     } finally {
       h.cleanup();
     }
@@ -1119,8 +1344,9 @@ describe("account MCP — grant-access", () => {
         ),
         mcpDeps(h),
       );
-      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
-      expect(body.error?.data?.error_type).toBe("grant_not_permitted");
+      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();
     }
@@ -1367,9 +1593,9 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await personal.json()) as { error?: { data?: { error_type?: string } } }).error?.data
-          ?.error_type,
-      ).toBe("grant_not_permitted");
+        ((await personal.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
+          .result?.content?.[0]?.text,
+      ).toMatch(/Unknown tool: grant-access/);
       const beta = await handleAccountMcp(
         bearerReq(
           token,
@@ -1381,9 +1607,9 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await beta.json()) as { error?: { data?: { error_type?: string } } }).error?.data
-          ?.error_type,
-      ).toBe("grant_not_permitted");
+        ((await beta.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
+          .result?.content?.[0]?.text,
+      ).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();
     }
@@ -1428,9 +1654,9 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await res.json()) as { error?: { data?: { error_type?: string } } }).error?.data
-          ?.error_type,
-      ).toBe("grant_not_permitted");
+        ((await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
+          .result?.content?.[0]?.text,
+      ).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/account-scope-consent.test.ts
+++ b/src/__tests__/account-scope-consent.test.ts
@@ -147,7 +147,10 @@ describe("requestable is NOT the same as advertised", () => {
     // The ordinary surface is advertised…
     expect(body.scopes_supported).toContain("vault:read");
     expect(body.scopes_supported).toContain("vault:admin");
-    // …account-wide authority is not.
+    // account:vaults is requestable at this door but not advertised here —
+    // catalog-copy would combine it with vault scopes, which authorize refuses.
+    expect(body.scopes_supported).not.toContain("account:vaults");
+    // …account-wide REST authority (delete-vault / mint credentials) is not.
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_ADMIN_SCOPE);
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_WRITE_SCOPE);
     expect(body.scopes_supported).not.toContain(ACCOUNT_SELF_READ_SCOPE);

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -7408,7 +7408,7 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
     }
   });
 
-  test("Bearer POST /mcp still proxies to the daemon (NIP-98 intercept is scheme-only)", async () => {
+  test("non-JWT Bearer POST /mcp still proxies to the daemon", async () => {
     const h = makeHarness();
     const upstream = startRecordingUpstream();
     try {
@@ -7463,6 +7463,59 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
             capabilities: {},
             clientInfo: { name: "t", version: "0" },
           },
+        }),
+      );
+      expect(res.status).toBe(200);
+      const body = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
+      expect(body.result?.serverInfo?.name).toBe("parachute-account");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      db.close();
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("aud=account Bearer POST /mcp initialize is answered by account-MCP, daemon never reached", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      rotateSigningKey(db);
+      const owner = await createUser(db, "owner", "pw", { passwordChanged: true });
+      const minted = await signAccessToken(db, {
+        sub: owner.id,
+        scopes: ["account:self:vaults"],
+        audience: "account",
+        clientId: "parachute-hub-spa",
+        issuer: "http://hub.example.com",
+        ttlSeconds: 600,
+      });
+      const fetcher = hubFetch(h.dir, {
+        getDb: () => db,
+        manifestPath: h.manifestPath,
+        issuer: "http://hub.example.com",
+      });
+      const res = await fetcher(
+        new Request("http://hub.example.com/mcp", {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${minted.token}`,
+            accept: BOTH_ACCEPT,
+            "content-type": "application/json",
+            host: "hub.example.com",
+          },
+          body: JSON.stringify({
+            jsonrpc: "2.0",
+            id: 1,
+            method: "initialize",
+            params: {
+              protocolVersion: "2025-11-25",
+              capabilities: {},
+              clientInfo: { name: "t", version: "0" },
+            },
+          }),
         }),
       );
       expect(res.status).toBe(200);

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -347,7 +347,8 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
 
   test("shares the bare PRM's requestable-scope filter, narrowed further to vault-only", async () => {
     // Both documents start from one registry and requestable-scope filter; the
-    // root document applies its additional vault-only door constraint.
+    // root document applies its additional vault-only advertisement. account:vaults
+    // is requestable at this door but not advertised (catalog-copy combine).
     const root = (await call().json()) as Record<string, unknown>;
     const bare = (await protectedResourceMetadata({
       issuer: ISSUER,
@@ -357,6 +358,7 @@ describe("rootMcpProtectedResourceMetadata (hub#789)", () => {
     expect([...(root.scopes_supported as string[])].sort()).toEqual(
       [...(bare.scopes_supported as string[])].sort(),
     );
+    expect(root.scopes_supported as string[]).not.toContain("account:vaults");
   });
 
   test("narrows the bare PRM's requestable catalog to vault scopes at the root door", async () => {
@@ -10114,6 +10116,146 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
       expect(html).toContain("vault:jon:read");
       expect(html).not.toContain("scribe:");
       expect(html).not.toContain('name="vault_pick"');
+    });
+
+    test("resource=<origin>/mcp + account:vaults is a legitimate grant, not empty", async () => {
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { challenge } = makePkce();
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: "account:vaults",
+              resource: `${ISSUER}/mcp`,
+            }),
+            {
+              headers: {
+                cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+              },
+            },
+          ),
+          RESOURCE_DEPS,
+        );
+        expect(res.status).toBe(200);
+        const html = await res.text();
+        expect(html).toContain("account:vaults");
+        expect(html).toContain("Let this app see which vaults you have");
+        expect(html).not.toContain("Pick a vault");
+        expect(html).not.toContain("scribe:");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("resource=<origin>/mcp + account:vaults mints aud=account (not invalid_target)", async () => {
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { verifier, challenge } = makePkce();
+        const consentRes = await handleAuthorizePost(
+          db,
+          new Request(`${ISSUER}/oauth/authorize`, {
+            method: "POST",
+            body: new URLSearchParams({
+              __action: "consent",
+              __csrf: TEST_CSRF,
+              approve: "yes",
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              scope: "account:vaults",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              resource: `${ISSUER}/mcp`,
+            }),
+            headers: {
+              "content-type": "application/x-www-form-urlencoded",
+              cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+            },
+          }),
+          RESOURCE_DEPS,
+        );
+        expect(consentRes.status).toBe(302);
+        const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+        expect(code).toBeTruthy();
+
+        const tokenRes = await handleToken(
+          db,
+          new Request(`${ISSUER}/oauth/token`, {
+            method: "POST",
+            body: new URLSearchParams({
+              grant_type: "authorization_code",
+              code: code ?? "",
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              code_verifier: verifier,
+            }),
+            headers: { "content-type": "application/x-www-form-urlencoded" },
+          }),
+          RESOURCE_DEPS,
+        );
+        expect(tokenRes.status).toBe(200);
+        const tok = (await tokenRes.json()) as { access_token: string; scope: string };
+        expect(tok.scope.split(" ")).toContain("account:self:vaults");
+        expect(tok.scope.split(" ")).not.toContain("account:vaults");
+        const { payload } = await validateAccessToken(db, tok.access_token, ISSUER);
+        expect(payload.aud).toBe("account");
+      } finally {
+        cleanup();
+      }
+    });
+
+    test("catalog-copy of the root PRM still reaches the vault picker (not invalid_scope)", async () => {
+      const prm = (await rootMcpProtectedResourceMetadata(RESOURCE_DEPS).json()) as {
+        scopes_supported: string[];
+      };
+      expect(prm.scopes_supported).not.toContain("account:vaults");
+      const html = await consentFor(`${ISSUER}/mcp`);
+      expect(html).toContain("Pick a vault");
+      expect(html).not.toContain("error=invalid_scope");
+      const { db, cleanup } = await makeDb();
+      try {
+        const user = await createUser(db, "owner", "pw");
+        const session = createSession(db, { userId: user.id });
+        const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+        const { challenge } = makePkce();
+        const res = handleAuthorizeGet(
+          db,
+          new Request(
+            authorizeUrl({
+              client_id: reg.client.clientId,
+              redirect_uri: "https://app.example/cb",
+              response_type: "code",
+              code_challenge: challenge,
+              code_challenge_method: "S256",
+              scope: prm.scopes_supported.join(" "),
+              resource: `${ISSUER}/mcp`,
+            }),
+            {
+              headers: {
+                cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, Math.floor(SESSION_TTL_MS / 1000))}`,
+              },
+            },
+          ),
+          RESOURCE_DEPS,
+        );
+        expect(res.status).toBe(200);
+        const copied = await res.text();
+        expect(copied).toContain("Pick a vault");
+      } finally {
+        cleanup();
+      }
     });
   });
 });

--- a/src/__tests__/resource-binding.test.ts
+++ b/src/__tests__/resource-binding.test.ts
@@ -4,6 +4,7 @@ import {
   narrowResourceVaultScopes,
   narrowRootMcpScopes,
   resolveResourceVault,
+  resolveRootMcpTokenAudience,
 } from "../resource-binding.ts";
 
 const ORIGIN = "https://hub.example";
@@ -195,6 +196,25 @@ describe("narrowRootMcpScopes", () => {
     ).toEqual(["vault:read", "vault:write", "vault:admin"]);
   });
 
+  test("keeps account:vaults — the other legitimate root-/mcp resource", () => {
+    expect(narrowRootMcpScopes(["account:vaults"])).toEqual(["account:vaults"]);
+    expect(narrowRootMcpScopes(["account:self:vaults"])).toEqual(["account:self:vaults"]);
+    expect(narrowRootMcpScopes(["account:vaults", "scribe:admin", "hub:admin"])).toEqual([
+      "account:vaults",
+    ]);
+  });
+
+  test("keeps vault scopes and account:vaults together (combine check refuses later)", () => {
+    expect(narrowRootMcpScopes(["vault:read", "account:vaults", "scribe:admin"])).toEqual([
+      "vault:read",
+      "account:vaults",
+    ]);
+  });
+
+  test("drops named account:self:vaults:<vault> — not the connection grant", () => {
+    expect(narrowRootMcpScopes(["account:self:vaults:beta:read", "hub:admin"])).toEqual([]);
+  });
+
   test("does NOT name the vault scopes — there is no vault in the resource", () => {
     // The picker supplies the name; `vault:<name>:<verb>` is minted downstream.
     // Naming them here would require inventing a vault the client never asked
@@ -214,5 +234,22 @@ describe("narrowRootMcpScopes", () => {
   test("is idempotent", () => {
     const once = narrowRootMcpScopes(["vault:read", "hub:admin"]);
     expect(narrowRootMcpScopes(once)).toEqual(once);
+    const account = narrowRootMcpScopes(["account:vaults", "hub:admin"]);
+    expect(narrowRootMcpScopes(account)).toEqual(account);
+  });
+});
+
+describe("resolveRootMcpTokenAudience", () => {
+  test("vault-named grants keep fallbackAudience", () => {
+    expect(resolveRootMcpTokenAudience(new Set(["beta"]), "vault.beta")).toBe("vault.beta");
+  });
+
+  test("account-vaults-only grant (no named vault) mints aud=account", () => {
+    expect(resolveRootMcpTokenAudience(new Set(), "account")).toBe("account");
+  });
+
+  test("empty/foreign grant is null — token handler rejects invalid_target", () => {
+    expect(resolveRootMcpTokenAudience(new Set(), "hub")).toBeNull();
+    expect(resolveRootMcpTokenAudience(new Set(), "scribe")).toBeNull();
   });
 });

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -22,11 +22,11 @@ import type { Database } from "bun:sqlite";
 import { ACCOUNT_VAULTS_UNNARROWED } from "@openparachute/door-contract";
 import type { AccountApiDeps } from "./account-api.ts";
 import {
-  ACCOUNT_MCP_TOOLS,
   type AccountMcpPrincipal,
   type AccountToolContext,
   AccountToolError,
   buildAccountConnectionGrant,
+  toolsForPrincipal,
 } from "./account-mcp.ts";
 import {
   AdminAuthError,
@@ -255,7 +255,7 @@ async function handleToolCall(
 ): Promise<JsonRpcMessage> {
   const name = typeof params?.name === "string" ? params.name : "";
   const args = (params?.arguments ?? {}) as Record<string, unknown>;
-  const tool = ACCOUNT_MCP_TOOLS.find((t) => t.name === name);
+  const tool = toolsForPrincipal(ctx).find((t) => t.name === name);
   if (!tool) {
     return result(id, {
       content: [{ type: "text", text: `Unknown tool: ${name}` }],
@@ -278,9 +278,10 @@ function instructions(): string {
   return (
     "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
     "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
-    "and query-notes to search across them (omit `vault` to fan out, pass it to target one). " +
+    "query-notes to search across them (omit `vault` to fan out, pass it to target one), " +
+    "and create-note to write in one vault (`vault` is required). " +
     "grant-access / revoke-access / list-access give a Nostr pubkey a vault (role read|write) " +
-    "if you can admin that vault."
+    "if you can admin that vault. tools/list hides tools you cannot call."
   );
 }
 
@@ -302,7 +303,7 @@ async function handleOne(m: JsonRpcMessage, ctx: AccountToolContext): Promise<Js
       }
       case "tools/list":
         return result(id, {
-          tools: ACCOUNT_MCP_TOOLS.map((t) => ({
+          tools: toolsForPrincipal(ctx).map((t) => ({
             name: t.name,
             description: t.description,
             inputSchema: t.inputSchema,

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -2,10 +2,11 @@
  * Account-level MCP tools for the self-host hub — the payload behind
  * `/account/mcp`.
  *
- * Cloud's twin lives in the identity worker (`account-mcp.ts`). Same three
- * coverage tools (list-vaults, create-vault, query-notes), same "no vault_token
- * in model context" rule. Hub adds grant-access / revoke-access / list-access
- * (pubkey → one `user_vaults` row). Those three are hub-only: cloud grants are
+ * Cloud's twin lives in the identity worker (`account-mcp.ts`). Coverage tools
+ * (list-vaults, create-vault, query-notes) plus hub-only grant-access /
+ * revoke-access / list-access (pubkey → one `user_vaults` row). create-note is
+ * the first cross-vault write tool: `vault` is required, write is checked
+ * per call, a 60s `vault:<name>:write` mint fans to REST. Cloud grants are
  * D1-ownership shaped, not `user_vaults`. Coverage is hub-shaped:
  *
  *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
@@ -28,10 +29,11 @@ import {
   type ComposedVaultVerb,
   accountVaultsGrant,
   composedAccountGrant,
+  composedVerbSatisfies,
 } from "@openparachute/door-contract";
 import { type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
 import { HOST_ADMIN_SCOPE, provisionVault } from "./admin-vaults.ts";
-import { GrantError, grantAccess, listAccess, revokeAccess } from "./grant-access.ts";
+import { GrantError, callerCanAdminVault, grantAccess, listAccess, revokeAccess } from "./grant-access.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
 
@@ -206,6 +208,39 @@ export function resolveCoverage(
 
 function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
   return listVaultsWithMeta(ctx.manifestPath, ctx.issuer);
+}
+
+function isUnrestricted(db: Database, principal: AccountMcpPrincipal): boolean {
+  return principal.isHubAdmin || isFirstAdmin(db, principal.userId);
+}
+
+/**
+ * Per-call write check. Opening the account door (list/query) is not write.
+ * First-admin / host:admin are unrestricted. Everyone else needs the `write`
+ * verb on that vault's `user_vaults` row. A Bearer named subset that does not
+ * include the vault cannot write it even if assignment would allow.
+ */
+export function canWriteVault(
+  db: Database,
+  principal: AccountMcpPrincipal,
+  vaultName: string,
+): boolean {
+  // Bearer coverage / named-verb BEFORE unrestricted — same order as
+  // callerCanAdminVault. A first-admin token named `…:beta:read` must not
+  // mint `vault:beta:write`. Coverage wildcards (`account:vaults`) are not
+  // a verb cap; first-admin still writes after the named-verb check.
+  if (principal.authKind === "bearer") {
+    const grant = principal.grant;
+    if (!grant) return false;
+    if (grant.wildcard === null && !grant.vaults.has(vaultName)) return false;
+    const named = grant.vaults.get(vaultName);
+    if (named !== undefined && !composedVerbSatisfies(named, "write")) return false;
+    if (grant.wildcard === "admin") return true;
+    if (isUnrestricted(db, principal)) return true;
+    return vaultVerbsForUserVault(db, principal.userId, vaultName)?.includes("write") === true;
+  }
+  if (isUnrestricted(db, principal)) return true;
+  return vaultVerbsForUserVault(db, principal.userId, vaultName)?.includes("write") === true;
 }
 
 const listVaultsTool: AccountMcpTool = {
@@ -402,6 +437,110 @@ const queryNotesTool: AccountMcpTool = {
   },
 };
 
+function noteWriteBody(args: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (typeof args.content === "string") body.content = args.content;
+  if (typeof args.path === "string") body.path = args.path;
+  if (Array.isArray(args.tags)) body.tags = args.tags;
+  if (args.metadata && typeof args.metadata === "object") body.metadata = args.metadata;
+  if (typeof args.if_exists === "string") body.if_exists = args.if_exists;
+  return body;
+}
+
+async function postNoteToVault(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  body: Record<string, unknown>,
+): Promise<unknown> {
+  const sign = ctx.signToken ?? signAccessToken;
+  const fetchImpl = ctx.fetchImpl ?? fetch;
+  const minted = await sign(ctx.db, {
+    sub: ctx.principal.userId,
+    scopes: [`vault:${vault.name}:write`],
+    audience: `vault.${vault.name}`,
+    clientId: ACCOUNT_MCP_CLIENT_ID,
+    issuer: ctx.issuer,
+    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    vaultScope: [vault.name],
+    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
+  });
+  const origin =
+    typeof vault.port === "number" && vault.port > 0
+      ? `http://127.0.0.1:${vault.port}`
+      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
+  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}/api/notes`;
+  const res = await fetchImpl(url, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${minted.token}`,
+      accept: "application/json",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
+  });
+  if (!res.ok) {
+    let detail = `vault responded ${res.status}`;
+    try {
+      const errBody = (await res.json()) as Record<string, unknown>;
+      if (typeof errBody.error === "string") detail = errBody.error;
+    } catch {
+      // Non-JSON error body — keep the status-only detail.
+    }
+    throw new AccountToolError("vault_error", detail, { status: res.status, vault: vault.name });
+  }
+  return res.json();
+}
+
+const createNoteTool: AccountMcpTool = {
+  name: "create-note",
+  description:
+    "Create a note in one vault this connection can write. `vault` is required — this " +
+    "door does not invent a target. Does not return a vault token.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      vault: {
+        type: "string",
+        description: "Target vault by name. Must be a reachable vault this connection can write.",
+      },
+      content: { type: "string", description: "Note body (markdown)." },
+      path: { type: "string", description: "Note path (e.g. 'Log/hello')." },
+      tags: { type: "array", items: { type: "string" }, description: "Tags to apply." },
+      metadata: { type: "object", description: "Metadata fields to set." },
+      if_exists: {
+        type: "string",
+        enum: ["error", "ignore", "update", "replace"],
+        description: "What to do when `path` already names a note. Default error.",
+      },
+    },
+    required: ["vault"],
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    if (typeof args.vault !== "string" || args.vault.length === 0) {
+      throw new AccountToolError("invalid_vault", "vault is required.");
+    }
+    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+    const wanted = args.vault.toLowerCase();
+    const hit = coverage.vaults.find((v) => v.name === wanted);
+    if (!hit) {
+      throw new AccountToolError(
+        "vault_not_covered",
+        `Vault "${args.vault}" is not among the vaults this connection can reach.`,
+      );
+    }
+    if (!canWriteVault(ctx.db, ctx.principal, hit.name)) {
+      throw new AccountToolError(
+        "write_not_granted",
+        `This connection cannot write vault "${hit.name}".`,
+      );
+    }
+    const note = await postNoteToVault(ctx, hit, noteWriteBody(args));
+    return { vault: hit.name, note };
+  },
+};
+
 function installedNameSet(ctx: AccountToolContext): Set<string> {
   return new Set(installedVaults(ctx).map((v) => v.name));
 }
@@ -506,7 +645,31 @@ export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
   listVaultsTool,
   createVaultTool,
   queryNotesTool,
+  createNoteTool,
   grantAccessTool,
   revokeAccessTool,
   listAccessTool,
 ];
+
+/**
+ * Catalog filtered by what this principal can actually call. Admin-shaped
+ * tools (grant/revoke/list-access) and write tools are invisible below the
+ * verb, not just refused. Same pattern as the vault door.
+ */
+export function toolsForPrincipal(ctx: AccountToolContext): readonly AccountMcpTool[] {
+  const installed = installedVaults(ctx);
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installed);
+  const canWrite = coverage.vaults.some((v) => canWriteVault(ctx.db, ctx.principal, v.name));
+  const canAdmin = coverage.vaults.some((v) =>
+    callerCanAdminVault(ctx.db, ctx.principal, v.name),
+  );
+  const create = canCreate(ctx.principal);
+  return ACCOUNT_MCP_TOOLS.filter((t) => {
+    if (t.name === "create-vault") return create;
+    if (t.name === "create-note") return canWrite;
+    if (t.name === "grant-access" || t.name === "revoke-access" || t.name === "list-access") {
+      return canAdmin;
+    }
+    return true;
+  });
+}

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -189,11 +189,12 @@
  *   # per-vault proxy and generic service mounts so no module can claim it
  *   # via services.json paths). Vault-audience Bearer / API key still proxy
  *   # to the vault daemon (token names the vault). NIP-98
- *   # (`Authorization: Nostr`) is hub-user auth the daemon does not speak,
- *   # so that scheme routes to handleAccountMcp — same door as /account/mcp.
- *   # OAuth authorize / narrowRootMcpScopes are untouched.
- *   /mcp, /mcp/*                                → NIP-98 → account-MCP;
- *                                                otherwise proxy to the vault daemon
+ *   # (`Authorization: Nostr`) and Bearer `aud=account` are hub-user auth
+ *   # the daemon does not speak, so those route to handleAccountMcp — same
+ *   # door as /account/mcp. Vault-audience Bearer / API key still proxy.
+ *   /mcp, /mcp/*                                → NIP-98 or aud=account →
+ *                                                account-MCP; otherwise proxy
+ *                                                to the vault daemon
  *
  *   # Per-vault content proxy (user-facing vault data: Notes PWA, MCP, etc.).
  *   /vault/<name>/*                            → proxy to the vault backend
@@ -233,6 +234,7 @@ import type { Database } from "bun:sqlite";
 import { existsSync } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { decodeJwt } from "jose";
 import pkg from "../package.json" with { type: "json" };
 import {
   ACCOUNT_MUTATION_SCOPES,
@@ -1766,6 +1768,24 @@ function dbNotConfigured(): Response {
     { error: "service_unavailable", error_description: "hub db not configured" },
     { status: 503 },
   );
+}
+
+/**
+ * Routing peek only — not auth. A well-formed JWT with `aud=account` is
+ * handed to account-MCP; anything else (malformed, vault audience, API key)
+ * stays on the daemon-proxy path which does its own auth.
+ */
+function peekBearerAudience(req: Request): string | undefined {
+  const header = req.headers.get("authorization");
+  if (!header) return undefined;
+  const match = header.match(/^Bearer\s+(\S+)/i);
+  if (!match?.[1]) return undefined;
+  try {
+    const payload = decodeJwt(match[1]);
+    return typeof payload.aud === "string" ? payload.aud : undefined;
+  } catch {
+    return undefined;
+  }
 }
 
 // Canonical 404 body for root `/mcp` + its PRM well-known when
@@ -4356,12 +4376,13 @@ export function hubFetch(
       // resource. Vault-audience Bearer / API key still proxy to the daemon
       // (the TOKEN names the vault). NIP-98 never goes through OAuth
       // authorize — it is a signed event per request — and the daemon does
-      // not speak it (401 "API key required"). Intercept that scheme and
-      // hand the request to handleAccountMcp, the same handler /account/mcp
-      // uses. narrowRootMcpScopes and the root-/mcp authorize branch stay
-      // vault-only; folding account:vaults into them is a separate decision.
-      // Hub-only until Cloud's twin (parachute-cloud#273) matches this scheme
-      // split — door-contract 0.6.0 already ratifies a unified /mcp gateway.
+      // not speak it (401 "API key required"). An `aud=account` Bearer is
+      // the OAuth twin of that path: minting happens at /oauth/token after
+      // narrowRootMcpScopes kept `account:vaults`. Intercept both and hand
+      // the request to handleAccountMcp, the same handler /account/mcp uses.
+      // Hub-only until Cloud's OAuth twin (parachute-cloud#274) matches this
+      // scheme split. #273 is NIP-98 only. door-contract 0.6.0 already
+      // ratifies a unified /mcp gateway.
       if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
         // Same per-request force-change-password gate as the twins above —
         // a pre-rotation signed-in user can't reach vault data through here
@@ -4370,7 +4391,8 @@ export function hubFetch(
           const gate = forceChangePasswordGate(getDb(), req);
           if (gate) return gate;
         }
-        if (isNostrAuthorization(req)) {
+        const accountMcp = isNostrAuthorization(req) || peekBearerAudience(req) === "account";
+        if (accountMcp) {
           if (!getDb) return dbNotConfigured();
           return handleAccountMcp(req, {
             db: getDb(),

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -87,6 +87,7 @@ import {
   narrowResourceVaultScopes,
   narrowRootMcpScopes,
   resolveResourceVault,
+  resolveRootMcpTokenAudience,
 } from "./resource-binding.ts";
 import {
   ACCOUNT_SELF_ADMIN_SCOPE,
@@ -506,16 +507,16 @@ function advertisedScopes(declared: ReadonlySet<string>, manifest: ServicesManif
  *
  *   - **Hub-level scopes now have an explicit door boundary.** The root PRM
  *     starts from hub's authoritative requestable/module-installed catalog,
- *     then filters to vault scopes because root `/mcp` only accepts
- *     vault-audience tokens. This keeps the root advertisement honest while
- *     the bare PRM continues to describe the full hub resource.
+ *     then filters to vault scopes. `account:vaults` is requestable at this
+ *     door (`narrowRootMcpScopes` keeps it) but is NOT advertised here: a
+ *     spec-following client copies the whole catalog, and combining
+ *     `account:vaults` with vault scopes is refused. Advertise it on
+ *     `/account/mcp`'s PRM; request it explicitly at root `/mcp`.
+ *     `scribe:*` / `agent:send` / `hub:admin` stay dropped.
  *
- * Both documents start from `advertisedScopes`: one scope registry, filtered
- * by one rule (requestable ∧ module-installed). The root document then applies
- * `narrowRootMcpScopes` because the root door only ever mints vault-audience
- * tokens; advertising a non-vault scope that this authorize branch drops would
- * mislead a spec-following client into requesting something the door cannot
- * accept.
+ * Both documents start from `advertisedScopes`. The root document then applies
+ * `narrowRootMcpScopes`, which still drops `account:vaults` out of this
+ * advertisement because `advertisedScopes` already stripped `account:*`.
  */
 export function rootMcpProtectedResourceMetadata(deps: OAuthDeps): Response {
   const iss = deps.issuer;
@@ -641,10 +642,10 @@ function invalidTargetResponse(resource: string): Response {
  *     vault's scope explicitly — and inferAudience's first-scope-wins scan
  *     can't tell which one the CALLER wants THIS token bound to; an explicit
  *     `resource` disambiguates).
- *   - names the vault-agnostic root door → allowed as long as at least one
- *     named vault scope is present (root tokens are vault tokens whose
- *     target the resource server derives from the token itself); audience
- *     stays `fallbackAudience` (unchanged — root doesn't rename anything).
+ *   - names the vault-agnostic root door → vault-named grants stay on
+ *     `fallbackAudience` (`vault.<name>`); an account-vaults-only grant
+ *     (no named vault, `inferAudience` → `"account"`) mints `aud=account`.
+ *     Empty/foreign grants still reject.
  *   - resolves to neither (off-origin, malformed, non-MCP path, or a vault
  *     name not in `grantedVaultNames`) → reject.
  */
@@ -663,10 +664,9 @@ function resolveTokenResourceAudience(
     return { audience: `vault.${boundVault}` };
   }
   if (isRootMcpResource(requestResource, boundOrigins)) {
-    if (grantedVaultNames.size === 0) {
-      return { errorResponse: invalidTargetResponse(requestResource) };
-    }
-    return { audience: fallbackAudience };
+    const audience = resolveRootMcpTokenAudience(grantedVaultNames, fallbackAudience);
+    if (audience === null) return { errorResponse: invalidTargetResponse(requestResource) };
+    return { audience };
   }
   return { errorResponse: invalidTargetResponse(requestResource) };
 }
@@ -1086,12 +1086,11 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // the URL) so the two never diverge. Re-entry after login re-narrows
   // idempotently (no foreign scopes left to drop).
   //
-  // The ROOT `/mcp` door takes the same treatment minus the naming. It is a
-  // vault door too (vault derives the target from the token), so foreign
-  // scopes are just as unusable in the token it mints — but the resource
-  // carries no vault name, so there is nothing to narrow the vault scopes TO
-  // and the consent picker still supplies that. Without this branch the root
-  // door was the one place the whole-hub catalog still reached consent.
+  // The ROOT `/mcp` door takes the same treatment minus the naming. Vault
+  // grants still pick a vault at consent; `account:vaults` is the other
+  // legitimate root resource and mints `aud=account` (no picker). Foreign
+  // scopes are unusable in either token. Without this branch the root door
+  // was the one place the whole-hub catalog still reached consent.
   //
   // No resource, or one that isn't an MCP resource we front (off-origin,
   // malformed, non-vault path) → neither branch fires and the flow is

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -27,6 +27,7 @@
  *
  * Source of truth for scope shape: `docs/contracts/oauth-scopes.md`.
  */
+import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
 
 import { VAULT_VERBS } from "./jwt-audience.ts";
 
@@ -198,40 +199,56 @@ export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: 
 }
 
 /**
- * The root-`/mcp` counterpart of `narrowResourceVaultScopes`: drop every
- * non-vault scope, and change nothing else.
+ * The root-`/mcp` counterpart of `narrowResourceVaultScopes`: keep vault
+ * scopes and the account-MCP connection grant (`account:vaults` /
+ * `account:self:vaults`), drop everything else.
  *
- * Root `/mcp` is a vault door — whichever vault the token names. So the same
- * argument that drops `scribe:*` / `agent:send` / `hub:admin` from a per-vault
- * consent applies verbatim here: the flow ends in a token stamped
- * `aud=vault.<picked>`, in which those scopes are unusable, and carrying them
- * only inflates the consent surface. Before this branch existed a `resource`
- * naming root `/mcp` fell through `resolveResourceVault` to null, the whole
- * binding path no-op'd, and the root door alone kept showing the entire hub
- * scope catalog — the exact "scary consent" this module was written to kill,
- * surviving at one of the two MCP doors.
+ * Root `/mcp` is two token shapes at one URL, branched on what arrives:
+ * vault-audience Bearer still names one vault; `account:vaults` mints
+ * `aud=account` and is answered by account-MCP. The same argument that drops
+ * `scribe:*` / `agent:send` / `hub:admin` from a per-vault consent applies
+ * verbatim: those scopes are unusable in either token this door mints, and
+ * carrying them only inflates the consent surface.
  *
- * What this deliberately does NOT do is name the scopes. Unnamed
- * `vault:<verb>` is left exactly as requested, because there is no vault in
- * the resource to name it after; the consent picker supplies the name and the
- * existing rewrite turns it into `vault:<picked>:<verb>` before the code is
- * issued (`docs/contracts/oauth-scopes.md`, "Parser rules"). That is also why
- * the root PRM advertises the bare `vault:read` / `vault:write` /
- * `vault:admin` shapes: at the root door the bare shape is the correct thing
- * for a client to *request*, even though it is never the shape that ships in
- * the minted token.
+ * `account:vaults` cannot be combined with other scopes (authorize already
+ * refuses that). This filter still keeps both if a client asked for both —
+ * the combine check, not this function, is the refusal. Named
+ * `account:self:vaults:<vault>` forms are NOT the connection grant and are
+ * dropped here.
  *
- * Already-named `vault:<name>:<verb>` rides through untouched, same as the
- * per-vault path — a client that named a vault is not second-guessed here.
+ * What this deliberately does NOT do is name vault scopes. Unnamed
+ * `vault:<verb>` is left exactly as requested; the consent picker supplies
+ * the name. Already-named `vault:<name>:<verb>` rides through untouched.
  *
  * A request that carries ONLY foreign scopes narrows to the empty list. The
- * root authorize handler refuses that case with `invalid_scope` rather than
- * reaching a zero-scope consent screen; the per-vault path deliberately keeps
- * its empty narrowed list and renders consent, because that existing behavior
- * is part of its contract.
+ * root authorize handler refuses that case with `invalid_scope`.
  *
  * Idempotent: a second pass has nothing left to drop.
  */
+export function isAccountVaultsRootScope(scope: string): boolean {
+  return scope === ACCOUNT_VAULTS_UNNARROWED || scope === accountVaultsScope("self");
+}
+
 export function narrowRootMcpScopes(scopes: readonly string[]): string[] {
-  return scopes.filter((s) => s.split(":")[0] === "vault");
+  return scopes.filter((s) => s.split(":")[0] === "vault" || isAccountVaultsRootScope(s));
+}
+
+/**
+ * Audience for a token minted against root `/mcp`.
+ *
+ * Vault-named grants stay on `fallbackAudience` (`inferAudience` →
+ * `vault.<name>`). An account-vaults-only grant has no named vault and
+ * `inferAudience` already returns `"account"` — accept that instead of
+ * rejecting an empty vault-name set.
+ *
+ * Returns `null` when the grant is neither (foreign-only / empty) — the
+ * token handler turns that into `invalid_target`.
+ */
+export function resolveRootMcpTokenAudience(
+  grantedVaultNames: ReadonlySet<string>,
+  fallbackAudience: string,
+): string | null {
+  if (grantedVaultNames.size > 0) return fallbackAudience;
+  if (fallbackAudience === "account") return "account";
+  return null;
 }

--- a/src/scope-explanations.ts
+++ b/src/scope-explanations.ts
@@ -199,7 +199,7 @@ export const SCOPE_EXPLANATIONS: Record<string, ScopeExplanation> = {
   // not the REST `account:self:read` list/usage surface.
   "account:vaults": {
     label:
-      "Connect across your vaults — list them, search their notes, and create new vaults. Does not delete vaults or mint long-lived access tokens.",
+      "Let this app see which vaults you have and manage access to them — list them, search their notes, create vaults, and grant access by public key. Does not delete vaults or mint long-lived access tokens.",
     level: "write",
     risk: "elevated",
   },


### PR DESCRIPTION
Merging this publishes `@openparachute/hub@0.7.18-rc.4` to npm `@rc` (and ghcr `:rc`). It is an **rc**, not stable. `@latest` stays 0.7.17.

**Merge-commit, do not squash.** Squash would split `next` from `main`.

This is the click that puts #892/#893 on the box (same dance as #891). Agents cannot merge `main` (triage only).

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What ships (on `next` after 0.7.18-rc.3)

- #892 root `/mcp` OAuth `account:vaults` → `aud=account` (NIP-98 twin). Not advertised on the root PRM.
- #893 `create-note({vault, …})` on account-MCP, per-call write, filtered `tools/list`/`tools/call`
- #894 version+changelog 0.7.18-rc.4 + merge `main` into `next`

Leaves #880 and #881 open. Auto-provision still defaults **off**. Do not suffix-drop 0.7.18.

## After merge

`parachute upgrade hub --channel rc` on this box (not bun-link). Then NIP-98 `create-note` as ourselves into a vault we can write.
