### PR TITLE
fix: stables publish from main only — not next, not a tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,16 +58,15 @@ on:
     # record).
     #
     # `next` publishes rc's directly (no more next→main hop just to cut an
-    # rc) — `decidePublish` in release-plan.ts is already branch-agnostic
-    # (idempotent on an already-published version, refuses to move a
-    # dist-tag backwards, refuses a `latest` publish unless npm already has
-    # a matching `-rc.*` and the diff is a pure suffix-drop). `main` stays
-    # the only path that can actually promote to `@latest`, because a
-    # stable publish requires an existing rc AND a version/changelog-only
-    # diff from it — a fresh feature merge on `next` can never satisfy that
-    # gate. The `paths` filter below means an ordinary feature merge (no
-    # version bump) never even runs this workflow a second time —
-    # `pr-verify.yml` already tested it before merge.
+    # rc). `decidePublish` is idempotent on an already-published version,
+    # refuses to move a dist-tag backwards, refuses a `latest` publish unless
+    # npm already has a matching `-rc.*` and the diff is a pure suffix-drop,
+    # AND refuses a stable unless the trigger is a branch push of `main`.
+    # Matching-rc + suffix-drop alone is not enough: after an rc lands on
+    # `next`, a version/changelog-only promotion PR targeting `next` would
+    # pass those two and publish `@latest`. The `paths` filter below means
+    # an ordinary feature merge (no version bump) never even runs this
+    # workflow a second time — `pr-verify.yml` already tested it before merge.
     branches:
       - main
       - next
@@ -110,10 +109,12 @@ jobs:
   # `scripts/release-plan.ts` (unit-tested — release logic that can
   # double-publish or drop a release shouldn't be untested shell in a `run:`).
   #
-  # Note the tag-push path: an explicit tag still publishes, and passes
-  # `--tag-push` so `decidePublish`'s tag short-circuit overrides every
-  # refuse-guard (an ambiguous registry response, an older-than-published
-  # version) — because a tag is a human saying "release this". hub#841.
+  # Note the tag-push path: an explicit **rc** tag still publishes, and
+  # passes `--tag-push` so `decidePublish`'s tag short-circuit overrides the
+  # registry refuse-guards (an ambiguous registry response, an
+  # older-than-published rc) — because an rc tag is a human saying "release
+  # this rc". hub#841. A tag push of a stable is refused; stables publish
+  # from `main` only. A write token can push a tag; it cannot merge to `main`.
   # ---------------------------------------------------------------------------
   plan:
     name: plan
@@ -202,7 +203,10 @@ jobs:
     name: publish hub to npm
     needs: [plan, test]
     # Hub-only: skip on scope-guard / depcheck / door-contract tags (a `v*` tag is hub's).
