### PR TITLE
release: hub 0.7.18-rc.5 — account-MCP update-note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.5] - 2026-08-28
+
+**Account-MCP update-note.** One PR on `next` after 0.7.18-rc.4.
+Version bump only; no new code in this commit. Merging this to `next`
+does not publish. The following next→main PR publishes `@rc`.
+
+- **Account-MCP `update-note({vault, id, …})` (#896).** Option B
+  second slice. `vault` and `id` are required. Same per-call write
+  gate as `create-note` (named Bearer `:read` cannot mint write,
+  including first-admin). 60s `vault:<name>:write` mint PATCHes REST
+  `/api/notes/:id` (path ids encoded). `tools/list` and `tools/call`
+  share the filtered catalog; hidden tools are `Unknown tool`. Cloud
+  follow-up: parachute-cloud#275.
+
+Leaves #880 and #881 open. Auto-provision still defaults off. Do not
+suffix-drop 0.7.18.
+
 ## [0.7.18-rc.4] - 2026-08-27
 
 **Account-MCP at root `/mcp` (OAuth) plus create-note.** Two PRs on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.4",
+  "version": "0.7.18-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## What

Version bump only. `package.json` `0.7.18-rc.4` → `0.7.18-rc.5` + CHANGELOG. No code.

Also merges `main` into `next` (the #895 merge commit next did not have). Same shape as #894. **Merge-commit this PR, do not squash** — squash would drop that merge commit and leave `next` behind `main` again.

Captures [hub#896](https://github.com/ParachuteComputer/parachute-hub/pull/896) (`update-note({vault,id})`). It landed on `next` at the already-published 0.7.18-rc.4 version, so it never reached npm.

Merging this to `next` does **not** publish. The following `next` → `main` merge-commit publishes `@openparachute/hub@0.7.18-rc.5` `@rc`. `@latest` stays 0.7.17.

Leaves #880 and #881 open. Auto-provision still defaults off. Do not suffix-drop 0.7.18.

Cloud follow-up: [parachute-cloud#275](https://github.com/ParachuteComputer/parachute-cloud/issues/275).

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

`release-check.sh` PASS vs `origin/main` (`0.7.18-rc.4` → `0.7.18-rc.5`). Lockfile WARN is version-only (deps untouched). Independent generalist: SHIP.