### PR TITLE
feat(hub): proxy account-MCP vault tools to vault MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [Unreleased]
+
+**Account-MCP proxies vault MCP instead of cloning REST.** Hub-native tools
+stay (`list-vaults`, `create-vault`, grant/revoke/list-access). Vault-shaped
+tools are a live `tools/list` from one covered vault (highest verb, fallback
+if that vault is down) plus JSON-RPC `tools/call` to
+`/vault/<name>/mcp` with a 60s mint. `query-notes` without `vault` still
+fans out; the envelope is unchanged. Per-vault `/vault/<name>/mcp` stays.
+
 ## [0.7.18-rc.8] - 2026-08-28
 
 **Account-MCP query-notes sort + bodies.** One PR on `next` after

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -176,6 +176,123 @@ async function bearer(h: Harness, scopes: string[], sub?: string): Promise<strin
   return minted.token;
 }
 
+function jwtScope(req: Request): string {
+  const parts = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").split(".");
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+      scope?: string;
+    };
+    return payload.scope ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function toolsForMintedScope(scope: string): Array<{
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}> {
+  const verb = scope.includes(":admin") ? "admin" : scope.includes(":write") ? "write" : "read";
+  const read = [
+    "query-notes",
+    "list-tags",
+    "find-path",
+    "vault-info",
+    "doctor",
+    "request-attachment-download",
+    "read-attachment",
+  ];
+  const write = [...read, "create-note", "update-note", "delete-note", "request-attachment-upload"];
+  const admin = [
+    ...write,
+    "manage-token",
+    "update-tag",
+    "delete-tag",
+    "rename-tag",
+    "merge-tags",
+    "prune-schema",
+  ];
+  const names = verb === "admin" ? admin : verb === "write" ? write : read;
+  return names.map((name) => ({
+    name,
+    description: `${name} (vault MCP)`,
+    inputSchema: {
+      type: "object",
+      properties:
+        name === "query-notes"
+          ? {
+              search: { type: "string" },
+              sort: { type: "string" },
+              include_content: { type: "boolean" },
+              order_by: { type: "string" },
+              cursor: { type: "string" },
+            }
+          : {},
+    },
+  }));
+}
+
+function jsonRpcOk(value: unknown): Response {
+  return Response.json({ jsonrpc: "2.0", id: 1, result: value });
+}
+
+function mcpTextResult(payload: unknown): Response {
+  return jsonRpcOk({ content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] });
+}
+
+interface VaultMcpCall {
+  url: string;
+  method: string;
+  rpc: { method?: string; params?: { name?: string; arguments?: Record<string, unknown> } };
+  scope: string;
+  vault: string;
+}
+
+async function routeVaultMcp(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+  hooks: {
+    onList?: (call: VaultMcpCall) => unknown | Response | Promise<unknown | Response>;
+    onCall?: (call: VaultMcpCall) => unknown | Response | Promise<unknown | Response>;
+    onRequest?: (call: VaultMcpCall) => void;
+  } = {},
+): Promise<Response> {
+  const req = input instanceof Request ? input : new Request(String(input), init);
+  const url = req.url;
+  let rpc: VaultMcpCall["rpc"] = {};
+  try {
+    rpc = JSON.parse(await req.text()) as VaultMcpCall["rpc"];
+  } catch {
+    rpc = {};
+  }
+  const call: VaultMcpCall = {
+    url,
+    method: req.method,
+    rpc,
+    scope: jwtScope(req),
+    vault: url.match(/\/vault\/([^/]+)\/mcp/)?.[1] ?? "",
+  };
+  hooks.onRequest?.(call);
+  if (rpc.method === "tools/list") {
+    const custom = await hooks.onList?.(call);
+    if (custom instanceof Response) return custom;
+    if (custom !== undefined) return jsonRpcOk(custom);
+    return jsonRpcOk({ tools: toolsForMintedScope(call.scope) });
+  }
+  if (rpc.method === "tools/call") {
+    const custom = await hooks.onCall?.(call);
+    if (custom instanceof Response) return custom;
+    if (custom !== undefined) {
+      if (custom && typeof custom === "object" && "content" in custom) return jsonRpcOk(custom);
+      return mcpTextResult(custom);
+    }
+    if (rpc.params?.name === "query-notes") return mcpTextResult([]);
+    return mcpTextResult({ ok: true });
+  }
+  return new Response("not mcp", { status: 404 });
+}
+
 function mcpDeps(
   h: Harness,
   extra: {
@@ -191,7 +308,7 @@ function mcpDeps(
     issuer: ISSUER,
     manifestPath: h.manifestPath,
     replay: h.replay,
-    ...(extra.fetchImpl ? { fetchImpl: extra.fetchImpl } : {}),
+    fetchImpl: extra.fetchImpl ?? ((input, init) => routeVaultMcp(input, init)),
     ...(extra.runCommand ? { runCommand: extra.runCommand } : {}),
   };
 }
@@ -426,26 +543,36 @@ describe("account MCP — initialize + tools", () => {
       );
       expect(init.status).toBe(200);
       const initBody = (await init.json()) as {
-        result: { serverInfo: { name: string }; protocolVersion: string };
+        result: { serverInfo: { name: string }; protocolVersion: string; instructions?: string };
       };
       expect(initBody.result.serverInfo.name).toBe("parachute-account");
       expect(initBody.result.protocolVersion).toBe("2025-11-25");
+      expect(initBody.result.instructions).toMatch(/union of what SOME covered vault/);
 
       const listed = await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h));
-      const listBody = (await listed.json()) as { result: { tools: Array<{ name: string }> } };
-      expect(listBody.result.tools.map((t) => t.name)).toEqual(
-        ACCOUNT_MCP_TOOLS.map((t) => t.name),
-      );
-      expect(listBody.result.tools.map((t) => t.name)).toEqual([
-        "list-vaults",
-        "create-vault",
-        "query-notes",
-        "create-note",
-        "update-note",
-        "grant-access",
-        "revoke-access",
-        "list-access",
-      ]);
+      const listBody = (await listed.json()) as {
+        result: {
+          tools: Array<{
+            name: string;
+            description?: string;
+            inputSchema?: { properties?: Record<string, unknown>; required?: string[] };
+          }>;
+        };
+      };
+      const names = listBody.result.tools.map((t) => t.name);
+      for (const n of ACCOUNT_MCP_TOOLS.map((t) => t.name)) expect(names).toContain(n);
+      expect(names).toContain("query-notes");
+      expect(names).toContain("create-note");
+      expect(names).toContain("delete-note");
+      expect(names).toContain("list-tags");
+      expect(names).toContain("manage-token");
+      expect(names[0]).toBe("list-vaults");
+      const qn = listBody.result.tools.find((t) => t.name === "query-notes");
+      expect(qn?.inputSchema?.properties).toHaveProperty("vault");
+      expect(qn?.inputSchema?.required ?? []).not.toContain("vault");
+      expect(qn?.description).toMatch(/Catalog caveat/);
+      const del = listBody.result.tools.find((t) => t.name === "delete-note");
+      expect(del?.inputSchema?.required).toContain("vault");
     } finally {
       h.cleanup();
     }
