### PR TITLE
feat(hub): consent picker XOR for this-vault vs all assigned vaults

### DIFF
--- a/src/__tests__/account-home-ui.test.ts
+++ b/src/__tests__/account-home-ui.test.ts
@@ -22,6 +22,8 @@ import {
   accountMcpEndpoint,
   assignedVaultClaudeMcpAddCommand,
   assignedVaultMcpEndpoint,
+  rootClaudeMcpAddCommand,
+  rootMcpEndpoint,
 } from "../mcp-connect-commands.ts";
 import type { VaultVerb } from "../users.ts";
 
@@ -179,8 +181,9 @@ describe("renderAccountHome", () => {
     // The MCP endpoint + connect command also drop the trailing slash — no
     // `//vault` or `//account` double-slash sneaks in.
     expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
-    expect(html).toContain(`${HUB_ORIGIN}/account/mcp`);
+    expect(html).toContain(`${HUB_ORIGIN}/mcp`);
     expect(html).not.toContain(`${HUB_ORIGIN}//vault`);
+    expect(html).not.toContain(`${HUB_ORIGIN}//mcp`);
     expect(html).not.toContain(`${HUB_ORIGIN}//account`);
   });
 
@@ -566,6 +569,10 @@ describe("renderAccountHome", () => {
     expect(accountClaudeMcpAddCommand("https://hub.example")).toBe(
       "claude mcp add --transport http parachute-account https://hub.example/account/mcp",
     );
+    expect(rootMcpEndpoint("https://hub.example")).toBe("https://hub.example/mcp");
+    expect(rootClaudeMcpAddCommand("https://hub.example")).toBe(
+      "claude mcp add --transport http parachute https://hub.example/mcp",
+    );
   });
 
   test("escapes hostile content in username and vault name", () => {
@@ -716,13 +723,13 @@ describe("renderAccountHome", () => {
     // suffix is load-bearing (only it returns the WWW-Authenticate header).
     expect(html).toContain(`${HUB_ORIGIN}/vault/alice/mcp`);
     expect(html).toMatch(/data-testid="onboarding-mcp-endpoint">[^<]*\/vault\/alice\/mcp</);
-    // Whole-house /account/mcp is the labeled second option, not a replacement.
+    // Root `/mcp` is the labeled second option (picker at consent), not a
+    // replacement for the per-vault door. `/account/mcp` is not shown.
     expect(html).toContain('data-testid="onboarding-house"');
-    expect(html).toContain("All assigned vaults");
-    expect(html).toMatch(/data-testid="onboarding-account-mcp-endpoint">[^<]*\/account\/mcp</);
-    expect(html).toContain(
-      `claude mcp add --transport http parachute-account ${HUB_ORIGIN}/account/mcp`,
-    );
+    expect(html).toContain("This hub");
+    expect(html).toMatch(/data-testid="onboarding-hub-mcp-endpoint">[^<]*\/mcp</);
+    expect(html).toContain(`claude mcp add --transport http parachute ${HUB_ORIGIN}/mcp`);
+    expect(html).not.toContain("/account/mcp");
     // Both connect methods are inline in step ②.
     expect(html).toContain('data-testid="onboarding-mcp-add-command"');
     expect(html).toContain("Add custom connector");
@@ -774,10 +781,11 @@ describe("renderAccountHome", () => {
     // whole-house door.
     expect(html).toContain('data-testid="onboarding-mcp-endpoint"');
     expect(html).toContain('data-testid="onboarding-mcp-add-command"');
-    expect(html).toContain('data-testid="onboarding-account-mcp-endpoint"');
+    expect(html).toContain('data-testid="onboarding-hub-mcp-endpoint"');
     expect(html).toContain("Claude.ai (web)");
     expect(html).toContain("Claude Code (terminal)");
-    expect(html).toContain("All assigned vaults");
+    expect(html).toContain("This hub");
+    expect(html).not.toContain("/account/mcp");
   });
 
   test("onboarding NON-condensed (not connected) state has no 'Connect another AI' expander (hub#583)", () => {
@@ -857,7 +865,7 @@ describe("renderAccountHome", () => {
     // per-vault tiles below still list every vault (by name + Notes CTA), but
     // no longer repeat the connect endpoint (dedup — connect lives only here).
     expect(html).toMatch(/data-testid="onboarding-mcp-endpoint">[^<]*\/vault\/personal\/mcp</);
-    expect(html).toContain(`${HUB_ORIGIN}/account/mcp`); // whole-house second option
+    expect(html).toContain(`${HUB_ORIGIN}/mcp`); // picker-at-consent second option
     expect(html).toContain("<strong>family</strong>"); // second vault still has a tile
     expect(html).not.toContain(`${HUB_ORIGIN}/vault/family/mcp`); // no duplicated connect
   });

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -39,6 +39,7 @@ import {
   rootMcpProtectedResourceMetadata,
   vaultScopeForUser,
 } from "../oauth-handlers.ts";
+import { VAULT_PICK_ACCOUNT } from "../oauth-ui.ts";
 import { PENDING_LOGIN_COOKIE_NAME, _resetPendingLogins } from "../pending-login.ts";
 import { __resetForTests as resetRateLimit } from "../rate-limit.ts";
 import type { ServicesManifest } from "../services-manifest.ts";
@@ -5482,6 +5483,60 @@ describe("handleAuthorizeGet — skip consent when scope already granted (#75)",
     }
   });
 
+  test("unnamed vault:read is skip-consent covered by a prior account:self:vaults grant", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const user = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: user.id });
+      const reg = registerClient(db, { redirectUris: ["https://app.example/cb"] });
+      const { verifier, challenge } = makePkce();
+      recordGrant(db, user.id, reg.client.clientId, ["account:self:vaults"]);
+
+      const getRes = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            scope: "vault:read vault:write",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+          }),
+          { headers: { cookie: buildSessionCookie(session.id, 86400) } },
+        ),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(getRes.status).toBe(302);
+      const code = new URL(getRes.headers.get("location") ?? "").searchParams.get("code");
+      expect(code).toBeTruthy();
+
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: new URLSearchParams({
+            grant_type: "authorization_code",
+            code: code ?? "",
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            code_verifier: verifier,
+          }),
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        { issuer: ISSUER, loadServicesManifest: fixtureLoadServicesManifest },
+      );
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string; scope: string };
+      expect(body.scope.split(" ")).toContain("account:self:vaults");
+      expect(body.scope.split(" ")).not.toContain("vault:read");
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(payload.aud).toBe("account");
+    } finally {
+      cleanup();
+    }
+  });
+
   test("re-registered client_id (different uuid) requires fresh consent", async () => {
     // Re-registration mints a new client_id; the grant row is keyed on
     // (user, client_id), so the new client has no prior grant. Consent
@@ -6673,12 +6728,12 @@ describe("handleAuthorizeGet — multi-user assigned vault picker lock (PR 4)", 
       expect(res.status).toBe(200);
       const html = await res.text();
       expect(html).toContain("vault-picker-locked");
-      expect(html).toContain("Assigned vault");
+      expect(html).toContain("Assigned");
       expect(html).toContain("admin-managed");
-      // Hidden input carries the assigned vault as the picker value.
-      expect(html).toContain('<input type="hidden" name="vault_pick" value="default"');
-      // No free-choice radio inputs.
-      expect(html).not.toContain('type="radio" name="vault_pick"');
+      // Assigned vault is the default radio; whole-account is the second option.
+      expect(html).toMatch(/name="vault_pick" value="default" checked/);
+      expect(html).toContain('data-testid="vault-pick-account"');
+      expect(html).not.toContain('<input type="hidden" name="vault_pick"');
     } finally {
       cleanup();
     }
@@ -6763,9 +6818,11 @@ describe("handleAuthorizeGet — resolved scope display (approval-UX rc.19)", ()
       });
       expect(res.status).toBe(200);
       const html = await res.text();
-      // The fixture services manifest has a single vault named "default" — the
-      // picker pre-checks it and the consent screen renders the resolved form.
-      expect(html).toContain('<code class="scope-name">vault:default:read</code>');
+      // Free picker defaults to whole-account, so the scope row stays
+      // unresolved (`<TBD>`) rather than pretending Approve mints
+      // `vault:default:read`.
+      expect(html).toContain('<code class="scope-name">vault:&lt;TBD&gt;:read</code>');
+      expect(html).toContain('data-testid="vault-pick-account"');
     } finally {
       cleanup();
     }
