### PR TITLE
release: hub 0.7.18-rc.5 (next → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.5] - 2026-08-28
+
+**Account-MCP update-note.** One PR on `next` after 0.7.18-rc.4.
+Version bump only; no new code in this commit. Merging this to `next`
+does not publish. The following next→main PR publishes `@rc`.
+
+- **Account-MCP `update-note({vault, id, …})` (#896).** Option B
+  second slice. `vault` and `id` are required. Same per-call write
+  gate as `create-note` (named Bearer `:read` cannot mint write,
+  including first-admin). 60s `vault:<name>:write` mint PATCHes REST
+  `/api/notes/:id` (path ids encoded). `tools/list` and `tools/call`
+  share the filtered catalog; hidden tools are `Unknown tool`. Cloud
+  follow-up: parachute-cloud#275.
+
+Leaves #880 and #881 open. Auto-provision still defaults off. Do not
+suffix-drop 0.7.18.
+
 ## [0.7.18-rc.4] - 2026-08-27
 
 **Account-MCP at root `/mcp` (OAuth) plus create-note.** Two PRs on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.4",
+  "version": "0.7.18-rc.5",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -14,6 +14,8 @@ import type { Database } from "bun:sqlite";
  *   - grant-access: grant-first creates a key-only user; one-row upsert;
  *     friend write can grant their vault, read cannot; owner unrestricted
  *     is a no-op; revoke leaves the user; list-access is pubkey-shaped;
+ *   - create-note / update-note: vault required; write-audience mint;
+ *     catalog-hidden below write; PATCH encodes path ids;
  *   - descriptor advertises account_mcp_endpoint (see account-api.test).
  */
 import { describe, expect, test } from "bun:test";
@@ -438,6 +440,7 @@ describe("account MCP — initialize + tools", () => {
         "create-vault",
         "query-notes",
         "create-note",
+        "update-note",
         "grant-access",
         "revoke-access",
         "list-access",
@@ -945,8 +948,229 @@ describe("account MCP — create-note", () => {
       ).result.tools.map((t) => t.name);
       expect(names).toEqual(["list-vaults", "query-notes"]);
       expect(names).not.toContain("create-note");
+      expect(names).not.toContain("update-note");
       expect(names).not.toContain("grant-access");
       expect(names).not.toContain("create-vault");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — update-note", () => {
+  test("owner PATCHes the named vault with a write-audience mint", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: Array<{ url: string; method: string; scope: string; body: unknown }> = [];
+      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(String(input), init);
+        const auth = req.headers.get("authorization") ?? "";
+        const parts = auth.replace(/^Bearer\s+/i, "").split(".");
+        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+          scope?: string;
+        };
+        seen.push({
+          url: req.url,
+          method: req.method,
+          scope: payload.scope ?? "",
+          body: JSON.parse(await req.text()),
+        });
+        return Response.json({ id: "n1", path: "Log/hello", content: "there" }, { status: 200 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "update-note",
+            arguments: { vault: "beta", id: "n1", content: "there" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const out = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string; note: { id: string; content: string } };
+      expect(out.vault).toBe("beta");
+      expect(out.note.id).toBe("n1");
+      expect(out.note.content).toBe("there");
+      expect(seen).toHaveLength(1);
+      expect(seen[0]?.url).toContain("/vault/beta/api/notes/n1");
+      expect(seen[0]?.method).toBe("PATCH");
+      expect(seen[0]?.scope).toBe("vault:beta:write");
+      expect(seen[0]?.body).toEqual({ content: "there" });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("path id is encoded on the PATCH URL", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: string[] = [];
+      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(String(input), init);
+        seen.push(req.url);
+        return Response.json({ id: "n1", path: "Log/hello" }, { status: 200 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "update-note",
+            arguments: { vault: "beta", id: "Log/hello", append: " more", force: true },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(res.status).toBe(200);
+      expect(seen).toHaveLength(1);
+      expect(seen[0]).toContain("/vault/beta/api/notes/Log%2Fhello");
+      expect(seen[0]).not.toContain("/api/notes/Log/hello");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("read-role cannot update-note — Unknown tool, fetch never called", async () => {
+    const h = await makeHarness();
+    const readerSecret = hexToBytes("66".repeat(32));
+    const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
+    let fetched = 0;
+    try {
+      const reader = await createUser(h.db, "reader3", "correct-horse-battery-staple", {
+        allowMulti: true,
+        passwordChanged: true,
+        assignedVaults: ["beta"],
+        role: "read",
+      });
+      bindPubkeyFromHttpAuth(h.db, {
+        userId: reader.id,
+        pubkey: readerPub,
+        proofEvent: "{}",
+        proofEventId: "f".repeat(64),
+        label: "test",
+        now: new Date(),
+      });
+      const res = await handleAccountMcp(
+        nostrReq(
+          readerSecret,
+          rpc("tools/call", {
+            name: "update-note",
+            arguments: { vault: "beta", id: "n1", content: "nope" },
+          }),
+        ),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return Response.json({}, { status: 200 });
+          },
+        }),
+      );
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: update-note/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("first-admin Bearer named beta:read cannot update-note on beta", async () => {
+    const h = await makeHarness();
+    let fetched = 0;
+    try {
+      const token = await bearer(h, ["account:self:vaults:beta:read"], h.ownerId);
+      const res = await handleAccountMcp(
+        bearerReq(
+          token,
+          rpc("tools/call", { name: "update-note", arguments: { vault: "beta", id: "n1", content: "nope" } }),
+        ),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return Response.json({}, { status: 200 });
+          },
+        }),
+      );
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: update-note/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("friend NIP-98 write-role can update-note on the assigned vault", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: Array<{ method: string; scope: string }> = [];
+      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
+        const req = input instanceof Request ? input : new Request(String(input), init);
+        const parts = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").split(".");
+        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+          scope?: string;
+        };
+        seen.push({ method: req.method, scope: payload.scope ?? "" });
+        return Response.json({ id: "n-friend", content: "edited" }, { status: 200 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "update-note",
+            arguments: { vault: "beta", id: "n-friend", append: " more" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const out = parseTool(
+        (await res.json()) as { result: { content: Array<{ text: string }> } },
+      ) as { vault: string; note: { id: string } };
+      expect(out.vault).toBe("beta");
+      expect(out.note.id).toBe("n-friend");
+      expect(seen).toEqual([{ method: "PATCH", scope: "vault:beta:write" }]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("missing id is invalid_id", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", { name: "update-note", arguments: { vault: "beta", content: "x" } }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("invalid_id");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("unassigned vault is vault_not_covered", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "update-note",
+            arguments: { vault: "personal", id: "n1", content: "nope" },
+          }),
+        ),
+        mcpDeps(h),
+      );
+      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
+      expect(body.error?.data?.error_type).toBe("vault_not_covered");
     } finally {
       h.cleanup();
     }

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -279,7 +279,7 @@ function instructions(): string {
     "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
     "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
     "query-notes to search across them (omit `vault` to fan out, pass it to target one), " +
-    "and create-note to write in one vault (`vault` is required). " +
+    "create-note / update-note to write in one vault (`vault` is required). " +
     "grant-access / revoke-access / list-access give a Nostr pubkey a vault (role read|write) " +
     "if you can admin that vault. tools/list hides tools you cannot call."
   );

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -4,10 +4,11 @@
  *
  * Cloud's twin lives in the identity worker (`account-mcp.ts`). Coverage tools
  * (list-vaults, create-vault, query-notes) plus hub-only grant-access /
- * revoke-access / list-access (pubkey → one `user_vaults` row). create-note is
- * the first cross-vault write tool: `vault` is required, write is checked
- * per call, a 60s `vault:<name>:write` mint fans to REST. Cloud grants are
- * D1-ownership shaped, not `user_vaults`. Coverage is hub-shaped:
+ * revoke-access / list-access (pubkey → one `user_vaults` row). create-note /
+ * update-note write one vault: `vault` is required, write is checked per call,
+ * a 60s `vault:<name>:write` mint fans to REST (POST /api/notes, PATCH
+ * /api/notes/:id). Cloud grants are D1-ownership shaped, not `user_vaults`.
+ * Coverage is hub-shaped:
  *
  *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
  *     (legacy blanket / narrowed) or composed `account:self:vaults:*:<verb>`,
@@ -447,10 +448,49 @@ function noteWriteBody(args: Record<string, unknown>): Record<string, unknown> {
   return body;
 }
 
-async function postNoteToVault(
+function noteUpdateBody(args: Record<string, unknown>): Record<string, unknown> {
+  const body: Record<string, unknown> = {};
+  if (typeof args.content === "string") body.content = args.content;
+  if (typeof args.append === "string") body.append = args.append;
+  if (typeof args.prepend === "string") body.prepend = args.prepend;
+  if (args.content_edit && typeof args.content_edit === "object") body.content_edit = args.content_edit;
+  if (typeof args.path === "string") body.path = args.path;
+  if (args.tags && typeof args.tags === "object") body.tags = args.tags;
+  if (args.metadata && typeof args.metadata === "object" && args.metadata !== null) {
+    body.metadata = args.metadata;
+  }
+  if (typeof args.if_updated_at === "string") body.if_updated_at = args.if_updated_at;
+  if (args.force === true) body.force = true;
+  if (typeof args.if_missing === "string") body.if_missing = args.if_missing;
+  return body;
+}
+
+function requireWritableVault(ctx: AccountToolContext, rawVault: unknown): AccountVaultMeta {
+  if (typeof rawVault !== "string" || rawVault.length === 0) {
+    throw new AccountToolError("invalid_vault", "vault is required.");
+  }
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+  const wanted = rawVault.toLowerCase();
+  const hit = coverage.vaults.find((v) => v.name === wanted);
+  if (!hit) {
+    throw new AccountToolError(
+      "vault_not_covered",
+      `Vault "${rawVault}" is not among the vaults this connection can reach.`,
+    );
+  }
+  if (!canWriteVault(ctx.db, ctx.principal, hit.name)) {
+    throw new AccountToolError(
+      "write_not_granted",
+      `This connection cannot write vault "${hit.name}".`,
+    );
+  }
+  return hit;
+}
+
+async function vaultNoteWrite(
   ctx: AccountToolContext,
   vault: AccountVaultMeta,
-  body: Record<string, unknown>,
+  opts: { method: string; path: string; body: Record<string, unknown> },
 ): Promise<unknown> {
   const sign = ctx.signToken ?? signAccessToken;
   const fetchImpl = ctx.fetchImpl ?? fetch;
@@ -468,15 +508,15 @@ async function postNoteToVault(
     typeof vault.port === "number" && vault.port > 0
       ? `http://127.0.0.1:${vault.port}`
       : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
-  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}/api/notes`;
+  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}${opts.path}`;
   const res = await fetchImpl(url, {
-    method: "POST",
+    method: opts.method,
     headers: {
       authorization: `Bearer ${minted.token}`,
       accept: "application/json",
       "content-type": "application/json",
     },
-    body: JSON.stringify(body),
+    body: JSON.stringify(opts.body),
     signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
   });
   if (!res.ok) {
@@ -484,6 +524,7 @@ async function postNoteToVault(
     try {
       const errBody = (await res.json()) as Record<string, unknown>;
       if (typeof errBody.error === "string") detail = errBody.error;
+      else if (typeof errBody.error_type === "string") detail = errBody.error_type;
     } catch {
       // Non-JSON error body — keep the status-only detail.
     }
@@ -518,25 +559,72 @@ const createNoteTool: AccountMcpTool = {
     additionalProperties: false,
   },
   async execute(args, ctx) {
-    if (typeof args.vault !== "string" || args.vault.length === 0) {
-      throw new AccountToolError("invalid_vault", "vault is required.");
+    const hit = requireWritableVault(ctx, args.vault);
+    const note = await vaultNoteWrite(ctx, hit, {
+      method: "POST",
+      path: "/api/notes",
+      body: noteWriteBody(args),
+    });
+    return { vault: hit.name, note };
+  },
+};
+
+const updateNoteTool: AccountMcpTool = {
+  name: "update-note",
+  description:
+    "Update a note in one vault this connection can write. `vault` and `id` are required. " +
+    "Same body as vault PATCH /api/notes/:id (content / append / prepend / content_edit / " +
+    "path / tags / metadata / if_updated_at / force). Does not return a vault token.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      vault: {
+        type: "string",
+        description: "Target vault by name. Must be a reachable vault this connection can write.",
+      },
+      id: {
+        type: "string",
+        description: "Note ID or path in that vault.",
+      },
+      content: { type: "string", description: "Full content replace." },
+      append: { type: "string", description: "Append to the end of the note." },
+      prepend: { type: "string", description: "Prepend to the start of the note." },
+      content_edit: {
+        type: "object",
+        properties: {
+          old_text: { type: "string" },
+          new_text: { type: "string" },
+        },
+        required: ["old_text", "new_text"],
+        description: "Find-and-replace one occurrence.",
+      },
+      path: { type: "string", description: "New path." },
+      tags: { type: "object", description: "Tag mutations `{ add, remove }`." },
+      metadata: { type: "object", description: "Metadata merge-patch." },
+      if_updated_at: {
+        type: "string",
+        description: "Optimistic concurrency: reject if the note changed since.",
+      },
+      force: { type: "boolean", description: "Waive if_updated_at requirement." },
+      if_missing: {
+        type: "string",
+        enum: ["fail", "create"],
+        description: "What to do when the note does not exist. Default fail.",
+      },
+    },
+    required: ["vault", "id"],
+    additionalProperties: false,
+  },
+  async execute(args, ctx) {
+    if (typeof args.id !== "string" || args.id.length === 0) {
+      throw new AccountToolError("invalid_id", "id is required.");
     }
-    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
-    const wanted = args.vault.toLowerCase();
-    const hit = coverage.vaults.find((v) => v.name === wanted);
-    if (!hit) {
-      throw new AccountToolError(
-        "vault_not_covered",
-        `Vault "${args.vault}" is not among the vaults this connection can reach.`,
-      );
-    }
-    if (!canWriteVault(ctx.db, ctx.principal, hit.name)) {
-      throw new AccountToolError(
-        "write_not_granted",
-        `This connection cannot write vault "${hit.name}".`,
-      );
-    }
-    const note = await postNoteToVault(ctx, hit, noteWriteBody(args));
+    const hit = requireWritableVault(ctx, args.vault);
+    const note = await vaultNoteWrite(ctx, hit, {
+      method: "PATCH",
+      path: `/api/notes/${encodeURIComponent(args.id)}`,
+      body: noteUpdateBody(args),
+    });
     return { vault: hit.name, note };
   },
 };
@@ -646,6 +734,7 @@ export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
   createVaultTool,
   queryNotesTool,
   createNoteTool,
+  updateNoteTool,
   grantAccessTool,
   revokeAccessTool,
   listAccessTool,
@@ -666,7 +755,7 @@ export function toolsForPrincipal(ctx: AccountToolContext): readonly AccountMcpT
   const create = canCreate(ctx.principal);
   return ACCOUNT_MCP_TOOLS.filter((t) => {
     if (t.name === "create-vault") return create;
-    if (t.name === "create-note") return canWrite;
+    if (t.name === "create-note" || t.name === "update-note") return canWrite;
     if (t.name === "grant-access" || t.name === "revoke-access" || t.name === "list-access") {
       return canAdmin;
     }


### PR DESCRIPTION
Merging this publishes `@openparachute/hub@0.7.18-rc.5` to npm `@rc` (and ghcr `:rc`). It is an **rc**, not stable. `@latest` stays 0.7.17.

**Merge-commit, do not squash.** Squash would split `next` from `main`.

This is the click that puts #896 on the box (same dance as #895). Agents cannot merge `main` (triage only).

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What ships (on `next` after 0.7.18-rc.4)

- #896 `update-note({vault, id, …})` on account-MCP, per-call write, PATCH `/api/notes/:id`, filtered `tools/list`/`tools/call`
- #897 version+changelog 0.7.18-rc.5 + merge `main` into `next`

Leaves #880 and #881 open. Auto-provision still defaults **off**. Do not suffix-drop 0.7.18.

Cloud follow-up: [parachute-cloud#275](https://github.com/ParachuteComputer/parachute-cloud/issues/275).

## After merge

`parachute upgrade hub --channel rc` on this box (not bun-link). Then NIP-98 `update-note` as ourselves on the create-note felt log.