### PR TITLE
release: hub 0.7.18-rc.6 — consent picker XOR at /mcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.6] - 2026-08-28
+
+**Consent picker XOR at `/mcp`.** Two PRs on `next` after 0.7.18-rc.5.
+Version bump only; no new code in this commit. Merging this to `next`
+does not publish. The following next→main PR publishes `@rc`.
+
+- **Onboarding copy for `/account/mcp` (#900).** Wizard and friend
+  onboarding named the whole-house door. Helper rename
+  `accountMcpEndpoint(origin, vault)` → `assignedVaultMcpEndpoint`.
+  Root PRM stayed vault-only. RFC 9728 §3.3 nit tracked as #899.
+
+- **Consent picker XOR (#901).** Unnamed `vault:*` at `/mcp` now offers
+  this vault XOR all assigned vaults (`vault_pick=:account:`). Cap
+  admits `isRequestableAccountScope` for non-admins (4-part pre-narrow
+  dropped). Same-hub auto-trust does not silently upgrade. Skip-consent
+  after a prior `account:self:vaults` grant covers later unnamed-at-root.
+  Wizard and friend copy lead humans at `/mcp` again; `/account/mcp`
+  stays the honest single-family discovery door, not in human copy.
+  Root PRM still vault-only.
+
+Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do
+not suffix-drop 0.7.18.
+
 ## [0.7.18-rc.5] - 2026-08-28
 
 **Account-MCP update-note.** One PR on `next` after 0.7.18-rc.4.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.5",
+  "version": "0.7.18-rc.6",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## What

Version bump only. `package.json` `0.7.18-rc.5` → `0.7.18-rc.6` + CHANGELOG. No code.

Also merges `main` into `next` (the #898 merge commit next did not have). Same shape as #897. **Merge-commit this PR, do not squash** — squash would drop that merge commit and leave `next` behind `main` again.

Captures:

- [hub#900](https://github.com/ParachuteComputer/parachute-hub/pull/900) — onboarding copy + helper rename
- [hub#901](https://github.com/ParachuteComputer/parachute-hub/pull/901) — consent picker XOR at `/mcp` (this vault vs all assigned vaults)

Both landed on `next` at the already-published 0.7.18-rc.5 version, so they never reached npm. #901 supersedes #900's human-facing copy: humans are pointed at `/mcp` again; `/account/mcp` stays the honest single-family discovery door, not in onboarding copy. Root PRM stays vault-only.

Merging this to `next` does **not** publish. The following `next` → `main` merge-commit publishes `@openparachute/hub@0.7.18-rc.6` `@rc`. `@latest` stays 0.7.17.

Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do not suffix-drop 0.7.18.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

Version + changelog only. `package.json` is `0.7.18-rc.6` at this tip. Feature tests for #901 already ran at `f971bdf` (502 pass / 1 skip / 0 fail on the four suites; CI 3m21s SUCCESS).
