### PR TITLE
release: hub 0.7.18-rc.8 (next → main)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.8] - 2026-08-28
+
+**Account-MCP query-notes sort + bodies.** One PR on `next` after
+0.7.18-rc.7. Version bump only; no new code in this commit. Merging
+this to `next` does not publish. The following next→main PR publishes
+`@rc`.
+
+- **Account-MCP `query-notes` forwards `sort` / `include_content` /
+  `order_by` / `offset` (#907).** Vault REST defaults stay oldest-first
+  lean preview; the tool description names them. Felt: "3 latest notes"
+  via `/mcp` returned the 3 oldest with no bodies. Cloud follow-up:
+  parachute-cloud#276.
+
+Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do
+not suffix-drop 0.7.18.
+
 ## [0.7.18-rc.7] - 2026-08-28
 
 **Same-audience REST extras with whole-account pick.** One PR on

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.7",
+  "version": "0.7.18-rc.8",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -10,7 +10,8 @@ import type { Database } from "bun:sqlite";
  *     auto-provisioned = empty; read-role still lists + queries;
  *   - create-vault: owner yes, friend no, no token in the tool result;
  *   - query-notes: fan-out attribution + one-vault failure isolation +
- *     vault_not_covered fail-closed;
+ *     vault_not_covered fail-closed; sort/include_content/order_by/offset
+ *     forwarded to vault REST;
  *   - grant-access: grant-first creates a key-only user; one-row upsert;
  *     friend write can grant their vault, read cannot; owner unrestricted
  *     is a no-op; revoke leaves the user; list-access is pubkey-shaped;
@@ -599,7 +600,9 @@ describe("account MCP — create-vault", () => {
         ),
         mcpDeps(h),
       );
-      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-vault/);
     } finally {
@@ -710,6 +713,107 @@ describe("account MCP — query-notes", () => {
     }
   });
 
