### PR TITLE
fix(hub): allow account:self REST extras with account:vaults

### DIFF
--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -10485,12 +10485,15 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
       });
       expect(extras).not.toContain("account:vaults");
       expect(extras).not.toContain("account:self:vaults");
+      expect(extras).toContain("account:self:read");
+      expect(extras).toContain("account:self:write");
+      expect(extras).toContain("account:self:admin");
     } finally {
       cleanup();
     }
   });
 
-  test("grantable extras are empty when the client already asked for account:vaults", async () => {
+  test("grantable extras offer the REST ladder when the client already asked for account:vaults", async () => {
     const { db, cleanup } = await makeDb();
     try {
       const admin = await createUser(db, "admin", "pw");
@@ -10499,7 +10502,12 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
         requested: ["account:vaults"],
         vaultName: undefined,
       });
-      expect(extras).toEqual([]);
+      expect(extras).toContain("account:self:read");
+      expect(extras).toContain("account:self:write");
+      expect(extras).toContain("account:self:admin");
+      expect(extras).not.toContain("vault:read");
+      expect(extras).not.toContain("vault:write");
+      expect(extras).not.toContain("account:vaults");
     } finally {
       cleanup();
     }
@@ -10783,7 +10791,7 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
     }
   });
 
-  test("account:vaults cannot be combined with other scopes", async () => {
+  test("account:vaults cannot be combined with vault-audience scopes", async () => {
     const { db, cleanup } = await makeDb();
     try {
       const owner = await createUser(db, "owner", "pw");
@@ -10804,6 +10812,187 @@ describe("single OAuth consent + grantable vault admin + delegate-only cap (2026
       const loc = consentRes.headers.get("location") ?? "";
       expect(loc).toContain("error=invalid_scope");
       expect(loc).not.toContain("code=");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("account:vaults plus account:self:read mints both at aud=account", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "account:vaults account:self:read",
+        challenge,
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).not.toContain("error=");
+      const code = new URL(loc).searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ").sort()).toEqual(["account:self:read", "account:self:vaults"]);
+      expect(aud).toBe("account");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("whole-account pick plus extra_scope account:self:admin at resource=/mcp mints both", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        {
+          vault_pick: VAULT_PICK_ACCOUNT,
+          extra_scope: "account:self:admin",
+          resource: `${ISSUER}/mcp`,
+        },
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).not.toContain("error=");
+      const code = new URL(loc).searchParams.get("code");
+      const tokenForm = new URLSearchParams({
+        grant_type: "authorization_code",
+        code: code ?? "",
+        client_id: reg.client.clientId,
+        redirect_uri: "https://app.example/cb",
+        code_verifier: verifier,
+        resource: `${ISSUER}/mcp`,
+      });
+      const tokenRes = await handleToken(
+        db,
+        new Request(`${ISSUER}/oauth/token`, {
+          method: "POST",
+          body: tokenForm,
+          headers: { "content-type": "application/x-www-form-urlencoded" },
+        }),
+        capDeps,
+      );
+      expect(tokenRes.status).toBe(200);
+      const body = (await tokenRes.json()) as { access_token: string; scope: string };
+      const { payload } = await validateAccessToken(db, body.access_token, ISSUER);
+      expect(body.scope.split(" ").sort()).toEqual(["account:self:admin", "account:self:vaults"]);
+      expect(payload.aud).toBe("account");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("whole-account pick plus extra_scope account:self:admin mints both", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        { vault_pick: VAULT_PICK_ACCOUNT, extra_scope: "account:self:admin" },
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).not.toContain("error=");
+      const code = new URL(loc).searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ").sort()).toEqual(["account:self:admin", "account:self:vaults"]);
+      expect(scope.split(" ")).not.toContain("vault:read");
+      expect(aud).toBe("account");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("whole-account pick drops leftover named vault extras (XOR)", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      await createUser(db, "owner", "pw");
+      const friend = await createUser(db, "friend", "pw", { allowMulti: true });
+      setUserVaults(db, friend.id, ["work"]);
+      const session = createSession(db, { userId: friend.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { verifier, challenge } = makePkce();
+      const consentRes = await submitConsent(
+        db,
+        session.id,
+        reg.client.clientId,
+        "vault:read",
+        challenge,
+        { vault_pick: VAULT_PICK_ACCOUNT, extra_scope: "vault:work:write" },
+      );
+      expect(consentRes.status).toBe(302);
+      const loc = consentRes.headers.get("location") ?? "";
+      expect(loc).not.toContain("error=");
+      const code = new URL(loc).searchParams.get("code");
+      const { scope, aud } = await redeemToScopeAud(db, code ?? "", reg.client.clientId, verifier);
+      expect(scope.split(" ")).toEqual(["account:self:vaults"]);
+      expect(scope).not.toContain("vault:work:write");
+      expect(aud).toBe("account");
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("GET account:vaults + account:self:read is not invalid_scope", async () => {
+    const { db, cleanup } = await makeDb();
+    try {
+      const owner = await createUser(db, "owner", "pw");
+      const session = createSession(db, { userId: owner.id });
+      const reg = registerClient(db, {
+        redirectUris: ["https://app.example/cb"],
+        status: "approved",
+      });
+      const { challenge } = makePkce();
+      const res = handleAuthorizeGet(
+        db,
+        new Request(
+          authorizeUrl({
+            client_id: reg.client.clientId,
+            redirect_uri: "https://app.example/cb",
+            response_type: "code",
+            code_challenge: challenge,
+            code_challenge_method: "S256",
+            scope: "account:vaults account:self:read",
+          }),
+          { headers: { cookie: `${CSRF_COOKIE}; ${buildSessionCookie(session.id, TTL_S)}` } },
+        ),
+        capDeps,
+      );
+      expect(res.status).toBe(200);
+      const html = await res.text();
+      expect(html).not.toContain("invalid_scope");
+      expect(html).toContain("account:vaults");
+      expect(html).toContain("account:self:read");
     } finally {
       cleanup();
     }

--- a/src/__tests__/resource-binding.test.ts
+++ b/src/__tests__/resource-binding.test.ts
@@ -204,6 +204,18 @@ describe("narrowRootMcpScopes", () => {
     ]);
   });
 
+  test("keeps same-audience account:self REST ladder with the connection grant", () => {
+    expect(
+      narrowRootMcpScopes([
+        "account:vaults",
+        "account:self:read",
+        "account:self:write",
+        "account:self:admin",
+        "scribe:admin",
+      ]),
+    ).toEqual(["account:vaults", "account:self:read", "account:self:write", "account:self:admin"]);
+  });
+
   test("keeps vault scopes and account:vaults together (combine check refuses later)", () => {
     expect(narrowRootMcpScopes(["vault:read", "account:vaults", "scribe:admin"])).toEqual([
       "vault:read",

--- a/src/oauth-handlers.ts
+++ b/src/oauth-handlers.ts
@@ -168,8 +168,9 @@ function isUnnamedVaultScope(scope: string): boolean {
 
 /**
  * XOR rewrite: unnamed `vault:<verb>` becomes the account-MCP connection
- * grant. Named vault scopes and everything else stay put — the mint
- * choke-point still refuses mixing `account:vaults` with other families.
+ * grant. Named vault scopes stay put here; the `:account:` picker path
+ * drops them after this rewrite so they cannot combine-refuse. Same-
+ * audience `account:self:{read,write,admin}` extras ride through.
  */
 function replaceUnnamedVaultScopesWithAccountVaults(scopes: readonly string[]): string[] {
   const rest = scopes.filter((s) => !isUnnamedVaultScope(s));
@@ -1585,10 +1586,32 @@ function isAccountVaultsConnectionScope(scope: string): boolean {
   return scope === ACCOUNT_VAULTS_UNNARROWED || scope === accountVaultsScope("self");
 }
 
+function isAccountSelfRestScope(scope: string): boolean {
+  return (
+    scope === ACCOUNT_SELF_READ_SCOPE ||
+    scope === ACCOUNT_SELF_WRITE_SCOPE ||
+    scope === ACCOUNT_SELF_ADMIN_SCOPE
+  );
+}
+
+/** Same `aud=account` companions of the connection grant. RFC 8707 forbids
+ * mixing vault-audience scopes with `account:vaults`; it does not forbid
+ * `account:self:{read,write,admin}` — they share the account audience. */
+function isAccountAudienceCompanion(scope: string): boolean {
+  return isAccountVaultsConnectionScope(scope) || isAccountSelfRestScope(scope);
+}
+
+function isNamedVaultScope(scope: string): boolean {
+  const parts = scope.split(":");
+  const name = parts[1];
+  const verb = parts[2];
+  return parts.length === 3 && parts[0] === "vault" && !!name && !!verb && VAULT_VERBS.has(verb);
+}
+
 function accountVaultsCombinedWithOtherScopes(scopes: readonly string[]): boolean {
   const has = scopes.some(isAccountVaultsConnectionScope);
   if (!has) return false;
-  return scopes.some((s) => !isAccountVaultsConnectionScope(s));
+  return scopes.some((s) => !isAccountAudienceCompanion(s));
 }
 
 function capScopesToUserAuthority(
@@ -1681,16 +1704,24 @@ export function grantableExtraScopes(
   // The picker is the only path to `account:vaults`. Offering it as an extra
   // next to the client's vault scopes hits `accountVaultsCombinedWithOtherScopes`
   // at mint — a checkbox that looks grantable and then bounces the whole
-  // authorize. The reverse landmine (requested `account:vaults`, extras offer
-  // vault verbs) is the same XOR: extras would combine-refuse, so offer none.
-  if (opts.requested.some(isAccountVaultsConnectionScope)) return [];
+  // authorize. When the client already asked for the connection grant,
+  // vault extras are still that landmine (cross-audience), but the REST
+  // ladder is the same `aud=account` and is what "plus account access" means.
+  const restLadder = [ACCOUNT_SELF_READ_SCOPE, ACCOUNT_SELF_WRITE_SCOPE, ACCOUNT_SELF_ADMIN_SCOPE];
+  if (opts.requested.some(isAccountVaultsConnectionScope)) {
+    const already = new Set(opts.requested);
+    return capScopesToUserAuthority(
+      db,
+      userId,
+      restLadder.filter((c) => !already.has(c)),
+      { userIsAdmin: opts.userIsAdmin },
+    );
+  }
   const candidates = [
     ...(v
       ? [`vault:${v}:read`, `vault:${v}:write`, `vault:${v}:admin`]
       : ["vault:read", "vault:write", "vault:admin"]),
-    ACCOUNT_SELF_READ_SCOPE,
-    ACCOUNT_SELF_WRITE_SCOPE,
-    ACCOUNT_SELF_ADMIN_SCOPE,
+    ...restLadder,
   ];
 
   // Compare both naming shapes in one canonical key space. When an admin's
@@ -2191,7 +2222,9 @@ async function handleConsentSubmit(
           400,
         );
       }
-      scopes = replaceUnnamedVaultScopesWithAccountVaults(scopes);
+      scopes = replaceUnnamedVaultScopesWithAccountVaults(scopes).filter(
+        (s) => !isNamedVaultScope(s),
+      );
     } else {
       const manifest = (deps.loadServicesManifest ?? readServicesManifest)();
       const validNames = listVaultNames(manifest);

--- a/src/resource-binding.ts
+++ b/src/resource-binding.ts
@@ -30,6 +30,11 @@
 import { ACCOUNT_VAULTS_UNNARROWED, accountVaultsScope } from "@openparachute/door-contract";
 
 import { VAULT_VERBS } from "./jwt-audience.ts";
+import {
+  ACCOUNT_SELF_ADMIN_SCOPE,
+  ACCOUNT_SELF_READ_SCOPE,
+  ACCOUNT_SELF_WRITE_SCOPE,
+} from "./scope-explanations.ts";
 
 /**
  * Two recognised per-vault resource shapes, both rooted at the hub origin:
@@ -200,8 +205,9 @@ export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: 
 
 /**
  * The root-`/mcp` counterpart of `narrowResourceVaultScopes`: keep vault
- * scopes and the account-MCP connection grant (`account:vaults` /
- * `account:self:vaults`), drop everything else.
+ * scopes, the account-MCP connection grant (`account:vaults` /
+ * `account:self:vaults`), and same-audience `account:self:{read,write,admin}`,
+ * drop everything else.
  *
  * Root `/mcp` is two token shapes at one URL, branched on what arrives:
  * vault-audience Bearer still names one vault; `account:vaults` mints
@@ -210,8 +216,10 @@ export function narrowResourceVaultScopes(scopes: readonly string[], vaultName: 
  * verbatim: those scopes are unusable in either token this door mints, and
  * carrying them only inflates the consent surface.
  *
- * `account:vaults` cannot be combined with other scopes (authorize already
- * refuses that). This filter still keeps both if a client asked for both —
+ * `account:vaults` cannot be combined with vault-audience scopes (authorize
+ * already refuses that). Same-audience `account:self:{read,write,admin}`
+ * extras are keepable — they mint `aud=account` too. This filter still
+ * keeps a mixed vault + connection request if a client asked for both;
  * the combine check, not this function, is the refusal. Named
  * `account:self:vaults:<vault>` forms are NOT the connection grant and are
  * dropped here.
@@ -229,8 +237,18 @@ export function isAccountVaultsRootScope(scope: string): boolean {
   return scope === ACCOUNT_VAULTS_UNNARROWED || scope === accountVaultsScope("self");
 }
 
+function isAccountSelfRestScope(scope: string): boolean {
+  return (
+    scope === ACCOUNT_SELF_READ_SCOPE ||
+    scope === ACCOUNT_SELF_WRITE_SCOPE ||
+    scope === ACCOUNT_SELF_ADMIN_SCOPE
+  );
+}
+
 export function narrowRootMcpScopes(scopes: readonly string[]): string[] {
-  return scopes.filter((s) => s.split(":")[0] === "vault" || isAccountVaultsRootScope(s));
+  return scopes.filter(
+    (s) => s.split(":")[0] === "vault" || isAccountVaultsRootScope(s) || isAccountSelfRestScope(s),
+  );
 }
 
 /**


### PR DESCRIPTION
## Why

Aaron's live consent on 0.7.18-rc.6: **All assigned vaults** plus **Grant additional access** (`account:self:*`) bounced with `invalid_scope: account:vaults cannot be combined with other scopes`.

The picker XOR rewrites unnamed `vault:<verb>` to `account:vaults` (`aud=account`). The extras checkboxes offer the REST ladder (`account:self:{read,write,admin}`), which is the same audience. RFC 8707 forbids mixing vault-audience scopes into that token; the mint choke-point was stricter than that and refused any companion.

## What

- `accountVaultsCombinedWithOtherScopes` admits `account:self:{read,write,admin}` next to the connection grant. `account:vaults` + `vault:work:read` still refuses.
- `:account:` pick drops leftover **named** vault extras (friend `vault:work:write` next to whole-account). Unnamed extras already collapse into the connection grant.
- `grantableExtraScopes` after a requested `account:vaults` offers the REST ladder, not `[]`. Vault extras stay omitted there (cross-audience).
- `narrowRootMcpScopes` keeps the REST ladder so a client that asked for it at `resource=/mcp` does not lose it before extras.

No version bump (feature PR onto `next`). Root PRM stays vault-only. Do not suffix-drop 0.7.18.

## Tests (HEAD `f21e4bb`)

- `bun run typecheck` clean.
- Targeted: new extras + mint + GET + `resource=/mcp` extra_scope cases pass.
- Full `bun test ./src` (worktree, bunfig sandboxes `PARACHUTE_HOME`; live hub still 0.7.18-rc.6 after): **4793 pass / 1 skip / 1 fail**. The fail is `src/__tests__/surface-command.test.ts` "command-minted write token pushes" timeout 5000ms — file not in this diff; reproduces in isolation. Not this change.

Not smoked through a live browser OAuth click on this box (still rc.6 until a later rc.7).

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.
