### PR TITLE
feat(hub): onboarding copy for /account/mcp; rename assigned-vault helper

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -16,11 +16,13 @@
  *     change-password link.
  */
 import { describe, expect, test } from "bun:test";
+import { renderAccountHome } from "../account-home-ui.ts";
 import {
   accountClaudeMcpAddCommand,
   accountMcpEndpoint,
-  renderAccountHome,
-} from "../account-home-ui.ts";
+  assignedVaultClaudeMcpAddCommand,
+  assignedVaultMcpEndpoint,
+} from "../mcp-connect-commands.ts";
 import type { VaultVerb } from "../users.ts";
 
 const HUB_ORIGIN = "https://hub.example";
@@ -175,9 +177,11 @@ describe("renderAccountHome", () => {
     const cleanEncoded = encodeURIComponent(`${HUB_ORIGIN}/vault/alice`);
     expect(html).toContain(`https://notes.parachute.computer/add?url=${cleanEncoded}`);
     // The MCP endpoint + connect command also drop the trailing slash — no
-    // `//vault` double-slash sneaks in.
+    // `//vault` or `//account` double-slash sneaks in.
     expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
+    expect(html).toContain(`${HUB_ORIGIN}/account/mcp`);
     expect(html).not.toContain(`${HUB_ORIGIN}//vault`);
+    expect(html).not.toContain(`${HUB_ORIGIN}//account`);
   });
 
   test("admin branch — null assignedVault + isFirstAdmin renders an /admin/ link", () => {
@@ -551,12 +555,16 @@ describe("renderAccountHome", () => {
     expect(html.split("<script>").length - 1).toBe(1);
   });
 
-  test("accountMcpEndpoint / accountClaudeMcpAddCommand build the canonical shapes", () => {
-    expect(accountMcpEndpoint("https://hub.example", "work")).toBe(
+  test("assignedVaultMcpEndpoint / accountMcpEndpoint build the two door shapes", () => {
+    expect(assignedVaultMcpEndpoint("https://hub.example", "work")).toBe(
       "https://hub.example/vault/work/mcp",
     );
-    expect(accountClaudeMcpAddCommand("https://hub.example", "work")).toBe(
+    expect(assignedVaultClaudeMcpAddCommand("https://hub.example", "work")).toBe(
       "claude mcp add --transport http parachute-work https://hub.example/vault/work/mcp",
+    );
+    expect(accountMcpEndpoint("https://hub.example")).toBe("https://hub.example/account/mcp");
+    expect(accountClaudeMcpAddCommand("https://hub.example")).toBe(
+      "claude mcp add --transport http parachute-account https://hub.example/account/mcp",
     );
   });
 
@@ -708,6 +716,13 @@ describe("renderAccountHome", () => {
     // suffix is load-bearing (only it returns the WWW-Authenticate header).
     expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
     expect(html).toMatch(/data-testid="onboarding-mcp-endpoint">[^<]*\/vault\/alice\/mcp</);
+    // Whole-house /account/mcp is the labeled second option, not a replacement.
+    expect(html).toContain('data-testid="onboarding-house"');
+    expect(html).toContain("All assigned vaults");
+    expect(html).toMatch(/data-testid="onboarding-account-mcp-endpoint">[^<]*\/account\/mcp</);
+    expect(html).toContain(
+      `claude mcp add --transport http parachute-account ${HUB_ORIGIN}/account/mcp`,
+    );
     // Both connect methods are inline in step ②.
     expect(html).toContain('data-testid="onboarding-mcp-add-command"');
     expect(html).toContain("Add custom connector");
@@ -755,11 +770,14 @@ describe("renderAccountHome", () => {
     expect(html).toContain('data-testid="onboarding-connect-another-summary"');
     expect(html).toContain("Connect another AI");
     // ...re-reveals the endpoint + BOTH connect methods that the condensed
-    // line used to delete entirely (the hub#583 defect).
+    // line used to delete entirely (the hub#583 defect), including the
+    // whole-house door.
     expect(html).toContain('data-testid="onboarding-mcp-endpoint"');
     expect(html).toContain('data-testid="onboarding-mcp-add-command"');
+    expect(html).toContain('data-testid="onboarding-account-mcp-endpoint"');
     expect(html).toContain("Claude.ai (web)");
     expect(html).toContain("Claude Code (terminal)");
+    expect(html).toContain("All assigned vaults");
   });
 
   test("onboarding NON-condensed (not connected) state has no 'Connect another AI' expander (hub#583)", () => {
@@ -839,6 +857,7 @@ describe("renderAccountHome", () => {
     // per-vault tiles below still list every vault (by name + Notes CTA), but
     // no longer repeat the connect endpoint (dedup — connect lives only here).
     expect(html).toMatch(/data-testid="onboarding-mcp-endpoint">[^<]*\/vault\/personal\/mcp</);
+    expect(html).toContain(`${HUB_ORIGIN}/account/mcp`); // whole-house second option
     expect(html).toContain("<strong>family</strong>"); // second vault still has a tile
     expect(html).not.toContain(`${HUB_ORIGIN}/vault/family/mcp`); // no duplicated connect
   });

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -2162,7 +2162,6 @@ describe("handleSetupVaultPost", () => {
       db.close();
     }
   }
-
 });
 
 // --- end-to-end through hubFetch -----------------------------------------
@@ -2642,26 +2641,39 @@ describe("done screen MCP command — OAuth-default, no auto-mint", () => {
       );
       expect(res.status).toBe(200);
       const html = await res.text();
-      // The bare OAuth command is the rendered command.
+      // Whole-house command is the recommended default; per-vault is the
+      // narrower option. Root `/mcp` is no longer the copy-paste target
+      // (its PRM is vault-only; `/account/mcp` is the honest house door).
       expect(html).toContain(
-        "claude mcp add --transport http parachute-default https://hub.example/mcp",
+        "claude mcp add --transport http parachute-account https://hub.example/account/mcp",
       );
+      expect(html).toContain(
+        "claude mcp add --transport http parachute-default https://hub.example/vault/default/mcp",
+      );
+      expect(html).toContain('data-testid="mcp-house-command"');
+      expect(html).toContain('data-testid="mcp-vault-command"');
       // Load-bearing regression (Austen's report): the rendered COMMAND
-      // (the MCP tile's <pre> block) must NOT carry a `--header
+      // (the MCP tile's <pre> blocks) must NOT carry a `--header
       // "Authorization: Bearer ..."` flag. This is the assertion that
       // would have caught the bug — the prior build baked the header into
       // the command. The headless-client fine print legitimately mentions
       // the header form with an escaped `<token>` placeholder, so we
-      // scope the negative assertion to the command block, not the whole
+      // scope the negative assertion to the command blocks, not the whole
       // document. Anchor to the MCP-tile <h2> so the regex can't drift
       // onto another tile's <pre> (e.g. the tailnet/public reachable
       // tile's bare Tailscale command) under a different expose mode.
-      const cmdPre = html.match(/<h2>Connect Claude Code \(MCP\)<\/h2>[\s\S]*?<pre>([^<]*)<\/pre>/);
-      expect(cmdPre).not.toBeNull();
-      const cmdText = cmdPre?.[1] ?? "";
-      expect(cmdText).not.toContain("--header");
-      expect(cmdText).not.toContain("Authorization");
-      expect(cmdText).not.toContain("Bearer");
+      const tile = html.match(
+        /<h2>Connect Claude Code \(MCP\)<\/h2>[\s\S]*?(?=<div class="done-tile">|$)/,
+      );
+      expect(tile).not.toBeNull();
+      const tileHtml = tile?.[0] ?? "";
+      const cmdPres = [...tileHtml.matchAll(/<pre[^>]*>([^<]*)<\/pre>/g)].map((m) => m[1]);
+      expect(cmdPres.length).toBe(2);
+      for (const cmdText of cmdPres) {
+        expect(cmdText).not.toContain("--header");
+        expect(cmdText).not.toContain("Authorization");
+        expect(cmdText).not.toContain("Bearer");
+      }
       // The document must NOT carry a real or masked Bearer token — the
       // only legitimate `Bearer` mention is the escaped placeholder in
       // the guidance.
@@ -3471,8 +3483,10 @@ describe("typed vault name (hub#267)", () => {
         },
       );
       const html = await res.text();
+      expect(html).toContain("parachute-account");
+      expect(html).toContain("https://hub.example/account/mcp");
       expect(html).toContain("parachute-my-personal-vault");
-      expect(html).toContain("https://hub.example/mcp");
+      expect(html).toContain("https://hub.example/vault/my-personal-vault/mcp");
     } finally {
       db.close();
     }

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -20,6 +20,12 @@
  */
 import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
+import {
+  accountClaudeMcpAddCommand,
+  accountMcpEndpoint,
+  assignedVaultClaudeMcpAddCommand,
+  assignedVaultMcpEndpoint,
+} from "./mcp-connect-commands.ts";
 import { escapeHtml } from "./oauth-ui.ts";
 import type { VaultVerb } from "./users.ts";
 
@@ -316,10 +322,12 @@ interface OnboardingChecklistOpts {
  * person an obvious path:
  *
  *   ① Your account is ready  — always done (they're signed in, password set).
- *   ② Connect your AI        — the hero. Inline endpoint (`/vault/<name>/mcp`)
- *                              with a copy button + the two short connect
- *                              methods (Claude.ai connector, Claude Code
- *                              `claude mcp add`). Marked done when `connected`.
+ *   ② Connect your AI        — the hero. Per-vault endpoint (`/vault/<name>/mcp`)
+ *                              first (narrower OAuth option), then a clearly
+ *                              labeled "all assigned vaults" `/account/mcp`
+ *                              command. Claude.ai connector + Claude Code
+ *                              `claude mcp add` for each. Marked done when
+ *                              `connected`.
  *   ③ Set up your vault      — links the vault-setup starter prompt.
  *
  * When `connected` is true the whole thing condenses to a quiet "✓ You're
@@ -332,28 +340,49 @@ interface OnboardingChecklistOpts {
 function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
   const { primaryVault, trimmedOrigin, connected } = opts;
   const safeVault = escapeHtml(primaryVault);
-  const endpoint = accountMcpEndpoint(trimmedOrigin, primaryVault);
-  const addCmd = accountClaudeMcpAddCommand(trimmedOrigin, primaryVault);
-  const safeEndpoint = escapeHtml(endpoint);
-  const safeAddCmd = escapeHtml(addCmd);
+  const vaultEndpoint = assignedVaultMcpEndpoint(trimmedOrigin, primaryVault);
+  const vaultAddCmd = assignedVaultClaudeMcpAddCommand(trimmedOrigin, primaryVault);
+  const houseEndpoint = accountMcpEndpoint(trimmedOrigin);
+  const houseAddCmd = accountClaudeMcpAddCommand(trimmedOrigin);
+  const safeVaultEndpoint = escapeHtml(vaultEndpoint);
+  const safeVaultAddCmd = escapeHtml(vaultAddCmd);
+  const safeHouseEndpoint = escapeHtml(houseEndpoint);
+  const safeHouseAddCmd = escapeHtml(houseAddCmd);
 
-  // The endpoint + both connect methods. Shared between the full checklist
-  // (step 2) and the condensed "Connect another AI" expander (hub#583) so a
-  // genuinely-connected user can still wire up a SECOND client without losing
-  // the instructions.
+  // Per-vault first (narrower OAuth option), then the whole-house door.
+  // Shared between the full checklist (step 2) and the condensed
+  // "Connect another AI" expander (hub#583) so a genuinely-connected
+  // user can still wire up a SECOND client without losing the instructions.
   const connectMethods = `
             <div class="copy-row">
-              <code data-testid="onboarding-mcp-endpoint">${safeEndpoint}</code>
-              <button type="button" class="btn btn-copy" data-copy="${safeEndpoint}"
+              <code data-testid="onboarding-mcp-endpoint">${safeVaultEndpoint}</code>
+              <button type="button" class="btn btn-copy" data-copy="${safeVaultEndpoint}"
                       data-testid="copy-onboarding-endpoint">Copy</button>
             </div>
             <p class="onboarding-method"><strong>Claude.ai (web):</strong> open
                Settings → Connectors → Add custom connector, and paste the address above.</p>
             <p class="onboarding-method"><strong>Claude Code (terminal):</strong> run this command:</p>
             <div class="copy-row">
-              <code data-testid="onboarding-mcp-add-command">${safeAddCmd}</code>
-              <button type="button" class="btn btn-copy" data-copy="${safeAddCmd}"
+              <code data-testid="onboarding-mcp-add-command">${safeVaultAddCmd}</code>
+              <button type="button" class="btn btn-copy" data-copy="${safeVaultAddCmd}"
                       data-testid="copy-onboarding-add-command">Copy</button>
+            </div>
+            <div class="onboarding-house" data-testid="onboarding-house">
+              <p class="onboarding-house-label" data-testid="onboarding-house-label">All assigned vaults</p>
+              <p class="onboarding-step-sub">One connection covering every vault this account can
+                 access. Paste this instead if you want the whole house, not just
+                 <code>${safeVault}</code>:</p>
+              <div class="copy-row">
+                <code data-testid="onboarding-account-mcp-endpoint">${safeHouseEndpoint}</code>
+                <button type="button" class="btn btn-copy" data-copy="${safeHouseEndpoint}"
+                        data-testid="copy-onboarding-account-endpoint">Copy</button>
+              </div>
+              <p class="onboarding-method"><strong>Claude Code (terminal):</strong></p>
+              <div class="copy-row">
+                <code data-testid="onboarding-account-mcp-add-command">${safeHouseAddCmd}</code>
+                <button type="button" class="btn btn-copy" data-copy="${safeHouseAddCmd}"
+                        data-testid="copy-onboarding-account-add-command">Copy</button>
+              </div>
             </div>`;
 
   // Condensed state — they've connected, so the checklist shrinks to a quiet
@@ -372,8 +401,9 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
       <details class="onboarding-connect-another" data-testid="onboarding-connect-another">
         <summary data-testid="onboarding-connect-another-summary">Connect another AI →</summary>
         <div class="onboarding-step-body">
-          <p class="onboarding-step-sub">Point another AI client at your vault using this
-             address — you'll sign in and approve the first time:</p>
+          <p class="onboarding-step-sub">Point another AI client at your vault — or at every
+             vault this account can access — using the addresses below. You'll sign in and
+             approve the first time:</p>
           ${connectMethods}
         </div>
       </details>
@@ -399,8 +429,10 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
           <span class="onboarding-num" aria-hidden="true">2</span>
           <div class="onboarding-step-body">
             <p class="onboarding-step-title">Connect your AI</p>
-            <p class="onboarding-step-sub">Point Claude (or another AI) at your vault using this
-               address — no token to copy, you'll sign in and approve the first time:</p>
+            <p class="onboarding-step-sub">Point Claude (or another AI) at your
+               <code>${safeVault}</code> vault using this address — no token to copy, you'll
+               sign in and approve the first time. A second command below covers every
+               vault this account can access:</p>
             ${connectMethods}
           </div>
         </li>
@@ -474,32 +506,6 @@ interface VaultCardOpts {
   mirrorPushing: Record<string, boolean>;
   /** `vaultName` → is the backup state good (drives the ✓ vs ! glyph). Absent = healthy. */
   mirrorHealthy: Record<string, boolean>;
-}
-
-/**
- * Build `<hub-origin>/vault/<name>/mcp` — the MCP endpoint a client connects
- * to. Mirrors the SPA's `mcpEndpointFor` (McpConnectCard.tsx) and the
- * wizard's `renderMcpTile`. The friend's `/account/` tile is server-rendered
- * (no SPA), so we compute it here from the hub origin + vault name rather
- * than the vault's well-known `url`.
- *
- * Exported for direct unit testing.
- */
-export function accountMcpEndpoint(trimmedOrigin: string, vaultName: string): string {
-  return `${trimmedOrigin}/vault/${vaultName}/mcp`;
-}
-
-/**
- * The OAuth-path `claude mcp add` command — no token, triggers browser OAuth
- * on first use. Same `parachute-<name>` server name as the SPA card and the
- * wizard tile, so a friend and the operator end up with identically-named
- * MCP servers. Exported for direct unit testing.
- */
-export function accountClaudeMcpAddCommand(trimmedOrigin: string, vaultName: string): string {
-  return `claude mcp add --transport http parachute-${vaultName} ${accountMcpEndpoint(
-    trimmedOrigin,
-    vaultName,
-  )}`;
 }
 
 function renderVaultCard(opts: VaultCardOpts): string {
@@ -971,6 +977,17 @@ const STYLES = `
     margin: 0.5rem 0 0.3rem;
   }
   .onboarding-method strong { color: ${PALETTE.fg}; }
+  .onboarding-house {
+    margin: 0.75rem 0 0;
+    padding-top: 0.65rem;
+    border-top: 1px solid ${PALETTE.borderLight};
+  }
+  .onboarding-house-label {
+    font-weight: 600;
+    font-size: 0.85rem;
+    color: ${PALETTE.fg};
+    margin: 0 0 0.2rem;
+  }
   .onboarding-step .copy-row { margin: 0.35rem 0; }
   .onboarding-foot {
     font-size: 0.82rem;
@@ -1262,7 +1279,9 @@ const STYLES = `
     .onboarding-foot { color: #a8a29a; }
     .vault-name strong,
     .onboarding-step-title, .onboarding-method strong,
+    .onboarding-house-label,
     .onboarding-done-line { color: #f0ece4; }
+    .onboarding-house { border-top-color: #3a362f; }
     .onboarding-step-done .onboarding-step-title { color: #a8a29a; }
     code { background: #1f1c18; color: #e8e4dc; }
     .copy-row code { background: transparent; }

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -124,6 +124,14 @@ function accountMcpResource(issuer: string): string {
 }
 
 function accountMcpChallenge(issuer: string): string {
+  // Always names the /account/mcp PRM. When handleAccountMcp answers a
+  // request that arrived at root /mcp (NIP-98 or the aud=account routing
+  // peek), RFC 9728 §3.3 wants resource_metadata to describe the URL the
+  // client requested — this PRM's `resource` is `/account/mcp`, so a
+  // strict client MUST discard the challenge. Valid-token dispatch at
+  // root is still the right alias. Tracked as hub#899. Do not "fix" by
+  // advertising `account:vaults` on the root PRM: catalog-copy +
+  // combine-refusal is a total `invalid_scope` bounce.
   const origin = issuer.replace(/\/$/, "");
   return `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/account/mcp"`;
 }

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -4393,6 +4393,10 @@ export function hubFetch(
         }
         const accountMcp = isNostrAuthorization(req) || peekBearerAudience(req) === "account";
         if (accountMcp) {
+          // Success path: same handler as /account/mcp. Failure path: that
+          // handler's 401 challenge still points at the /account/mcp PRM
+          // (RFC 9728 §3.3 mismatch vs the requested /mcp URL). hub#899;
+          // do not mix scope families on the root PRM to paper over it.
           if (!getDb) return dbNotConfigured();
           return handleAccountMcp(req, {
             db: getDb(),

--- a/src/mcp-connect-commands.ts
+++ b/src/mcp-connect-commands.ts
@@ -1,0 +1,37 @@
+/**
+ * Copy-paste MCP connect URLs and Claude Code commands.
+ *
+ * Two doors, two names — do not mix them:
+ *   - `/account/mcp` — whole house / all assigned vaults (`account:vaults`)
+ *   - `/vault/<name>/mcp` — one assigned vault (`vault:<name>:*`)
+ *
+ * Root `/mcp` is a convenience alias for NIP-98 and for a Bearer that
+ * already has `aud=account`. OAuth discovery at root advertises vault
+ * scopes only; a generic client that catalog-copies that list cannot
+ * learn `account:vaults` (and must not be taught it there — combining
+ * the two families is `invalid_scope`). Point OAuth clients at
+ * `/account/mcp` for the house, `/vault/<name>/mcp` for one vault.
+ */
+
+/** `<hub-origin>/vault/<name>/mcp` — one assigned vault. */
+export function assignedVaultMcpEndpoint(trimmedOrigin: string, vaultName: string): string {
+  return `${trimmedOrigin}/vault/${vaultName}/mcp`;
+}
+
+/** OAuth `claude mcp add` for one assigned vault. Server name `parachute-<name>`. */
+export function assignedVaultClaudeMcpAddCommand(trimmedOrigin: string, vaultName: string): string {
+  return `claude mcp add --transport http parachute-${vaultName} ${assignedVaultMcpEndpoint(
+    trimmedOrigin,
+    vaultName,
+  )}`;
+}
+
+/** `<hub-origin>/account/mcp` — all assigned vaults. */
+export function accountMcpEndpoint(trimmedOrigin: string): string {
+  return `${trimmedOrigin}/account/mcp`;
+}
+
+/** OAuth `claude mcp add` for the whole house. Server name `parachute-account`. */
+export function accountClaudeMcpAddCommand(trimmedOrigin: string): string {
+  return `claude mcp add --transport http parachute-account ${accountMcpEndpoint(trimmedOrigin)}`;
+}

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -69,6 +69,10 @@ import {
   setSetting,
 } from "./hub-settings.ts";
 import { signAccessToken } from "./jwt-sign.ts";
+import {
+  accountClaudeMcpAddCommand,
+  assignedVaultClaudeMcpAddCommand,
+} from "./mcp-connect-commands.ts";
 import { escapeHtml } from "./oauth-ui.ts";
 import {
   type IssueOperatorTokenResult,
@@ -1130,9 +1134,9 @@ export function renderDoneStep(props: RenderDoneStepProps): string {
 }
 
 /**
- * The MCP-connect tile. Renders the bare `claude mcp add` command —
+ * The MCP-connect tile. Renders two bare `claude mcp add` commands —
  * no token, no `--header`. Vault/init is OAuth-default (parachute-vault
- * #491), so the command triggers browser OAuth on first use: the
+ * #491), so each command triggers browser OAuth on first use: the
  * operator signs in to this hub + approves access, and Claude Code
  * stores the resulting credential. For headless clients that can't do
  * the browser flow, the fine print points at `/admin/tokens` (the
@@ -1147,24 +1151,32 @@ export function renderDoneStep(props: RenderDoneStepProps): string {
  * was a privilege over-grant + a shoulder-surf hazard. The bare OAuth
  * command was always the correct UX; it's now the only one.
  *
- * URL shape (hub#777): points at the canonical root `<hubOrigin>/mcp`
- * rather than the per-vault `/vault/<name>/mcp` form — root `/mcp` is
- * vault-agnostic (the OAuth consent picks the audience), so it stays
- * correct even if the operator renames this vault or adds more later.
- * At this point in the wizard there's exactly one vault, so the OAuth
- * consent screen has nothing to pick between. The server name stays
- * `parachute-<vault>` so the connection is still labeled by vault.
+ * URL shape: lead with `/account/mcp` (whole house / all assigned
+ * vaults). That is vault-agnostic — it stays correct if this vault is
+ * renamed or more vaults are added — and its PRM advertises
+ * `account:vaults` alone, so a catalog-copy OAuth client can actually
+ * complete. Root `/mcp` OAuth discovery is the one-vault path (its PRM
+ * is vault-only; advertising `account:vaults` there next to `vault:*`
+ * would bounce the whole authorize request). NIP-98 clients can still
+ * POST a signed request to `/account/mcp` or `/mcp`. The per-vault
+ * command is the narrower OAuth option.
  */
 function renderMcpTile(vaultName: string, hubOrigin: string): string {
   const safeVault = escapeHtml(vaultName);
-  const bareCmd = `claude mcp add --transport http parachute-${vaultName} ${hubOrigin}/mcp`;
+  const houseCmd = accountClaudeMcpAddCommand(hubOrigin);
+  const vaultCmd = assignedVaultClaudeMcpAddCommand(hubOrigin, vaultName);
   return `<div class="done-tile">
     <h2>Connect Claude Code (MCP)</h2>
-    <p>Wire <code>vault:${safeVault}</code> into Claude Code as an MCP server:</p>
-    <pre>${escapeHtml(bareCmd)}</pre>
+    <p>All assigned vaults — one connection, capability grows from grants:</p>
+    <pre data-testid="mcp-house-command">${escapeHtml(houseCmd)}</pre>
+    <p>Or just this vault (<code>vault:${safeVault}</code>):</p>
+    <pre data-testid="mcp-vault-command">${escapeHtml(vaultCmd)}</pre>
     <p class="fine">No token needed — the command triggers browser OAuth on
-      first use (you sign in to this hub and approve access). For headless
-      clients that can't do the browser flow, mint a hub token at
+      first use (you sign in to this hub and approve access). The whole-house
+      URL is <code>/account/mcp</code>. Root <code>/mcp</code> is the
+      one-vault OAuth path; NIP-98 clients can still POST a signed request
+      there. For headless clients that can't do the browser flow, mint a hub
+      token at
       <a href="/admin/tokens"><code>/admin/tokens</code></a> (or with
       <code>parachute auth mint-token</code>) and append
       <code>--header "Authorization: Bearer &lt;token&gt;"</code>.</p>


### PR DESCRIPTION
## What

Onboarding copy for the whole-house door, plus a helper rename so the next edit cannot confuse the two MCP URLs.

Three-way yes in parachute (GrokJi / ClaudeJi / CodexJi): **SHIP** Bearer `account:vaults` dispatch at root `/mcp`; **keep root PRM vault-only**; **expose `/account/mcp` in onboarding**.

- **Wizard done-tile** (agent / Claude Code): recommended command is now `claude mcp add … parachute-account <origin>/account/mcp`. Per-vault `/vault/<name>/mcp` stays as the narrower option. Root `/mcp` is no longer the copy-paste target (its PRM is vault-only; NIP-98 can still POST a signed request there).
- **Friend `/account/` onboarding** (OAuth human): per-vault stays the explicit option. A labeled **All assigned vaults** block adds `/account/mcp`.
- **Rename:** `accountMcpEndpoint(origin, vault)` → `assignedVaultMcpEndpoint`. New `accountMcpEndpoint(origin)` returns `/account/mcp`. Shared builders live in `src/mcp-connect-commands.ts`.
- **Not this PR:** RFC 9728 §3.3 — invalid `aud=account` at root `/mcp` still returns a challenge pointing at the `/account/mcp` PRM. Tracked as [hub#899](https://github.com/ParachuteComputer/parachute-hub/issues/899). Do not fix by mixing scope families on root PRM.

`McpConnectCard` (per-vault row) is unchanged.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

At `1221007`:

- `bun run typecheck` 0 errors
- `bun test ./src/__tests__/account-home-ui.test.ts ./src/__tests__/setup-wizard.test.ts` — 142 pass / 1 skip (pre-existing scribe tile skip) / 0 fail

Not run: full `bun test ./src` (live box; launchd-label tests). Feature PR — no version bump.

## Not this PR

- Root PRM advertisement of `account:vaults` (deferred on purpose)
- hub#899 challenge URL
- Cloud twin