-    if: ${{ (github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true') }}
+    # Plan is consulted on tag pushes too — a tag is not a bypass of the
+    # stable-from-main gate. The prefix clause still stops a scope-guard
+    # tag from also publishing hub (all four plan steps run --tag-push).
+    if: ${{ needs.plan.outputs.hub == 'true' && (github.ref_type != 'tag' || (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -264,8 +268,9 @@ jobs:
   publish-scope-guard-npm:
     name: publish scope-guard to npm
     needs: [plan, test]
-    # scope-guard-only: skip on hub (`v*`) tags.
-    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'scope-guard-'))) || (github.ref_type != 'tag' && needs.plan.outputs.scope_guard == 'true') }}
+    # scope-guard-only: skip on hub (`v*`) tags. Plan is consulted on tag
+    # pushes too — a tag is not a bypass of the stable-from-main gate.
+    if: ${{ needs.plan.outputs.scope_guard == 'true' && (github.ref_type != 'tag' || startsWith(github.ref_name, 'scope-guard-')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -322,8 +327,9 @@ jobs:
   publish-depcheck-npm:
     name: publish depcheck to npm
     needs: [plan, test]
-    # depcheck-only: skip on hub (`v*`) + scope-guard tags.
-    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'depcheck-'))) || (github.ref_type != 'tag' && needs.plan.outputs.depcheck == 'true') }}
+    # depcheck-only: skip on hub (`v*`) + scope-guard tags. Plan is consulted
+    # on tag pushes too — a tag is not a bypass of the stable-from-main gate.
+    if: ${{ needs.plan.outputs.depcheck == 'true' && (github.ref_type != 'tag' || startsWith(github.ref_name, 'depcheck-')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -381,7 +387,9 @@ jobs:
     name: publish door-contract to npm
     needs: [plan, test]
     # door-contract-only: skip on hub (`v*`) + scope-guard + depcheck tags.
-    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.door_contract == 'true') }}
+    # Plan is consulted on tag pushes too — a tag is not a bypass of the
+    # stable-from-main gate.
+    if: ${{ needs.plan.outputs.door_contract == 'true' && (github.ref_type != 'tag' || startsWith(github.ref_name, 'door-contract-')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -439,7 +447,9 @@ jobs:
     name: publish to ghcr.io
     needs: [plan, test]
     # Hub-only: scope-guard / depcheck / door-contract don't ship a container image.
-    if: ${{ (github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true') }}
+    # Plan is consulted on tag pushes too — a tag is not a bypass of the
+    # stable-from-main gate (same shape as publish-hub-npm).
+    if: ${{ needs.plan.outputs.hub == 'true' && (github.ref_type != 'tag' || (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,9 +9,9 @@ This repo publishes FOUR npm packages on independent release cadences via [`.git
 | `@openparachute/depcheck` | `depcheck-v...` (e.g. `depcheck-v0.1.1`) | no |
 | `@openparachute/door-contract` | `door-contract-v...` (e.g. `door-contract-v0.6.0`) | no |
 
-**Merging a version bump to `next` or `main` is the release signal** (hub#790, `next` added so an rc cut no longer needs a `next`→`main` hop). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. `next` can only ever produce an rc or an idempotent no-op — `release-plan.ts` refuses a `latest`/stable publish unless a matching `-rc.*` is already on npm and the diff from that rc tag is a pure version/changelog/lockfile suffix-drop, which a fresh feature merge on `next` can never satisfy. Only `main` can promote to stable. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
+**Merging a version bump to `next` or `main` is the release signal** (hub#790, `next` added so an rc cut no longer needs a `next`→`main` hop). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. `next` can only ever produce an rc or an idempotent no-op — `release-plan.ts` refuses a `latest`/stable publish unless the trigger is a branch push of `main` (a write token can merge to `next` and can push tags; it cannot merge to `main`). On `main`, it further refuses a stable unless a matching `-rc.*` is already on npm and the diff from that rc tag is a pure version/changelog/lockfile suffix-drop. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
 
-Pushing a tag is the explicit override: the `plan` job passes `--tag-push`, which makes `release-plan.ts` publish regardless of what the guards would otherwise say — an unpublished-older version, an ambiguous registry response, none of it blocks a tag push, because a tag is a human saying "release this" (hub#841). The one thing a tag can't force is npm itself: republishing an **already-published** version still gets rejected by npm (the npm job goes red — expected), so a deliberate re-release only actually re-pushes the image. The merge path is the normal one; reach for a tag push when you need to bypass the guards on purpose.
+Pushing an **rc** tag is the explicit override for registry guards: the `plan` job passes `--tag-push`, which makes `release-plan.ts` publish an rc regardless of an unpublished-older version or an ambiguous registry response (hub#841). A tag push of a **stable** is refused — stables publish from `main` only. The one thing a tag can't force is npm itself: republishing an **already-published** version still gets rejected by npm (the npm job goes red — expected), so a deliberate re-release of an rc only actually re-pushes the image. The merge path is the normal one.
 
 ## Version conventions
 
@@ -40,7 +40,7 @@ Always cut an **rc** first. Stable is a suffix-drop from that rc, never a
 skip — `release-plan.ts` refuses a stable unless npm already has a matching
 `X.Y.Z-rc.*`, and refuses again unless the tree is a suffix-drop from that
 rc tag (version / changelog / lockfile only). `0.7.13`–`0.7.16` skipped this;
-the hook starts at `0.7.17-rc.1`. An explicit tag push still overrides.
+the hook starts at `0.7.17-rc.1`. An explicit **rc** tag push still overrides the registry guards; a tag push of a stable does not.
 
 Feature work lands on `next`. The rc cut is a version bump PR that targets
 `next` directly — merging it publishes `@rc`. No `next` → `main` hop needed

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -21,15 +21,21 @@
  * version order. Merging rc.6 and then rc.5 would leave the `rc` dist-tag
  * pointing at rc.5 — older than what consumers already had — so an operator
  * installing `@rc` would silently DOWNGRADE. We refuse to move a dist-tag
- * backwards. (Re-publishing an older version deliberately is still possible
- * via an explicit tag push, which takes the tag branch below.)
+ * backwards. (Re-publishing an older **rc** deliberately is still possible
+ * via an explicit tag push, which takes the tag branch below. A tag push of
+ * a stable is refused — stables publish from `main` only.)
  *
  * **Stable that skipped rc.** 0.7.13 through 0.7.16 shipped `@latest` with
  * new code and no matching `X.Y.Z-rc.*`. Stable is a suffix-drop from an rc
  * of the same X.Y.Z, never a skip: `decidePublish` refuses a stable unless
  * npm already has that rc, and the CLI refuses again unless `git diff` from
  * the latest matching rc tag only touches version/changelog/lockfile paths.
- * An explicit tag push still overrides — a human saying "release this".
+ *
+ * **Stable from `next` or a tag push.** A write token can merge to `next`
+ * and can push tags; it cannot merge to `main`. So a stable version is
+ * published only when the trigger is a branch push of `main`. `isTagPush`
+ * still overrides the registry guards for **rc** versions (re-release, an
+ * older rc, an ambiguous registry). It does not override this gate.
  */
 
 import { appendFileSync } from "node:fs";
@@ -176,15 +182,28 @@ export function stablePromotionDiffArgs(rcTag: string): string[] {
 }
 
 /**
- * The decision. `isTagPush` short-circuits every check but the shape one — an
- * explicit tag is a human saying "release this", including a deliberate
- * re-release of something older.
+ * The decision. `isTagPush` short-circuits the registry guards for **rc**
+ * versions — an explicit rc tag is a human saying "release this", including
+ * a deliberate re-release of something older. It does **not** short-circuit
+ * the stable-from-main gate: a write token can push a tag, and that is not
+ * the same as merging to `main`.
  */
 export function decidePublish(
   version: string,
   registry: RegistryView | { ambiguous: true },
-  opts: { isTagPush?: boolean } = {},
+  opts: { isTagPush?: boolean; branch?: string } = {},
 ): PublishDecision {
+  // Stables publish from `main` only. Checked first so a tag push of
+  // `vX.Y.Z` (or a suffix-drop merged to `next`) cannot promote `@latest`.
+  if (distTagFor(version) !== "rc") {
+    const fromMain = !opts.isTagPush && opts.branch === "main";
+    if (!fromMain) {
+      return {
+        publish: false,
+        reason: `${version} is a stable version — stable promotions publish from main only (not next, not a tag push)`,
+      };
+    }
+  }
   if (opts.isTagPush) {
     return { publish: true, reason: `explicit tag push for ${version}` };
   }
@@ -346,6 +365,7 @@ if (import.meta.main) {
   const registry = await readRegistry(npmName, version);
   const decision = decidePublish(version, registry, {
     isTagPush: rest.includes("--tag-push"),
+    branch: process.env.GITHUB_REF_NAME,
   });
 
   if ("refuse" in decision) {

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -72,7 +72,7 @@ describe("decidePublish", () => {
   });
 
   test("first-ever release of a package publishes", () => {
-    const d = decidePublish("0.1.0", { versionExists: false });
+    const d = decidePublish("0.1.0", { versionExists: false }, { branch: "main" });
     expect(d).toMatchObject({ publish: true });
   });
 
@@ -102,12 +102,12 @@ describe("decidePublish", () => {
   test("an ambiguous registry REFUSES rather than guessing", () => {
     // A false "not published" double-publishes; a false "published" drops a
     // release. Guessing is worse than failing loudly.
-    const d = decidePublish("0.7.9", { ambiguous: true });
+    const d = decidePublish("0.7.9", { ambiguous: true }, { branch: "main" });
     expect(d).toMatchObject({ refuse: true });
     expect("refuse" in d && d.reason).toMatch(/refusing to guess/);
   });
 
-  test("an explicit tag push overrides every check — a human said release this", () => {
+  test("an explicit rc tag push overrides the registry checks — a human said release this rc", () => {
     const d = decidePublish(
       "0.7.0-rc.1",
       {
@@ -119,53 +119,69 @@ describe("decidePublish", () => {
     expect(d).toMatchObject({ publish: true });
   });
 
-  test("a tag push even overrides ambiguity", () => {
-    const d = decidePublish("0.7.9", { ambiguous: true }, { isTagPush: true });
+  test("an rc tag push even overrides ambiguity", () => {
+    const d = decidePublish("0.7.9-rc.1", { ambiguous: true }, { isTagPush: true });
     expect(d).toMatchObject({ publish: true });
   });
 
   test("a stable without a matching rc is refused — 0.7.13 through 0.7.16 skipped this", () => {
     // Cutting @latest with new code and no rc of the same X.Y.Z is how
     // 0.7.13–0.7.16 shipped. Stable is a suffix-drop, never a skip.
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-      publishedVersions: ["0.7.16", "0.7.12-rc.2"],
-    });
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16", "0.7.12-rc.2"],
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ refuse: true });
     expect("refuse" in d && d.reason).toMatch(/0\.7\.17-rc/);
     expect("refuse" in d && d.reason).toMatch(/suffix-drop|Cut an rc first/i);
   });
 
   test("a stable whose only published rcs are a different X.Y.Z is still refused", () => {
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-      publishedVersions: ["0.7.16", "0.7.16-rc.1"],
-    });
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16", "0.7.16-rc.1"],
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ refuse: true });
   });
 
-  test("a stable with a matching rc publishes — suffix-drop is the only legal stable", () => {
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-      publishedVersions: ["0.7.16", "0.7.17-rc.1"],
-    });
+  test("a stable with a matching rc publishes from main — suffix-drop is the only legal stable", () => {
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16", "0.7.17-rc.1"],
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ publish: true });
   });
 
   test("omitted publishedVersions still refuses a stable when latest already exists", () => {
     // Callers that forget to plumb the version list must not silently skip
     // the gate — that's how 0.7.13–0.7.16 would keep shipping.
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-    });
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ refuse: true });
   });
 
-  test("tag-push still overrides the rc-required check", () => {
+  test("a tag push of a stable does NOT override the matching-rc check — stables publish from main only", () => {
     const d = decidePublish(
       "0.7.17",
       {
@@ -175,7 +191,46 @@ describe("decidePublish", () => {
       },
       { isTagPush: true },
     );
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/from main only/);
+  });
+
+  test("next skips a stable even when a matching rc exists — tonight's hole", () => {
+    // After 0.7.18-rc.9, next HEAD *is* that rc. A suffix-drop PR targeting
+    // next would pass matching-rc + the version/changelog-only diff. This
+    // gate is what stops it from publishing @latest.
+    const d = decidePublish(
+      "0.7.18",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.17",
+        publishedVersions: ["0.7.17", "0.7.18-rc.9"],
+      },
+      { branch: "next" },
+    );
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/from main only/);
+  });
+
+  test("next still publishes an rc", () => {
+    const d = decidePublish(
+      "0.7.18-rc.9",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.18-rc.8",
+      },
+      { branch: "next" },
+    );
     expect(d).toMatchObject({ publish: true });
+  });
+
+  test("a stable with no branch is refused — fail closed, don't guess the trigger", () => {
+    const d = decidePublish("0.7.18", {
+      versionExists: false,
+      publishedVersions: ["0.7.18-rc.9"],
+    });
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/from main only/);
   });
 });
 
@@ -483,14 +538,16 @@ describe("release.yml image tags (hub#829)", () => {
 });
 
 /**
- * The tag-push override (hub#841).
+ * The rc tag-push override (hub#841).
  *
- * `decidePublish`'s `isTagPush` short-circuit is unit-tested above, but
- * unreachable unless the workflow actually passes `--tag-push` on a tag
- * push. That was the bug: the `plan` steps never passed it, so the flag path
- * was dead code and a stale comment claimed otherwise. Assert the wiring
- * directly on the YAML, same rationale as the hub#829 block below — a
- * `run:` string is otherwise only exercised by shipping a release.
+ * `decidePublish`'s `isTagPush` short-circuit (rc versions only) is
+ * unit-tested above, but unreachable unless the workflow actually passes
+ * `--tag-push` on a tag push. That was the bug: the `plan` steps never
+ * passed it, so the flag path was dead code and a stale comment claimed
+ * otherwise. Assert the wiring directly on the YAML, same rationale as the
+ * hub#829 block below — a `run:` string is otherwise only exercised by
+ * shipping a release. Stables are refused even with this flag; the wiring
+ * is still required so an rc tag-push reaches the short-circuit.
  */
 describe("release.yml tag-push override (hub#841)", () => {
   const workflow = readFileSync(
@@ -508,6 +565,20 @@ describe("release.yml tag-push override (hub#841)", () => {
     ]) {
       expect(workflow).toContain(`${cmd} ${flag}`);
     }
+  });
+
+  test("publish jobs consult plan even on a tag push — a tag is not a bypass of the stable-from-main gate", () => {
+    // The hole: `github.ref_type == 'tag' && <prefix>` without consulting
+    // plan published a stable from a write-token tag push. Both npm and
+    // ghcr used that shape.
+    const oldBypass =
+      "(github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true')";
+    expect(workflow).not.toContain(oldBypass);
+    const gated =
+      "needs.plan.outputs.hub == 'true' && (github.ref_type != 'tag' || (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-')))";
+    expect(workflow).toContain(gated);
+    // Two jobs share it: publish-hub-npm and publish-image.
+    expect(workflow.split(gated).length - 1).toBe(2);
   });
 });
 


### PR DESCRIPTION
## Why

Aaron: could an agent just push to stable? Independent check against `origin/next` (`ff7071a`), not the comments.

Hub `decidePublish()` had **no branch check**. After `0.7.18-rc.9` landed on npm, `next` HEAD *is* that rc, so a version/changelog-only suffix-drop PR targeting `next` would pass matching-rc + suffix-drop and publish `@latest`. The "Do not merge next" line was an error string, not a check.

A tag push short-circuited every guard (`isTagPush → publish: true`), and the publish jobs' `if:` treated `github.ref_type == 'tag'` as a bypass of plan entirely. This token (`push: true`, `admin: false`) created `refs/tags/v-grokji-probe` on hub and deleted it — no `v*` tag protection is enforcing.

## What

Stables publish from a branch push of `main` only. Checked *before* `isTagPush`. Rc tag-pushes still override the registry guards. Publish jobs (npm + ghcr) consult plan even on a tag; the tag-prefix selector remains so a `scope-guard-v*` tag doesn't also publish hub.

No version bump — this is a gate, not a release. Merging to `next` does not publish (paths filter is `package.json`).

## Tests

`bun test ./src/__tests__/release-plan.test.ts` — 58 pass / 0 fail at `9b71441`.
`bun run typecheck` — clean.
Did **not** run `bun test ./src` on this box (launchd-hardcoded lifecycle tests).

## Still needs a human

GitHub tag protection / a ruleset. Classic `v*` would also block `tag-record`'s `git push origin "$T"` (GITHUB_TOKEN is not admin). A ruleset that restricts tag creation but lets Actions bypass is the GitHub-side half. I cannot apply it (`admin: false`; POST 404s).

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.