@@ -8038,8 +8095,9 @@ describe("handleAuthorizeGet — stale assigned_vault surfaces banner (hub#284)"
       const html = await res.text();
       expect(html).not.toContain('class="stale-assignment-banner"');
       expect(html).not.toContain("Your assigned vault was removed");
-      // Locked-picker still rendered as before.
-      expect(html).toContain('<input type="hidden" name="vault_pick" value="default"');
+      // Locked picker: assigned vault is the default radio.
+      expect(html).toContain("vault-picker-locked");
+      expect(html).toMatch(/name="vault_pick" value="default" checked/);
     } finally {
       cleanup();
     }
@@ -10253,6 +10311,8 @@ describe("RFC 8707 resource binding — vault-bound MCP (fix #461)", () => {
         expect(res.status).toBe(200);
         const copied = await res.text();
         expect(copied).toContain("Pick a vault");
+        expect(copied).toContain("All assigned vaults");
+        expect(copied).toContain('data-testid="vault-pick-account"');
       } finally {
         cleanup();
       }
@@ -10404,6 +10464,42 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
       expect(extras.indexOf("account:self:write")).toBeLessThan(
         extras.indexOf("account:self:admin"),
       );
+      // Picker is the only path to account:vaults — extras must not offer it
+      // even on an empty request (ticking it plus a vault extra is the
+      // combine-refusal landmine).
+      expect(extras).not.toContain("account:vaults");
+      expect(extras).not.toContain("account:self:vaults");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("grantable extras omit account:vaults when the client already asked for vault scopes", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin", "pw");
+      const extras = grantableExtraScopes(db, admin.id, {
+        userIsAdmin: true,
+        requested: ["vault:read"],
+        vaultName: undefined,
+      });
+      expect(extras).not.toContain("account:vaults");
+      expect(extras).not.toContain("account:self:vaults");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("grantable extras are empty when the client already asked for account:vaults", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const admin = await createUser(db, "admin", "pw");
+      const extras = grantableExtraScopes(db, admin.id, {
+        userIsAdmin: true,
+        requested: ["account:vaults"],
+        vaultName: undefined,
+      });
+      expect(extras).toEqual([]);
     } finally {
       cleanup();
     }
@@ -10708,6 +10804,102 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
       const loc = consentRes.headers.get("location") ?? "";
       expect(loc).toContain("error=invalid_scope");
       expect(loc).not.toContain("code=");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin picking whole-account mints account:self:vaults (cap admits the connection grant)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]);
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        { vault_pick: VAULT_PICK_ACCOUNT },
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).not.toContain("error=");
+      const code = new URL(loc).searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ")).toContain("account:self:vaults");
+      expect(scope.split(" ")).not.toContain("vault:read");
+      expect(scope.split(" ")).not.toContain("vault:work:read");
+      expect(aud).toBe("account");
+      const grant = findGrant(db, friend.id, reg.client.clientId);
+      expect(grant?.scopes).toContain("account:self:vaults");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("non-admin 4-part account:self:vaults:<vault> is dropped (client cannot pre-narrow)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]);
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:self:vaults:work vault:work:read",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).not.toContain("error=");
+      const code = new URL(loc).searchParams.get("code");
+      const { scope } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ")).toContain("vault:work:read");
+      expect(scope).not.toContain("account:self:vaults:work");
+      expect(scope.split(" ")).not.toContain("account:self:vaults");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("owner picking whole-account rewrites unnamed vault:read to account:self:vaults", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read vault:write",
+        challenge,
+        { vault_pick: VAULT_PICK_ACCOUNT },
+      );
+      expect(consentRes.status).toBe(302);
+      const code = new URL(consentRes.headers.get("location") ?? "").searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ")).toEqual(["account:self:vaults"]);
+      expect(aud).toBe("account");
     } finally {
       cleanup();
     }

--- a/src/__tests__/oauth-ui.test.ts
+++ b/src/__tests__/oauth-ui.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   type AuthorizeFormParams,
+  VAULT_PICK_ACCOUNT,
   escapeHtml,
   renderApprovePending,
   renderConsent,
