### PR TITLE
fix: NIP-98 u-tag honors X-Forwarded-Proto behind TLS terminate

### DIFF
--- a/src/__tests__/nostr-http-auth.test.ts
+++ b/src/__tests__/nostr-http-auth.test.ts
@@ -4,26 +4,27 @@
  * Watch-fail: these tests signed against an unpatched verify (no replay
  * cache, no u/method bind) before the implementation landed.
  */
+import type { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { schnorr } from "@noble/curves/secp256k1.js";
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createHash } from "node:crypto";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { requireScope } from "../admin-auth.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import type { Database } from "bun:sqlite";
 import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
 import {
   NIP98_MAX_SKEW_SECONDS,
   NostrReplayCache,
   authenticateNostrRequest,
   extractNostrEvent,
+  requestAbsoluteUrl,
   verifyNostrHttpEvent,
 } from "../nostr-http-auth.ts";
-import { requireScope } from "../admin-auth.ts";
-import { createUser } from "../users.ts";
 import { bindPubkeyFromHttpAuth, findPubkeyLink } from "../pubkey-links.ts";
 import { issuePubkeyChallenge, linkPubkey } from "../pubkey-links.ts";
+import { createUser } from "../users.ts";
 
 const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
 const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
@@ -57,12 +58,14 @@ function reqFor(
   method: string,
   event: NostrEvent,
   body?: string,
+  extraHeaders?: Record<string, string>,
 ): Request {
   return new Request(url, {
     method,
     headers: {
       authorization: nostrHeader(event),
       ...(body !== undefined ? { "content-type": "application/json" } : {}),
+      ...extraHeaders,
     },
     ...(body !== undefined ? { body } : {}),
   });
@@ -88,17 +91,60 @@ describe("extractNostrEvent", () => {
   });
 });
 