@@ -662,18 +789,14 @@ describe("account MCP — query-notes", () => {
     const h = await makeHarness();
     try {
       const token = await bearer(h, [HOST_ADMIN_SCOPE]);
-      const fetchImpl = async (input: string | URL | Request) => {
-        const href =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.href
-              : (input as Request).url;
-        if (href.includes("127.0.0.1:4101/vault/beta/")) {
-          return Response.json([{ id: "n-beta" }], { status: 200 });
-        }
-        throw new Error("personal is down");
-      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ vault, rpc }) => {
+            if (rpc.params?.name !== "query-notes") return undefined;
+            if (vault === "personal") throw new Error("personal is down");
+            return [{ id: "n-beta" }];
+          },
+        });
       const res = await handleAccountMcp(
         bearerReq(
           token,
@@ -713,20 +836,21 @@ describe("account MCP — query-notes", () => {
     }
   });
 
-  test("forwards sort, include_content, order_by, offset to vault REST", async () => {
+  test("forwards sort/include_content/cursor as MCP arguments, not REST query params", async () => {
     const h = await makeHarness();
     try {
-      const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request) => {
-        const href =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.href
-              : (input as Request).url;
-        seen.push(href);
-        return Response.json([{ id: "n-beta" }], { status: 200 });
-      };
+      const seen: Array<Record<string, unknown> | undefined> = [];
+      const urls: string[] = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onRequest: ({ url, rpc }) => {
+            if (rpc.method === "tools/call") urls.push(url);
+          },
+          onCall: ({ rpc }) => {
+            seen.push(rpc.params?.arguments);
+            return [{ id: "n-beta" }];
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -739,38 +863,42 @@ describe("account MCP — query-notes", () => {
               order_by: "updated_at",
               offset: 2,
               limit: 3,
+              cursor: "",
             },
           }),
         ),
         mcpDeps(h, { fetchImpl }),
       );
       expect(res.status).toBe(200);
+      expect(urls).toHaveLength(1);
+      expect(urls[0]).toContain("/vault/beta/mcp");
+      expect(urls[0]).not.toContain("/api/notes");
       expect(seen).toHaveLength(1);
-      const u = new URL(seen[0]!);
-      expect(u.searchParams.get("sort")).toBe("desc");
-      expect(u.searchParams.get("include_content")).toBe("true");
-      expect(u.searchParams.get("order_by")).toBe("updated_at");
-      expect(u.searchParams.get("offset")).toBe("2");
-      expect(u.searchParams.get("limit")).toBe("3");
+      expect(seen[0]).toMatchObject({
+        sort: "desc",
+        include_content: true,
+        order_by: "updated_at",
+        offset: 2,
+        limit: 3,
+        cursor: "",
+      });
+      expect(seen[0]).not.toHaveProperty("vault");
     } finally {
       h.cleanup();
     }
   });
 
-  test("omits unknown sort rather than forwarding it", async () => {
+  test("does not allowlist sort — unknown values ride through to vault MCP", async () => {
     const h = await makeHarness();
     try {
-      const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request) => {
-        const href =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.href
-              : (input as Request).url;
-        seen.push(href);
-        return Response.json([], { status: 200 });
-      };
+      const seen: Array<Record<string, unknown> | undefined> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ rpc }) => {
+            seen.push(rpc.params?.arguments);
+            return [];
+          },
+        });
       await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -782,14 +910,13 @@ describe("account MCP — query-notes", () => {
         mcpDeps(h, { fetchImpl }),
       );
       expect(seen).toHaveLength(1);
-      const u = new URL(seen[0]!);
-      expect(u.searchParams.has("sort")).toBe(false);
+      expect(seen[0]?.sort).toBe("newest");
     } finally {
       h.cleanup();
     }
   });
 