+  test("forwards sort, include_content, order_by, offset to vault REST", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: string[] = [];
+      const fetchImpl = async (input: string | URL | Request) => {
+        const href =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : (input as Request).url;
+        seen.push(href);
+        return Response.json([{ id: "n-beta" }], { status: 200 });
+      };
+      const res = await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "query-notes",
+            arguments: {
+              vault: "beta",
+              sort: "desc",
+              include_content: true,
+              order_by: "updated_at",
+              offset: 2,
+              limit: 3,
+            },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(res.status).toBe(200);
+      expect(seen).toHaveLength(1);
+      const u = new URL(seen[0]!);
+      expect(u.searchParams.get("sort")).toBe("desc");
+      expect(u.searchParams.get("include_content")).toBe("true");
+      expect(u.searchParams.get("order_by")).toBe("updated_at");
+      expect(u.searchParams.get("offset")).toBe("2");
+      expect(u.searchParams.get("limit")).toBe("3");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("omits unknown sort rather than forwarding it", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: string[] = [];
+      const fetchImpl = async (input: string | URL | Request) => {
+        const href =
+          typeof input === "string"
+            ? input
+            : input instanceof URL
+              ? input.href
+              : (input as Request).url;
+        seen.push(href);
+        return Response.json([], { status: 200 });
+      };
+      await handleAccountMcp(
+        nostrReq(
+          FRIEND_SECRET,
+          rpc("tools/call", {
+            name: "query-notes",
+            arguments: { vault: "beta", sort: "newest" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(seen).toHaveLength(1);
+      const u = new URL(seen[0]!);
+      expect(u.searchParams.has("sort")).toBe(false);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("tools/list advertises sort and include_content on query-notes", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const listed = await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h));
+      const listBody = (await listed.json()) as {
+        result: {
+          tools: Array<{
+            name: string;
+            description?: string;
+            inputSchema?: { properties?: Record<string, unknown> };
+          }>;
+        };
+      };
+      const qn = listBody.result.tools.find((t) => t.name === "query-notes");
+      expect(qn?.inputSchema?.properties).toHaveProperty("sort");
+      expect(qn?.inputSchema?.properties).toHaveProperty("include_content");
+      expect(qn?.inputSchema?.properties).toHaveProperty("order_by");
+      expect(qn?.description).toMatch(/sort/);
+      expect(qn?.description).toMatch(/include_content/);
+    } finally {
+      h.cleanup();
+    }
+  });
+
   test("friend can query their assigned vault", async () => {
     const h = await makeHarness();
     try {
@@ -800,12 +904,16 @@ describe("account MCP — create-note", () => {
             arguments: { vault: "beta", content: "nope" },
           }),
         ),
-        mcpDeps(h, { fetchImpl: async () => {
-          fetched += 1;
-          return Response.json({}, { status: 201 });
-        } }),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return Response.json({}, { status: 201 });
+          },
+        }),
       );
-      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
       expect(fetched).toBe(0);
@@ -824,10 +932,12 @@ describe("account MCP — create-note", () => {
           token,
           rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
         ),
-        mcpDeps(h, { fetchImpl: async () => {
-          fetched += 1;
-          return Response.json({}, { status: 201 });
-        } }),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return Response.json({}, { status: 201 });
+          },
+        }),
       );
       const body = (await res.json()) as {
         result?: { isError?: boolean; content?: Array<{ text?: string }> };
@@ -850,10 +960,12 @@ describe("account MCP — create-note", () => {
           token,
           rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
         ),
-        mcpDeps(h, { fetchImpl: async () => {
-          fetched += 1;
-          return Response.json({}, { status: 201 });
-        } }),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return Response.json({}, { status: 201 });
+          },
+        }),
       );
       const body = (await res.json()) as {
         result?: { isError?: boolean; content?: Array<{ text?: string }> };
@@ -872,7 +984,9 @@ describe("account MCP — create-note", () => {
       const seen: string[] = [];
       const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
         const req = input instanceof Request ? input : new Request(String(input), init);
-        const parts = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").split(".");
+        const parts = (req.headers.get("authorization") ?? "")
+          .replace(/^Bearer\s+/i, "")
+          .split(".");
         const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
           scope?: string;
         };
@@ -939,10 +1053,7 @@ describe("account MCP — create-note", () => {
         label: "test",
         now: new Date(),
       });
-      const listed = await handleAccountMcp(
-        nostrReq(readerSecret, rpc("tools/list")),
-        mcpDeps(h),
-      );
+      const listed = await handleAccountMcp(nostrReq(readerSecret, rpc("tools/list")), mcpDeps(h));
       const names = (
         (await listed.json()) as { result: { tools: Array<{ name: string }> } }
       ).result.tools.map((t) => t.name);
@@ -1085,7 +1196,10 @@ describe("account MCP — update-note", () => {
       const res = await handleAccountMcp(
         bearerReq(
           token,
-          rpc("tools/call", { name: "update-note", arguments: { vault: "beta", id: "n1", content: "nope" } }),
+          rpc("tools/call", {
+            name: "update-note",
+            arguments: { vault: "beta", id: "n1", content: "nope" },
+          }),
         ),
         mcpDeps(h, {
           fetchImpl: async () => {
@@ -1111,7 +1225,9 @@ describe("account MCP — update-note", () => {
       const seen: Array<{ method: string; scope: string }> = [];
       const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
         const req = input instanceof Request ? input : new Request(String(input), init);
-        const parts = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").split(".");
+        const parts = (req.headers.get("authorization") ?? "")
+          .replace(/^Bearer\s+/i, "")
+          .split(".");
         const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
           scope?: string;
         };
@@ -1568,7 +1684,9 @@ describe("account MCP — grant-access", () => {
         ),
         mcpDeps(h),
       );
-      const body = (await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+      const body = (await res.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: grant-access/);
     } finally {
@@ -1817,8 +1935,11 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await personal.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
-          .result?.content?.[0]?.text,
+        (
+          (await personal.json()) as {
+            result?: { isError?: boolean; content?: Array<{ text?: string }> };
+          }
+        ).result?.content?.[0]?.text,
       ).toMatch(/Unknown tool: grant-access/);
       const beta = await handleAccountMcp(
         bearerReq(
@@ -1831,8 +1952,11 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await beta.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
-          .result?.content?.[0]?.text,
+        (
+          (await beta.json()) as {
+            result?: { isError?: boolean; content?: Array<{ text?: string }> };
+          }
+        ).result?.content?.[0]?.text,
       ).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();
@@ -1878,8 +2002,11 @@ describe("account MCP — grant-access", () => {
         mcpDeps(h),
       );
       expect(
-        ((await res.json()) as { result?: { isError?: boolean; content?: Array<{ text?: string }> } })
-          .result?.content?.[0]?.text,
+        (
+          (await res.json()) as {
+            result?: { isError?: boolean; content?: Array<{ text?: string }> };
+          }
+        ).result?.content?.[0]?.text,
       ).toMatch(/Unknown tool: grant-access/);
     } finally {
       h.cleanup();

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -286,7 +286,8 @@ function instructions(): string {
   return (
     "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
     "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
-    "query-notes to search across them (omit `vault` to fan out, pass it to target one), " +
+    "query-notes to search across them (omit `vault` to fan out, pass it to target one; " +
+    "default oldest-first preview — pass sort=desc and include_content=true for latest bodies), " +
     "create-note / update-note to write in one vault (`vault` is required). " +
     "grant-access / revoke-access / list-access give a Nostr pubkey a vault (role read|write) " +
     "if you can admin that vault. tools/list hides tools you cannot call."

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -34,7 +34,13 @@ import {
 } from "@openparachute/door-contract";
 import { type AccountVaultMeta, listVaultsWithMeta } from "./account-api.ts";
 import { HOST_ADMIN_SCOPE, provisionVault } from "./admin-vaults.ts";
-import { GrantError, callerCanAdminVault, grantAccess, listAccess, revokeAccess } from "./grant-access.ts";
+import {
+  GrantError,
+  callerCanAdminVault,
+  grantAccess,
+  listAccess,
+  revokeAccess,
+} from "./grant-access.ts";
 import { signAccessToken } from "./jwt-sign.ts";
 import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
 
@@ -331,6 +337,27 @@ function buildNotesQuery(args: Record<string, unknown>): string {
     const clamped = Math.min(Math.max(1, Math.floor(rawLimit)), MAX_NOTES_LIMIT);
     p.set("limit", String(clamped));
   }
+  // Vault REST defaults: created_at ASC, lean ~120-char preview. Forward the
+  // params that make "latest notes with bodies" expressible. Unknown sort is
+  // dropped rather than 400'd so a hallucinated value does not fail the fan-out.
+  if (args.sort === "asc" || args.sort === "desc") p.set("sort", args.sort);
+  if (typeof args.order_by === "string" && args.order_by.length > 0) {
+    p.set("order_by", args.order_by);
+  }
+  if (args.include_content === true || args.include_content === "true") {
+    p.set("include_content", "true");
+  } else if (args.include_content === false || args.include_content === "false") {
+    p.set("include_content", "false");
+  }
+  const rawOffset =
+    typeof args.offset === "number"
+      ? args.offset
+      : typeof args.offset === "string"
+        ? Number.parseInt(args.offset, 10)
+        : undefined;
+  if (rawOffset !== undefined && Number.isFinite(rawOffset) && rawOffset >= 0) {
+    p.set("offset", String(Math.floor(rawOffset)));
+  }
   return p.toString();
 }
 
@@ -396,7 +423,10 @@ const queryNotesTool: AccountMcpTool = {
   description:
     "Search notes across the vaults this connection can reach. Omit `vault` to fan the query out " +
     "(results are grouped per vault, not ranked across vaults); pass `vault` to target one. " +
-    "Supports keyword `search`, `tag` and `metadata` filters, and `limit`.",
+    "Default order is created_at ASC (oldest first) and the lean ~120-char preview — pass " +
+    '`sort: "desc"` for newest-first and `include_content: true` for bodies. Also: keyword ' +
+    "`search`, `tag`, `metadata`, `limit` (per vault, default 50), `order_by` (`updated_at` or " +
+    "an indexed field), `offset`.",
   inputSchema: {
     type: "object",
     properties: {
@@ -416,6 +446,25 @@ const queryNotesTool: AccountMcpTool = {
         description: 'Structured metadata filters, e.g. {"status":{"eq":"open"}}.',
       },
       limit: { type: "number", description: "Maximum notes per vault (default 50)." },
+      sort: {
+        type: "string",
+        enum: ["asc", "desc"],
+        description: "Order by created_at. Default asc (oldest first). Pass desc for newest first.",
+      },
+      order_by: {
+        type: "string",
+        description:
+          "Sort by this field instead of created_at. `updated_at` needs no schema; other " +
+          "fields must be indexed on the target vault.",
+      },
+      include_content: {
+        type: "boolean",
+        description: "Return full note bodies. Default false: lean rows with a ~120-char preview.",
+      },
+      offset: {
+        type: "number",
+        description: "Skip this many notes per vault (default 0).",
+      },
     },
     additionalProperties: false,
   },
@@ -453,7 +502,8 @@ function noteUpdateBody(args: Record<string, unknown>): Record<string, unknown> 
   if (typeof args.content === "string") body.content = args.content;
   if (typeof args.append === "string") body.append = args.append;
   if (typeof args.prepend === "string") body.prepend = args.prepend;
-  if (args.content_edit && typeof args.content_edit === "object") body.content_edit = args.content_edit;
+  if (args.content_edit && typeof args.content_edit === "object")
+    body.content_edit = args.content_edit;
   if (typeof args.path === "string") body.path = args.path;
   if (args.tags && typeof args.tags === "object") body.tags = args.tags;
   if (args.metadata && typeof args.metadata === "object" && args.metadata !== null) {
@@ -749,9 +799,7 @@ export function toolsForPrincipal(ctx: AccountToolContext): readonly AccountMcpT
   const installed = installedVaults(ctx);
   const coverage = resolveCoverage(ctx.db, ctx.principal, installed);
   const canWrite = coverage.vaults.some((v) => canWriteVault(ctx.db, ctx.principal, v.name));
-  const canAdmin = coverage.vaults.some((v) =>
-    callerCanAdminVault(ctx.db, ctx.principal, v.name),
-  );
+  const canAdmin = coverage.vaults.some((v) => callerCanAdminVault(ctx.db, ctx.principal, v.name));
   const create = canCreate(ctx.principal);
   return ACCOUNT_MCP_TOOLS.filter((t) => {
     if (t.name === "create-vault") return create;


### PR DESCRIPTION
Merging this publishes `@openparachute/hub@0.7.18-rc.8` to npm `@rc`. It is an **rc**, not stable. `@latest` stays 0.7.17.

**Merge-commit, do not squash.** Squash would split `next` from `main`.

This is the click that puts #907 (account-MCP `query-notes` sort + bodies) on the box. Agents cannot merge `main` (triage only).

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

## What ships (on `next` after 0.7.18-rc.7)

- #907 account-MCP `query-notes` forwards `sort` / `include_content` / `order_by` / `offset`; defaults stay oldest-first lean preview; tool description names them
- #908 version+changelog 0.7.18-rc.8 + merge `main` into `next`

Cloud follow-up: [parachute-cloud#276](https://github.com/ParachuteComputer/parachute-cloud/issues/276).

Leaves #880, #881, and #899 open. Auto-provision still defaults **off**. Do not suffix-drop 0.7.18.

## After merge

`parachute upgrade hub --channel rc` on this box. Then retry "3 latest notes" at `/mcp` — the model should now be able to pass `sort: "desc"` and `include_content: true`.
