### PR TITLE
release: hub 0.7.18-rc.8 — account-MCP query-notes sort + bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.8] - 2026-08-28
+
+**Account-MCP query-notes sort + bodies.** One PR on `next` after
+0.7.18-rc.7. Version bump only; no new code in this commit. Merging
+this to `next` does not publish. The following next→main PR publishes
+`@rc`.
+
+- **Account-MCP `query-notes` forwards `sort` / `include_content` /
+  `order_by` / `offset` (#907).** Vault REST defaults stay oldest-first
+  lean preview; the tool description names them. Felt: "3 latest notes"
+  via `/mcp` returned the 3 oldest with no bodies. Cloud follow-up:
+  parachute-cloud#276.
+
+Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do
+not suffix-drop 0.7.18.
+
 ## [0.7.18-rc.7] - 2026-08-28
 
 **Same-audience REST extras with whole-account pick.** One PR on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.7",
+  "version": "0.7.18-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {


### PR DESCRIPTION
## What

Version bump only. `package.json` `0.7.18-rc.7` → `0.7.18-rc.8` + CHANGELOG. No code.

Also merges `main` into `next` (the #906 merge commit next did not have). **Merge-commit this PR, do not squash.**

Captures:

- [hub#907](https://github.com/ParachuteComputer/parachute-hub/pull/907) — account-MCP `query-notes` forwards `sort` / `include_content` / `order_by` / `offset`

Merging this to `next` does **not** publish. The following `next` → `main` merge-commit publishes `@openparachute/hub@0.7.18-rc.8` `@rc`. `@latest` stays 0.7.17.

Cloud follow-up: [parachute-cloud#276](https://github.com/ParachuteComputer/parachute-cloud/issues/276).

Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do not suffix-drop 0.7.18.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## Test

Version + changelog only. Feature tests for #907 ran at `a1270de` (`bun test ./src/__tests__/account-mcp.test.ts` 64 pass). CI on #907: typecheck + unit tests SUCCESS 3m26s. Reviews: generalist SHIP; wire-contract asked for the cloud issue, now filed as #276.
