### PR TITLE
release: hub 0.7.18-rc.7 — account:self extras with account:vaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.7] - 2026-08-28
+
+**Same-audience REST extras with whole-account pick.** One PR on
+`next` after 0.7.18-rc.6. Version bump only; no new code in this
+commit. Merging this to `next` does not publish. The following
+next→main PR publishes `@rc`.
+
+- **Allow `account:self:{read,write,admin}` next to `account:vaults`
+  (#904).** Live bounce on rc.6: All assigned vaults plus Grant
+  additional access was `invalid_scope`. Those extras share
+  `aud=account`; vault-audience mixes still refuse. `:account:` pick
+  drops leftover named vault extras. Root PRM stays vault-only.
+
+Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do
+not suffix-drop 0.7.18.
+
 ## [0.7.18-rc.6] - 2026-08-28
 
 **Consent picker XOR at `/mcp`.** Two PRs on `next` after 0.7.18-rc.5.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.6",
+  "version": "0.7.18-rc.7",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## What

Version bump only. `package.json` `0.7.18-rc.6` → `0.7.18-rc.7` + CHANGELOG. No code.

Also merges `main` into `next` (the #903 merge commit next did not have). Same shape as #902. **Merge-commit this PR, do not squash** — squash would drop that merge commit and leave `next` behind `main` again.

Captures:

- [hub#904](https://github.com/ParachuteComputer/parachute-hub/pull/904) — same-audience `account:self:{read,write,admin}` extras with `account:vaults` (the live bounce on rc.6)

#904 landed on `next` at the already-published 0.7.18-rc.6 version, so it never reached npm.

Merging this to `next` does **not** publish. The following `next` → `main` merge-commit publishes `@openparachute/hub@0.7.18-rc.7` `@rc`. `@latest` stays 0.7.17.

Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do not suffix-drop 0.7.18.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

Version + changelog only. Feature tests for #904 ran at `f21e4bb` (`bun test ./src` 4793 pass / 1 skip / 1 fail: pre-existing `surface-command` git-credential timeout, file not in #904). CI on #904: typecheck + unit tests SUCCESS 3m27s. Reviews on #904: generalist SHIP, auth-and-scope SHIP, wire-contract SHIP; no must-fixes.