+describe("requestAbsoluteUrl", () => {
+  test("loopback http is unchanged — no stored origin, no header rewrite", () => {
+    const req = new Request("http://127.0.0.1:1939/mcp", { method: "POST" });
+    expect(requestAbsoluteUrl(req)).toBe("http://127.0.0.1:1939/mcp");
+  });
+
+  test("X-Forwarded-Proto https upgrades the scheme on an http request URL", () => {
+    // Tonight's hole: Tailscale Serve terminates TLS and forwards HTTP.
+    // Hub sees http://uni.taildf9ce2.ts.net/mcp; the client signed https.
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp", {
+      method: "POST",
+      headers: { "x-forwarded-proto": "https" },
+    });
+    expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp");
+  });
+
+  test("keeps host/path/query from req.url — not X-Forwarded-Host", () => {
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp?x=1", {
+      method: "POST",
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "evil.example",
+      },
+    });
+    expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp?x=1");
+  });
+
+  test("direct https req.url is a no-op even without X-Forwarded-Proto", () => {
+    const req = new Request("https://uni.taildf9ce2.ts.net/mcp", { method: "POST" });
+    expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp");
+  });
+});
+
 describe("verifyNostrHttpEvent", () => {
   test("accepts a fresh GET with matching u and method", () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const replay = new NostrReplayCache();
     verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
   });
 
   test("rejects a replayed event id", () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const replay = new NostrReplayCache();
     verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
     expect(() => verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay })).toThrow(
@@ -114,8 +160,39 @@ describe("verifyNostrHttpEvent", () => {
       ],
     });
     expect(() =>
+      verifyNostrHttpEvent(reqFor("http://127.0.0.1:1939/api/me", "GET", event), event, {
+        replay: new NostrReplayCache(),
+      }),
+    ).toThrow(/u tag/);
+  });
+
+  test("accepts https u-tag when X-Forwarded-Proto says the client used TLS — tonight's hole", () => {
+    const publicUrl = "https://uni.taildf9ce2.ts.net/mcp";
+    const behindTls = "http://uni.taildf9ce2.ts.net/mcp";
+    const event = signEvent({
+      tags: [
+        ["u", publicUrl],
+        ["method", "POST"],
+      ],
+    });
+    verifyNostrHttpEvent(
+      reqFor(behindTls, "POST", event, undefined, { "x-forwarded-proto": "https" }),
+      event,
+      { replay: new NostrReplayCache() },
+    );
+  });
+
+  test("rejects the internal http u-tag on a TLS-terminated request", () => {
+    const behindTls = "http://uni.taildf9ce2.ts.net/mcp";
+    const event = signEvent({
+      tags: [
+        ["u", behindTls],
+        ["method", "POST"],
+      ],
+    });
+    expect(() =>
       verifyNostrHttpEvent(
-        reqFor("http://127.0.0.1:1939/api/me", "GET", event),
+        reqFor(behindTls, "POST", event, undefined, { "x-forwarded-proto": "https" }),
         event,
         { replay: new NostrReplayCache() },
       ),
@@ -124,7 +201,12 @@ describe("verifyNostrHttpEvent", () => {
 
   test("rejects method mismatch", () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "POST"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "POST"],
+      ],
+    });
     expect(() =>
       verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
     ).toThrow(/method tag/);
@@ -134,7 +216,10 @@ describe("verifyNostrHttpEvent", () => {
     const url = "http://127.0.0.1:1939/api/me";
     const event = signEvent({
       created_at: Math.floor(Date.now() / 1000) - (NIP98_MAX_SKEW_SECONDS + 5),
-      tags: [["u", url], ["method", "GET"]],
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
     });
     expect(() =>
       verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
@@ -192,7 +277,12 @@ describe("authenticateNostrRequest", () => {
       passwordChanged: true,
     });
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     await expect(
       authenticateNostrRequest(db, reqFor(url, "GET", event), {
         autoProvision: false,
@@ -222,7 +312,12 @@ describe("authenticateNostrRequest", () => {
     expect(linked.ok).toBe(true);
 
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
       autoProvision: false,
       replay: new NostrReplayCache(),
@@ -240,7 +335,12 @@ describe("authenticateNostrRequest", () => {
       passwordChanged: true,
     });
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
       autoProvision: true,
       replay: new NostrReplayCache(),
@@ -255,7 +355,12 @@ describe("authenticateNostrRequest", () => {
 
   test("auto-provision refuses when the hub has no owner yet", async () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     await expect(
       authenticateNostrRequest(db, reqFor(url, "GET", event), {
         autoProvision: true,
@@ -286,7 +391,12 @@ describe("authenticateNostrRequest", () => {
       }).ok,
     ).toBe(true);
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
       autoProvision: false,
       replay: new NostrReplayCache(),
@@ -299,11 +409,21 @@ describe("authenticateNostrRequest", () => {
       passwordChanged: true,
     });
     const url = "http://127.0.0.1:1939/api/users";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     process.env.PARACHUTE_NOSTR_AUTO_PROVISION = "1";
     try {
       await expect(
-        requireScope(db, reqFor(url, "GET", event), "parachute:host:admin", "http://127.0.0.1:1939"),
+        requireScope(
+          db,
+          reqFor(url, "GET", event),
+          "parachute:host:admin",
+          "http://127.0.0.1:1939",
+        ),
       ).rejects.toThrow(/parachute:host:admin/);
     } finally {
       delete process.env.PARACHUTE_NOSTR_AUTO_PROVISION;

--- a/src/nostr-http-auth.ts
+++ b/src/nostr-http-auth.ts
@@ -15,8 +15,8 @@
  * unchanged. This path never asks for a password: the signature *is* the
  * possession proof.
  */
-import { createHash, randomBytes } from "node:crypto";
 import type { Database } from "bun:sqlite";
+import { createHash, randomBytes } from "node:crypto";
 import {
   NOSTR_AUTH_KIND,
   type NostrEvent,
@@ -25,6 +25,7 @@ import {
   verifyNostrEvent,
 } from "./nostr-event.ts";
 import { bindPubkeyFromHttpAuth, findPubkeyLink } from "./pubkey-links.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
 import {
   createUser,
   getFirstAdminId,
@@ -124,7 +125,25 @@ export function extractNostrEvent(req: Request): NostrEvent {
   return parsed.event;
 }
 
+/**
+ * Absolute URL the NIP-98 `u` tag must equal.
+ *
+ * Hub binds 127.0.0.1:1939 over plain HTTP. Tailscale Serve, cloudflared,
+ * and Render terminate TLS at the edge and forward HTTP, so `req.url` is
+ * `http://<public-host>/…` while the client POSTed — and signed —
+ * `https://<public-host>/…`. Same reconstruction as `resolveIssuer`'s
+ * request fallback: upgrade the scheme when `isHttpsRequest` is true
+ * (URL protocol or `X-Forwarded-Proto: https`). Host, path, and query
+ * stay on `req.url`. We do not honor `X-Forwarded-Host` here, and we do
+ * not substitute stored `hub_origin` — loopback NIP-98 stays bound to
+ * loopback.
+ */
 export function requestAbsoluteUrl(req: Request): string {
+  const url = new URL(req.url);
+  if (isHttpsRequest(req) && url.protocol === "http:") {
+    url.protocol = "https:";
+    return url.href;
+  }
   return req.url;
 }
 
@@ -166,7 +185,11 @@ export function verifyNostrHttpEvent(
   const createdAtMs = event.created_at * 1000;
   const skewMs = NIP98_MAX_SKEW_SECONDS * 1000;
   if (Math.abs(now.getTime() - createdAtMs) > skewMs) {
-    throw new NostrHttpAuthError(401, "expired", "Nostr event created_at is outside the 60s window");
+    throw new NostrHttpAuthError(
+      401,
+      "expired",
+      "Nostr event created_at is outside the 60s window",
+    );
   }
 
   if (replay.consume(event.id, now.getTime())) {
@@ -176,7 +199,11 @@ export function verifyNostrHttpEvent(
   const u = tagValue(event, "u");
   const expectedUrl = requestAbsoluteUrl(req);
   if (u !== expectedUrl) {
-    throw new NostrHttpAuthError(401, "url_mismatch", "Nostr event u tag must equal this request URL");
+    throw new NostrHttpAuthError(
+      401,
+      "url_mismatch",
+      "Nostr event u tag must equal this request URL",
+    );
   }
   const method = tagValue(event, "method");
   if (!method || method.toUpperCase() !== req.method.toUpperCase()) {
@@ -250,11 +277,7 @@ export async function resolveNostrPrincipal(
     return principalFromUser(db, user.id, user.username, event.pubkey, false);
   }
   if (!opts.autoProvision) {
-    throw new NostrHttpAuthError(
-      401,
-      "unknown_pubkey",
-      "Nostr pubkey is not linked to a hub user",
-    );
+    throw new NostrHttpAuthError(401, "unknown_pubkey", "Nostr pubkey is not linked to a hub user");
   }
   if (getFirstAdminId(db) === null) {
     throw new NostrHttpAuthError(
@@ -297,7 +320,11 @@ export async function resolveNostrPrincipal(
     now,
   });
   if (!bound.ok) {
-    throw new NostrHttpAuthError(401, "pubkey_taken", "Nostr pubkey is already bound to another user");
+    throw new NostrHttpAuthError(
+      401,
+      "pubkey_taken",
+      "Nostr pubkey is already bound to another user",
+    );
   }
   return principalFromUser(db, user.id, user.username, event.pubkey, true);
 }


### PR DESCRIPTION
## Why

Live-box gauntlet on hub `0.7.18-rc.9`: `POST https://uni.taildf9ce2.ts.net/mcp` with a NIP-98 `u` tag of that same https URL returns 401 `url_mismatch`. Signing the *http* URL hub actually sees (`http://uni.taildf9ce2.ts.net/mcp`) against the https POST returns 200. Loopback NIP-98 is fine. Bearer on the same tailnet door is fine.

`requestAbsoluteUrl` was `return req.url`. Tailscale Serve terminates TLS and forwards HTTP; hub binds `127.0.0.1:1939` over plain HTTP. A client that tags the URL it actually called fails on the public origin.

OAuth already handles this: `resolveIssuer`'s request fallback upgrades the scheme via `isHttpsRequest()` (`X-Forwarded-Proto: https`). Discovery on this box publishes `https://uni.taildf9ce2.ts.net`. NIP-98 did not share that reconstruction.

Aaron: "lets fix it."

## What

`requestAbsoluteUrl` now upgrades `http:` → `https:` when `isHttpsRequest(req)` is true. Host, path, and query stay on `req.url`. We do **not** honor `X-Forwarded-Host` and we do **not** substitute stored `hub_origin` — loopback NIP-98 stays bound to loopback.

No version bump. Merging to `next` does not publish (`package.json` unchanged).

## Tests

Watch-fail: the four new cases failed on unpatched `return req.url` (https u-tag rejected; internal http u-tag accepted on an X-Forwarded-Proto request), then passed after the rewrite.

`bun test ./src/__tests__/nostr-http-auth.test.ts` — 21 pass / 0 fail at `23eb236`.
`bun run typecheck` — clean at the same SHA.
Did **not** run `bun test ./src` on this box (launchd-hardcoded lifecycle tests).
Did **not** load this onto the live hub (port 1939 is the running rc.9). Live tailnet NIP-98 re-gauntlet is after the next rc is on the box.

## Still open

Claude's remaining live-box paths (`create-vault`, grant/revoke, tag admin, `prune-schema`, `manage-token`, attachments) — tracked, not this PR.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.