-  test("tools/list advertises sort and include_content on query-notes", async () => {
+  test("tools/list advertises live query-notes schema plus injected vault", async () => {
     const h = await makeHarness();
     try {
       const token = await bearer(h, [HOST_ADMIN_SCOPE]);
@@ -799,7 +926,7 @@ describe("account MCP — query-notes", () => {
           tools: Array<{
             name: string;
             description?: string;
-            inputSchema?: { properties?: Record<string, unknown> };
+            inputSchema?: { properties?: Record<string, unknown>; required?: string[] };
           }>;
         };
       };
@@ -807,8 +934,9 @@ describe("account MCP — query-notes", () => {
       expect(qn?.inputSchema?.properties).toHaveProperty("sort");
       expect(qn?.inputSchema?.properties).toHaveProperty("include_content");
       expect(qn?.inputSchema?.properties).toHaveProperty("order_by");
-      expect(qn?.description).toMatch(/sort/);
-      expect(qn?.description).toMatch(/include_content/);
+      expect(qn?.inputSchema?.properties).toHaveProperty("vault");
+      expect(qn?.inputSchema?.required ?? []).not.toContain("vault");
+      expect(qn?.description).toMatch(/Catalog caveat/);
     } finally {
       h.cleanup();
     }
@@ -817,7 +945,8 @@ describe("account MCP — query-notes", () => {
   test("friend can query their assigned vault", async () => {
     const h = await makeHarness();
     try {
-      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, { onCall: () => [{ id: "n-beta" }] });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -838,20 +967,17 @@ describe("account MCP — query-notes", () => {
 });
 
 describe("account MCP — create-note", () => {
-  test("owner posts to the named vault with a write-audience mint", async () => {
+  test("owner forwards JSON-RPC to the named vault with a write-or-higher mint", async () => {
     const h = await makeHarness();
     try {
-      const seen: Array<{ url: string; method: string; scope: string }> = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const auth = req.headers.get("authorization") ?? "";
-        const parts = auth.replace(/^Bearer\s+/i, "").split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push({ url: req.url, method: req.method, scope: payload.scope ?? "" });
-        return Response.json({ id: "n1", path: "Log/hello" }, { status: 201 });
-      };
+      const seen: Array<{ url: string; method: string; scope: string; args: unknown }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ url, method, scope, rpc }) => {
+            seen.push({ url, method, scope, args: rpc.params?.arguments });
+            return { id: "n1", path: "Log/hello" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           OWNER_SECRET,
@@ -864,23 +990,24 @@ describe("account MCP — create-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n1");
+      ) as { id: string };
+      expect(out.id).toBe("n1");
       expect(seen).toHaveLength(1);
-      expect(seen[0]?.url).toContain("/vault/beta/api/notes");
+      expect(seen[0]?.url).toContain("/vault/beta/mcp");
+      expect(seen[0]?.url).not.toContain("/api/notes");
       expect(seen[0]?.method).toBe("POST");
-      expect(seen[0]?.scope).toBe("vault:beta:write");
+      expect(seen[0]?.scope).toMatch(/^vault:beta:(write|admin)$/);
+      expect(seen[0]?.args).toEqual({ path: "Log/hello", content: "hi" });
     } finally {
       h.cleanup();
     }
   });
 
-  test("read-role cannot create-note — write_not_granted, fetch never called", async () => {
+  test("read-role cannot create-note — Unknown tool, no tools/call", async () => {
     const h = await makeHarness();
     const readerSecret = hexToBytes("44".repeat(32));
     const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const reader = await createUser(h.db, "reader", "correct-horse-battery-staple", {
         allowMulti: true,
@@ -905,10 +1032,10 @@ describe("account MCP — create-note", () => {
           }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 201 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -916,7 +1043,7 @@ describe("account MCP — create-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -924,7 +1051,7 @@ describe("account MCP — create-note", () => {
 
   test("first-admin Bearer named beta:read cannot create-note on beta", async () => {
     const h = await makeHarness();
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const token = await bearer(h, ["account:self:vaults:beta:read"], h.ownerId);
       const res = await handleAccountMcp(
@@ -933,10 +1060,10 @@ describe("account MCP — create-note", () => {
           rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 201 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -944,7 +1071,7 @@ describe("account MCP — create-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -952,7 +1079,7 @@ describe("account MCP — create-note", () => {
 
   test("friend Bearer named beta:read cannot create-note even with write assignment", async () => {
     const h = await makeHarness();
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const token = await bearer(h, ["account:self:vaults:beta:read"], h.friendId);
       const res = await handleAccountMcp(
@@ -961,10 +1088,10 @@ describe("account MCP — create-note", () => {
           rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 201 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -972,7 +1099,7 @@ describe("account MCP — create-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -982,17 +1109,13 @@ describe("account MCP — create-note", () => {
     const h = await makeHarness();
     try {
       const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const parts = (req.headers.get("authorization") ?? "")
-          .replace(/^Bearer\s+/i, "")
-          .split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push(payload.scope ?? "");
-        return Response.json({ id: "n-friend" }, { status: 201 });
-      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ scope }) => {
+            seen.push(scope);
+            return { id: "n-friend" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -1005,10 +1128,9 @@ describe("account MCP — create-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n-friend");
-      expect(seen).toEqual(["vault:beta:write"]);
+      ) as { id: string };
+      expect(out.id).toBe("n-friend");
+      expect(seen).toEqual(["vault:beta:admin"]);
     } finally {
       h.cleanup();
     }
@@ -1057,11 +1179,13 @@ describe("account MCP — create-note", () => {
       const names = (
         (await listed.json()) as { result: { tools: Array<{ name: string }> } }
       ).result.tools.map((t) => t.name);
-      expect(names).toEqual(["list-vaults", "query-notes"]);
+      expect(names).toContain("list-vaults");
+      expect(names).toContain("query-notes");
       expect(names).not.toContain("create-note");
       expect(names).not.toContain("update-note");
       expect(names).not.toContain("grant-access");
       expect(names).not.toContain("create-vault");
+      expect(names).not.toContain("manage-token");
     } finally {
       h.cleanup();
     }
@@ -1069,25 +1193,17 @@ describe("account MCP — create-note", () => {
 });
 
 describe("account MCP — update-note", () => {
-  test("owner PATCHes the named vault with a write-audience mint", async () => {
+  test("owner forwards JSON-RPC update-note with a write-or-higher mint", async () => {
     const h = await makeHarness();
     try {
-      const seen: Array<{ url: string; method: string; scope: string; body: unknown }> = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const auth = req.headers.get("authorization") ?? "";
-        const parts = auth.replace(/^Bearer\s+/i, "").split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push({
-          url: req.url,
-          method: req.method,
-          scope: payload.scope ?? "",
-          body: JSON.parse(await req.text()),
+      const seen: Array<{ url: string; method: string; scope: string; args: unknown }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ url, method, scope, rpc }) => {
+            seen.push({ url, method, scope, args: rpc.params?.arguments });
+            return { id: "n1", path: "Log/hello", content: "there" };
+          },
         });
-        return Response.json({ id: "n1", path: "Log/hello", content: "there" }, { status: 200 });
-      };
       const res = await handleAccountMcp(
         nostrReq(
           OWNER_SECRET,
@@ -1100,29 +1216,30 @@ describe("account MCP — update-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string; content: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n1");
-      expect(out.note.content).toBe("there");
+      ) as { id: string; content: string };
+      expect(out.id).toBe("n1");
+      expect(out.content).toBe("there");
       expect(seen).toHaveLength(1);
-      expect(seen[0]?.url).toContain("/vault/beta/api/notes/n1");
-      expect(seen[0]?.method).toBe("PATCH");
-      expect(seen[0]?.scope).toBe("vault:beta:write");
-      expect(seen[0]?.body).toEqual({ content: "there" });
+      expect(seen[0]?.url).toContain("/vault/beta/mcp");
+      expect(seen[0]?.method).toBe("POST");
+      expect(seen[0]?.scope).toMatch(/^vault:beta:(write|admin)$/);
+      expect(seen[0]?.args).toEqual({ id: "n1", content: "there" });
     } finally {
       h.cleanup();
     }
   });
 
-  test("path id is encoded on the PATCH URL", async () => {
+  test("path id stays in MCP arguments, not a REST URL", async () => {
     const h = await makeHarness();
     try {
-      const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        seen.push(req.url);
-        return Response.json({ id: "n1", path: "Log/hello" }, { status: 200 });
-      };
+      const seen: Array<{ url: string; args: Record<string, unknown> | undefined }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ url, rpc }) => {
+            seen.push({ url, args: rpc.params?.arguments });
+            return { id: "n1", path: "Log/hello" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           OWNER_SECRET,
@@ -1135,18 +1252,19 @@ describe("account MCP — update-note", () => {
       );
       expect(res.status).toBe(200);
       expect(seen).toHaveLength(1);
-      expect(seen[0]).toContain("/vault/beta/api/notes/Log%2Fhello");
-      expect(seen[0]).not.toContain("/api/notes/Log/hello");
+      expect(seen[0]?.url).toContain("/vault/beta/mcp");
+      expect(seen[0]?.url).not.toContain("/api/notes");
+      expect(seen[0]?.args).toEqual({ id: "Log/hello", append: " more", force: true });
     } finally {
       h.cleanup();
     }
   });
 
-  test("read-role cannot update-note — Unknown tool, fetch never called", async () => {
+  test("read-role cannot update-note — Unknown tool, no tools/call", async () => {
     const h = await makeHarness();
     const readerSecret = hexToBytes("66".repeat(32));
     const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const reader = await createUser(h.db, "reader3", "correct-horse-battery-staple", {
         allowMulti: true,
@@ -1171,10 +1289,10 @@ describe("account MCP — update-note", () => {
           }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 200 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -1182,7 +1300,7 @@ describe("account MCP — update-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: update-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -1190,7 +1308,7 @@ describe("account MCP — update-note", () => {
 
   test("first-admin Bearer named beta:read cannot update-note on beta", async () => {
     const h = await makeHarness();
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const token = await bearer(h, ["account:self:vaults:beta:read"], h.ownerId);
       const res = await handleAccountMcp(
@@ -1202,10 +1320,10 @@ describe("account MCP — update-note", () => {
           }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 200 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -1213,7 +1331,7 @@ describe("account MCP — update-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: update-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -1223,17 +1341,13 @@ describe("account MCP — update-note", () => {
     const h = await makeHarness();
     try {
       const seen: Array<{ method: string; scope: string }> = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const parts = (req.headers.get("authorization") ?? "")
-          .replace(/^Bearer\s+/i, "")
-          .split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push({ method: req.method, scope: payload.scope ?? "" });
-        return Response.json({ id: "n-friend", content: "edited" }, { status: 200 });
-      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ method, scope }) => {
+            seen.push({ method, scope });
+            return { id: "n-friend", content: "edited" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -1246,27 +1360,9 @@ describe("account MCP — update-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n-friend");
-      expect(seen).toEqual([{ method: "PATCH", scope: "vault:beta:write" }]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("missing id is invalid_id", async () => {
-    const h = await makeHarness();
-    try {
-      const res = await handleAccountMcp(
-        nostrReq(
-          OWNER_SECRET,
-          rpc("tools/call", { name: "update-note", arguments: { vault: "beta", content: "x" } }),
-        ),
-        mcpDeps(h),
-      );
-      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
-      expect(body.error?.data?.error_type).toBe("invalid_id");
+      ) as { id: string };
+      expect(out.id).toBe("n-friend");
+      expect(seen).toEqual([{ method: "POST", scope: "vault:beta:admin" }]);
     } finally {
       h.cleanup();
     }
@@ -1287,6 +1383,199 @@ describe("account MCP — update-note", () => {
       );
       const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
       expect(body.error?.data?.error_type).toBe("vault_not_covered");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+describe("account MCP — vault module proxy", () => {
+  test("schema-source is one tools/list POST to the highest-verb vault", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const lists: string[] = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onRequest: ({ vault, rpc }) => {
+            if (rpc.method === "tools/list") lists.push(vault);
+          },
+        });
+      await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h, { fetchImpl }));
+      expect(lists).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("schema-source falls back to the next covered vault when the highest-verb one is down", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const lists: string[] = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onList: ({ vault }) => {
+            lists.push(vault);
+            if (vault === "beta") throw new Error("beta down");
+            return { tools: toolsForMintedScope("vault:personal:admin") };
+          },
+        });
+      const listed = await handleAccountMcp(
+        bearerReq(token, rpc("tools/list")),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(lists).toEqual(["beta", "personal"]);
+      expect(names).toContain("query-notes");
+      expect(names).toContain("manage-token");
+      expect(names).toContain("list-vaults");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("schema-source all down degrades to hub-native only", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const fetchImpl = async () => {
+        throw new Error("all vaults down");
+      };
+      const listed = await handleAccountMcp(
+        bearerReq(token, rpc("tools/list")),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(listed.status).toBe(200);
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toEqual([
+        "list-vaults",
+        "create-vault",
+        "grant-access",
+        "revoke-access",
+        "list-access",
+      ]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no vaults installed: hub-native only, no fetch", async () => {
+    const h = await makeHarness([]);
+    let fetched = 0;
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const listed = await handleAccountMcp(
+        bearerReq(token, rpc("tools/list")),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return new Response("nope", { status: 500 });
+          },
+        }),
+      );
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toEqual(["list-vaults", "create-vault"]);
+      expect(fetched).toBe(0);
+      const queried = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "query-notes", arguments: {} })),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return new Response("nope", { status: 500 });
+          },
+        }),
+      );
+      const body = (await queried.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: query-notes/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("list-tags and manage-token exist only because the live list included them", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const listed = await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h));
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toContain("list-tags");
+      expect(names).toContain("manage-token");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("read-attachment image content is passed through, not stringified", async () => {
+    const h = await makeHarness();
+    try {
+      const image = {
+        content: [
+          { type: "image", data: "abc", mimeType: "image/png" },
+          { type: "text", text: '{"id":"att1"}' },
+        ],
+      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ rpc }) => {
+            if (rpc.params?.name === "read-attachment") return image;
+            return undefined;
+          },
+        });
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "read-attachment",
+            arguments: { vault: "beta", attachment_id: "att1" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const body = (await res.json()) as {
+        result: { content: Array<{ type: string; data?: string; mimeType?: string }> };
+      };
+      expect(body.result.content[0]).toEqual({
+        type: "image",
+        data: "abc",
+        mimeType: "image/png",
+      });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("delete-note forwards to vault MCP", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: Array<{ name?: string; args?: Record<string, unknown> }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ rpc }) => {
+            seen.push({ name: rpc.params?.name, args: rpc.params?.arguments });
+            return { deleted: true };
+          },
+        });
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", { name: "delete-note", arguments: { vault: "beta", id: "n1" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(res.status).toBe(200);
+      expect(seen).toEqual([{ name: "delete-note", args: { id: "n1" } }]);
     } finally {
       h.cleanup();
     }
@@ -1453,7 +1742,8 @@ describe("account MCP — extra pins", () => {
         (await listed.json()) as { result: { content: Array<{ text: string }> } },
       ) as { vaults: Array<{ name: string }> };
       expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
-      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, { onCall: () => [{ id: "n-beta" }] });
       const queried = await handleAccountMcp(
         nostrReq(
           readerSecret,

--- a/src/account-mcp-backend.ts
+++ b/src/account-mcp-backend.ts
@@ -1,0 +1,318 @@
+/**
+ * Module backends for the account MCP — live-list + JSON-RPC forward.
+ *
+ * Vault is the first implementation. A second module (scribe, surface, …)
+ * is another object of this shape, not another REST clone.
+ *
+ * OPEN (module #2): hub-native names win against a backend (filtered here).
+ * Two BACKENDS defining the same tool name have no resolution rule yet —
+ * leave that until a second backend actually exists.
+ *
+ * Schema source: one covered vault's live `tools/list` stands in for all
+ * installed vaults. Assumption — same vault-core version across vaults
+ * (`parachute upgrade` keeps them together). Candidates are tried in
+ * highest-verb order; only if every covered vault is down do we degrade
+ * to hub-native only.
+ */
+import { COMPOSED_VERB_RANK, type ComposedVaultVerb } from "@openparachute/door-contract";
+import type { AccountVaultMeta } from "./account-api.ts";
+import {
+  ACCOUNT_MCP_CLIENT_ID,
+  type AccountToolContext,
+  AccountToolError,
+  FANOUT_TIMEOUT_MS,
+  FANOUT_TOKEN_TTL_SECONDS,
+  HUB_NATIVE_TOOL_NAMES,
+  installedVaults,
+  resolveCoverage,
+  verbForVault,
+} from "./account-mcp.ts";
+import { signAccessToken } from "./jwt-sign.ts";
+
+export interface ListedMcpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface ModuleMcpBackend {
+  readonly id: string;
+  listTools(ctx: AccountToolContext): Promise<readonly ListedMcpTool[]>;
+  callTool(name: string, args: Record<string, unknown>, ctx: AccountToolContext): Promise<unknown>;
+}
+
+const UNION_CATALOG_LINE =
+  "Catalog caveat: advertised from one covered vault's live list (highest verb this connection holds). Calling this against a different covered vault may return Unknown tool if that vault grants a lower verb.";
+
+const VAULT_FIELD_DESCRIPTION =
+  "Target vault by name. Omit on query-notes to fan the query across every reachable vault; required on every other vault-shaped tool.";
+
+const listCache = new WeakMap<AccountToolContext, Promise<readonly ListedMcpTool[]>>();
+
+export function vaultMcpUrl(vault: AccountVaultMeta): string {
+  const origin =
+    typeof vault.port === "number" && vault.port > 0
+      ? `http://127.0.0.1:${vault.port}`
+      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
+  return `${origin.replace(/\/$/, "")}/vault/${vault.name}/mcp`;
+}
+
+export async function mintVaultMcpToken(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  verb: ComposedVaultVerb,
+): Promise<string> {
+  const sign = ctx.signToken ?? signAccessToken;
+  const minted = await sign(ctx.db, {
+    sub: ctx.principal.userId,
+    scopes: [`vault:${vault.name}:${verb}`],
+    audience: `vault.${vault.name}`,
+    clientId: ACCOUNT_MCP_CLIENT_ID,
+    issuer: ctx.issuer,
+    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    vaultScope: [vault.name],
+    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
+  });
+  return minted.token;
+}
+
+async function parseJsonRpcResult(res: Response, vaultName: string): Promise<unknown> {
+  const text = await res.text();
+  if (!res.ok) {
+    let detail = `vault responded ${res.status}`;
+    try {
+      const body = JSON.parse(text) as { error?: unknown; message?: unknown };
+      if (typeof body.error === "string") detail = body.error;
+      else if (typeof body.message === "string") detail = body.message;
+    } catch {
+      // keep status-only detail
+    }
+    throw new AccountToolError("vault_error", detail, { status: res.status, vault: vaultName });
+  }
+  let parsed: { result?: unknown; error?: { message?: unknown; code?: unknown } };
+  const trimmed = text.trim();
+  if (trimmed.startsWith("event:") || trimmed.includes("\ndata:")) {
+    const dataLines = [...text.matchAll(/^data:\s*(.*)$/gm)].map((m) => m[1] ?? "");
+    const last = dataLines.at(-1);
+    if (!last) {
+      throw new AccountToolError("vault_error", "empty SSE MCP response", { vault: vaultName });
+    }
+    parsed = JSON.parse(last) as typeof parsed;
+  } else {
+    parsed = JSON.parse(text) as typeof parsed;
+  }
+  if (parsed.error) {
+    const msg = typeof parsed.error.message === "string" ? parsed.error.message : "vault MCP error";
+    throw new AccountToolError("vault_error", msg, {
+      vault: vaultName,
+      ...(parsed.error.code !== undefined ? { code: parsed.error.code } : {}),
+    });
+  }
+  return parsed.result;
+}
+
+export async function postVaultMcp(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  verb: ComposedVaultVerb,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<unknown> {
+  const token = await mintVaultMcpToken(ctx, vault, verb);
+  const fetchImpl = ctx.fetchImpl ?? fetch;
+  const res = await fetchImpl(vaultMcpUrl(vault), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      ...(params ? { params } : {}),
+    }),
+    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
+  });
+  return parseJsonRpcResult(res, vault.name);
+}
+
+function injectVaultSelector(tool: {
+  name: string;
+  description?: unknown;
+  inputSchema?: unknown;
+}): ListedMcpTool {
+  const rawSchema =
+    tool.inputSchema && typeof tool.inputSchema === "object"
+      ? (tool.inputSchema as Record<string, unknown>)
+      : { type: "object" };
+  const properties = {
+    ...((rawSchema.properties && typeof rawSchema.properties === "object"
+      ? rawSchema.properties
+      : {}) as Record<string, unknown>),
+    vault: { type: "string", description: VAULT_FIELD_DESCRIPTION },
+  };
+  const schema: Record<string, unknown> = { ...rawSchema, properties };
+  if (tool.name !== "query-notes") {
+    const req = Array.isArray(schema.required)
+      ? schema.required.filter((x): x is string => typeof x === "string")
+      : [];
+    if (!req.includes("vault")) schema.required = [...req, "vault"];
+  }
+  const base = typeof tool.description === "string" ? tool.description : tool.name;
+  const description = base.includes("Catalog caveat:") ? base : `${base}\n\n${UNION_CATALOG_LINE}`;
+  return { name: tool.name, description, inputSchema: schema };
+}
+
+/**
+ * Covered vaults, highest verb first, then name. Schema-source tries this
+ * order and takes the first `tools/list` that succeeds.
+ */
+export function schemaSourceCandidates(
+  ctx: AccountToolContext,
+  vaults: readonly AccountVaultMeta[],
+): AccountVaultMeta[] {
+  return [...vaults].sort((a, b) => {
+    const rank =
+      COMPOSED_VERB_RANK[verbForVault(ctx, b.name)] - COMPOSED_VERB_RANK[verbForVault(ctx, a.name)];
+    if (rank !== 0) return rank;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+async function listVaultToolsUncached(ctx: AccountToolContext): Promise<readonly ListedMcpTool[]> {
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+  if (coverage.vaults.length === 0) return [];
+  for (const vault of schemaSourceCandidates(ctx, coverage.vaults)) {
+    try {
+      const result = await postVaultMcp(ctx, vault, verbForVault(ctx, vault.name), "tools/list");
+      const tools =
+        result && typeof result === "object" && Array.isArray((result as { tools?: unknown }).tools)
+          ? (result as { tools: unknown[] }).tools
+          : null;
+      if (!tools) continue;
+      return tools
+        .filter(
+          (t): t is { name: string; description?: unknown; inputSchema?: unknown } =>
+            !!t && typeof t === "object" && typeof (t as { name?: unknown }).name === "string",
+        )
+        .filter((t) => !HUB_NATIVE_TOOL_NAMES.has(t.name))
+        .map(injectVaultSelector);
+    } catch {
+      // Try the next covered vault (highest-verb first). Empty catch continues.
+    }
+  }
+  return [];
+}
+
+export function listVaultModuleTools(ctx: AccountToolContext): Promise<readonly ListedMcpTool[]> {
+  let pending = listCache.get(ctx);
+  if (!pending) {
+    pending = listVaultToolsUncached(ctx);
+    listCache.set(ctx, pending);
+  }
+  return pending;
+}
+
+function coveredVault(ctx: AccountToolContext, raw: unknown): AccountVaultMeta {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new AccountToolError("invalid_vault", "vault is required.");
+  }
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+  const wanted = raw.toLowerCase();
+  const hit = coverage.vaults.find((v) => v.name === wanted);
+  if (!hit) {
+    throw new AccountToolError(
+      "vault_not_covered",
+      `Vault "${raw}" is not among the vaults this connection can reach.`,
+    );
+  }
+  return hit;
+}
+
+function stripVaultArg(args: Record<string, unknown>): Record<string, unknown> {
+  const { vault: _vault, ...rest } = args;
+  return rest;
+}
+
+function notesFromMcpResult(result: unknown): unknown {
+  if (!result || typeof result !== "object") {
+    throw new Error("vault MCP result was not an object");
+  }
+  const rec = result as { isError?: unknown; content?: Array<{ type?: unknown; text?: unknown }> };
+  if (rec.isError === true) {
+    const text = rec.content?.find((c) => c.type === "text")?.text;
+    throw new Error(typeof text === "string" ? text : "query failed");
+  }
+  const text = rec.content?.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") throw new Error("vault MCP result had no text content");
+  return JSON.parse(text) as unknown;
+}
+
+async function queryOneVaultMcp(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  args: Record<string, unknown>,
+): Promise<{ vault: string; notes: unknown } | { vault: string; error: string }> {
+  try {
+    const result = await postVaultMcp(ctx, vault, "read", "tools/call", {
+      name: "query-notes",
+      arguments: args,
+    });
+    return { vault: vault.name, notes: notesFromMcpResult(result) };
+  } catch (err) {
+    return {
+      vault: vault.name,
+      error: err instanceof Error ? err.message : "query failed",
+    };
+  }
+}
+
+async function queryNotesOverlay(
+  args: Record<string, unknown>,
+  ctx: AccountToolContext,
+): Promise<{
+  vaults_queried: string[];
+  results: Array<{ vault: string; notes?: unknown; error?: string }>;
+}> {
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+  let targets = coverage.vaults;
+  if (typeof args.vault === "string" && args.vault.length > 0) {
+    targets = [coveredVault(ctx, args.vault)];
+  }
+  const stripped = stripVaultArg(args);
+  const settled = await Promise.allSettled(targets.map((v) => queryOneVaultMcp(ctx, v, stripped)));
+  return {
+    vaults_queried: targets.map((v) => v.name),
+    results: settled.map((s, i) =>
+      s.status === "fulfilled"
+        ? s.value
+        : {
+            vault: targets[i]!.name,
+            error: s.reason instanceof Error ? s.reason.message : "query failed",
+          },
+    ),
+  };
+}
+
+export async function callVaultModuleTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: AccountToolContext,
+): Promise<unknown> {
+  if (name === "query-notes") return queryNotesOverlay(args, ctx);
+
+  const hit = coveredVault(ctx, args.vault);
+  const verb = verbForVault(ctx, hit.name);
+  return postVaultMcp(ctx, hit, verb, "tools/call", {
+    name,
+    arguments: stripVaultArg(args),
+  });
+}
+
+export const vaultModuleBackend: ModuleMcpBackend = {
+  id: "vault",
+  listTools: listVaultModuleTools,
+  callTool: callVaultModuleTool,
+};

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -21,6 +21,7 @@
 import type { Database } from "bun:sqlite";
 import { ACCOUNT_VAULTS_UNNARROWED } from "@openparachute/door-contract";
 import type { AccountApiDeps } from "./account-api.ts";
+import { callVaultModuleTool, listVaultModuleTools } from "./account-mcp-backend.ts";
 import {
   type AccountMcpPrincipal,
   type AccountToolContext,
@@ -256,6 +257,12 @@ async function authenticate(
   return authenticateBearer(db, req, deps.knownIssuers ?? [deps.issuer]);
 }
 
+function isMcpToolResult(value: unknown): value is { content: unknown[] } {
+  return (
+    !!value && typeof value === "object" && Array.isArray((value as { content?: unknown }).content)
+  );
+}
+
 async function handleToolCall(
   id: JsonRpcId,
   params: Record<string, unknown> | undefined,
@@ -263,15 +270,35 @@ async function handleToolCall(
 ): Promise<JsonRpcMessage> {
   const name = typeof params?.name === "string" ? params.name : "";
   const args = (params?.arguments ?? {}) as Record<string, unknown>;
-  const tool = toolsForPrincipal(ctx).find((t) => t.name === name);
-  if (!tool) {
+  const hub = toolsForPrincipal(ctx).find((t) => t.name === name);
+  if (hub) {
+    try {
+      const out = await hub.execute(args, ctx);
+      return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+    } catch (err) {
+      if (err instanceof AccountToolError) {
+        return rpcError(id, INVALID_PARAMS, err.message, {
+          error_type: err.errorType,
+          ...err.extra,
+        });
+      }
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return result(id, { content: [{ type: "text", text: `Error: ${message}` }], isError: true });
+    }
+  }
+  const vaultTools = await listVaultModuleTools(ctx);
+  if (!vaultTools.some((t) => t.name === name)) {
     return result(id, {
       content: [{ type: "text", text: `Unknown tool: ${name}` }],
       isError: true,
     });
   }
   try {
-    const out = await tool.execute(args, ctx);
+    const out = await callVaultModuleTool(name, args, ctx);
+    if (name === "query-notes") {
+      return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+    }
+    if (isMcpToolResult(out)) return result(id, out);
     return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
   } catch (err) {
     if (err instanceof AccountToolError) {
@@ -282,15 +309,27 @@ async function handleToolCall(
   }
 }
 
+async function listedTools(
+  ctx: AccountToolContext,
+): Promise<Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>> {
+  const hub = toolsForPrincipal(ctx).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  }));
+  const vault = await listVaultModuleTools(ctx);
+  return [...hub, ...vault];
+}
+
 function instructions(): string {
   return (
     "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
-    "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
-    "query-notes to search across them (omit `vault` to fan out, pass it to target one; " +
-    "default oldest-first preview — pass sort=desc and include_content=true for latest bodies), " +
-    "create-note / update-note to write in one vault (`vault` is required). " +
-    "grant-access / revoke-access / list-access give a Nostr pubkey a vault (role read|write) " +
-    "if you can admin that vault. tools/list hides tools you cannot call."
+    "Hub-native: list-vaults, create-vault (owner / account write), grant-access / revoke-access / " +
+    "list-access (if you can admin a vault). Everything else is the vault MCP catalog, live-listed, " +
+    "with a `vault` selector injected (omit on query-notes to fan out; required on every other vault tool). " +
+    "The vault-shaped catalog is a union of what SOME covered vault supports at the highest verb this " +
+    "connection holds — a listed tool may be Unknown against a different vault where this connection " +
+    "holds a lower verb. tools/list hides tools you cannot call on any covered vault."
   );
 }
 
@@ -311,13 +350,7 @@ async function handleOne(m: JsonRpcMessage, ctx: AccountToolContext): Promise<Js
         });
       }
       case "tools/list":
-        return result(id, {
-          tools: toolsForPrincipal(ctx).map((t) => ({
-            name: t.name,
-            description: t.description,
-            inputSchema: t.inputSchema,
-          })),
-        });
+        return result(id, { tools: await listedTools(ctx) });
       case "tools/call":
         return await handleToolCall(id, params, ctx);
       case "ping":

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -2,13 +2,11 @@
  * Account-level MCP tools for the self-host hub — the payload behind
  * `/account/mcp`.
  *
- * Cloud's twin lives in the identity worker (`account-mcp.ts`). Coverage tools
- * (list-vaults, create-vault, query-notes) plus hub-only grant-access /
- * revoke-access / list-access (pubkey → one `user_vaults` row). create-note /
- * update-note write one vault: `vault` is required, write is checked per call,
- * a 60s `vault:<name>:write` mint fans to REST (POST /api/notes, PATCH
- * /api/notes/:id). Cloud grants are D1-ownership shaped, not `user_vaults`.
- * Coverage is hub-shaped:
+ * Hub-native tools live here (list-vaults, create-vault, grant/revoke/
+ * list-access). Vault-shaped tools are a live `tools/list` + JSON-RPC
+ * proxy (`account-mcp-backend.ts`) onto `/vault/<name>/mcp` — not REST
+ * clones. Cloud's twin in the identity worker is still a REST facade and
+ * is out of this cut. Coverage is hub-shaped:
  *
  *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
  *     (legacy blanket / narrowed) or composed `account:self:vaults:*:<verb>`,
@@ -18,9 +16,9 @@
  *     else → `user_vaults` ∩ services.json (fail-closed; read verb required).
  *     Auto-provisioned key-only users have no rows → empty list, no create.
  *
- * query-notes fans out through a 60s `vault:<name>:read` mint, the same
- * authority `account-usage.ts` already uses for the friend home tiles. A
- * failed vault becomes that vault's `{ vault, error }` — never a whole-call
+ * query-notes (the one account overlay) fans out through a 60s
+ * `vault:<name>:read` mint to each vault's MCP `query-notes`. A failed
+ * vault becomes that vault's `{ vault, error }` — never a whole-call
  * failure.
  */
 import type { Database } from "bun:sqlite";
@@ -41,20 +39,17 @@ import {
   listAccess,
   revokeAccess,
 } from "./grant-access.ts";
-import { signAccessToken } from "./jwt-sign.ts";
+import type { SignAccessTokenOpts } from "./jwt-sign.ts";
 import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
 
 /** Hub account sentinel — account ≡ box. */
 export const HUB_ACCOUNT_ID = "self";
 
-/** Per-vault timeout for the query-notes fan-out. */
+/** Per-vault timeout for MCP JSON-RPC forwards and query-notes fan-out. */
 export const FANOUT_TIMEOUT_MS = 10_000;
 
-/** Per-vault `limit` ceiling on a fan-out query. */
-export const MAX_NOTES_LIMIT = 100;
-
-const ACCOUNT_MCP_CLIENT_ID = "parachute-account";
-const FANOUT_TOKEN_TTL_SECONDS = 60;
+export const ACCOUNT_MCP_CLIENT_ID = "parachute-account";
+export const FANOUT_TOKEN_TTL_SECONDS = 60;
 
 export type AccountMcpAuthKind = "bearer" | "nostr";
 
@@ -105,7 +100,7 @@ export interface AccountToolContext {
     stderr: string;
   }>;
   fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
-  signToken?: typeof signAccessToken;
+  signToken?: (db: Database, opts: SignAccessTokenOpts) => Promise<{ token: string }>;
 }
 
 export interface AccountMcpTool {
@@ -213,7 +208,7 @@ export function resolveCoverage(
   return { covered: "listed", vaults, names: vaults.map((v) => v.name), create };
 }
 
-function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
+export function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
   return listVaultsWithMeta(ctx.manifestPath, ctx.issuer);
 }
 
@@ -248,6 +243,13 @@ export function canWriteVault(
   }
   if (isUnrestricted(db, principal)) return true;
   return vaultVerbsForUserVault(db, principal.userId, vaultName)?.includes("write") === true;
+}
+
+/** Highest verb this principal actually holds on `vaultName`. */
+export function verbForVault(ctx: AccountToolContext, vaultName: string): ComposedVaultVerb {
+  if (callerCanAdminVault(ctx.db, ctx.principal, vaultName)) return "admin";
+  if (canWriteVault(ctx.db, ctx.principal, vaultName)) return "write";
+  return "read";
 }
 
 const listVaultsTool: AccountMcpTool = {
@@ -311,371 +313,6 @@ const createVaultTool: AccountMcpTool = {
       throw new AccountToolError("vault_taken", "That vault name is already taken.");
     }
     return { name: provisioned.entry.name, url: provisioned.entry.url };
-  },
-};
-
-type VaultQueryEntry = { vault: string; notes: unknown } | { vault: string; error: string };
-
-function buildNotesQuery(args: Record<string, unknown>): string {
-  const p = new URLSearchParams();
-  if (typeof args.search === "string" && args.search.length > 0) p.set("search", args.search);
-  const rawTags = Array.isArray(args.tag)
-    ? args.tag
-    : typeof args.tag === "string"
-      ? [args.tag]
-      : [];
-  for (const t of rawTags) if (typeof t === "string" && t.length > 0) p.append("tag", t);
-  if (args.metadata && typeof args.metadata === "object")
-    p.set("metadata", JSON.stringify(args.metadata));
-  const rawLimit =
-    typeof args.limit === "number"
-      ? args.limit
-      : typeof args.limit === "string"
-        ? Number.parseInt(args.limit, 10)
-        : undefined;
-  if (rawLimit !== undefined && Number.isFinite(rawLimit)) {
-    const clamped = Math.min(Math.max(1, Math.floor(rawLimit)), MAX_NOTES_LIMIT);
-    p.set("limit", String(clamped));
-  }
-  // Vault REST defaults: created_at ASC, lean ~120-char preview. Forward the
-  // params that make "latest notes with bodies" expressible. Unknown sort is
-  // dropped rather than 400'd so a hallucinated value does not fail the fan-out.
-  if (args.sort === "asc" || args.sort === "desc") p.set("sort", args.sort);
-  if (typeof args.order_by === "string" && args.order_by.length > 0) {
-    p.set("order_by", args.order_by);
-  }
-  if (args.include_content === true || args.include_content === "true") {
-    p.set("include_content", "true");
-  } else if (args.include_content === false || args.include_content === "false") {
-    p.set("include_content", "false");
-  }
-  const rawOffset =
-    typeof args.offset === "number"
-      ? args.offset
-      : typeof args.offset === "string"
-        ? Number.parseInt(args.offset, 10)
-        : undefined;
-  if (rawOffset !== undefined && Number.isFinite(rawOffset) && rawOffset >= 0) {
-    p.set("offset", String(Math.floor(rawOffset)));
-  }
-  return p.toString();
-}
-
-async function queryOneVault(
-  ctx: AccountToolContext,
-  vault: AccountVaultMeta,
-  args: Record<string, unknown>,
-): Promise<VaultQueryEntry> {
-  const sign = ctx.signToken ?? signAccessToken;
-  const fetchImpl = ctx.fetchImpl ?? fetch;
-  const qs = buildNotesQuery(args);
-  const minted = await sign(ctx.db, {
-    sub: ctx.principal.userId,
-    scopes: [`vault:${vault.name}:read`],
-    audience: `vault.${vault.name}`,
-    clientId: ACCOUNT_MCP_CLIENT_ID,
-    issuer: ctx.issuer,
-    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
-    vaultScope: [vault.name],
-    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
-  });
-  const origin =
-    typeof vault.port === "number" && vault.port > 0
-      ? `http://127.0.0.1:${vault.port}`
-      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
-  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}/api/notes${qs ? `?${qs}` : ""}`;
-  const res = await fetchImpl(url, {
-    headers: { authorization: `Bearer ${minted.token}`, accept: "application/json" },
-    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    let detail = `vault responded ${res.status}`;
-    try {
-      const body = (await res.json()) as Record<string, unknown>;
-      if (typeof body.error === "string") detail = body.error;
-    } catch {
-      // Non-JSON error body — keep the status-only detail.
-    }
-    return { vault: vault.name, error: detail };
-  }
-  const notes = await res.json();
-  return { vault: vault.name, notes };
-}
-
-async function fanOut(
-  ctx: AccountToolContext,
-  targets: AccountVaultMeta[],
-  args: Record<string, unknown>,
-): Promise<VaultQueryEntry[]> {
-  const settled = await Promise.allSettled(targets.map((v) => queryOneVault(ctx, v, args)));
-  return settled.map((s, i) =>
-    s.status === "fulfilled"
-      ? s.value
-      : {
-          vault: targets[i]!.name,
-          error: s.reason instanceof Error ? s.reason.message : "query failed",
-        },
-  );
-}
-
-const queryNotesTool: AccountMcpTool = {
-  name: "query-notes",
-  description:
-    "Search notes across the vaults this connection can reach. Omit `vault` to fan the query out " +
-    "(results are grouped per vault, not ranked across vaults); pass `vault` to target one. " +
-    "Default order is created_at ASC (oldest first) and the lean ~120-char preview — pass " +
-    '`sort: "desc"` for newest-first and `include_content: true` for bodies. Also: keyword ' +
-    "`search`, `tag`, `metadata`, `limit` (per vault, default 50), `order_by` (`updated_at` or " +
-    "an indexed field), `offset`.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      vault: {
-        type: "string",
-        description:
-          "Target a single vault by name. Must be one of the reachable vaults. Omit to query all.",
-      },
-      search: { type: "string", description: "Full-text keyword query." },
-      tag: {
-        type: ["string", "array"],
-        items: { type: "string" },
-        description: "Restrict to notes carrying this tag (or any of these tags).",
-      },
-      metadata: {
-        type: "object",
-        description: 'Structured metadata filters, e.g. {"status":{"eq":"open"}}.',
-      },
-      limit: { type: "number", description: "Maximum notes per vault (default 50)." },
-      sort: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Order by created_at. Default asc (oldest first). Pass desc for newest first.",
-      },
-      order_by: {
-        type: "string",
-        description:
-          "Sort by this field instead of created_at. `updated_at` needs no schema; other " +
-          "fields must be indexed on the target vault.",
-      },
-      include_content: {
-        type: "boolean",
-        description: "Return full note bodies. Default false: lean rows with a ~120-char preview.",
-      },
-      offset: {
-        type: "number",
-        description: "Skip this many notes per vault (default 0).",
-      },
-    },
-    additionalProperties: false,
-  },
-  async execute(args, ctx) {
-    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
-    let targets = coverage.vaults;
-    if (typeof args.vault === "string" && args.vault.length > 0) {
-      const wanted = args.vault.toLowerCase();
-      const hit = coverage.vaults.find((v) => v.name === wanted);
-      if (!hit) {
-        throw new AccountToolError(
-          "vault_not_covered",
-          `Vault "${args.vault}" is not among the vaults this connection can reach.`,
-        );
-      }
-      targets = [hit];
-    }
-    const results = await fanOut(ctx, targets, args);
-    return { vaults_queried: targets.map((v) => v.name), results };
-  },
-};
-
-function noteWriteBody(args: Record<string, unknown>): Record<string, unknown> {
-  const body: Record<string, unknown> = {};
-  if (typeof args.content === "string") body.content = args.content;
-  if (typeof args.path === "string") body.path = args.path;
-  if (Array.isArray(args.tags)) body.tags = args.tags;
-  if (args.metadata && typeof args.metadata === "object") body.metadata = args.metadata;
-  if (typeof args.if_exists === "string") body.if_exists = args.if_exists;
-  return body;
-}
-
-function noteUpdateBody(args: Record<string, unknown>): Record<string, unknown> {
-  const body: Record<string, unknown> = {};
-  if (typeof args.content === "string") body.content = args.content;
-  if (typeof args.append === "string") body.append = args.append;
-  if (typeof args.prepend === "string") body.prepend = args.prepend;
-  if (args.content_edit && typeof args.content_edit === "object")
-    body.content_edit = args.content_edit;
-  if (typeof args.path === "string") body.path = args.path;
-  if (args.tags && typeof args.tags === "object") body.tags = args.tags;
-  if (args.metadata && typeof args.metadata === "object" && args.metadata !== null) {
-    body.metadata = args.metadata;
-  }
-  if (typeof args.if_updated_at === "string") body.if_updated_at = args.if_updated_at;
-  if (args.force === true) body.force = true;
-  if (typeof args.if_missing === "string") body.if_missing = args.if_missing;
-  return body;
-}
-
-function requireWritableVault(ctx: AccountToolContext, rawVault: unknown): AccountVaultMeta {
-  if (typeof rawVault !== "string" || rawVault.length === 0) {
-    throw new AccountToolError("invalid_vault", "vault is required.");
-  }
-  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
-  const wanted = rawVault.toLowerCase();
-  const hit = coverage.vaults.find((v) => v.name === wanted);
-  if (!hit) {
-    throw new AccountToolError(
-      "vault_not_covered",
-      `Vault "${rawVault}" is not among the vaults this connection can reach.`,
-    );
-  }
-  if (!canWriteVault(ctx.db, ctx.principal, hit.name)) {
-    throw new AccountToolError(
-      "write_not_granted",
-      `This connection cannot write vault "${hit.name}".`,
-    );
-  }
-  return hit;
-}
-
-async function vaultNoteWrite(
-  ctx: AccountToolContext,
-  vault: AccountVaultMeta,
-  opts: { method: string; path: string; body: Record<string, unknown> },
-): Promise<unknown> {
-  const sign = ctx.signToken ?? signAccessToken;
-  const fetchImpl = ctx.fetchImpl ?? fetch;
-  const minted = await sign(ctx.db, {
-    sub: ctx.principal.userId,
-    scopes: [`vault:${vault.name}:write`],
-    audience: `vault.${vault.name}`,
-    clientId: ACCOUNT_MCP_CLIENT_ID,
-    issuer: ctx.issuer,
-    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
-    vaultScope: [vault.name],
-    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
-  });
-  const origin =
-    typeof vault.port === "number" && vault.port > 0
-      ? `http://127.0.0.1:${vault.port}`
-      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
-  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}${opts.path}`;
-  const res = await fetchImpl(url, {
-    method: opts.method,
-    headers: {
-      authorization: `Bearer ${minted.token}`,
-      accept: "application/json",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(opts.body),
-    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    let detail = `vault responded ${res.status}`;
-    try {
-      const errBody = (await res.json()) as Record<string, unknown>;
-      if (typeof errBody.error === "string") detail = errBody.error;
-      else if (typeof errBody.error_type === "string") detail = errBody.error_type;
-    } catch {
-      // Non-JSON error body — keep the status-only detail.
-    }
-    throw new AccountToolError("vault_error", detail, { status: res.status, vault: vault.name });
-  }
-  return res.json();
-}
-
-const createNoteTool: AccountMcpTool = {
-  name: "create-note",
-  description:
-    "Create a note in one vault this connection can write. `vault` is required — this " +
-    "door does not invent a target. Does not return a vault token.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      vault: {
-        type: "string",
-        description: "Target vault by name. Must be a reachable vault this connection can write.",
-      },
-      content: { type: "string", description: "Note body (markdown)." },
-      path: { type: "string", description: "Note path (e.g. 'Log/hello')." },
-      tags: { type: "array", items: { type: "string" }, description: "Tags to apply." },
-      metadata: { type: "object", description: "Metadata fields to set." },
-      if_exists: {
-        type: "string",
-        enum: ["error", "ignore", "update", "replace"],
-        description: "What to do when `path` already names a note. Default error.",
-      },
-    },
-    required: ["vault"],
-    additionalProperties: false,
-  },
-  async execute(args, ctx) {
-    const hit = requireWritableVault(ctx, args.vault);
-    const note = await vaultNoteWrite(ctx, hit, {
-      method: "POST",
-      path: "/api/notes",
-      body: noteWriteBody(args),
-    });
-    return { vault: hit.name, note };
-  },
-};
-
-const updateNoteTool: AccountMcpTool = {
-  name: "update-note",
-  description:
-    "Update a note in one vault this connection can write. `vault` and `id` are required. " +
-    "Same body as vault PATCH /api/notes/:id (content / append / prepend / content_edit / " +
-    "path / tags / metadata / if_updated_at / force). Does not return a vault token.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      vault: {
-        type: "string",
-        description: "Target vault by name. Must be a reachable vault this connection can write.",
-      },
-      id: {
-        type: "string",
-        description: "Note ID or path in that vault.",
-      },
-      content: { type: "string", description: "Full content replace." },
-      append: { type: "string", description: "Append to the end of the note." },
-      prepend: { type: "string", description: "Prepend to the start of the note." },
-      content_edit: {
-        type: "object",
-        properties: {
-          old_text: { type: "string" },
-          new_text: { type: "string" },
-        },
-        required: ["old_text", "new_text"],
-        description: "Find-and-replace one occurrence.",
-      },
-      path: { type: "string", description: "New path." },
-      tags: { type: "object", description: "Tag mutations `{ add, remove }`." },
-      metadata: { type: "object", description: "Metadata merge-patch." },
-      if_updated_at: {
-        type: "string",
-        description: "Optimistic concurrency: reject if the note changed since.",
-      },
-      force: { type: "boolean", description: "Waive if_updated_at requirement." },
-      if_missing: {
-        type: "string",
-        enum: ["fail", "create"],
-        description: "What to do when the note does not exist. Default fail.",
-      },
-    },
-    required: ["vault", "id"],
-    additionalProperties: false,
-  },
-  async execute(args, ctx) {
-    if (typeof args.id !== "string" || args.id.length === 0) {
-      throw new AccountToolError("invalid_id", "id is required.");
-    }
-    const hit = requireWritableVault(ctx, args.vault);
-    const note = await vaultNoteWrite(ctx, hit, {
-      method: "PATCH",
-      path: `/api/notes/${encodeURIComponent(args.id)}`,
-      body: noteUpdateBody(args),
-    });
-    return { vault: hit.name, note };
   },
 };
 
@@ -778,32 +415,32 @@ const listAccessTool: AccountMcpTool = {
   },
 };
 
-/** Order is stable so `tools/list` is deterministic. */
+/** Hub-native catalog. Vault-shaped tools come from a live module `tools/list`. */
 export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
   listVaultsTool,
   createVaultTool,
-  queryNotesTool,
-  createNoteTool,
-  updateNoteTool,
   grantAccessTool,
   revokeAccessTool,
   listAccessTool,
 ];
 
+/** Hub-native names win on collision with a module backend. */
+export const HUB_NATIVE_TOOL_NAMES: ReadonlySet<string> = new Set(
+  ACCOUNT_MCP_TOOLS.map((t) => t.name),
+);
+
 /**
- * Catalog filtered by what this principal can actually call. Admin-shaped
- * tools (grant/revoke/list-access) and write tools are invisible below the
- * verb, not just refused. Same pattern as the vault door.
+ * Hub-native catalog filtered by what this principal can actually call.
+ * Admin-shaped tools are invisible below the verb, not just refused.
+ * Vault-shaped tools are merged in by `account-mcp-http.ts` from a live list.
  */
 export function toolsForPrincipal(ctx: AccountToolContext): readonly AccountMcpTool[] {
   const installed = installedVaults(ctx);
   const coverage = resolveCoverage(ctx.db, ctx.principal, installed);
-  const canWrite = coverage.vaults.some((v) => canWriteVault(ctx.db, ctx.principal, v.name));
   const canAdmin = coverage.vaults.some((v) => callerCanAdminVault(ctx.db, ctx.principal, v.name));
   const create = canCreate(ctx.principal);
   return ACCOUNT_MCP_TOOLS.filter((t) => {
     if (t.name === "create-vault") return create;
-    if (t.name === "create-note" || t.name === "update-note") return canWrite;
     if (t.name === "grant-access" || t.name === "revoke-access" || t.name === "list-access") {
       return canAdmin;
     }


### PR DESCRIPTION
## What

Account-MCP was a handwritten REST facade (8 tools, `GET/POST /api/notes`, `additionalProperties: false`). That is why #907 had to hand-wire `sort`, and why 14 vault tools had no account equivalent.

This PR makes the account door a **module router**: hub-native tools stay as hub code; vault-shaped tools are a live `tools/list` + JSON-RPC `tools/call` onto `/vault/<name>/mcp` with a 60s mint. Vault MCP itself is unchanged (already multi-vault at the process, one-vault at the session). Per-vault `/vault/<name>/mcp` stays. Cloud twin is out of this PR.

```
handleAccountMcp
  tools/list  = hub-native ∪ vault-backend.listTools (live)
  tools/call  = hub-native execute | vault-backend.call (mint + JSON-RPC)
```

Hub-native: `list-vaults`, `create-vault`, grant/revoke/list-access.

Vault backend (new `account-mcp-backend.ts`):

- Schema-source tries covered vaults in highest-verb order; only hub-native if every one is down.
- Injects `vault` (required except `query-notes`). Catalog caveat on each vault tool description: advertised from one vault's live list, may be Unknown against a lower-verb target.
- `query-notes` omit-`vault` still fans out; envelope `{vaults_queried, results}` unchanged even for a single named vault.
- Proxied `tools/call` returns vault MCP `result` as-is (image blocks on `read-attachment`).
- Tiny `ModuleMcpBackend` interface, one implementation. Hub-native names win on collision. Two backends colliding is left as a comment for module #2.

ClaudeJi reviewed the plan before this landed (holes 1–3 folded in).

## Tests

`bun test ./src/__tests__/account-mcp.test.ts` at `327b1a2`: 70 pass / 0 fail.

`bun test ./src` on the same tree immediately before commit: **4802 pass / 1 skip / 1 fail / 177 files**. The fail is pre-existing and unrelated: `surface-command.test.ts` "a command-minted write token pushes; revoke then blocks the next push" times out at 5s (reproduced in isolation on this worktree; this PR does not touch that file).

`bun run typecheck` clean. `biome check` on the four changed source files clean.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.