@@ -319,8 +320,10 @@ describe("renderConsent", () => {
     expect(html).toContain("Pick a vault");
     expect(html).toContain('name="vault_pick" value="work"');
     expect(html).toContain('name="vault_pick" value="personal"');
-    // First option pre-checked so a single-vault host doesn't force a click.
-    expect(html).toMatch(/name="vault_pick" value="work" checked/);
+    expect(html).toContain(`name="vault_pick" value="${VAULT_PICK_ACCOUNT}"`);
+    // Whole-account is the free-picker default, not the first vault.
+    expect(html).toMatch(new RegExp(`name="vault_pick" value="${VAULT_PICK_ACCOUNT}" checked`));
+    expect(html).not.toMatch(/name="vault_pick" value="work" checked/);
   });
 
   test("escapes a hostile vault name in the picker", () => {
@@ -389,6 +392,22 @@ describe("renderConsent", () => {
       vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
     });
     expect(html.match(/name="verb_select"/g) ?? []).toHaveLength(0);
+  });
+
+  test("locked picker defaults to the assigned vault and offers whole-account", () => {
+    const html = renderConsent({
+      params: { ...PARAMS, scope: "vault:read" },
+      csrfToken: CSRF,
+      clientId: "c",
+      clientName: "App",
+      scopes: ["vault:read"],
+      vaultPicker: { unnamedVerbs: ["read"], availableVaults: ["work"], lockedVault: "work" },
+    });
+    expect(html).toMatch(/name="vault_pick" value="work" checked/);
+    expect(html).toContain(`name="vault_pick" value="${VAULT_PICK_ACCOUNT}"`);
+    expect(html).toContain("All assigned vaults");
+    expect(html).not.toContain('<input type="hidden" name="vault_pick"');
+    expect(VAULT_PICK_ACCOUNT).toContain(":");
   });
 
   // hub#314 — same-hub vs external trust marker. The `.badge-trust-*` class

--- a/src/__tests__/setup-wizard.test.ts
+++ b/src/__tests__/setup-wizard.test.ts
@@ -2641,15 +2641,14 @@ describe("done screen MCP command — OAuth-default, no auto-mint", () => {
       );
       expect(res.status).toBe(200);
       const html = await res.text();
-      // Whole-house command is the recommended default; per-vault is the
-      // narrower option. Root `/mcp` is no longer the copy-paste target
-      // (its PRM is vault-only; `/account/mcp` is the honest house door).
-      expect(html).toContain(
-        "claude mcp add --transport http parachute-account https://hub.example/account/mcp",
-      );
+      // Root `/mcp` is the recommended default (picker chooses this vault
+      // XOR all assigned vaults). Per-vault is the skip-picker narrower
+      // option. `/account/mcp` is not in the human-facing copy.
+      expect(html).toContain("claude mcp add --transport http parachute https://hub.example/mcp");
       expect(html).toContain(
         "claude mcp add --transport http parachute-default https://hub.example/vault/default/mcp",
       );
+      expect(html).not.toContain("/account/mcp");
       expect(html).toContain('data-testid="mcp-house-command"');
       expect(html).toContain('data-testid="mcp-vault-command"');
       // Load-bearing regression (Austen's report): the rendered COMMAND
@@ -3483,8 +3482,8 @@ describe("typed vault name (hub#267)", () => {
         },
       );
       const html = await res.text();
-      expect(html).toContain("parachute-account");
-      expect(html).toContain("https://hub.example/account/mcp");
+      expect(html).toContain("claude mcp add --transport http parachute https://hub.example/mcp");
+      expect(html).not.toContain("/account/mcp");
       expect(html).toContain("parachute-my-personal-vault");
       expect(html).toContain("https://hub.example/vault/my-personal-vault/mcp");
     } finally {

--- a/src/account-home-ui.ts
+++ b/src/account-home-ui.ts
@@ -21,10 +21,10 @@
 import { WORDMARK_TEXT, brandMarkSvg } from "./brand.ts";
 import { renderCsrfHiddenInput } from "./csrf.ts";
 import {
-  accountClaudeMcpAddCommand,
-  accountMcpEndpoint,
   assignedVaultClaudeMcpAddCommand,
   assignedVaultMcpEndpoint,
+  rootClaudeMcpAddCommand,
+  rootMcpEndpoint,
 } from "./mcp-connect-commands.ts";
 import { escapeHtml } from "./oauth-ui.ts";
 import type { VaultVerb } from "./users.ts";
@@ -342,8 +342,8 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
   const safeVault = escapeHtml(primaryVault);
   const vaultEndpoint = assignedVaultMcpEndpoint(trimmedOrigin, primaryVault);
   const vaultAddCmd = assignedVaultClaudeMcpAddCommand(trimmedOrigin, primaryVault);
-  const houseEndpoint = accountMcpEndpoint(trimmedOrigin);
-  const houseAddCmd = accountClaudeMcpAddCommand(trimmedOrigin);
+  const houseEndpoint = rootMcpEndpoint(trimmedOrigin);
+  const houseAddCmd = rootClaudeMcpAddCommand(trimmedOrigin);
   const safeVaultEndpoint = escapeHtml(vaultEndpoint);
   const safeVaultAddCmd = escapeHtml(vaultAddCmd);
   const safeHouseEndpoint = escapeHtml(houseEndpoint);
@@ -368,20 +368,20 @@ function renderOnboardingChecklist(opts: OnboardingChecklistOpts): string {
                       data-testid="copy-onboarding-add-command">Copy</button>
             </div>
             <div class="onboarding-house" data-testid="onboarding-house">
-              <p class="onboarding-house-label" data-testid="onboarding-house-label">All assigned vaults</p>
-              <p class="onboarding-step-sub">One connection covering every vault this account can
-                 access. Paste this instead if you want the whole house, not just
+              <p class="onboarding-house-label" data-testid="onboarding-house-label">This hub</p>
+              <p class="onboarding-step-sub">Paste this instead of the per-vault URL to pick at
+                 consent — this vault, or all assigned vaults, not just
                  <code>${safeVault}</code>:</p>
               <div class="copy-row">
-                <code data-testid="onboarding-account-mcp-endpoint">${safeHouseEndpoint}</code>
+                <code data-testid="onboarding-hub-mcp-endpoint">${safeHouseEndpoint}</code>
                 <button type="button" class="btn btn-copy" data-copy="${safeHouseEndpoint}"
-                        data-testid="copy-onboarding-account-endpoint">Copy</button>
+                        data-testid="copy-onboarding-hub-endpoint">Copy</button>
               </div>
               <p class="onboarding-method"><strong>Claude Code (terminal):</strong></p>
               <div class="copy-row">
-                <code data-testid="onboarding-account-mcp-add-command">${safeHouseAddCmd}</code>
+                <code data-testid="onboarding-hub-mcp-add-command">${safeHouseAddCmd}</code>
                 <button type="button" class="btn btn-copy" data-copy="${safeHouseAddCmd}"
-                        data-testid="copy-onboarding-account-add-command">Copy</button>
+                        data-testid="copy-onboarding-hub-add-command">Copy</button>
               </div>
             </div>`;
 

--- a/src/mcp-connect-commands.ts
+++ b/src/mcp-connect-commands.ts
@@ -1,16 +1,16 @@
 /**
  * Copy-paste MCP connect URLs and Claude Code commands.
  *
- * Two doors, two names — do not mix them:
- *   - `/account/mcp` — whole house / all assigned vaults (`account:vaults`)
- *   - `/vault/<name>/mcp` — one assigned vault (`vault:<name>:*`)
+ * Humans are pointed at:
+ *   - `/mcp` — one URL; the consent picker chooses this vault XOR all
+ *     assigned vaults. Root PRM stays vault-only (catalog-copy must not
+ *     mix `account:vaults` with `vault:*` — that combination is
+ *     `invalid_scope`).
+ *   - `/vault/<name>/mcp` — skip the picker; one assigned vault.
  *
- * Root `/mcp` is a convenience alias for NIP-98 and for a Bearer that
- * already has `aud=account`. OAuth discovery at root advertises vault
- * scopes only; a generic client that catalog-copies that list cannot
- * learn `account:vaults` (and must not be taught it there — combining
- * the two families is `invalid_scope`). Point OAuth clients at
- * `/account/mcp` for the house, `/vault/<name>/mcp` for one vault.
+ * `/account/mcp` stays the honest single-family discovery door (its PRM
+ * advertises `account:vaults` alone). Do not put it in human-facing
+ * onboarding copy — the picker at `/mcp` is the choice.
  */
 
 /** `<hub-origin>/vault/<name>/mcp` — one assigned vault. */
@@ -26,12 +26,22 @@ export function assignedVaultClaudeMcpAddCommand(trimmedOrigin: string, vaultNam
   )}`;
 }
 
-/** `<hub-origin>/account/mcp` — all assigned vaults. */
+/** `<hub-origin>/mcp` — picker chooses this vault or all assigned vaults. */
+export function rootMcpEndpoint(trimmedOrigin: string): string {
+  return `${trimmedOrigin}/mcp`;
+}
+
+/** OAuth `claude mcp add` for the hub root. Server name `parachute`. */
+export function rootClaudeMcpAddCommand(trimmedOrigin: string): string {
+  return `claude mcp add --transport http parachute ${rootMcpEndpoint(trimmedOrigin)}`;
+}
+
+/** `<hub-origin>/account/mcp` — honest single-family discovery door. */
 export function accountMcpEndpoint(trimmedOrigin: string): string {
   return `${trimmedOrigin}/account/mcp`;
 }
 
-/** OAuth `claude mcp add` for the whole house. Server name `parachute-account`. */
+/** OAuth `claude mcp add` for `/account/mcp`. Server name `parachute-account`. */
 export function accountClaudeMcpAddCommand(trimmedOrigin: string): string {
   return `claude mcp add --transport http parachute-account ${accountMcpEndpoint(trimmedOrigin)}`;
 }

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -22,7 +22,11 @@
  * on presentation.
  */
 import type { Database } from "bun:sqlite";
-import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
+import {
+  ACCOUNT_VAULTS_UNNARROWED,
+  accountVaultsScope,
+  isRequestableAccountScope,
+} from "@openparachute/door-contract";
 import { AdminAuthError, adminAuthErrorResponse, requireScope } from "./admin-auth.ts";
 import { recordLoginUnlock } from "./admin-lock.ts";
 import { renderTotpChallenge } from "./admin-login-ui.ts";
@@ -48,7 +52,12 @@ import {
   verifyClientSecret,
 } from "./clients.ts";
 import { CSRF_FIELD_NAME, ensureCsrfToken, verifyCsrfToken } from "./csrf.ts";
-import { isCoveredByGrant, isCoveredByGrantForClientName, recordGrant } from "./grants.ts";
+import {
+  findGrant,
+  isCoveredByGrant,
+  isCoveredByGrantForClientName,
+  recordGrant,
+} from "./grants.ts";
 import { consumeFirstClientAutoApproveWindow } from "./hub-settings.ts";
 import { VAULT_VERBS, inferAudience } from "./jwt-audience.ts";
 import {
@@ -66,6 +75,7 @@ import {
 } from "./jwt-sign.ts";
 import {
   type AuthorizeFormParams,
+  VAULT_PICK_ACCOUNT,
   canonicalConsentScope,
   renderApprovePending,
   renderConsent,
@@ -148,6 +158,53 @@ function narrowVaultScopes(scopes: string[], pickedVault: string): string[] {
     }
     return s;
   });
+}
+
+function isUnnamedVaultScope(scope: string): boolean {
+  const parts = scope.split(":");
+  const verb = parts[1];
+  return parts.length === 2 && parts[0] === "vault" && !!verb && VAULT_VERBS.has(verb);
+}
+
+/**
+ * XOR rewrite: unnamed `vault:<verb>` becomes the account-MCP connection
+ * grant. Named vault scopes and everything else stay put — the mint
+ * choke-point still refuses mixing `account:vaults` with other families.
+ */
+function replaceUnnamedVaultScopesWithAccountVaults(scopes: readonly string[]): string[] {
+  const rest = scopes.filter((s) => !isUnnamedVaultScope(s));
+  return [...new Set([...rest, ACCOUNT_VAULTS_UNNARROWED])];
+}
+
+/**
+ * A prior `account:vaults` / `account:self:vaults` grant covers a later
+ * unnamed `vault:<verb>` request at root `/mcp`. Without this, skip-consent
+ * refuses unnamed verbs forever (they never match the stored bound form)
+ * and the picker re-prompts on every catalog-copy reconnect.
+ *
+ * Does NOT change `isCoveredByGrant` — that helper stays exact-match (plus
+ * the account-vaults equivalent pair) so trust-by-client_name cannot record
+ * unnamed verbs onto a fresh client_id.
+ */
+function accountGrantCoversUnnamedAtRoot(
+  db: Database,
+  userId: string,
+  clientId: string,
+  requestedScopes: readonly string[],
+): boolean {
+  if (unnamedVaultVerbs([...requestedScopes]).length === 0) return false;
+  const grant = findGrant(db, userId, clientId);
+  if (!grant) return false;
+  const granted = new Set(grant.scopes);
+  if (!granted.has(ACCOUNT_VAULTS_UNNARROWED) && !granted.has(accountVaultsScope("self"))) {
+    return false;
+  }
+  for (const s of requestedScopes) {
+    if (isUnnamedVaultScope(s)) continue;
+    if (s === ACCOUNT_VAULTS_UNNARROWED || s === accountVaultsScope("self")) continue;
+    if (!granted.has(s)) return false;
+  }
+  return true;
 }
 
 /**
@@ -1309,9 +1366,12 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   // requested scope to this client, mint the auth code immediately. Three
   // important constraints:
   //   - Unnamed vault verbs (`vault:read`) need the picker even if a prior
-  //     grant exists, because the operator's vault choice isn't recorded
-  //     literally — grants store narrowed `vault:<name>:<verb>` scopes, so
-  //     a fresh unnamed request never matches. Force consent to re-pick.
+  //     *named-vault* grant exists, because the operator's vault choice isn't
+  //     recorded literally — grants store narrowed `vault:<name>:<verb>`
+  //     scopes, so a fresh unnamed request never matches. Exception: a prior
+  //     `account:self:vaults` grant covers unnamed-at-root (rewrite at skip
+  //     to the bound connection grant). Same-hub auto-trust does not get
+  //     that rewrite.
   //   - The grant covers `requestedScopes` exactly when every requested
   //     scope appears in the stored set. A strict superset (client wants
   //     something new) falls through to the consent screen.
@@ -1333,16 +1393,31 @@ export function handleAuthorizeGet(db: Database, req: Request, deps: OAuthDeps):
   //     `handleAuthorizeGet` after promoting the pending client.
   const hasUnnamedVault = unnamedVaultVerbs(requestedScopes).length > 0;
   const userHasVaultPosture = userIsAdmin || assignedVaults.length > 0;
+  // Unnamed `vault:<verb>` still needs the picker on first contact — except
+  // when a prior whole-account grant already covers this client. Then skip
+  // and mint `account:vaults` (bound at the choke-point) instead of
+  // re-prompting forever. Same-hub auto-trust below does NOT get this
+  // rewrite: silently upgrading unnamed `vault:read` to whole-account on
+  // first contact is the privilege-creep that path exists to prevent.
+  const unnamedCoveredByAccountGrant = accountGrantCoversUnnamedAtRoot(
+    db,
+    session.userId,
+    client.clientId,
+    requestedScopes,
+  );
   if (
     !hasStaleAssignment &&
-    !hasUnnamedVault &&
     userHasVaultPosture &&
-    isCoveredByGrant(db, session.userId, client.clientId, requestedScopes)
+    ((!hasUnnamedVault && isCoveredByGrant(db, session.userId, client.clientId, requestedScopes)) ||
+      unnamedCoveredByAccountGrant)
   ) {
+    const mintScopes = unnamedCoveredByAccountGrant
+      ? replaceUnnamedVaultScopesWithAccountVaults(requestedScopes)
+      : requestedScopes;
     console.log(
-      `consent skipped: existing grant covers requested scope client_id=${client.clientId} user_id=${session.userId} scopes=${requestedScopes.join(" ")}`,
+      `consent skipped: existing grant covers requested scope client_id=${client.clientId} user_id=${session.userId} scopes=${mintScopes.join(" ")}`,
     );
-    return issueAuthCodeRedirect(db, parsed, requestedScopes, session.userId, deps);
+    return issueAuthCodeRedirect(db, parsed, mintScopes, session.userId, deps);
   }
 
   // -------------------------------------------------------------------------
@@ -1541,7 +1616,21 @@ function capScopesToUserAuthority(
     // Admins are unaffected: they returned above, and on self-host the admin
     // IS the account holder, so they're delegating authority they actually
     // have.
-    if (s.toLowerCase().startsWith("account:")) return false;
+    // Account scopes are ACCOUNT-WIDE, and on self-host the account IS the
+    // box. `account:self:{read,write,admin}` must never be consentable by a
+    // non-owner. The one exception is the account-MCP connection grant —
+    // 2-part `account:vaults` or 3-part `account:<id>:vaults` — which
+    // account-MCP intersects with the caller's assignment (`resolveCoverage`).
+    // Reuse `isRequestableAccountScope` rather than re-deriving the shape:
+    // that helper deliberately excludes the 4-part consent-narrowed form
+    // (`account:<id>:vaults:<vault>`), so a client cannot pre-narrow itself
+    // by asking for it here.
+    //
+    // Exact-lowercase: casing variants (`Account:vaults`) fail closed, same
+    // as the door-contract. Detect the family case-insensitively so
+    // `ACCOUNT:self:admin` is still dropped rather than passing through to
+    // the vault-verb branch.
+    if (s.toLowerCase().startsWith("account:")) return isRequestableAccountScope(s);
     const parts = s.split(":");
     if (parts.length !== 3 || parts[0] !== "vault") return true; // non-named — pass through
     const name = parts[1];
@@ -1589,6 +1678,12 @@ export function grantableExtraScopes(
   opts: { userIsAdmin: boolean; requested: readonly string[]; vaultName?: string | undefined },
 ): string[] {
   const v = opts.vaultName;
+  // The picker is the only path to `account:vaults`. Offering it as an extra
+  // next to the client's vault scopes hits `accountVaultsCombinedWithOtherScopes`
+  // at mint — a checkbox that looks grantable and then bounces the whole
+  // authorize. The reverse landmine (requested `account:vaults`, extras offer
+  // vault verbs) is the same XOR: extras would combine-refuse, so offer none.
+  if (opts.requested.some(isAccountVaultsConnectionScope)) return [];
   const candidates = [
     ...(v
       ? [`vault:${v}:read`, `vault:${v}:write`, `vault:${v}:admin`]
@@ -1596,7 +1691,6 @@ export function grantableExtraScopes(
     ACCOUNT_SELF_READ_SCOPE,
     ACCOUNT_SELF_WRITE_SCOPE,
     ACCOUNT_SELF_ADMIN_SCOPE,
-    ACCOUNT_VAULTS_UNNARROWED,
   ];
 
   // Compare both naming shapes in one canonical key space. When an admin's
@@ -2085,67 +2179,82 @@ async function handleConsentSubmit(
         400,
       );
     }
-    const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
-    const validNames = listVaultNames(manifest);
-    if (!validNames.includes(pickedVault)) {
-      // Stale-assignment branch (hub#284, generalized Phase 2 PR 2). The
-      // user is consenting via an assignment that points at a vault no
-      // longer in services.json. The new copy names the actual condition
-      // (assignment removed) and points at the admin remediation surface.
-      //
-      // The check fires when the picked vault is in the user's assigned
-      // list — narrows the special-case to the "user is consenting via
-      // a now-stale assignment" shape rather than swallowing every
-      // Unknown-vault. A hand-crafted POST naming a never-existed vault
-      // still hits the generic branch.
-      if (isPinned && assignedVaults.includes(pickedVault)) {
+    if (pickedVault === VAULT_PICK_ACCOUNT) {
+      // Whole-account sentinel. Not a vault name (colon is outside the
+      // charset). A zero-vault non-admin cannot mint this — they have
+      // nothing to cover. Friends with assignments can: account-MCP
+      // intersects Bearer coverage with assignment.
+      if (!userIsAdmin && assignedVaults.length === 0) {
         return htmlError(
-          "Assigned vault was removed",
-          `Your assigned vault "${pickedVault}" is no longer registered on this hub. Ask the hub admin to reassign you to an existing vault via /admin/users, then try again.`,
+          "No vaults assigned",
+          "vault_scope_mismatch: you have no assigned vaults on this hub yet, so you can't authorize an app for vault access. Ask the hub admin to assign you at least one vault via /admin/users, then try again.",
           400,
         );
       }
-      return htmlError(
-        "Unknown vault",
-        `vault "${pickedVault}" is not registered on this host.`,
-        400,
-      );
+      scopes = replaceUnnamedVaultScopesWithAccountVaults(scopes);
+    } else {
+      const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
+      const validNames = listVaultNames(manifest);
+      if (!validNames.includes(pickedVault)) {
+        // Stale-assignment branch (hub#284, generalized Phase 2 PR 2). The
+        // user is consenting via an assignment that points at a vault no
+        // longer in services.json. The new copy names the actual condition
+        // (assignment removed) and points at the admin remediation surface.
+        //
+        // The check fires when the picked vault is in the user's assigned
+        // list — narrows the special-case to the "user is consenting via
+        // a now-stale assignment" shape rather than swallowing every
+        // Unknown-vault. A hand-crafted POST naming a never-existed vault
+        // still hits the generic branch.
+        if (isPinned && assignedVaults.includes(pickedVault)) {
+          return htmlError(
+            "Assigned vault was removed",
+            `Your assigned vault "${pickedVault}" is no longer registered on this hub. Ask the hub admin to reassign you to an existing vault via /admin/users, then try again.`,
+            400,
+          );
+        }
+        return htmlError(
+          "Unknown vault",
+          `vault "${pickedVault}" is not registered on this host.`,
+          400,
+        );
+      }
+      // Server-side defense: non-admin user submitted a vault that's not in
+      // their assigned list. The picker rendered as narrowed, so a UI-path
+      // user couldn't reach this — but a hand-crafted form bypassing the
+      // narrowed input lands here. Refuse the mint instead of silently
+      // overwriting; the explicit error tells the operator the assignment
+      // is load-bearing.
+      if (isPinned && !assignedVaults.includes(pickedVault)) {
+        return htmlError(
+          "Vault assignment mismatch",
+          `vault_scope_mismatch: the picked vault "${pickedVault}" is not in your vault assignment. Ask the hub admin to update your assignment, or pick a vault shown on the consent screen.`,
+          400,
+        );
+      }
+      // hub#689's owner verb-widening selector is GONE (retired 2026-07-30).
+      //
+      // It was one radio applied to every requested verb, so a multi-verb request
+      // could not survive it: `vault:read vault:write vault:admin` with the
+      // selector's admin default rewrote to `vault:admin` three times. Observed
+      // live by an external team — a read-only research agent was simply not
+      // expressible, because both agents got admin or neither ran.
+      //
+      // Worse, it now CONTRADICTS per-scope consent (#804): a user unchecks
+      // write and admin, and this block rewrote their surviving `vault:read`
+      // back to admin. The checkboxes said read-only; the token said admin.
+      //
+      // Both of the selector's jobs are covered elsewhere now:
+      //   - downgrade → uncheck the scope row (per-scope consent)
+      //   - upgrade   → tick it in the additional-access list, which
+      //                 `grantableExtraScopes` builds through the SAME cap the
+      //                 mint uses, so it can't offer more than the user holds
+      //
+      // A stale `verb_select` from a cached consent page is now simply ignored,
+      // which fails NARROWER — it mints what was requested and checked. That's
+      // the safe direction for an unread field.
+      scopes = narrowVaultScopes(scopes, pickedVault);
     }
-    // Server-side defense: non-admin user submitted a vault that's not in
-    // their assigned list. The picker rendered as narrowed, so a UI-path
-    // user couldn't reach this — but a hand-crafted form bypassing the
-    // narrowed input lands here. Refuse the mint instead of silently
-    // overwriting; the explicit error tells the operator the assignment
-    // is load-bearing.
-    if (isPinned && !assignedVaults.includes(pickedVault)) {
-      return htmlError(
-        "Vault assignment mismatch",
-        `vault_scope_mismatch: the picked vault "${pickedVault}" is not in your vault assignment. Ask the hub admin to update your assignment, or pick a vault shown on the consent screen.`,
-        400,
-      );
-    }
-    // hub#689's owner verb-widening selector is GONE (retired 2026-07-30).
-    //
-    // It was one radio applied to every requested verb, so a multi-verb request
-    // could not survive it: `vault:read vault:write vault:admin` with the
-    // selector's admin default rewrote to `vault:admin` three times. Observed
-    // live by an external team — a read-only research agent was simply not
-    // expressible, because both agents got admin or neither ran.
-    //
-    // Worse, it now CONTRADICTS per-scope consent (#804): a user unchecks
-    // write and admin, and this block rewrote their surviving `vault:read`
-    // back to admin. The checkboxes said read-only; the token said admin.
-    //
-    // Both of the selector's jobs are covered elsewhere now:
-    //   - downgrade → uncheck the scope row (per-scope consent)
-    //   - upgrade   → tick it in the additional-access list, which
-    //                 `grantableExtraScopes` builds through the SAME cap the
-    //                 mint uses, so it can't offer more than the user holds
-    //
-    // A stale `verb_select` from a cached consent page is now simply ignored,
-    // which fails NARROWER — it mints what was requested and checked. That's
-    // the safe direction for an unread field.
-    scopes = narrowVaultScopes(scopes, pickedVault);
   }
 
   // Server-side defense for named-vault scopes (`vault:<name>:<verb>`) too.
@@ -3353,16 +3462,11 @@ function consentProps(
   if (!hasStaleAssignment && remainingValidAssigned.length === 1) {
     const only = remainingValidAssigned[0];
     if (only !== undefined) displayVault = only;
-  } else if (
-    !hasStaleAssignment &&
-    assignedVaults.length === 0 &&
-    unnamedVerbs.length > 0 &&
-    vaultNames.length === 1
-  ) {
-    // Admin with a single vault on the hub: pre-check pattern from Phase 1.
-    const only = vaultNames[0];
-    if (only) displayVault = only;
   }
+  // Admin (free picker) defaults to whole-account, not the first vault —
+  // do not substitute unnamed rows as `vault:<that-vault>:<verb>` or the
+  // consent screen would lie about what Approve mints. Multi-vault already
+  // used the `<TBD>` placeholder; single-vault admin now does too.
   // Keep the first wire value for each display-normalized scope. Resource
   // narrowing can produce the same named value from distinct requested forms,
   // and the consent page should offer one row/checkbox for that permission.

--- a/src/oauth-ui.ts
+++ b/src/oauth-ui.ts
@@ -178,6 +178,14 @@ export interface ConsentViewProps {
   sameHub?: boolean;
 }
 
+/**
+ * Radio value for "all assigned vaults". Colon is outside
+ * `VAULT_NAME_CHARSET_RE` (`[a-z0-9_-]+`), so this cannot collide with a
+ * vault name. Underscores alone would not be a safe sentinel — `__account__`
+ * is a legal vault name.
+ */
+export const VAULT_PICK_ACCOUNT = ":account:";
+
 export interface VaultPicker {
   /** Verbs (`read`, `write`, `admin`) requested in unnamed shape. */
   unnamedVerbs: string[];
@@ -491,31 +499,50 @@ export function renderConsent(props: ConsentViewProps): string {
   return baseDocument(`Approve ${clientName}`, body);
 }
 
+function renderAccountVaultOption(checked: boolean): string {
+  return `
+            <label class="vault-option vault-option-account">
+              <input type="radio" name="vault_pick" value="${escapeHtml(VAULT_PICK_ACCOUNT)}"${checked ? " checked" : ""} required data-testid="vault-pick-account" />
+              <span class="vault-option-name">All assigned vaults</span>
+            </label>`;
+}
+
+function renderVaultNameOption(name: string, checked: boolean): string {
+  return `
+            <label class="vault-option">
+              <input type="radio" name="vault_pick" value="${escapeHtml(name)}"${checked ? " checked" : ""} required />
+              <span class="vault-option-name"><code>${escapeHtml(name)}</code></span>
+            </label>`;
+}
+
 function renderVaultPicker(picker: VaultPicker): string {
   const verbList = picker.unnamedVerbs.map((v) => `<code>vault:${escapeHtml(v)}</code>`).join(", ");
 
-  // Multi-user Phase 1: non-admin users see the picker locked to their
-  // `assigned_vault`. The form still posts via `vault_pick` so the
-  // server-side defense in `handleConsentSubmit` sees the value — but the
-  // user can't change it through the UI. A small `<input type=hidden>` and
-  // a read-only label is the smallest diff that ships the lock without
-  // disabling the broader form flow (Approve / Deny still work).
+  // Multi-user Phase 1: non-admin users with exactly one assigned vault
+  // used to see a locked hidden input. The picker now also offers
+  // "All assigned vaults" (mints `account:vaults`); the assigned vault
+  // stays the default so a friend who just hits Approve still grants
+  // the narrower scope. The form still posts via `vault_pick`.
   if (picker.lockedVault !== undefined) {
     const locked = escapeHtml(picker.lockedVault);
     return `
         <section class="vault-picker vault-picker-locked">
           <h2 class="scopes-title">Vault</h2>
           <p class="picker-help">
-            ${verbList} apply to your assigned vault.
+            ${verbList} apply to the vault you select, or to all assigned vaults.
           </p>
-          <div class="vault-locked-row">
-            <code class="vault-locked-name">${locked}</code>
-            <span class="vault-locked-badge">Assigned</span>
+          <div class="vault-options">
+            <label class="vault-option">
+              <input type="radio" name="vault_pick" value="${locked}" checked required />
+              <span class="vault-option-name"><code>${locked}</code></span>
+              <span class="vault-locked-badge">Assigned</span>
+            </label>
+            ${renderAccountVaultOption(false)}
           </div>
           <p class="vault-locked-note">
-            Assigned vault — admin-managed; you can't change this here.
+            Assigned vault is the default (admin-managed). All assigned vaults
+            covers every vault this account can access.
           </p>
-          <input type="hidden" name="vault_pick" value="${locked}" />
         </section>`;
   }
 
@@ -536,20 +563,18 @@ function renderVaultPicker(picker: VaultPicker): string {
           </p>
         </section>`;
   }
-  const options = picker.availableVaults
-    .map(
-      (name, i) => `
-            <label class="vault-option">
-              <input type="radio" name="vault_pick" value="${escapeHtml(name)}"${i === 0 ? " checked" : ""} required />
-              <span class="vault-option-name"><code>${escapeHtml(name)}</code></span>
-            </label>`,
-    )
-    .join("");
+  // Free picker (admin, or friend with 2+ assigned vaults): whole-account
+  // is the default. Catalog-copy of root PRM still asks unnamed `vault:*`;
+  // the picker is the XOR, not a second advertised scope family.
+  const options = [
+    renderAccountVaultOption(true),
+    ...picker.availableVaults.map((name) => renderVaultNameOption(name, false)),
+  ].join("");
   return `
         <section class="vault-picker">
           <h2 class="scopes-title">Pick a vault</h2>
           <p class="picker-help">
-            ${verbList} apply to the vault you select below.
+            ${verbList} apply to the vault you select, or to all assigned vaults.
           </p>
           <div class="vault-options">${options}
           </div>
@@ -1529,6 +1554,10 @@ const STYLES = `
     font-size: 0.88rem;
     color: ${PALETTE.fg};
   }
+  .vault-option-account .vault-option-name {
+    font-weight: 600;
+  }
+  .vault-option .vault-locked-badge { margin-left: auto; }
   .vault-picker-empty .picker-help { color: ${PALETTE.danger}; }
   .vault-picker-empty .picker-help code { color: ${PALETTE.fg}; }
   .vault-picker-locked .picker-help { color: ${PALETTE.fgMuted}; }

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -70,8 +70,8 @@ import {
 } from "./hub-settings.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import {
-  accountClaudeMcpAddCommand,
   assignedVaultClaudeMcpAddCommand,
+  rootClaudeMcpAddCommand,
 } from "./mcp-connect-commands.ts";
 import { escapeHtml } from "./oauth-ui.ts";
 import {
@@ -1151,32 +1151,28 @@ export function renderDoneStep(props: RenderDoneStepProps): string {
  * was a privilege over-grant + a shoulder-surf hazard. The bare OAuth
  * command was always the correct UX; it's now the only one.
  *
- * URL shape: lead with `/account/mcp` (whole house / all assigned
- * vaults). That is vault-agnostic — it stays correct if this vault is
- * renamed or more vaults are added — and its PRM advertises
- * `account:vaults` alone, so a catalog-copy OAuth client can actually
- * complete. Root `/mcp` OAuth discovery is the one-vault path (its PRM
- * is vault-only; advertising `account:vaults` there next to `vault:*`
- * would bounce the whole authorize request). NIP-98 clients can still
- * POST a signed request to `/account/mcp` or `/mcp`. The per-vault
- * command is the narrower OAuth option.
+ * URL shape: lead with `/mcp`. The consent picker is the XOR — this vault
+ * or all assigned vaults — so humans never need a second URL for the
+ * house. Root PRM stays vault-only (advertising `account:vaults` next to
+ * `vault:*` would bounce a catalog-copy authorize). The per-vault command
+ * is the skip-picker narrower option. `/account/mcp` stays the honest
+ * single-family discovery door; it is not in this copy.
  */
 function renderMcpTile(vaultName: string, hubOrigin: string): string {
   const safeVault = escapeHtml(vaultName);
-  const houseCmd = accountClaudeMcpAddCommand(hubOrigin);
+  const houseCmd = rootClaudeMcpAddCommand(hubOrigin);
   const vaultCmd = assignedVaultClaudeMcpAddCommand(hubOrigin, vaultName);
   return `<div class="done-tile">
     <h2>Connect Claude Code (MCP)</h2>
-    <p>All assigned vaults — one connection, capability grows from grants:</p>
+    <p>This hub — when you approve, pick this vault or all assigned vaults:</p>
     <pre data-testid="mcp-house-command">${escapeHtml(houseCmd)}</pre>
-    <p>Or just this vault (<code>vault:${safeVault}</code>):</p>
+    <p>Or skip the picker and connect just this vault (<code>vault:${safeVault}</code>):</p>
     <pre data-testid="mcp-vault-command">${escapeHtml(vaultCmd)}</pre>
     <p class="fine">No token needed — the command triggers browser OAuth on
-      first use (you sign in to this hub and approve access). The whole-house
-      URL is <code>/account/mcp</code>. Root <code>/mcp</code> is the
-      one-vault OAuth path; NIP-98 clients can still POST a signed request
-      there. For headless clients that can't do the browser flow, mint a hub
-      token at
+      first use (you sign in to this hub and approve access). Root
+      <code>/mcp</code> is the one URL; the consent picker chooses the
+      grant. The per-vault URL is the narrower option. For headless
+      clients that can't do the browser flow, mint a hub token at
       <a href="/admin/tokens"><code>/admin/tokens</code></a> (or with
       <code>parachute auth mint-token</code>) and append
       <code>--header "Authorization: Bearer &lt;token&gt;"</code>.</p>


### PR DESCRIPTION
## What

Aaron's push: credentials at `/mcp` already dispatch; the unbuilt gap was first-token OAuth. Catalog-copy of root PRM still asks unnamed `vault:*`, so the existing consent picker is the XOR — this vault vs all assigned vaults — not a second advertised scope family.

- **Picker:** radio `vault_pick=:account:` (colon is outside `VAULT_NAME_CHARSET_RE`; `__account__` would be a legal vault name). Free picker (admin / multi-vault) pre-checks whole-account. Locked friend: assigned vault stays default, whole-account is the second option.
- **Submit:** sentinel replaces unnamed `vault:<verb>` with `account:vaults` and mints through the existing #892 choke-point (`bindAccountVaultsScopes` → `aud=account`).
- **Cap:** `capScopesToUserAuthority` now admits `isRequestableAccountScope` only (2-part `account:vaults` or 3-part `account:<id>:vaults`). 4-part `account:<id>:vaults:<vault>` stays NOT requestable — reused the door-contract helper rather than re-deriving the shape. `account:self:{read,write,admin}` still dropped for non-admins.
- **Same-hub auto-trust:** unchanged. Does **not** silently upgrade unnamed `vault:read` to whole-account.
- **Skip-consent:** a prior `account:self:vaults` grant covers a later unnamed request at root (rewrite to the bound connection grant) so reconnect does not re-prompt forever. `isCoveredByGrant` stays exact-match so trust-by-client_name cannot record unnamed verbs.
- **Extras:** omit `account:vaults` (picker is the only path). Requested `account:vaults` → extras empty (the reverse combine-refusal landmine).
- **Copy:** wizard and friend onboarding lead humans at `/mcp` again. Per-vault URL is the skip-picker narrower option. `/account/mcp` stays the honest single-family discovery door — not in human copy. Root PRM stays vault-only.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

At `f971bdf`:

- `bun run typecheck` 0 errors
- `bun test ./src/__tests__/oauth-handlers.test.ts` — 288 pass / 0 fail
- `bun test ./src/__tests__/oauth-ui.test.ts ./src/__tests__/account-home-ui.test.ts ./src/__tests__/setup-wizard.test.ts` — 214 pass / 1 skip (pre-existing scribe tile skip) / 0 fail

Not run: full `bun test ./src` (live box; launchd-label tests). Feature PR — no version bump.

## Not this PR

- Root PRM advertisement of `account:vaults` (still deferred: catalog-copy would `invalid_scope` the whole authorize)
- hub#899 challenge URL
- Cloud twin
- Same-hub auto-upgrade of unnamed `vault:read` to `account:vaults` (deliberately not; picker is the only first-contact path)
