### PR TITLE
release: hub 0.7.18 — suffix-drop of 0.7.18-rc.10

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# Release workflow — triggered by a merge to `main` (hub#790), or by pushing a
-# semver tag.
+# Release workflow — triggered by a merge to `next` or `main` (hub#790, and
+# the `next` trigger added when the rc cut stopped needing a `next`→`main`
+# hop of its own), or by pushing a semver tag.
 #
 # This workflow publishes FOUR packages on different tag namespaces:
 #
@@ -26,16 +27,19 @@
 #                                    (door-contract-v0.6.0)
 #
 # Release flow (publish-on-merge — the tag path below still works, see `plan`):
-#   1. When ready to ship: open a release PR bumping `version` in the relevant
-#      package.json (root for hub, packages/scope-guard/ for scope-guard,
-#      packages/depcheck/ for depcheck, packages/door-contract/ for
-#      door-contract).
+#   1. Cutting an rc: open a release PR bumping `version` to an `-rc.N`
+#      shape, targeting `next` directly — no `next`→`main` hop needed just
+#      to publish an rc. Promoting to stable: same shape, but the PR targets
+#      `main` and drops the `-rc.N` suffix; `plan` refuses it unless npm
+#      already has that core version as an rc AND the diff from that rc tag
+#      is version/changelog/lockfile only (RELEASING.md).
 #   2. Merge it. That IS the release signal — `plan` compares each
 #      package.json against npm and publishes what's new.
 #   3. CI runs tests once (workspace-wide), then publishes whichever packages
 #      `plan` selected. Hub also publishes a container image to ghcr.io, tagged
 #      from the published VERSION (`:vX.Y.Z` + `:rc`/`:stable` + `:latest`) —
-#      not from the ref, which on a merge run is just `main` (hub#829).
+#      not from the ref, which on a merge run is just the branch name
+#      (`next` or `main`), never a version (hub#829).
 #   4. `tag-record` pushes `vX.Y.Z` afterwards as a RECORD of what shipped.
 #      Nothing needs to be tagged by hand.
 #
@@ -52,8 +56,26 @@ on:
     # hub#790: publish-on-merge. See the `plan` job for why the tag was
     # replaced as the release SIGNAL (it's still honoured, and still cut as a
     # record).
+    #
+    # `next` publishes rc's directly (no more next→main hop just to cut an
+    # rc) — `decidePublish` in release-plan.ts is already branch-agnostic
+    # (idempotent on an already-published version, refuses to move a
+    # dist-tag backwards, refuses a `latest` publish unless npm already has
+    # a matching `-rc.*` and the diff is a pure suffix-drop). `main` stays
+    # the only path that can actually promote to `@latest`, because a
+    # stable publish requires an existing rc AND a version/changelog-only
+    # diff from it — a fresh feature merge on `next` can never satisfy that
+    # gate. The `paths` filter below means an ordinary feature merge (no
+    # version bump) never even runs this workflow a second time —
+    # `pr-verify.yml` already tested it before merge.
     branches:
       - main
+      - next
+    paths:
+      - 'package.json'
+      - 'packages/scope-guard/package.json'
+      - 'packages/depcheck/package.json'
+      - 'packages/door-contract/package.json'
     tags:
       # Hub release tags
       - 'v[0-9]+.[0-9]+.[0-9]+'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,16 +58,15 @@ on:
     # record).
     #
     # `next` publishes rc's directly (no more next→main hop just to cut an
-    # rc) — `decidePublish` in release-plan.ts is already branch-agnostic
-    # (idempotent on an already-published version, refuses to move a
-    # dist-tag backwards, refuses a `latest` publish unless npm already has
-    # a matching `-rc.*` and the diff is a pure suffix-drop). `main` stays
-    # the only path that can actually promote to `@latest`, because a
-    # stable publish requires an existing rc AND a version/changelog-only
-    # diff from it — a fresh feature merge on `next` can never satisfy that
-    # gate. The `paths` filter below means an ordinary feature merge (no
-    # version bump) never even runs this workflow a second time —
-    # `pr-verify.yml` already tested it before merge.
+    # rc). `decidePublish` is idempotent on an already-published version,
+    # refuses to move a dist-tag backwards, refuses a `latest` publish unless
+    # npm already has a matching `-rc.*` and the diff is a pure suffix-drop,
+    # AND refuses a stable unless the trigger is a branch push of `main`.
+    # Matching-rc + suffix-drop alone is not enough: after an rc lands on
+    # `next`, a version/changelog-only promotion PR targeting `next` would
+    # pass those two and publish `@latest`. The `paths` filter below means
+    # an ordinary feature merge (no version bump) never even runs this
+    # workflow a second time — `pr-verify.yml` already tested it before merge.
     branches:
       - main
       - next
@@ -110,10 +109,12 @@ jobs:
   # `scripts/release-plan.ts` (unit-tested — release logic that can
   # double-publish or drop a release shouldn't be untested shell in a `run:`).
   #
-  # Note the tag-push path: an explicit tag still publishes, and passes
-  # `--tag-push` so `decidePublish`'s tag short-circuit overrides every
-  # refuse-guard (an ambiguous registry response, an older-than-published
-  # version) — because a tag is a human saying "release this". hub#841.
+  # Note the tag-push path: an explicit **rc** tag still publishes, and
+  # passes `--tag-push` so `decidePublish`'s tag short-circuit overrides the
+  # registry refuse-guards (an ambiguous registry response, an
+  # older-than-published rc) — because an rc tag is a human saying "release
+  # this rc". hub#841. A tag push of a stable is refused; stables publish
+  # from `main` only. A write token can push a tag; it cannot merge to `main`.
   # ---------------------------------------------------------------------------
   plan:
     name: plan
@@ -202,7 +203,10 @@ jobs:
     name: publish hub to npm
     needs: [plan, test]
     # Hub-only: skip on scope-guard / depcheck / door-contract tags (a `v*` tag is hub's).
-    if: ${{ (github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true') }}
+    # Plan is consulted on tag pushes too — a tag is not a bypass of the
+    # stable-from-main gate. The prefix clause still stops a scope-guard
+    # tag from also publishing hub (all four plan steps run --tag-push).
+    if: ${{ needs.plan.outputs.hub == 'true' && (github.ref_type != 'tag' || (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -264,8 +268,9 @@ jobs:
   publish-scope-guard-npm:
     name: publish scope-guard to npm
     needs: [plan, test]
-    # scope-guard-only: skip on hub (`v*`) tags.
-    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'scope-guard-'))) || (github.ref_type != 'tag' && needs.plan.outputs.scope_guard == 'true') }}
+    # scope-guard-only: skip on hub (`v*`) tags. Plan is consulted on tag
+    # pushes too — a tag is not a bypass of the stable-from-main gate.
+    if: ${{ needs.plan.outputs.scope_guard == 'true' && (github.ref_type != 'tag' || startsWith(github.ref_name, 'scope-guard-')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -322,8 +327,9 @@ jobs:
   publish-depcheck-npm:
     name: publish depcheck to npm
     needs: [plan, test]
-    # depcheck-only: skip on hub (`v*`) + scope-guard tags.
-    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'depcheck-'))) || (github.ref_type != 'tag' && needs.plan.outputs.depcheck == 'true') }}
+    # depcheck-only: skip on hub (`v*`) + scope-guard tags. Plan is consulted
+    # on tag pushes too — a tag is not a bypass of the stable-from-main gate.
+    if: ${{ needs.plan.outputs.depcheck == 'true' && (github.ref_type != 'tag' || startsWith(github.ref_name, 'depcheck-')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -381,7 +387,9 @@ jobs:
     name: publish door-contract to npm
     needs: [plan, test]
     # door-contract-only: skip on hub (`v*`) + scope-guard + depcheck tags.
-    if: ${{ (github.ref_type == 'tag' && (startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.door_contract == 'true') }}
+    # Plan is consulted on tag pushes too — a tag is not a bypass of the
+    # stable-from-main gate.
+    if: ${{ needs.plan.outputs.door_contract == 'true' && (github.ref_type != 'tag' || startsWith(github.ref_name, 'door-contract-')) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -439,7 +447,9 @@ jobs:
     name: publish to ghcr.io
     needs: [plan, test]
     # Hub-only: scope-guard / depcheck / door-contract don't ship a container image.
-    if: ${{ (github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true') }}
+    # Plan is consulted on tag pushes too — a tag is not a bypass of the
+    # stable-from-main gate (same shape as publish-hub-npm).
+    if: ${{ needs.plan.outputs.hub == 'true' && (github.ref_type != 'tag' || (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18] - 2026-08-29
+
+**Stable promotion of 0.7.18-rc.10.** No new code. Suffix-drop only. npm `@rc`
+is 0.7.18-rc.10; this is the matching `@latest`.
+
+The 0.7.18 line (rc.1-rc.10) ships key-as-account: a Nostr key is now a
+first-class hub identity. NIP-98 request auth (#882) and the account-MCP
+door (#883); NIP-98 accepted at root `/mcp` plus grant-vault-access by
+pubkey (#888, #889); OAuth `account:vaults` and account-MCP at root `/mcp`
+(#892) with create-note / update-note / query-notes forwarding (#893, #896,
+#907); the consent-picker XOR (#901) and `account:self:*` extras minting
+alongside `account:vaults` (#904); account-MCP proxies vault MCP instead of
+cloning REST (#910); NIP-98 `u`-tag honors `X-Forwarded-Proto` behind a
+TLS-terminating proxy (#914). Also in this line: person-mint `users.id`,
+Account SPA, leftover CAS (#872, #874, #875); rc cuts publish directly from
+`next` (#911) and stables publish from `main` only (#913).
+
+Auto-provision stays off by default: an unlinked key gets nothing unless
+granted or `PARACHUTE_NOSTR_AUTO_PROVISION=1`. Leaves #880, #881, #899 open.
+
 ## [0.7.18-rc.10] - 2026-08-29
 
 **Two security/correctness fixes from tonight's release-automation hardening pass.** Version bump only; no new code in this commit. Merging this to `next` publishes `@rc` (hub#911 — no next→main hop).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [Unreleased]
+
+**Account-MCP proxies vault MCP instead of cloning REST.** Hub-native tools
+stay (`list-vaults`, `create-vault`, grant/revoke/list-access). Vault-shaped
+tools are a live `tools/list` from one covered vault (highest verb, fallback
+if that vault is down) plus JSON-RPC `tools/call` to
+`/vault/<name>/mcp` with a 60s mint. `query-notes` without `vault` still
+fans out; the envelope is unchanged. Per-vault `/vault/<name>/mcp` stays.
+
 ## [0.7.18-rc.8] - 2026-08-28
 
 **Account-MCP query-notes sort + bodies.** One PR on `next` after

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,26 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
-## [Unreleased]
+## [0.7.18-rc.9] - 2026-08-29
 
-**Account-MCP proxies vault MCP instead of cloning REST.** Hub-native tools
-stay (`list-vaults`, `create-vault`, grant/revoke/list-access). Vault-shaped
-tools are a live `tools/list` from one covered vault (highest verb, fallback
-if that vault is down) plus JSON-RPC `tools/call` to
-`/vault/<name>/mcp` with a 60s mint. `query-notes` without `vault` still
-fans out; the envelope is unchanged. Per-vault `/vault/<name>/mcp` stays.
+**Account-MCP proxies vault MCP.** Two PRs on `next` after
+0.7.18-rc.8. Version bump only; no new code in this commit. Merging
+this to `next` publishes `@rc` (hub#911 — no next→main hop).
+
+- **Account-MCP proxies vault MCP instead of cloning REST (#910).**
+  Hub-native tools stay (`list-vaults`, `create-vault`,
+  grant/revoke/list-access). Vault-shaped tools are a live `tools/list`
+  from one covered vault (highest verb, fallback if that vault is down)
+  plus JSON-RPC `tools/call` to `/vault/<name>/mcp` with a 60s mint.
+  `query-notes` without `vault` still fans out; the envelope is
+  unchanged. Per-vault `/vault/<name>/mcp` stays.
+
+- **Rc cuts publish from `next` (#911).** `release.yml` now triggers
+  on `next` as well as `main`, with a `paths` filter on the four
+  package.json files. This is the first rc that uses that path.
+
+Leaves #880, #881, and #899 open. Auto-provision still defaults off. Do
+not suffix-drop 0.7.18.
 
 ## [0.7.18-rc.8] - 2026-08-28
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 >
 > This backfill covers the 0.6.x line only. Two pre-existing gaps remain undocumented and are **not** addressed here: the `0.5.13` stable itself (the file's newest entry is `0.5.13-rc.48`, never the stable) and the entire `0.5.14-rc` chain (rc.1–rc.21 on npm), which never promoted to a `0.5.14` stable — its work folded forward into 0.6.0.
 
+## [0.7.18-rc.10] - 2026-08-29
+
+**Two security/correctness fixes from tonight's release-automation hardening pass.** Version bump only; no new code in this commit. Merging this to `next` publishes `@rc` (hub#911 — no next→main hop).
+
+- **Stables publish from `main` only — not `next`, not a tag push (#913).** `decidePublish()` previously had no branch check, only "does a matching rc already exist on npm." With an rc already published, an ordinary version/changelog-only PR merged to `next` could have published straight to `@latest`, bypassing `main`'s branch protection entirely (branch protection never covered `next` or tags). Checked first now, before any other rule.
+- **NIP-98 `u` tag honors `X-Forwarded-Proto` behind a TLS-terminating reverse proxy (#914).** Tailscale Serve (and cloudflared, and Render) terminate TLS and forward plain HTTP; hub saw `http://…` while a client correctly signed `https://…`, so every NIP-98 request through such a proxy 401'd with `url_mismatch`. Reuses `isHttpsRequest()`, the same helper `resolveIssuer` already trusts for the cookie-`Secure` decision — not new trust surface. Host/path stay bound to `req.url`, not `X-Forwarded-Host`, so loopback NIP-98 stays loopback.
+
 ## [0.7.18-rc.9] - 2026-08-29
 
 **Account-MCP proxies vault MCP.** Two PRs on `next` after

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,7 +9,7 @@ This repo publishes FOUR npm packages on independent release cadences via [`.git
 | `@openparachute/depcheck` | `depcheck-v...` (e.g. `depcheck-v0.1.1`) | no |
 | `@openparachute/door-contract` | `door-contract-v...` (e.g. `door-contract-v0.6.0`) | no |
 
-**Merging a version bump to `main` is the release signal** (hub#790). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
+**Merging a version bump to `next` or `main` is the release signal** (hub#790, `next` added so an rc cut no longer needs a `next`→`main` hop). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. `next` can only ever produce an rc or an idempotent no-op — `release-plan.ts` refuses a `latest`/stable publish unless a matching `-rc.*` is already on npm and the diff from that rc tag is a pure version/changelog/lockfile suffix-drop, which a fresh feature merge on `next` can never satisfy. Only `main` can promote to stable. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
 
 Pushing a tag is the explicit override: the `plan` job passes `--tag-push`, which makes `release-plan.ts` publish regardless of what the guards would otherwise say — an unpublished-older version, an ambiguous registry response, none of it blocks a tag push, because a tag is a human saying "release this" (hub#841). The one thing a tag can't force is npm itself: republishing an **already-published** version still gets rejected by npm (the npm job goes red — expected), so a deliberate re-release only actually re-pushes the image. The merge path is the normal one; reach for a tag push when you need to bypass the guards on purpose.
 
@@ -42,18 +42,19 @@ skip — `release-plan.ts` refuses a stable unless npm already has a matching
 rc tag (version / changelog / lockfile only). `0.7.13`–`0.7.16` skipped this;
 the hook starts at `0.7.17-rc.1`. An explicit tag push still overrides.
 
-Feature work lands on `next`. The rc cut is a version bump on `next`, then
-`next` → `main`. That merge publishes `@rc`.
+Feature work lands on `next`. The rc cut is a version bump PR that targets
+`next` directly — merging it publishes `@rc`. No `next` → `main` hop needed
+just to cut an rc.
 
 ```sh
 git fetch && git checkout -b release/hub-X.Y.Z-rc.N origin/next
 # Bump ./package.json to X.Y.Z-rc.N + CHANGELOG.
 git commit -am "release: hub X.Y.Z-rc.N — <what shipped>"
 gh pr create --base next
-# After that merges: open next → main. That click publishes @rc.
+# Merging this PR publishes @rc.
 ```
 
-Merge the `next` → `main` PR. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
+Merge the release PR into `next`. CI takes over — watch the run at [Actions](https://github.com/ParachuteComputer/parachute-hub/actions). On success:
 - npm gets the new version with the appropriate dist-tag
 - ghcr gets a new image at `:vX.Y.Z` plus `:rc`, or `:stable` + `:latest`
 - a `vX.Y.Z` git tag is pushed as a record
@@ -133,7 +134,7 @@ There's no "unpublish" path for either npm (npm has a strict 72-hour unpublish p
 
 - **Workflow ran but nothing published**: the `plan` job decided there was nothing to do — read its log. `<pkg>@<version> is already on npm` means the version wasn't bumped. `plan` also warns (never fails) when commits sit on `main` that no published version contains; that warning is the cue to cut a release PR.
 - **`plan` failed with "refusing to guess" / "is OLDER than the current"**: an ambiguous npm response, or two release PRs merged out of version order so the merge would move a dist-tag backwards. Bump past the published version and re-merge.
-- **Workflow doesn't trigger at all**: for the merge path, confirm the merge landed on `main`. For a tag push, confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`; depcheck: `depcheck-v[0-9]+...`; door-contract: `door-contract-v[0-9]+...`).
+- **Workflow doesn't trigger at all**: for the merge path, confirm the merge landed on `next` or `main`, and that it actually touched one of the `paths` the workflow filters on (a `package.json` at the root or under `packages/{scope-guard,depcheck,door-contract}/`) — a merge that doesn't touch those paths never fires this workflow, by design. For a tag push, confirm the tag matches one of the patterns in `on.push.tags` (hub: `v[0-9]+...`; scope-guard: `scope-guard-v[0-9]+...`; depcheck: `depcheck-v[0-9]+...`; door-contract: `door-contract-v[0-9]+...`).
 - **`version mismatch` error in publish-npm**: tag path only — the relevant `package.json` version differs from the tag. Re-tag the correct commit, or fix the version in `package.json`.
 - **Image published with no `:vX.Y.Z` tag**: pre-hub#829 behaviour, where the image tags came from the ref (`main` on a merge run). Fixed by deriving every tag from `plan`'s `hub_version`.
 - **`npm ERR! 403 You do not have permission to publish`**: Trusted Publisher rule on npm doesn't match this workflow. Verify org/repo/workflow filename are exactly `ParachuteComputer` / `parachute-hub` / `release.yml`. If the workflow file was renamed, the rule needs updating on npm.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,9 +9,9 @@ This repo publishes FOUR npm packages on independent release cadences via [`.git
 | `@openparachute/depcheck` | `depcheck-v...` (e.g. `depcheck-v0.1.1`) | no |
 | `@openparachute/door-contract` | `door-contract-v...` (e.g. `door-contract-v0.6.0`) | no |
 
-**Merging a version bump to `next` or `main` is the release signal** (hub#790, `next` added so an rc cut no longer needs a `next`→`main` hop). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. `next` can only ever produce an rc or an idempotent no-op — `release-plan.ts` refuses a `latest`/stable publish unless a matching `-rc.*` is already on npm and the diff from that rc tag is a pure version/changelog/lockfile suffix-drop, which a fresh feature merge on `next` can never satisfy. Only `main` can promote to stable. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
+**Merging a version bump to `next` or `main` is the release signal** (hub#790, `next` added so an rc cut no longer needs a `next`→`main` hop). CI runs `bun run typecheck` + the four test suites once, then `scripts/release-plan.ts` compares each `package.json` against npm and publishes whatever is new. `next` can only ever produce an rc or an idempotent no-op — `release-plan.ts` refuses a `latest`/stable publish unless the trigger is a branch push of `main` (a write token can merge to `next` and can push tags; it cannot merge to `main`). On `main`, it further refuses a stable unless a matching `-rc.*` is already on npm and the diff from that rc tag is a pure version/changelog/lockfile suffix-drop. Nothing is tagged by hand — the `tag-record` job pushes `vX.Y.Z` afterwards as a record of what shipped.
 
-Pushing a tag is the explicit override: the `plan` job passes `--tag-push`, which makes `release-plan.ts` publish regardless of what the guards would otherwise say — an unpublished-older version, an ambiguous registry response, none of it blocks a tag push, because a tag is a human saying "release this" (hub#841). The one thing a tag can't force is npm itself: republishing an **already-published** version still gets rejected by npm (the npm job goes red — expected), so a deliberate re-release only actually re-pushes the image. The merge path is the normal one; reach for a tag push when you need to bypass the guards on purpose.
+Pushing an **rc** tag is the explicit override for registry guards: the `plan` job passes `--tag-push`, which makes `release-plan.ts` publish an rc regardless of an unpublished-older version or an ambiguous registry response (hub#841). A tag push of a **stable** is refused — stables publish from `main` only. The one thing a tag can't force is npm itself: republishing an **already-published** version still gets rejected by npm (the npm job goes red — expected), so a deliberate re-release of an rc only actually re-pushes the image. The merge path is the normal one.
 
 ## Version conventions
 
@@ -40,7 +40,7 @@ Always cut an **rc** first. Stable is a suffix-drop from that rc, never a
 skip — `release-plan.ts` refuses a stable unless npm already has a matching
 `X.Y.Z-rc.*`, and refuses again unless the tree is a suffix-drop from that
 rc tag (version / changelog / lockfile only). `0.7.13`–`0.7.16` skipped this;
-the hook starts at `0.7.17-rc.1`. An explicit tag push still overrides.
+the hook starts at `0.7.17-rc.1`. An explicit **rc** tag push still overrides the registry guards; a tag push of a stable does not.
 
 Feature work lands on `next`. The rc cut is a version bump PR that targets
 `next` directly — merging it publishes `@rc`. No `next` → `main` hop needed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.10",
+  "version": "0.7.18",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.8",
+  "version": "0.7.18-rc.9",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openparachute/hub",
-  "version": "0.7.18-rc.9",
+  "version": "0.7.18-rc.10",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
   "license": "AGPL-3.0",
   "publishConfig": {

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -21,15 +21,21 @@
  * version order. Merging rc.6 and then rc.5 would leave the `rc` dist-tag
  * pointing at rc.5 — older than what consumers already had — so an operator
  * installing `@rc` would silently DOWNGRADE. We refuse to move a dist-tag
- * backwards. (Re-publishing an older version deliberately is still possible
- * via an explicit tag push, which takes the tag branch below.)
+ * backwards. (Re-publishing an older **rc** deliberately is still possible
+ * via an explicit tag push, which takes the tag branch below. A tag push of
+ * a stable is refused — stables publish from `main` only.)
  *
  * **Stable that skipped rc.** 0.7.13 through 0.7.16 shipped `@latest` with
  * new code and no matching `X.Y.Z-rc.*`. Stable is a suffix-drop from an rc
  * of the same X.Y.Z, never a skip: `decidePublish` refuses a stable unless
  * npm already has that rc, and the CLI refuses again unless `git diff` from
  * the latest matching rc tag only touches version/changelog/lockfile paths.
- * An explicit tag push still overrides — a human saying "release this".
+ *
+ * **Stable from `next` or a tag push.** A write token can merge to `next`
+ * and can push tags; it cannot merge to `main`. So a stable version is
+ * published only when the trigger is a branch push of `main`. `isTagPush`
+ * still overrides the registry guards for **rc** versions (re-release, an
+ * older rc, an ambiguous registry). It does not override this gate.
  */
 
 import { appendFileSync } from "node:fs";
@@ -176,15 +182,28 @@ export function stablePromotionDiffArgs(rcTag: string): string[] {
 }
 
 /**
- * The decision. `isTagPush` short-circuits every check but the shape one — an
- * explicit tag is a human saying "release this", including a deliberate
- * re-release of something older.
+ * The decision. `isTagPush` short-circuits the registry guards for **rc**
+ * versions — an explicit rc tag is a human saying "release this", including
+ * a deliberate re-release of something older. It does **not** short-circuit
+ * the stable-from-main gate: a write token can push a tag, and that is not
+ * the same as merging to `main`.
  */
 export function decidePublish(
   version: string,
   registry: RegistryView | { ambiguous: true },
-  opts: { isTagPush?: boolean } = {},
+  opts: { isTagPush?: boolean; branch?: string } = {},
 ): PublishDecision {
+  // Stables publish from `main` only. Checked first so a tag push of
+  // `vX.Y.Z` (or a suffix-drop merged to `next`) cannot promote `@latest`.
+  if (distTagFor(version) !== "rc") {
+    const fromMain = !opts.isTagPush && opts.branch === "main";
+    if (!fromMain) {
+      return {
+        publish: false,
+        reason: `${version} is a stable version — stable promotions publish from main only (not next, not a tag push)`,
+      };
+    }
+  }
   if (opts.isTagPush) {
     return { publish: true, reason: `explicit tag push for ${version}` };
   }
@@ -346,6 +365,7 @@ if (import.meta.main) {
   const registry = await readRegistry(npmName, version);
   const decision = decidePublish(version, registry, {
     isTagPush: rest.includes("--tag-push"),
+    branch: process.env.GITHUB_REF_NAME,
   });
 
   if ("refuse" in decision) {

--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -282,7 +282,7 @@ export function unpublishedDrift(commitSubjects: readonly string[]): {
     drifted: true,
     count: commits.length,
     summary:
-      `${commits.length} commit(s) on main are NOT in any published version:\n` +
+      `${commits.length} commit(s) are NOT in any published version:\n` +
       commits.map((c) => `  - ${c}`).join("\n") +
       "\nOpen a release PR to ship them.",
   };
@@ -420,7 +420,7 @@ if (import.meta.main) {
           if (sum) {
             await Bun.write(
               sum,
-              `### Unpublished work on main\n\n\`\`\`\n${drift.summary}\n\`\`\`\n`,
+              `### Unpublished work\n\n\`\`\`\n${drift.summary}\n\`\`\`\n`,
               {
                 createPath: false,
               },

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -176,6 +176,123 @@ async function bearer(h: Harness, scopes: string[], sub?: string): Promise<strin
   return minted.token;
 }
 
+function jwtScope(req: Request): string {
+  const parts = (req.headers.get("authorization") ?? "").replace(/^Bearer\s+/i, "").split(".");
+  try {
+    const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
+      scope?: string;
+    };
+    return payload.scope ?? "";
+  } catch {
+    return "";
+  }
+}
+
+function toolsForMintedScope(scope: string): Array<{
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}> {
+  const verb = scope.includes(":admin") ? "admin" : scope.includes(":write") ? "write" : "read";
+  const read = [
+    "query-notes",
+    "list-tags",
+    "find-path",
+    "vault-info",
+    "doctor",
+    "request-attachment-download",
+    "read-attachment",
+  ];
+  const write = [...read, "create-note", "update-note", "delete-note", "request-attachment-upload"];
+  const admin = [
+    ...write,
+    "manage-token",
+    "update-tag",
+    "delete-tag",
+    "rename-tag",
+    "merge-tags",
+    "prune-schema",
+  ];
+  const names = verb === "admin" ? admin : verb === "write" ? write : read;
+  return names.map((name) => ({
+    name,
+    description: `${name} (vault MCP)`,
+    inputSchema: {
+      type: "object",
+      properties:
+        name === "query-notes"
+          ? {
+              search: { type: "string" },
+              sort: { type: "string" },
+              include_content: { type: "boolean" },
+              order_by: { type: "string" },
+              cursor: { type: "string" },
+            }
+          : {},
+    },
+  }));
+}
+
+function jsonRpcOk(value: unknown): Response {
+  return Response.json({ jsonrpc: "2.0", id: 1, result: value });
+}
+
+function mcpTextResult(payload: unknown): Response {
+  return jsonRpcOk({ content: [{ type: "text", text: JSON.stringify(payload, null, 2) }] });
+}
+
+interface VaultMcpCall {
+  url: string;
+  method: string;
+  rpc: { method?: string; params?: { name?: string; arguments?: Record<string, unknown> } };
+  scope: string;
+  vault: string;
+}
+
+async function routeVaultMcp(
+  input: string | URL | Request,
+  init: RequestInit | undefined,
+  hooks: {
+    onList?: (call: VaultMcpCall) => unknown | Response | Promise<unknown | Response>;
+    onCall?: (call: VaultMcpCall) => unknown | Response | Promise<unknown | Response>;
+    onRequest?: (call: VaultMcpCall) => void;
+  } = {},
+): Promise<Response> {
+  const req = input instanceof Request ? input : new Request(String(input), init);
+  const url = req.url;
+  let rpc: VaultMcpCall["rpc"] = {};
+  try {
+    rpc = JSON.parse(await req.text()) as VaultMcpCall["rpc"];
+  } catch {
+    rpc = {};
+  }
+  const call: VaultMcpCall = {
+    url,
+    method: req.method,
+    rpc,
+    scope: jwtScope(req),
+    vault: url.match(/\/vault\/([^/]+)\/mcp/)?.[1] ?? "",
+  };
+  hooks.onRequest?.(call);
+  if (rpc.method === "tools/list") {
+    const custom = await hooks.onList?.(call);
+    if (custom instanceof Response) return custom;
+    if (custom !== undefined) return jsonRpcOk(custom);
+    return jsonRpcOk({ tools: toolsForMintedScope(call.scope) });
+  }
+  if (rpc.method === "tools/call") {
+    const custom = await hooks.onCall?.(call);
+    if (custom instanceof Response) return custom;
+    if (custom !== undefined) {
+      if (custom && typeof custom === "object" && "content" in custom) return jsonRpcOk(custom);
+      return mcpTextResult(custom);
+    }
+    if (rpc.params?.name === "query-notes") return mcpTextResult([]);
+    return mcpTextResult({ ok: true });
+  }
+  return new Response("not mcp", { status: 404 });
+}
+
 function mcpDeps(
   h: Harness,
   extra: {
@@ -191,7 +308,7 @@ function mcpDeps(
     issuer: ISSUER,
     manifestPath: h.manifestPath,
     replay: h.replay,
-    ...(extra.fetchImpl ? { fetchImpl: extra.fetchImpl } : {}),
+    fetchImpl: extra.fetchImpl ?? ((input, init) => routeVaultMcp(input, init)),
     ...(extra.runCommand ? { runCommand: extra.runCommand } : {}),
   };
 }
@@ -426,26 +543,36 @@ describe("account MCP — initialize + tools", () => {
       );
       expect(init.status).toBe(200);
       const initBody = (await init.json()) as {
-        result: { serverInfo: { name: string }; protocolVersion: string };
+        result: { serverInfo: { name: string }; protocolVersion: string; instructions?: string };
       };
       expect(initBody.result.serverInfo.name).toBe("parachute-account");
       expect(initBody.result.protocolVersion).toBe("2025-11-25");
+      expect(initBody.result.instructions).toMatch(/union of what SOME covered vault/);
 
       const listed = await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h));
-      const listBody = (await listed.json()) as { result: { tools: Array<{ name: string }> } };
-      expect(listBody.result.tools.map((t) => t.name)).toEqual(
-        ACCOUNT_MCP_TOOLS.map((t) => t.name),
-      );
-      expect(listBody.result.tools.map((t) => t.name)).toEqual([
-        "list-vaults",
-        "create-vault",
-        "query-notes",
-        "create-note",
-        "update-note",
-        "grant-access",
-        "revoke-access",
-        "list-access",
-      ]);
+      const listBody = (await listed.json()) as {
+        result: {
+          tools: Array<{
+            name: string;
+            description?: string;
+            inputSchema?: { properties?: Record<string, unknown>; required?: string[] };
+          }>;
+        };
+      };
+      const names = listBody.result.tools.map((t) => t.name);
+      for (const n of ACCOUNT_MCP_TOOLS.map((t) => t.name)) expect(names).toContain(n);
+      expect(names).toContain("query-notes");
+      expect(names).toContain("create-note");
+      expect(names).toContain("delete-note");
+      expect(names).toContain("list-tags");
+      expect(names).toContain("manage-token");
+      expect(names[0]).toBe("list-vaults");
+      const qn = listBody.result.tools.find((t) => t.name === "query-notes");
+      expect(qn?.inputSchema?.properties).toHaveProperty("vault");
+      expect(qn?.inputSchema?.required ?? []).not.toContain("vault");
+      expect(qn?.description).toMatch(/Catalog caveat/);
+      const del = listBody.result.tools.find((t) => t.name === "delete-note");
+      expect(del?.inputSchema?.required).toContain("vault");
     } finally {
       h.cleanup();
     }
@@ -662,18 +789,14 @@ describe("account MCP — query-notes", () => {
     const h = await makeHarness();
     try {
       const token = await bearer(h, [HOST_ADMIN_SCOPE]);
-      const fetchImpl = async (input: string | URL | Request) => {
-        const href =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.href
-              : (input as Request).url;
-        if (href.includes("127.0.0.1:4101/vault/beta/")) {
-          return Response.json([{ id: "n-beta" }], { status: 200 });
-        }
-        throw new Error("personal is down");
-      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ vault, rpc }) => {
+            if (rpc.params?.name !== "query-notes") return undefined;
+            if (vault === "personal") throw new Error("personal is down");
+            return [{ id: "n-beta" }];
+          },
+        });
       const res = await handleAccountMcp(
         bearerReq(
           token,
@@ -713,20 +836,21 @@ describe("account MCP — query-notes", () => {
     }
   });
 
-  test("forwards sort, include_content, order_by, offset to vault REST", async () => {
+  test("forwards sort/include_content/cursor as MCP arguments, not REST query params", async () => {
     const h = await makeHarness();
     try {
-      const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request) => {
-        const href =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.href
-              : (input as Request).url;
-        seen.push(href);
-        return Response.json([{ id: "n-beta" }], { status: 200 });
-      };
+      const seen: Array<Record<string, unknown> | undefined> = [];
+      const urls: string[] = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onRequest: ({ url, rpc }) => {
+            if (rpc.method === "tools/call") urls.push(url);
+          },
+          onCall: ({ rpc }) => {
+            seen.push(rpc.params?.arguments);
+            return [{ id: "n-beta" }];
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -739,38 +863,42 @@ describe("account MCP — query-notes", () => {
               order_by: "updated_at",
               offset: 2,
               limit: 3,
+              cursor: "",
             },
           }),
         ),
         mcpDeps(h, { fetchImpl }),
       );
       expect(res.status).toBe(200);
+      expect(urls).toHaveLength(1);
+      expect(urls[0]).toContain("/vault/beta/mcp");
+      expect(urls[0]).not.toContain("/api/notes");
       expect(seen).toHaveLength(1);
-      const u = new URL(seen[0]!);
-      expect(u.searchParams.get("sort")).toBe("desc");
-      expect(u.searchParams.get("include_content")).toBe("true");
-      expect(u.searchParams.get("order_by")).toBe("updated_at");
-      expect(u.searchParams.get("offset")).toBe("2");
-      expect(u.searchParams.get("limit")).toBe("3");
+      expect(seen[0]).toMatchObject({
+        sort: "desc",
+        include_content: true,
+        order_by: "updated_at",
+        offset: 2,
+        limit: 3,
+        cursor: "",
+      });
+      expect(seen[0]).not.toHaveProperty("vault");
     } finally {
       h.cleanup();
     }
   });
 
-  test("omits unknown sort rather than forwarding it", async () => {
+  test("does not allowlist sort — unknown values ride through to vault MCP", async () => {
     const h = await makeHarness();
     try {
-      const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request) => {
-        const href =
-          typeof input === "string"
-            ? input
-            : input instanceof URL
-              ? input.href
-              : (input as Request).url;
-        seen.push(href);
-        return Response.json([], { status: 200 });
-      };
+      const seen: Array<Record<string, unknown> | undefined> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ rpc }) => {
+            seen.push(rpc.params?.arguments);
+            return [];
+          },
+        });
       await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -782,14 +910,13 @@ describe("account MCP — query-notes", () => {
         mcpDeps(h, { fetchImpl }),
       );
       expect(seen).toHaveLength(1);
-      const u = new URL(seen[0]!);
-      expect(u.searchParams.has("sort")).toBe(false);
+      expect(seen[0]?.sort).toBe("newest");
     } finally {
       h.cleanup();
     }
   });
 
-  test("tools/list advertises sort and include_content on query-notes", async () => {
+  test("tools/list advertises live query-notes schema plus injected vault", async () => {
     const h = await makeHarness();
     try {
       const token = await bearer(h, [HOST_ADMIN_SCOPE]);
@@ -799,7 +926,7 @@ describe("account MCP — query-notes", () => {
           tools: Array<{
             name: string;
             description?: string;
-            inputSchema?: { properties?: Record<string, unknown> };
+            inputSchema?: { properties?: Record<string, unknown>; required?: string[] };
           }>;
         };
       };
@@ -807,8 +934,9 @@ describe("account MCP — query-notes", () => {
       expect(qn?.inputSchema?.properties).toHaveProperty("sort");
       expect(qn?.inputSchema?.properties).toHaveProperty("include_content");
       expect(qn?.inputSchema?.properties).toHaveProperty("order_by");
-      expect(qn?.description).toMatch(/sort/);
-      expect(qn?.description).toMatch(/include_content/);
+      expect(qn?.inputSchema?.properties).toHaveProperty("vault");
+      expect(qn?.inputSchema?.required ?? []).not.toContain("vault");
+      expect(qn?.description).toMatch(/Catalog caveat/);
     } finally {
       h.cleanup();
     }
@@ -817,7 +945,8 @@ describe("account MCP — query-notes", () => {
   test("friend can query their assigned vault", async () => {
     const h = await makeHarness();
     try {
-      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, { onCall: () => [{ id: "n-beta" }] });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -838,20 +967,17 @@ describe("account MCP — query-notes", () => {
 });
 
 describe("account MCP — create-note", () => {
-  test("owner posts to the named vault with a write-audience mint", async () => {
+  test("owner forwards JSON-RPC to the named vault with a write-or-higher mint", async () => {
     const h = await makeHarness();
     try {
-      const seen: Array<{ url: string; method: string; scope: string }> = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const auth = req.headers.get("authorization") ?? "";
-        const parts = auth.replace(/^Bearer\s+/i, "").split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push({ url: req.url, method: req.method, scope: payload.scope ?? "" });
-        return Response.json({ id: "n1", path: "Log/hello" }, { status: 201 });
-      };
+      const seen: Array<{ url: string; method: string; scope: string; args: unknown }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ url, method, scope, rpc }) => {
+            seen.push({ url, method, scope, args: rpc.params?.arguments });
+            return { id: "n1", path: "Log/hello" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           OWNER_SECRET,
@@ -864,23 +990,24 @@ describe("account MCP — create-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n1");
+      ) as { id: string };
+      expect(out.id).toBe("n1");
       expect(seen).toHaveLength(1);
-      expect(seen[0]?.url).toContain("/vault/beta/api/notes");
+      expect(seen[0]?.url).toContain("/vault/beta/mcp");
+      expect(seen[0]?.url).not.toContain("/api/notes");
       expect(seen[0]?.method).toBe("POST");
-      expect(seen[0]?.scope).toBe("vault:beta:write");
+      expect(seen[0]?.scope).toMatch(/^vault:beta:(write|admin)$/);
+      expect(seen[0]?.args).toEqual({ path: "Log/hello", content: "hi" });
     } finally {
       h.cleanup();
     }
   });
 
-  test("read-role cannot create-note — write_not_granted, fetch never called", async () => {
+  test("read-role cannot create-note — Unknown tool, no tools/call", async () => {
     const h = await makeHarness();
     const readerSecret = hexToBytes("44".repeat(32));
     const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const reader = await createUser(h.db, "reader", "correct-horse-battery-staple", {
         allowMulti: true,
@@ -905,10 +1032,10 @@ describe("account MCP — create-note", () => {
           }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 201 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -916,7 +1043,7 @@ describe("account MCP — create-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -924,7 +1051,7 @@ describe("account MCP — create-note", () => {
 
   test("first-admin Bearer named beta:read cannot create-note on beta", async () => {
     const h = await makeHarness();
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const token = await bearer(h, ["account:self:vaults:beta:read"], h.ownerId);
       const res = await handleAccountMcp(
@@ -933,10 +1060,10 @@ describe("account MCP — create-note", () => {
           rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 201 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -944,7 +1071,7 @@ describe("account MCP — create-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -952,7 +1079,7 @@ describe("account MCP — create-note", () => {
 
   test("friend Bearer named beta:read cannot create-note even with write assignment", async () => {
     const h = await makeHarness();
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const token = await bearer(h, ["account:self:vaults:beta:read"], h.friendId);
       const res = await handleAccountMcp(
@@ -961,10 +1088,10 @@ describe("account MCP — create-note", () => {
           rpc("tools/call", { name: "create-note", arguments: { vault: "beta", content: "nope" } }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 201 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -972,7 +1099,7 @@ describe("account MCP — create-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: create-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -982,17 +1109,13 @@ describe("account MCP — create-note", () => {
     const h = await makeHarness();
     try {
       const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const parts = (req.headers.get("authorization") ?? "")
-          .replace(/^Bearer\s+/i, "")
-          .split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push(payload.scope ?? "");
-        return Response.json({ id: "n-friend" }, { status: 201 });
-      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ scope }) => {
+            seen.push(scope);
+            return { id: "n-friend" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -1005,10 +1128,9 @@ describe("account MCP — create-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n-friend");
-      expect(seen).toEqual(["vault:beta:write"]);
+      ) as { id: string };
+      expect(out.id).toBe("n-friend");
+      expect(seen).toEqual(["vault:beta:admin"]);
     } finally {
       h.cleanup();
     }
@@ -1057,11 +1179,13 @@ describe("account MCP — create-note", () => {
       const names = (
         (await listed.json()) as { result: { tools: Array<{ name: string }> } }
       ).result.tools.map((t) => t.name);
-      expect(names).toEqual(["list-vaults", "query-notes"]);
+      expect(names).toContain("list-vaults");
+      expect(names).toContain("query-notes");
       expect(names).not.toContain("create-note");
       expect(names).not.toContain("update-note");
       expect(names).not.toContain("grant-access");
       expect(names).not.toContain("create-vault");
+      expect(names).not.toContain("manage-token");
     } finally {
       h.cleanup();
     }
@@ -1069,25 +1193,17 @@ describe("account MCP — create-note", () => {
 });
 
 describe("account MCP — update-note", () => {
-  test("owner PATCHes the named vault with a write-audience mint", async () => {
+  test("owner forwards JSON-RPC update-note with a write-or-higher mint", async () => {
     const h = await makeHarness();
     try {
-      const seen: Array<{ url: string; method: string; scope: string; body: unknown }> = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const auth = req.headers.get("authorization") ?? "";
-        const parts = auth.replace(/^Bearer\s+/i, "").split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push({
-          url: req.url,
-          method: req.method,
-          scope: payload.scope ?? "",
-          body: JSON.parse(await req.text()),
+      const seen: Array<{ url: string; method: string; scope: string; args: unknown }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ url, method, scope, rpc }) => {
+            seen.push({ url, method, scope, args: rpc.params?.arguments });
+            return { id: "n1", path: "Log/hello", content: "there" };
+          },
         });
-        return Response.json({ id: "n1", path: "Log/hello", content: "there" }, { status: 200 });
-      };
       const res = await handleAccountMcp(
         nostrReq(
           OWNER_SECRET,
@@ -1100,29 +1216,30 @@ describe("account MCP — update-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string; content: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n1");
-      expect(out.note.content).toBe("there");
+      ) as { id: string; content: string };
+      expect(out.id).toBe("n1");
+      expect(out.content).toBe("there");
       expect(seen).toHaveLength(1);
-      expect(seen[0]?.url).toContain("/vault/beta/api/notes/n1");
-      expect(seen[0]?.method).toBe("PATCH");
-      expect(seen[0]?.scope).toBe("vault:beta:write");
-      expect(seen[0]?.body).toEqual({ content: "there" });
+      expect(seen[0]?.url).toContain("/vault/beta/mcp");
+      expect(seen[0]?.method).toBe("POST");
+      expect(seen[0]?.scope).toMatch(/^vault:beta:(write|admin)$/);
+      expect(seen[0]?.args).toEqual({ id: "n1", content: "there" });
     } finally {
       h.cleanup();
     }
   });
 
-  test("path id is encoded on the PATCH URL", async () => {
+  test("path id stays in MCP arguments, not a REST URL", async () => {
     const h = await makeHarness();
     try {
-      const seen: string[] = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        seen.push(req.url);
-        return Response.json({ id: "n1", path: "Log/hello" }, { status: 200 });
-      };
+      const seen: Array<{ url: string; args: Record<string, unknown> | undefined }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ url, rpc }) => {
+            seen.push({ url, args: rpc.params?.arguments });
+            return { id: "n1", path: "Log/hello" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           OWNER_SECRET,
@@ -1135,18 +1252,19 @@ describe("account MCP — update-note", () => {
       );
       expect(res.status).toBe(200);
       expect(seen).toHaveLength(1);
-      expect(seen[0]).toContain("/vault/beta/api/notes/Log%2Fhello");
-      expect(seen[0]).not.toContain("/api/notes/Log/hello");
+      expect(seen[0]?.url).toContain("/vault/beta/mcp");
+      expect(seen[0]?.url).not.toContain("/api/notes");
+      expect(seen[0]?.args).toEqual({ id: "Log/hello", append: " more", force: true });
     } finally {
       h.cleanup();
     }
   });
 
-  test("read-role cannot update-note — Unknown tool, fetch never called", async () => {
+  test("read-role cannot update-note — Unknown tool, no tools/call", async () => {
     const h = await makeHarness();
     const readerSecret = hexToBytes("66".repeat(32));
     const readerPub = bytesToHex(schnorr.getPublicKey(readerSecret));
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const reader = await createUser(h.db, "reader3", "correct-horse-battery-staple", {
         allowMulti: true,
@@ -1171,10 +1289,10 @@ describe("account MCP — update-note", () => {
           }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 200 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -1182,7 +1300,7 @@ describe("account MCP — update-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: update-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -1190,7 +1308,7 @@ describe("account MCP — update-note", () => {
 
   test("first-admin Bearer named beta:read cannot update-note on beta", async () => {
     const h = await makeHarness();
-    let fetched = 0;
+    const methods: string[] = [];
     try {
       const token = await bearer(h, ["account:self:vaults:beta:read"], h.ownerId);
       const res = await handleAccountMcp(
@@ -1202,10 +1320,10 @@ describe("account MCP — update-note", () => {
           }),
         ),
         mcpDeps(h, {
-          fetchImpl: async () => {
-            fetched += 1;
-            return Response.json({}, { status: 200 });
-          },
+          fetchImpl: (input, init) =>
+            routeVaultMcp(input, init, {
+              onRequest: ({ rpc }) => methods.push(rpc.method ?? ""),
+            }),
         }),
       );
       const body = (await res.json()) as {
@@ -1213,7 +1331,7 @@ describe("account MCP — update-note", () => {
       };
       expect(body.result?.isError).toBe(true);
       expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: update-note/);
-      expect(fetched).toBe(0);
+      expect(methods).toEqual(["tools/list"]);
     } finally {
       h.cleanup();
     }
@@ -1223,17 +1341,13 @@ describe("account MCP — update-note", () => {
     const h = await makeHarness();
     try {
       const seen: Array<{ method: string; scope: string }> = [];
-      const fetchImpl = async (input: string | URL | Request, init?: RequestInit) => {
-        const req = input instanceof Request ? input : new Request(String(input), init);
-        const parts = (req.headers.get("authorization") ?? "")
-          .replace(/^Bearer\s+/i, "")
-          .split(".");
-        const payload = JSON.parse(Buffer.from(parts[1] ?? "", "base64url").toString()) as {
-          scope?: string;
-        };
-        seen.push({ method: req.method, scope: payload.scope ?? "" });
-        return Response.json({ id: "n-friend", content: "edited" }, { status: 200 });
-      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ method, scope }) => {
+            seen.push({ method, scope });
+            return { id: "n-friend", content: "edited" };
+          },
+        });
       const res = await handleAccountMcp(
         nostrReq(
           FRIEND_SECRET,
@@ -1246,27 +1360,9 @@ describe("account MCP — update-note", () => {
       );
       const out = parseTool(
         (await res.json()) as { result: { content: Array<{ text: string }> } },
-      ) as { vault: string; note: { id: string } };
-      expect(out.vault).toBe("beta");
-      expect(out.note.id).toBe("n-friend");
-      expect(seen).toEqual([{ method: "PATCH", scope: "vault:beta:write" }]);
-    } finally {
-      h.cleanup();
-    }
-  });
-
-  test("missing id is invalid_id", async () => {
-    const h = await makeHarness();
-    try {
-      const res = await handleAccountMcp(
-        nostrReq(
-          OWNER_SECRET,
-          rpc("tools/call", { name: "update-note", arguments: { vault: "beta", content: "x" } }),
-        ),
-        mcpDeps(h),
-      );
-      const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
-      expect(body.error?.data?.error_type).toBe("invalid_id");
+      ) as { id: string };
+      expect(out.id).toBe("n-friend");
+      expect(seen).toEqual([{ method: "POST", scope: "vault:beta:admin" }]);
     } finally {
       h.cleanup();
     }
@@ -1287,6 +1383,199 @@ describe("account MCP — update-note", () => {
       );
       const body = (await res.json()) as { error?: { data?: { error_type?: string } } };
       expect(body.error?.data?.error_type).toBe("vault_not_covered");
+    } finally {
+      h.cleanup();
+    }
+  });
+});
+describe("account MCP — vault module proxy", () => {
+  test("schema-source is one tools/list POST to the highest-verb vault", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const lists: string[] = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onRequest: ({ vault, rpc }) => {
+            if (rpc.method === "tools/list") lists.push(vault);
+          },
+        });
+      await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h, { fetchImpl }));
+      expect(lists).toEqual(["beta"]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("schema-source falls back to the next covered vault when the highest-verb one is down", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const lists: string[] = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onList: ({ vault }) => {
+            lists.push(vault);
+            if (vault === "beta") throw new Error("beta down");
+            return { tools: toolsForMintedScope("vault:personal:admin") };
+          },
+        });
+      const listed = await handleAccountMcp(
+        bearerReq(token, rpc("tools/list")),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(lists).toEqual(["beta", "personal"]);
+      expect(names).toContain("query-notes");
+      expect(names).toContain("manage-token");
+      expect(names).toContain("list-vaults");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("schema-source all down degrades to hub-native only", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const fetchImpl = async () => {
+        throw new Error("all vaults down");
+      };
+      const listed = await handleAccountMcp(
+        bearerReq(token, rpc("tools/list")),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(listed.status).toBe(200);
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toEqual([
+        "list-vaults",
+        "create-vault",
+        "grant-access",
+        "revoke-access",
+        "list-access",
+      ]);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("no vaults installed: hub-native only, no fetch", async () => {
+    const h = await makeHarness([]);
+    let fetched = 0;
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const listed = await handleAccountMcp(
+        bearerReq(token, rpc("tools/list")),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return new Response("nope", { status: 500 });
+          },
+        }),
+      );
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toEqual(["list-vaults", "create-vault"]);
+      expect(fetched).toBe(0);
+      const queried = await handleAccountMcp(
+        bearerReq(token, rpc("tools/call", { name: "query-notes", arguments: {} })),
+        mcpDeps(h, {
+          fetchImpl: async () => {
+            fetched += 1;
+            return new Response("nope", { status: 500 });
+          },
+        }),
+      );
+      const body = (await queried.json()) as {
+        result?: { isError?: boolean; content?: Array<{ text?: string }> };
+      };
+      expect(body.result?.isError).toBe(true);
+      expect(body.result?.content?.[0]?.text).toMatch(/Unknown tool: query-notes/);
+      expect(fetched).toBe(0);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("list-tags and manage-token exist only because the live list included them", async () => {
+    const h = await makeHarness();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      const listed = await handleAccountMcp(bearerReq(token, rpc("tools/list")), mcpDeps(h));
+      const names = (
+        (await listed.json()) as { result: { tools: Array<{ name: string }> } }
+      ).result.tools.map((t) => t.name);
+      expect(names).toContain("list-tags");
+      expect(names).toContain("manage-token");
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("read-attachment image content is passed through, not stringified", async () => {
+    const h = await makeHarness();
+    try {
+      const image = {
+        content: [
+          { type: "image", data: "abc", mimeType: "image/png" },
+          { type: "text", text: '{"id":"att1"}' },
+        ],
+      };
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ rpc }) => {
+            if (rpc.params?.name === "read-attachment") return image;
+            return undefined;
+          },
+        });
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", {
+            name: "read-attachment",
+            arguments: { vault: "beta", attachment_id: "att1" },
+          }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      const body = (await res.json()) as {
+        result: { content: Array<{ type: string; data?: string; mimeType?: string }> };
+      };
+      expect(body.result.content[0]).toEqual({
+        type: "image",
+        data: "abc",
+        mimeType: "image/png",
+      });
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("delete-note forwards to vault MCP", async () => {
+    const h = await makeHarness();
+    try {
+      const seen: Array<{ name?: string; args?: Record<string, unknown> }> = [];
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, {
+          onCall: ({ rpc }) => {
+            seen.push({ name: rpc.params?.name, args: rpc.params?.arguments });
+            return { deleted: true };
+          },
+        });
+      const res = await handleAccountMcp(
+        nostrReq(
+          OWNER_SECRET,
+          rpc("tools/call", { name: "delete-note", arguments: { vault: "beta", id: "n1" } }),
+        ),
+        mcpDeps(h, { fetchImpl }),
+      );
+      expect(res.status).toBe(200);
+      expect(seen).toEqual([{ name: "delete-note", args: { id: "n1" } }]);
     } finally {
       h.cleanup();
     }
@@ -1453,7 +1742,8 @@ describe("account MCP — extra pins", () => {
         (await listed.json()) as { result: { content: Array<{ text: string }> } },
       ) as { vaults: Array<{ name: string }> };
       expect(payload.vaults.map((v) => v.name)).toEqual(["beta"]);
-      const fetchImpl = async () => Response.json([{ id: "n-beta" }], { status: 200 });
+      const fetchImpl = (input: string | URL | Request, init?: RequestInit) =>
+        routeVaultMcp(input, init, { onCall: () => [{ id: "n-beta" }] });
       const queried = await handleAccountMcp(
         nostrReq(
           readerSecret,

--- a/src/__tests__/nostr-http-auth.test.ts
+++ b/src/__tests__/nostr-http-auth.test.ts
@@ -4,26 +4,27 @@
  * Watch-fail: these tests signed against an unpatched verify (no replay
  * cache, no u/method bind) before the implementation landed.
  */
+import type { Database } from "bun:sqlite";
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
-import { schnorr } from "@noble/curves/secp256k1.js";
+import { createHash } from "node:crypto";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { createHash } from "node:crypto";
+import { schnorr } from "@noble/curves/secp256k1.js";
+import { requireScope } from "../admin-auth.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
-import type { Database } from "bun:sqlite";
 import { NOSTR_AUTH_KIND, type NostrEvent, nostrEventId } from "../nostr-event.ts";
 import {
   NIP98_MAX_SKEW_SECONDS,
   NostrReplayCache,
   authenticateNostrRequest,
   extractNostrEvent,
+  requestAbsoluteUrl,
   verifyNostrHttpEvent,
 } from "../nostr-http-auth.ts";
-import { requireScope } from "../admin-auth.ts";
-import { createUser } from "../users.ts";
 import { bindPubkeyFromHttpAuth, findPubkeyLink } from "../pubkey-links.ts";
 import { issuePubkeyChallenge, linkPubkey } from "../pubkey-links.ts";
+import { createUser } from "../users.ts";
 
 const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
 const bytesToHex = (bytes: Uint8Array): string => Buffer.from(bytes).toString("hex");
@@ -57,12 +58,14 @@ function reqFor(
   method: string,
   event: NostrEvent,
   body?: string,
+  extraHeaders?: Record<string, string>,
 ): Request {
   return new Request(url, {
     method,
     headers: {
       authorization: nostrHeader(event),
       ...(body !== undefined ? { "content-type": "application/json" } : {}),
+      ...extraHeaders,
     },
     ...(body !== undefined ? { body } : {}),
   });
@@ -88,17 +91,60 @@ describe("extractNostrEvent", () => {
   });
 });
 
+describe("requestAbsoluteUrl", () => {
+  test("loopback http is unchanged — no stored origin, no header rewrite", () => {
+    const req = new Request("http://127.0.0.1:1939/mcp", { method: "POST" });
+    expect(requestAbsoluteUrl(req)).toBe("http://127.0.0.1:1939/mcp");
+  });
+
+  test("X-Forwarded-Proto https upgrades the scheme on an http request URL", () => {
+    // Tonight's hole: Tailscale Serve terminates TLS and forwards HTTP.
+    // Hub sees http://uni.taildf9ce2.ts.net/mcp; the client signed https.
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp", {
+      method: "POST",
+      headers: { "x-forwarded-proto": "https" },
+    });
+    expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp");
+  });
+
+  test("keeps host/path/query from req.url — not X-Forwarded-Host", () => {
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp?x=1", {
+      method: "POST",
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "evil.example",
+      },
+    });
+    expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp?x=1");
+  });
+
+  test("direct https req.url is a no-op even without X-Forwarded-Proto", () => {
+    const req = new Request("https://uni.taildf9ce2.ts.net/mcp", { method: "POST" });
+    expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp");
+  });
+});
+
 describe("verifyNostrHttpEvent", () => {
   test("accepts a fresh GET with matching u and method", () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const replay = new NostrReplayCache();
     verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
   });
 
   test("rejects a replayed event id", () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const replay = new NostrReplayCache();
     verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay });
     expect(() => verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay })).toThrow(
@@ -114,8 +160,39 @@ describe("verifyNostrHttpEvent", () => {
       ],
     });
     expect(() =>
+      verifyNostrHttpEvent(reqFor("http://127.0.0.1:1939/api/me", "GET", event), event, {
+        replay: new NostrReplayCache(),
+      }),
+    ).toThrow(/u tag/);
+  });
+
+  test("accepts https u-tag when X-Forwarded-Proto says the client used TLS — tonight's hole", () => {
+    const publicUrl = "https://uni.taildf9ce2.ts.net/mcp";
+    const behindTls = "http://uni.taildf9ce2.ts.net/mcp";
+    const event = signEvent({
+      tags: [
+        ["u", publicUrl],
+        ["method", "POST"],
+      ],
+    });
+    verifyNostrHttpEvent(
+      reqFor(behindTls, "POST", event, undefined, { "x-forwarded-proto": "https" }),
+      event,
+      { replay: new NostrReplayCache() },
+    );
+  });
+
+  test("rejects the internal http u-tag on a TLS-terminated request", () => {
+    const behindTls = "http://uni.taildf9ce2.ts.net/mcp";
+    const event = signEvent({
+      tags: [
+        ["u", behindTls],
+        ["method", "POST"],
+      ],
+    });
+    expect(() =>
       verifyNostrHttpEvent(
-        reqFor("http://127.0.0.1:1939/api/me", "GET", event),
+        reqFor(behindTls, "POST", event, undefined, { "x-forwarded-proto": "https" }),
         event,
         { replay: new NostrReplayCache() },
       ),
@@ -124,7 +201,12 @@ describe("verifyNostrHttpEvent", () => {
 
   test("rejects method mismatch", () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "POST"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "POST"],
+      ],
+    });
     expect(() =>
       verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
     ).toThrow(/method tag/);
@@ -134,7 +216,10 @@ describe("verifyNostrHttpEvent", () => {
     const url = "http://127.0.0.1:1939/api/me";
     const event = signEvent({
       created_at: Math.floor(Date.now() / 1000) - (NIP98_MAX_SKEW_SECONDS + 5),
-      tags: [["u", url], ["method", "GET"]],
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
     });
     expect(() =>
       verifyNostrHttpEvent(reqFor(url, "GET", event), event, { replay: new NostrReplayCache() }),
@@ -192,7 +277,12 @@ describe("authenticateNostrRequest", () => {
       passwordChanged: true,
     });
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     await expect(
       authenticateNostrRequest(db, reqFor(url, "GET", event), {
         autoProvision: false,
@@ -222,7 +312,12 @@ describe("authenticateNostrRequest", () => {
     expect(linked.ok).toBe(true);
 
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
       autoProvision: false,
       replay: new NostrReplayCache(),
@@ -240,7 +335,12 @@ describe("authenticateNostrRequest", () => {
       passwordChanged: true,
     });
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
       autoProvision: true,
       replay: new NostrReplayCache(),
@@ -255,7 +355,12 @@ describe("authenticateNostrRequest", () => {
 
   test("auto-provision refuses when the hub has no owner yet", async () => {
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     await expect(
       authenticateNostrRequest(db, reqFor(url, "GET", event), {
         autoProvision: true,
@@ -286,7 +391,12 @@ describe("authenticateNostrRequest", () => {
       }).ok,
     ).toBe(true);
     const url = "http://127.0.0.1:1939/api/me";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     const principal = await authenticateNostrRequest(db, reqFor(url, "GET", event), {
       autoProvision: false,
       replay: new NostrReplayCache(),
@@ -299,11 +409,21 @@ describe("authenticateNostrRequest", () => {
       passwordChanged: true,
     });
     const url = "http://127.0.0.1:1939/api/users";
-    const event = signEvent({ tags: [["u", url], ["method", "GET"]] });
+    const event = signEvent({
+      tags: [
+        ["u", url],
+        ["method", "GET"],
+      ],
+    });
     process.env.PARACHUTE_NOSTR_AUTO_PROVISION = "1";
     try {
       await expect(
-        requireScope(db, reqFor(url, "GET", event), "parachute:host:admin", "http://127.0.0.1:1939"),
+        requireScope(
+          db,
+          reqFor(url, "GET", event),
+          "parachute:host:admin",
+          "http://127.0.0.1:1939",
+        ),
       ).rejects.toThrow(/parachute:host:admin/);
     } finally {
       delete process.env.PARACHUTE_NOSTR_AUTO_PROVISION;

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -72,7 +72,7 @@ describe("decidePublish", () => {
   });
 
   test("first-ever release of a package publishes", () => {
-    const d = decidePublish("0.1.0", { versionExists: false });
+    const d = decidePublish("0.1.0", { versionExists: false }, { branch: "main" });
     expect(d).toMatchObject({ publish: true });
   });
 
@@ -102,12 +102,12 @@ describe("decidePublish", () => {
   test("an ambiguous registry REFUSES rather than guessing", () => {
     // A false "not published" double-publishes; a false "published" drops a
     // release. Guessing is worse than failing loudly.
-    const d = decidePublish("0.7.9", { ambiguous: true });
+    const d = decidePublish("0.7.9", { ambiguous: true }, { branch: "main" });
     expect(d).toMatchObject({ refuse: true });
     expect("refuse" in d && d.reason).toMatch(/refusing to guess/);
   });
 
-  test("an explicit tag push overrides every check — a human said release this", () => {
+  test("an explicit rc tag push overrides the registry checks — a human said release this rc", () => {
     const d = decidePublish(
       "0.7.0-rc.1",
       {
@@ -119,53 +119,69 @@ describe("decidePublish", () => {
     expect(d).toMatchObject({ publish: true });
   });
 
-  test("a tag push even overrides ambiguity", () => {
-    const d = decidePublish("0.7.9", { ambiguous: true }, { isTagPush: true });
+  test("an rc tag push even overrides ambiguity", () => {
+    const d = decidePublish("0.7.9-rc.1", { ambiguous: true }, { isTagPush: true });
     expect(d).toMatchObject({ publish: true });
   });
 
   test("a stable without a matching rc is refused — 0.7.13 through 0.7.16 skipped this", () => {
     // Cutting @latest with new code and no rc of the same X.Y.Z is how
     // 0.7.13–0.7.16 shipped. Stable is a suffix-drop, never a skip.
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-      publishedVersions: ["0.7.16", "0.7.12-rc.2"],
-    });
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16", "0.7.12-rc.2"],
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ refuse: true });
     expect("refuse" in d && d.reason).toMatch(/0\.7\.17-rc/);
     expect("refuse" in d && d.reason).toMatch(/suffix-drop|Cut an rc first/i);
   });
 
   test("a stable whose only published rcs are a different X.Y.Z is still refused", () => {
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-      publishedVersions: ["0.7.16", "0.7.16-rc.1"],
-    });
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16", "0.7.16-rc.1"],
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ refuse: true });
   });
 
-  test("a stable with a matching rc publishes — suffix-drop is the only legal stable", () => {
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-      publishedVersions: ["0.7.16", "0.7.17-rc.1"],
-    });
+  test("a stable with a matching rc publishes from main — suffix-drop is the only legal stable", () => {
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+        publishedVersions: ["0.7.16", "0.7.17-rc.1"],
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ publish: true });
   });
 
   test("omitted publishedVersions still refuses a stable when latest already exists", () => {
     // Callers that forget to plumb the version list must not silently skip
     // the gate — that's how 0.7.13–0.7.16 would keep shipping.
-    const d = decidePublish("0.7.17", {
-      versionExists: false,
-      currentDistTagVersion: "0.7.16",
-    });
+    const d = decidePublish(
+      "0.7.17",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.16",
+      },
+      { branch: "main" },
+    );
     expect(d).toMatchObject({ refuse: true });
   });
 
-  test("tag-push still overrides the rc-required check", () => {
+  test("a tag push of a stable does NOT override the matching-rc check — stables publish from main only", () => {
     const d = decidePublish(
       "0.7.17",
       {
@@ -175,7 +191,46 @@ describe("decidePublish", () => {
       },
       { isTagPush: true },
     );
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/from main only/);
+  });
+
+  test("next skips a stable even when a matching rc exists — tonight's hole", () => {
+    // After 0.7.18-rc.9, next HEAD *is* that rc. A suffix-drop PR targeting
+    // next would pass matching-rc + the version/changelog-only diff. This
+    // gate is what stops it from publishing @latest.
+    const d = decidePublish(
+      "0.7.18",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.17",
+        publishedVersions: ["0.7.17", "0.7.18-rc.9"],
+      },
+      { branch: "next" },
+    );
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/from main only/);
+  });
+
+  test("next still publishes an rc", () => {
+    const d = decidePublish(
+      "0.7.18-rc.9",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.7.18-rc.8",
+      },
+      { branch: "next" },
+    );
     expect(d).toMatchObject({ publish: true });
+  });
+
+  test("a stable with no branch is refused — fail closed, don't guess the trigger", () => {
+    const d = decidePublish("0.7.18", {
+      versionExists: false,
+      publishedVersions: ["0.7.18-rc.9"],
+    });
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/from main only/);
   });
 });
 
@@ -483,14 +538,16 @@ describe("release.yml image tags (hub#829)", () => {
 });
 
 /**
- * The tag-push override (hub#841).
+ * The rc tag-push override (hub#841).
  *
- * `decidePublish`'s `isTagPush` short-circuit is unit-tested above, but
- * unreachable unless the workflow actually passes `--tag-push` on a tag
- * push. That was the bug: the `plan` steps never passed it, so the flag path
- * was dead code and a stale comment claimed otherwise. Assert the wiring
- * directly on the YAML, same rationale as the hub#829 block below — a
- * `run:` string is otherwise only exercised by shipping a release.
+ * `decidePublish`'s `isTagPush` short-circuit (rc versions only) is
+ * unit-tested above, but unreachable unless the workflow actually passes
+ * `--tag-push` on a tag push. That was the bug: the `plan` steps never
+ * passed it, so the flag path was dead code and a stale comment claimed
+ * otherwise. Assert the wiring directly on the YAML, same rationale as the
+ * hub#829 block below — a `run:` string is otherwise only exercised by
+ * shipping a release. Stables are refused even with this flag; the wiring
+ * is still required so an rc tag-push reaches the short-circuit.
  */
 describe("release.yml tag-push override (hub#841)", () => {
   const workflow = readFileSync(
@@ -508,6 +565,20 @@ describe("release.yml tag-push override (hub#841)", () => {
     ]) {
       expect(workflow).toContain(`${cmd} ${flag}`);
     }
+  });
+
+  test("publish jobs consult plan even on a tag push — a tag is not a bypass of the stable-from-main gate", () => {
+    // The hole: `github.ref_type == 'tag' && <prefix>` without consulting
+    // plan published a stable from a write-token tag push. Both npm and
+    // ghcr used that shape.
+    const oldBypass =
+      "(github.ref_type == 'tag' && (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-'))) || (github.ref_type != 'tag' && needs.plan.outputs.hub == 'true')";
+    expect(workflow).not.toContain(oldBypass);
+    const gated =
+      "needs.plan.outputs.hub == 'true' && (github.ref_type != 'tag' || (!startsWith(github.ref_name, 'scope-guard-') && !startsWith(github.ref_name, 'depcheck-') && !startsWith(github.ref_name, 'door-contract-')))";
+    expect(workflow).toContain(gated);
+    // Two jobs share it: publish-hub-npm and publish-image.
+    expect(workflow.split(gated).length - 1).toBe(2);
   });
 });
 

--- a/src/account-mcp-backend.ts
+++ b/src/account-mcp-backend.ts
@@ -1,0 +1,318 @@
+/**
+ * Module backends for the account MCP — live-list + JSON-RPC forward.
+ *
+ * Vault is the first implementation. A second module (scribe, surface, …)
+ * is another object of this shape, not another REST clone.
+ *
+ * OPEN (module #2): hub-native names win against a backend (filtered here).
+ * Two BACKENDS defining the same tool name have no resolution rule yet —
+ * leave that until a second backend actually exists.
+ *
+ * Schema source: one covered vault's live `tools/list` stands in for all
+ * installed vaults. Assumption — same vault-core version across vaults
+ * (`parachute upgrade` keeps them together). Candidates are tried in
+ * highest-verb order; only if every covered vault is down do we degrade
+ * to hub-native only.
+ */
+import { COMPOSED_VERB_RANK, type ComposedVaultVerb } from "@openparachute/door-contract";
+import type { AccountVaultMeta } from "./account-api.ts";
+import {
+  ACCOUNT_MCP_CLIENT_ID,
+  type AccountToolContext,
+  AccountToolError,
+  FANOUT_TIMEOUT_MS,
+  FANOUT_TOKEN_TTL_SECONDS,
+  HUB_NATIVE_TOOL_NAMES,
+  installedVaults,
+  resolveCoverage,
+  verbForVault,
+} from "./account-mcp.ts";
+import { signAccessToken } from "./jwt-sign.ts";
+
+export interface ListedMcpTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+export interface ModuleMcpBackend {
+  readonly id: string;
+  listTools(ctx: AccountToolContext): Promise<readonly ListedMcpTool[]>;
+  callTool(name: string, args: Record<string, unknown>, ctx: AccountToolContext): Promise<unknown>;
+}
+
+const UNION_CATALOG_LINE =
+  "Catalog caveat: advertised from one covered vault's live list (highest verb this connection holds). Calling this against a different covered vault may return Unknown tool if that vault grants a lower verb.";
+
+const VAULT_FIELD_DESCRIPTION =
+  "Target vault by name. Omit on query-notes to fan the query across every reachable vault; required on every other vault-shaped tool.";
+
+const listCache = new WeakMap<AccountToolContext, Promise<readonly ListedMcpTool[]>>();
+
+export function vaultMcpUrl(vault: AccountVaultMeta): string {
+  const origin =
+    typeof vault.port === "number" && vault.port > 0
+      ? `http://127.0.0.1:${vault.port}`
+      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
+  return `${origin.replace(/\/$/, "")}/vault/${vault.name}/mcp`;
+}
+
+export async function mintVaultMcpToken(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  verb: ComposedVaultVerb,
+): Promise<string> {
+  const sign = ctx.signToken ?? signAccessToken;
+  const minted = await sign(ctx.db, {
+    sub: ctx.principal.userId,
+    scopes: [`vault:${vault.name}:${verb}`],
+    audience: `vault.${vault.name}`,
+    clientId: ACCOUNT_MCP_CLIENT_ID,
+    issuer: ctx.issuer,
+    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    vaultScope: [vault.name],
+    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
+  });
+  return minted.token;
+}
+
+async function parseJsonRpcResult(res: Response, vaultName: string): Promise<unknown> {
+  const text = await res.text();
+  if (!res.ok) {
+    let detail = `vault responded ${res.status}`;
+    try {
+      const body = JSON.parse(text) as { error?: unknown; message?: unknown };
+      if (typeof body.error === "string") detail = body.error;
+      else if (typeof body.message === "string") detail = body.message;
+    } catch {
+      // keep status-only detail
+    }
+    throw new AccountToolError("vault_error", detail, { status: res.status, vault: vaultName });
+  }
+  let parsed: { result?: unknown; error?: { message?: unknown; code?: unknown } };
+  const trimmed = text.trim();
+  if (trimmed.startsWith("event:") || trimmed.includes("\ndata:")) {
+    const dataLines = [...text.matchAll(/^data:\s*(.*)$/gm)].map((m) => m[1] ?? "");
+    const last = dataLines.at(-1);
+    if (!last) {
+      throw new AccountToolError("vault_error", "empty SSE MCP response", { vault: vaultName });
+    }
+    parsed = JSON.parse(last) as typeof parsed;
+  } else {
+    parsed = JSON.parse(text) as typeof parsed;
+  }
+  if (parsed.error) {
+    const msg = typeof parsed.error.message === "string" ? parsed.error.message : "vault MCP error";
+    throw new AccountToolError("vault_error", msg, {
+      vault: vaultName,
+      ...(parsed.error.code !== undefined ? { code: parsed.error.code } : {}),
+    });
+  }
+  return parsed.result;
+}
+
+export async function postVaultMcp(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  verb: ComposedVaultVerb,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<unknown> {
+  const token = await mintVaultMcpToken(ctx, vault, verb);
+  const fetchImpl = ctx.fetchImpl ?? fetch;
+  const res = await fetchImpl(vaultMcpUrl(vault), {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${token}`,
+      accept: "application/json, text/event-stream",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 1,
+      method,
+      ...(params ? { params } : {}),
+    }),
+    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
+  });
+  return parseJsonRpcResult(res, vault.name);
+}
+
+function injectVaultSelector(tool: {
+  name: string;
+  description?: unknown;
+  inputSchema?: unknown;
+}): ListedMcpTool {
+  const rawSchema =
+    tool.inputSchema && typeof tool.inputSchema === "object"
+      ? (tool.inputSchema as Record<string, unknown>)
+      : { type: "object" };
+  const properties = {
+    ...((rawSchema.properties && typeof rawSchema.properties === "object"
+      ? rawSchema.properties
+      : {}) as Record<string, unknown>),
+    vault: { type: "string", description: VAULT_FIELD_DESCRIPTION },
+  };
+  const schema: Record<string, unknown> = { ...rawSchema, properties };
+  if (tool.name !== "query-notes") {
+    const req = Array.isArray(schema.required)
+      ? schema.required.filter((x): x is string => typeof x === "string")
+      : [];
+    if (!req.includes("vault")) schema.required = [...req, "vault"];
+  }
+  const base = typeof tool.description === "string" ? tool.description : tool.name;
+  const description = base.includes("Catalog caveat:") ? base : `${base}\n\n${UNION_CATALOG_LINE}`;
+  return { name: tool.name, description, inputSchema: schema };
+}
+
+/**
+ * Covered vaults, highest verb first, then name. Schema-source tries this
+ * order and takes the first `tools/list` that succeeds.
+ */
+export function schemaSourceCandidates(
+  ctx: AccountToolContext,
+  vaults: readonly AccountVaultMeta[],
+): AccountVaultMeta[] {
+  return [...vaults].sort((a, b) => {
+    const rank =
+      COMPOSED_VERB_RANK[verbForVault(ctx, b.name)] - COMPOSED_VERB_RANK[verbForVault(ctx, a.name)];
+    if (rank !== 0) return rank;
+    return a.name.localeCompare(b.name);
+  });
+}
+
+async function listVaultToolsUncached(ctx: AccountToolContext): Promise<readonly ListedMcpTool[]> {
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+  if (coverage.vaults.length === 0) return [];
+  for (const vault of schemaSourceCandidates(ctx, coverage.vaults)) {
+    try {
+      const result = await postVaultMcp(ctx, vault, verbForVault(ctx, vault.name), "tools/list");
+      const tools =
+        result && typeof result === "object" && Array.isArray((result as { tools?: unknown }).tools)
+          ? (result as { tools: unknown[] }).tools
+          : null;
+      if (!tools) continue;
+      return tools
+        .filter(
+          (t): t is { name: string; description?: unknown; inputSchema?: unknown } =>
+            !!t && typeof t === "object" && typeof (t as { name?: unknown }).name === "string",
+        )
+        .filter((t) => !HUB_NATIVE_TOOL_NAMES.has(t.name))
+        .map(injectVaultSelector);
+    } catch {
+      // Try the next covered vault (highest-verb first). Empty catch continues.
+    }
+  }
+  return [];
+}
+
+export function listVaultModuleTools(ctx: AccountToolContext): Promise<readonly ListedMcpTool[]> {
+  let pending = listCache.get(ctx);
+  if (!pending) {
+    pending = listVaultToolsUncached(ctx);
+    listCache.set(ctx, pending);
+  }
+  return pending;
+}
+
+function coveredVault(ctx: AccountToolContext, raw: unknown): AccountVaultMeta {
+  if (typeof raw !== "string" || raw.length === 0) {
+    throw new AccountToolError("invalid_vault", "vault is required.");
+  }
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+  const wanted = raw.toLowerCase();
+  const hit = coverage.vaults.find((v) => v.name === wanted);
+  if (!hit) {
+    throw new AccountToolError(
+      "vault_not_covered",
+      `Vault "${raw}" is not among the vaults this connection can reach.`,
+    );
+  }
+  return hit;
+}
+
+function stripVaultArg(args: Record<string, unknown>): Record<string, unknown> {
+  const { vault: _vault, ...rest } = args;
+  return rest;
+}
+
+function notesFromMcpResult(result: unknown): unknown {
+  if (!result || typeof result !== "object") {
+    throw new Error("vault MCP result was not an object");
+  }
+  const rec = result as { isError?: unknown; content?: Array<{ type?: unknown; text?: unknown }> };
+  if (rec.isError === true) {
+    const text = rec.content?.find((c) => c.type === "text")?.text;
+    throw new Error(typeof text === "string" ? text : "query failed");
+  }
+  const text = rec.content?.find((c) => c.type === "text")?.text;
+  if (typeof text !== "string") throw new Error("vault MCP result had no text content");
+  return JSON.parse(text) as unknown;
+}
+
+async function queryOneVaultMcp(
+  ctx: AccountToolContext,
+  vault: AccountVaultMeta,
+  args: Record<string, unknown>,
+): Promise<{ vault: string; notes: unknown } | { vault: string; error: string }> {
+  try {
+    const result = await postVaultMcp(ctx, vault, "read", "tools/call", {
+      name: "query-notes",
+      arguments: args,
+    });
+    return { vault: vault.name, notes: notesFromMcpResult(result) };
+  } catch (err) {
+    return {
+      vault: vault.name,
+      error: err instanceof Error ? err.message : "query failed",
+    };
+  }
+}
+
+async function queryNotesOverlay(
+  args: Record<string, unknown>,
+  ctx: AccountToolContext,
+): Promise<{
+  vaults_queried: string[];
+  results: Array<{ vault: string; notes?: unknown; error?: string }>;
+}> {
+  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
+  let targets = coverage.vaults;
+  if (typeof args.vault === "string" && args.vault.length > 0) {
+    targets = [coveredVault(ctx, args.vault)];
+  }
+  const stripped = stripVaultArg(args);
+  const settled = await Promise.allSettled(targets.map((v) => queryOneVaultMcp(ctx, v, stripped)));
+  return {
+    vaults_queried: targets.map((v) => v.name),
+    results: settled.map((s, i) =>
+      s.status === "fulfilled"
+        ? s.value
+        : {
+            vault: targets[i]!.name,
+            error: s.reason instanceof Error ? s.reason.message : "query failed",
+          },
+    ),
+  };
+}
+
+export async function callVaultModuleTool(
+  name: string,
+  args: Record<string, unknown>,
+  ctx: AccountToolContext,
+): Promise<unknown> {
+  if (name === "query-notes") return queryNotesOverlay(args, ctx);
+
+  const hit = coveredVault(ctx, args.vault);
+  const verb = verbForVault(ctx, hit.name);
+  return postVaultMcp(ctx, hit, verb, "tools/call", {
+    name,
+    arguments: stripVaultArg(args),
+  });
+}
+
+export const vaultModuleBackend: ModuleMcpBackend = {
+  id: "vault",
+  listTools: listVaultModuleTools,
+  callTool: callVaultModuleTool,
+};

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -21,6 +21,7 @@
 import type { Database } from "bun:sqlite";
 import { ACCOUNT_VAULTS_UNNARROWED } from "@openparachute/door-contract";
 import type { AccountApiDeps } from "./account-api.ts";
+import { callVaultModuleTool, listVaultModuleTools } from "./account-mcp-backend.ts";
 import {
   type AccountMcpPrincipal,
   type AccountToolContext,
@@ -256,6 +257,12 @@ async function authenticate(
   return authenticateBearer(db, req, deps.knownIssuers ?? [deps.issuer]);
 }
 
+function isMcpToolResult(value: unknown): value is { content: unknown[] } {
+  return (
+    !!value && typeof value === "object" && Array.isArray((value as { content?: unknown }).content)
+  );
+}
+
 async function handleToolCall(
   id: JsonRpcId,
   params: Record<string, unknown> | undefined,
@@ -263,15 +270,35 @@ async function handleToolCall(
 ): Promise<JsonRpcMessage> {
   const name = typeof params?.name === "string" ? params.name : "";
   const args = (params?.arguments ?? {}) as Record<string, unknown>;
-  const tool = toolsForPrincipal(ctx).find((t) => t.name === name);
-  if (!tool) {
+  const hub = toolsForPrincipal(ctx).find((t) => t.name === name);
+  if (hub) {
+    try {
+      const out = await hub.execute(args, ctx);
+      return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+    } catch (err) {
+      if (err instanceof AccountToolError) {
+        return rpcError(id, INVALID_PARAMS, err.message, {
+          error_type: err.errorType,
+          ...err.extra,
+        });
+      }
+      const message = err instanceof Error ? err.message : "Unknown error";
+      return result(id, { content: [{ type: "text", text: `Error: ${message}` }], isError: true });
+    }
+  }
+  const vaultTools = await listVaultModuleTools(ctx);
+  if (!vaultTools.some((t) => t.name === name)) {
     return result(id, {
       content: [{ type: "text", text: `Unknown tool: ${name}` }],
       isError: true,
     });
   }
   try {
-    const out = await tool.execute(args, ctx);
+    const out = await callVaultModuleTool(name, args, ctx);
+    if (name === "query-notes") {
+      return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
+    }
+    if (isMcpToolResult(out)) return result(id, out);
     return result(id, { content: [{ type: "text", text: JSON.stringify(out, null, 2) }] });
   } catch (err) {
     if (err instanceof AccountToolError) {
@@ -282,15 +309,27 @@ async function handleToolCall(
   }
 }
 
+async function listedTools(
+  ctx: AccountToolContext,
+): Promise<Array<{ name: string; description: string; inputSchema: Record<string, unknown> }>> {
+  const hub = toolsForPrincipal(ctx).map((t) => ({
+    name: t.name,
+    description: t.description,
+    inputSchema: t.inputSchema,
+  }));
+  const vault = await listVaultModuleTools(ctx);
+  return [...hub, ...vault];
+}
+
 function instructions(): string {
   return (
     "The Parachute hub account MCP — one connection across the vaults this key or token can use. " +
-    "Use list-vaults to see them, create-vault to add one (hub owner / account write), " +
-    "query-notes to search across them (omit `vault` to fan out, pass it to target one; " +
-    "default oldest-first preview — pass sort=desc and include_content=true for latest bodies), " +
-    "create-note / update-note to write in one vault (`vault` is required). " +
-    "grant-access / revoke-access / list-access give a Nostr pubkey a vault (role read|write) " +
-    "if you can admin that vault. tools/list hides tools you cannot call."
+    "Hub-native: list-vaults, create-vault (owner / account write), grant-access / revoke-access / " +
+    "list-access (if you can admin a vault). Everything else is the vault MCP catalog, live-listed, " +
+    "with a `vault` selector injected (omit on query-notes to fan out; required on every other vault tool). " +
+    "The vault-shaped catalog is a union of what SOME covered vault supports at the highest verb this " +
+    "connection holds — a listed tool may be Unknown against a different vault where this connection " +
+    "holds a lower verb. tools/list hides tools you cannot call on any covered vault."
   );
 }
 
@@ -311,13 +350,7 @@ async function handleOne(m: JsonRpcMessage, ctx: AccountToolContext): Promise<Js
         });
       }
       case "tools/list":
-        return result(id, {
-          tools: toolsForPrincipal(ctx).map((t) => ({
-            name: t.name,
-            description: t.description,
-            inputSchema: t.inputSchema,
-          })),
-        });
+        return result(id, { tools: await listedTools(ctx) });
       case "tools/call":
         return await handleToolCall(id, params, ctx);
       case "ping":

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -2,13 +2,11 @@
  * Account-level MCP tools for the self-host hub — the payload behind
  * `/account/mcp`.
  *
- * Cloud's twin lives in the identity worker (`account-mcp.ts`). Coverage tools
- * (list-vaults, create-vault, query-notes) plus hub-only grant-access /
- * revoke-access / list-access (pubkey → one `user_vaults` row). create-note /
- * update-note write one vault: `vault` is required, write is checked per call,
- * a 60s `vault:<name>:write` mint fans to REST (POST /api/notes, PATCH
- * /api/notes/:id). Cloud grants are D1-ownership shaped, not `user_vaults`.
- * Coverage is hub-shaped:
+ * Hub-native tools live here (list-vaults, create-vault, grant/revoke/
+ * list-access). Vault-shaped tools are a live `tools/list` + JSON-RPC
+ * proxy (`account-mcp-backend.ts`) onto `/vault/<name>/mcp` — not REST
+ * clones. Cloud's twin in the identity worker is still a REST facade and
+ * is out of this cut. Coverage is hub-shaped:
  *
  *   - Bearer is the cloud-shaped connection grant: `account:self:vaults`
  *     (legacy blanket / narrowed) or composed `account:self:vaults:*:<verb>`,
@@ -18,9 +16,9 @@
  *     else → `user_vaults` ∩ services.json (fail-closed; read verb required).
  *     Auto-provisioned key-only users have no rows → empty list, no create.
  *
- * query-notes fans out through a 60s `vault:<name>:read` mint, the same
- * authority `account-usage.ts` already uses for the friend home tiles. A
- * failed vault becomes that vault's `{ vault, error }` — never a whole-call
+ * query-notes (the one account overlay) fans out through a 60s
+ * `vault:<name>:read` mint to each vault's MCP `query-notes`. A failed
+ * vault becomes that vault's `{ vault, error }` — never a whole-call
  * failure.
  */
 import type { Database } from "bun:sqlite";
@@ -41,20 +39,17 @@ import {
   listAccess,
   revokeAccess,
 } from "./grant-access.ts";
-import { signAccessToken } from "./jwt-sign.ts";
+import type { SignAccessTokenOpts } from "./jwt-sign.ts";
 import { getUserById, isFirstAdmin, vaultVerbsForUserVault } from "./users.ts";
 
 /** Hub account sentinel — account ≡ box. */
 export const HUB_ACCOUNT_ID = "self";
 
-/** Per-vault timeout for the query-notes fan-out. */
+/** Per-vault timeout for MCP JSON-RPC forwards and query-notes fan-out. */
 export const FANOUT_TIMEOUT_MS = 10_000;
 
-/** Per-vault `limit` ceiling on a fan-out query. */
-export const MAX_NOTES_LIMIT = 100;
-
-const ACCOUNT_MCP_CLIENT_ID = "parachute-account";
-const FANOUT_TOKEN_TTL_SECONDS = 60;
+export const ACCOUNT_MCP_CLIENT_ID = "parachute-account";
+export const FANOUT_TOKEN_TTL_SECONDS = 60;
 
 export type AccountMcpAuthKind = "bearer" | "nostr";
 
@@ -105,7 +100,7 @@ export interface AccountToolContext {
     stderr: string;
   }>;
   fetchImpl?: (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
-  signToken?: typeof signAccessToken;
+  signToken?: (db: Database, opts: SignAccessTokenOpts) => Promise<{ token: string }>;
 }
 
 export interface AccountMcpTool {
@@ -213,7 +208,7 @@ export function resolveCoverage(
   return { covered: "listed", vaults, names: vaults.map((v) => v.name), create };
 }
 
-function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
+export function installedVaults(ctx: AccountToolContext): AccountVaultMeta[] {
   return listVaultsWithMeta(ctx.manifestPath, ctx.issuer);
 }
 
@@ -248,6 +243,13 @@ export function canWriteVault(
   }
   if (isUnrestricted(db, principal)) return true;
   return vaultVerbsForUserVault(db, principal.userId, vaultName)?.includes("write") === true;
+}
+
+/** Highest verb this principal actually holds on `vaultName`. */
+export function verbForVault(ctx: AccountToolContext, vaultName: string): ComposedVaultVerb {
+  if (callerCanAdminVault(ctx.db, ctx.principal, vaultName)) return "admin";
+  if (canWriteVault(ctx.db, ctx.principal, vaultName)) return "write";
+  return "read";
 }
 
 const listVaultsTool: AccountMcpTool = {
@@ -311,371 +313,6 @@ const createVaultTool: AccountMcpTool = {
       throw new AccountToolError("vault_taken", "That vault name is already taken.");
     }
     return { name: provisioned.entry.name, url: provisioned.entry.url };
-  },
-};
-
-type VaultQueryEntry = { vault: string; notes: unknown } | { vault: string; error: string };
-
-function buildNotesQuery(args: Record<string, unknown>): string {
-  const p = new URLSearchParams();
-  if (typeof args.search === "string" && args.search.length > 0) p.set("search", args.search);
-  const rawTags = Array.isArray(args.tag)
-    ? args.tag
-    : typeof args.tag === "string"
-      ? [args.tag]
-      : [];
-  for (const t of rawTags) if (typeof t === "string" && t.length > 0) p.append("tag", t);
-  if (args.metadata && typeof args.metadata === "object")
-    p.set("metadata", JSON.stringify(args.metadata));
-  const rawLimit =
-    typeof args.limit === "number"
-      ? args.limit
-      : typeof args.limit === "string"
-        ? Number.parseInt(args.limit, 10)
-        : undefined;
-  if (rawLimit !== undefined && Number.isFinite(rawLimit)) {
-    const clamped = Math.min(Math.max(1, Math.floor(rawLimit)), MAX_NOTES_LIMIT);
-    p.set("limit", String(clamped));
-  }
-  // Vault REST defaults: created_at ASC, lean ~120-char preview. Forward the
-  // params that make "latest notes with bodies" expressible. Unknown sort is
-  // dropped rather than 400'd so a hallucinated value does not fail the fan-out.
-  if (args.sort === "asc" || args.sort === "desc") p.set("sort", args.sort);
-  if (typeof args.order_by === "string" && args.order_by.length > 0) {
-    p.set("order_by", args.order_by);
-  }
-  if (args.include_content === true || args.include_content === "true") {
-    p.set("include_content", "true");
-  } else if (args.include_content === false || args.include_content === "false") {
-    p.set("include_content", "false");
-  }
-  const rawOffset =
-    typeof args.offset === "number"
-      ? args.offset
-      : typeof args.offset === "string"
-        ? Number.parseInt(args.offset, 10)
-        : undefined;
-  if (rawOffset !== undefined && Number.isFinite(rawOffset) && rawOffset >= 0) {
-    p.set("offset", String(Math.floor(rawOffset)));
-  }
-  return p.toString();
-}
-
-async function queryOneVault(
-  ctx: AccountToolContext,
-  vault: AccountVaultMeta,
-  args: Record<string, unknown>,
-): Promise<VaultQueryEntry> {
-  const sign = ctx.signToken ?? signAccessToken;
-  const fetchImpl = ctx.fetchImpl ?? fetch;
-  const qs = buildNotesQuery(args);
-  const minted = await sign(ctx.db, {
-    sub: ctx.principal.userId,
-    scopes: [`vault:${vault.name}:read`],
-    audience: `vault.${vault.name}`,
-    clientId: ACCOUNT_MCP_CLIENT_ID,
-    issuer: ctx.issuer,
-    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
-    vaultScope: [vault.name],
-    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
-  });
-  const origin =
-    typeof vault.port === "number" && vault.port > 0
-      ? `http://127.0.0.1:${vault.port}`
-      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
-  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}/api/notes${qs ? `?${qs}` : ""}`;
-  const res = await fetchImpl(url, {
-    headers: { authorization: `Bearer ${minted.token}`, accept: "application/json" },
-    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    let detail = `vault responded ${res.status}`;
-    try {
-      const body = (await res.json()) as Record<string, unknown>;
-      if (typeof body.error === "string") detail = body.error;
-    } catch {
-      // Non-JSON error body — keep the status-only detail.
-    }
-    return { vault: vault.name, error: detail };
-  }
-  const notes = await res.json();
-  return { vault: vault.name, notes };
-}
-
-async function fanOut(
-  ctx: AccountToolContext,
-  targets: AccountVaultMeta[],
-  args: Record<string, unknown>,
-): Promise<VaultQueryEntry[]> {
-  const settled = await Promise.allSettled(targets.map((v) => queryOneVault(ctx, v, args)));
-  return settled.map((s, i) =>
-    s.status === "fulfilled"
-      ? s.value
-      : {
-          vault: targets[i]!.name,
-          error: s.reason instanceof Error ? s.reason.message : "query failed",
-        },
-  );
-}
-
-const queryNotesTool: AccountMcpTool = {
-  name: "query-notes",
-  description:
-    "Search notes across the vaults this connection can reach. Omit `vault` to fan the query out " +
-    "(results are grouped per vault, not ranked across vaults); pass `vault` to target one. " +
-    "Default order is created_at ASC (oldest first) and the lean ~120-char preview — pass " +
-    '`sort: "desc"` for newest-first and `include_content: true` for bodies. Also: keyword ' +
-    "`search`, `tag`, `metadata`, `limit` (per vault, default 50), `order_by` (`updated_at` or " +
-    "an indexed field), `offset`.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      vault: {
-        type: "string",
-        description:
-          "Target a single vault by name. Must be one of the reachable vaults. Omit to query all.",
-      },
-      search: { type: "string", description: "Full-text keyword query." },
-      tag: {
-        type: ["string", "array"],
-        items: { type: "string" },
-        description: "Restrict to notes carrying this tag (or any of these tags).",
-      },
-      metadata: {
-        type: "object",
-        description: 'Structured metadata filters, e.g. {"status":{"eq":"open"}}.',
-      },
-      limit: { type: "number", description: "Maximum notes per vault (default 50)." },
-      sort: {
-        type: "string",
-        enum: ["asc", "desc"],
-        description: "Order by created_at. Default asc (oldest first). Pass desc for newest first.",
-      },
-      order_by: {
-        type: "string",
-        description:
-          "Sort by this field instead of created_at. `updated_at` needs no schema; other " +
-          "fields must be indexed on the target vault.",
-      },
-      include_content: {
-        type: "boolean",
-        description: "Return full note bodies. Default false: lean rows with a ~120-char preview.",
-      },
-      offset: {
-        type: "number",
-        description: "Skip this many notes per vault (default 0).",
-      },
-    },
-    additionalProperties: false,
-  },
-  async execute(args, ctx) {
-    const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
-    let targets = coverage.vaults;
-    if (typeof args.vault === "string" && args.vault.length > 0) {
-      const wanted = args.vault.toLowerCase();
-      const hit = coverage.vaults.find((v) => v.name === wanted);
-      if (!hit) {
-        throw new AccountToolError(
-          "vault_not_covered",
-          `Vault "${args.vault}" is not among the vaults this connection can reach.`,
-        );
-      }
-      targets = [hit];
-    }
-    const results = await fanOut(ctx, targets, args);
-    return { vaults_queried: targets.map((v) => v.name), results };
-  },
-};
-
-function noteWriteBody(args: Record<string, unknown>): Record<string, unknown> {
-  const body: Record<string, unknown> = {};
-  if (typeof args.content === "string") body.content = args.content;
-  if (typeof args.path === "string") body.path = args.path;
-  if (Array.isArray(args.tags)) body.tags = args.tags;
-  if (args.metadata && typeof args.metadata === "object") body.metadata = args.metadata;
-  if (typeof args.if_exists === "string") body.if_exists = args.if_exists;
-  return body;
-}
-
-function noteUpdateBody(args: Record<string, unknown>): Record<string, unknown> {
-  const body: Record<string, unknown> = {};
-  if (typeof args.content === "string") body.content = args.content;
-  if (typeof args.append === "string") body.append = args.append;
-  if (typeof args.prepend === "string") body.prepend = args.prepend;
-  if (args.content_edit && typeof args.content_edit === "object")
-    body.content_edit = args.content_edit;
-  if (typeof args.path === "string") body.path = args.path;
-  if (args.tags && typeof args.tags === "object") body.tags = args.tags;
-  if (args.metadata && typeof args.metadata === "object" && args.metadata !== null) {
-    body.metadata = args.metadata;
-  }
-  if (typeof args.if_updated_at === "string") body.if_updated_at = args.if_updated_at;
-  if (args.force === true) body.force = true;
-  if (typeof args.if_missing === "string") body.if_missing = args.if_missing;
-  return body;
-}
-
-function requireWritableVault(ctx: AccountToolContext, rawVault: unknown): AccountVaultMeta {
-  if (typeof rawVault !== "string" || rawVault.length === 0) {
-    throw new AccountToolError("invalid_vault", "vault is required.");
-  }
-  const coverage = resolveCoverage(ctx.db, ctx.principal, installedVaults(ctx));
-  const wanted = rawVault.toLowerCase();
-  const hit = coverage.vaults.find((v) => v.name === wanted);
-  if (!hit) {
-    throw new AccountToolError(
-      "vault_not_covered",
-      `Vault "${rawVault}" is not among the vaults this connection can reach.`,
-    );
-  }
-  if (!canWriteVault(ctx.db, ctx.principal, hit.name)) {
-    throw new AccountToolError(
-      "write_not_granted",
-      `This connection cannot write vault "${hit.name}".`,
-    );
-  }
-  return hit;
-}
-
-async function vaultNoteWrite(
-  ctx: AccountToolContext,
-  vault: AccountVaultMeta,
-  opts: { method: string; path: string; body: Record<string, unknown> },
-): Promise<unknown> {
-  const sign = ctx.signToken ?? signAccessToken;
-  const fetchImpl = ctx.fetchImpl ?? fetch;
-  const minted = await sign(ctx.db, {
-    sub: ctx.principal.userId,
-    scopes: [`vault:${vault.name}:write`],
-    audience: `vault.${vault.name}`,
-    clientId: ACCOUNT_MCP_CLIENT_ID,
-    issuer: ctx.issuer,
-    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
-    vaultScope: [vault.name],
-    ...(ctx.now !== undefined ? { now: ctx.now } : {}),
-  });
-  const origin =
-    typeof vault.port === "number" && vault.port > 0
-      ? `http://127.0.0.1:${vault.port}`
-      : vault.url.replace(/\/vault\/[^/]+\/?$/, "");
-  const url = `${origin.replace(/\/$/, "")}/vault/${vault.name}${opts.path}`;
-  const res = await fetchImpl(url, {
-    method: opts.method,
-    headers: {
-      authorization: `Bearer ${minted.token}`,
-      accept: "application/json",
-      "content-type": "application/json",
-    },
-    body: JSON.stringify(opts.body),
-    signal: AbortSignal.timeout(FANOUT_TIMEOUT_MS),
-  });
-  if (!res.ok) {
-    let detail = `vault responded ${res.status}`;
-    try {
-      const errBody = (await res.json()) as Record<string, unknown>;
-      if (typeof errBody.error === "string") detail = errBody.error;
-      else if (typeof errBody.error_type === "string") detail = errBody.error_type;
-    } catch {
-      // Non-JSON error body — keep the status-only detail.
-    }
-    throw new AccountToolError("vault_error", detail, { status: res.status, vault: vault.name });
-  }
-  return res.json();
-}
-
-const createNoteTool: AccountMcpTool = {
-  name: "create-note",
-  description:
-    "Create a note in one vault this connection can write. `vault` is required — this " +
-    "door does not invent a target. Does not return a vault token.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      vault: {
-        type: "string",
-        description: "Target vault by name. Must be a reachable vault this connection can write.",
-      },
-      content: { type: "string", description: "Note body (markdown)." },
-      path: { type: "string", description: "Note path (e.g. 'Log/hello')." },
-      tags: { type: "array", items: { type: "string" }, description: "Tags to apply." },
-      metadata: { type: "object", description: "Metadata fields to set." },
-      if_exists: {
-        type: "string",
-        enum: ["error", "ignore", "update", "replace"],
-        description: "What to do when `path` already names a note. Default error.",
-      },
-    },
-    required: ["vault"],
-    additionalProperties: false,
-  },
-  async execute(args, ctx) {
-    const hit = requireWritableVault(ctx, args.vault);
-    const note = await vaultNoteWrite(ctx, hit, {
-      method: "POST",
-      path: "/api/notes",
-      body: noteWriteBody(args),
-    });
-    return { vault: hit.name, note };
-  },
-};
-
-const updateNoteTool: AccountMcpTool = {
-  name: "update-note",
-  description:
-    "Update a note in one vault this connection can write. `vault` and `id` are required. " +
-    "Same body as vault PATCH /api/notes/:id (content / append / prepend / content_edit / " +
-    "path / tags / metadata / if_updated_at / force). Does not return a vault token.",
-  inputSchema: {
-    type: "object",
-    properties: {
-      vault: {
-        type: "string",
-        description: "Target vault by name. Must be a reachable vault this connection can write.",
-      },
-      id: {
-        type: "string",
-        description: "Note ID or path in that vault.",
-      },
-      content: { type: "string", description: "Full content replace." },
-      append: { type: "string", description: "Append to the end of the note." },
-      prepend: { type: "string", description: "Prepend to the start of the note." },
-      content_edit: {
-        type: "object",
-        properties: {
-          old_text: { type: "string" },
-          new_text: { type: "string" },
-        },
-        required: ["old_text", "new_text"],
-        description: "Find-and-replace one occurrence.",
-      },
-      path: { type: "string", description: "New path." },
-      tags: { type: "object", description: "Tag mutations `{ add, remove }`." },
-      metadata: { type: "object", description: "Metadata merge-patch." },
-      if_updated_at: {
-        type: "string",
-        description: "Optimistic concurrency: reject if the note changed since.",
-      },
-      force: { type: "boolean", description: "Waive if_updated_at requirement." },
-      if_missing: {
-        type: "string",
-        enum: ["fail", "create"],
-        description: "What to do when the note does not exist. Default fail.",
-      },
-    },
-    required: ["vault", "id"],
-    additionalProperties: false,
-  },
-  async execute(args, ctx) {
-    if (typeof args.id !== "string" || args.id.length === 0) {
-      throw new AccountToolError("invalid_id", "id is required.");
-    }
-    const hit = requireWritableVault(ctx, args.vault);
-    const note = await vaultNoteWrite(ctx, hit, {
-      method: "PATCH",
-      path: `/api/notes/${encodeURIComponent(args.id)}`,
-      body: noteUpdateBody(args),
-    });
-    return { vault: hit.name, note };
   },
 };
 
@@ -778,32 +415,32 @@ const listAccessTool: AccountMcpTool = {
   },
 };
 
-/** Order is stable so `tools/list` is deterministic. */
+/** Hub-native catalog. Vault-shaped tools come from a live module `tools/list`. */
 export const ACCOUNT_MCP_TOOLS: readonly AccountMcpTool[] = [
   listVaultsTool,
   createVaultTool,
-  queryNotesTool,
-  createNoteTool,
-  updateNoteTool,
   grantAccessTool,
   revokeAccessTool,
   listAccessTool,
 ];
 
+/** Hub-native names win on collision with a module backend. */
+export const HUB_NATIVE_TOOL_NAMES: ReadonlySet<string> = new Set(
+  ACCOUNT_MCP_TOOLS.map((t) => t.name),
+);
+
 /**
- * Catalog filtered by what this principal can actually call. Admin-shaped
- * tools (grant/revoke/list-access) and write tools are invisible below the
- * verb, not just refused. Same pattern as the vault door.
+ * Hub-native catalog filtered by what this principal can actually call.
+ * Admin-shaped tools are invisible below the verb, not just refused.
+ * Vault-shaped tools are merged in by `account-mcp-http.ts` from a live list.
  */
 export function toolsForPrincipal(ctx: AccountToolContext): readonly AccountMcpTool[] {
   const installed = installedVaults(ctx);
   const coverage = resolveCoverage(ctx.db, ctx.principal, installed);
-  const canWrite = coverage.vaults.some((v) => canWriteVault(ctx.db, ctx.principal, v.name));
   const canAdmin = coverage.vaults.some((v) => callerCanAdminVault(ctx.db, ctx.principal, v.name));
   const create = canCreate(ctx.principal);
   return ACCOUNT_MCP_TOOLS.filter((t) => {
     if (t.name === "create-vault") return create;
-    if (t.name === "create-note" || t.name === "update-note") return canWrite;
     if (t.name === "grant-access" || t.name === "revoke-access" || t.name === "list-access") {
       return canAdmin;
     }

--- a/src/nostr-http-auth.ts
+++ b/src/nostr-http-auth.ts
@@ -15,8 +15,8 @@
  * unchanged. This path never asks for a password: the signature *is* the
  * possession proof.
  */
-import { createHash, randomBytes } from "node:crypto";
 import type { Database } from "bun:sqlite";
+import { createHash, randomBytes } from "node:crypto";
 import {
   NOSTR_AUTH_KIND,
   type NostrEvent,
@@ -25,6 +25,7 @@ import {
   verifyNostrEvent,
 } from "./nostr-event.ts";
 import { bindPubkeyFromHttpAuth, findPubkeyLink } from "./pubkey-links.ts";
+import { isHttpsRequest } from "./request-protocol.ts";
 import {
   createUser,
   getFirstAdminId,
@@ -124,7 +125,25 @@ export function extractNostrEvent(req: Request): NostrEvent {
   return parsed.event;
 }
 
+/**
+ * Absolute URL the NIP-98 `u` tag must equal.
+ *
+ * Hub binds 127.0.0.1:1939 over plain HTTP. Tailscale Serve, cloudflared,
+ * and Render terminate TLS at the edge and forward HTTP, so `req.url` is
+ * `http://<public-host>/…` while the client POSTed — and signed —
+ * `https://<public-host>/…`. Same reconstruction as `resolveIssuer`'s
+ * request fallback: upgrade the scheme when `isHttpsRequest` is true
+ * (URL protocol or `X-Forwarded-Proto: https`). Host, path, and query
+ * stay on `req.url`. We do not honor `X-Forwarded-Host` here, and we do
+ * not substitute stored `hub_origin` — loopback NIP-98 stays bound to
+ * loopback.
+ */
 export function requestAbsoluteUrl(req: Request): string {
+  const url = new URL(req.url);
+  if (isHttpsRequest(req) && url.protocol === "http:") {
+    url.protocol = "https:";
+    return url.href;
+  }
   return req.url;
 }
 
@@ -166,7 +185,11 @@ export function verifyNostrHttpEvent(
   const createdAtMs = event.created_at * 1000;
   const skewMs = NIP98_MAX_SKEW_SECONDS * 1000;
   if (Math.abs(now.getTime() - createdAtMs) > skewMs) {
-    throw new NostrHttpAuthError(401, "expired", "Nostr event created_at is outside the 60s window");
+    throw new NostrHttpAuthError(
+      401,
+      "expired",
+      "Nostr event created_at is outside the 60s window",
+    );
   }
 
   if (replay.consume(event.id, now.getTime())) {
@@ -176,7 +199,11 @@ export function verifyNostrHttpEvent(
   const u = tagValue(event, "u");
   const expectedUrl = requestAbsoluteUrl(req);
   if (u !== expectedUrl) {
-    throw new NostrHttpAuthError(401, "url_mismatch", "Nostr event u tag must equal this request URL");
+    throw new NostrHttpAuthError(
+      401,
+      "url_mismatch",
+      "Nostr event u tag must equal this request URL",
+    );
   }
   const method = tagValue(event, "method");
   if (!method || method.toUpperCase() !== req.method.toUpperCase()) {
@@ -250,11 +277,7 @@ export async function resolveNostrPrincipal(
     return principalFromUser(db, user.id, user.username, event.pubkey, false);
   }
   if (!opts.autoProvision) {
-    throw new NostrHttpAuthError(
-      401,
-      "unknown_pubkey",
-      "Nostr pubkey is not linked to a hub user",
-    );
+    throw new NostrHttpAuthError(401, "unknown_pubkey", "Nostr pubkey is not linked to a hub user");
   }
   if (getFirstAdminId(db) === null) {
     throw new NostrHttpAuthError(
@@ -297,7 +320,11 @@ export async function resolveNostrPrincipal(
     now,
   });
   if (!bound.ok) {
-    throw new NostrHttpAuthError(401, "pubkey_taken", "Nostr pubkey is already bound to another user");
+    throw new NostrHttpAuthError(
+      401,
+      "pubkey_taken",
+      "Nostr pubkey is already bound to another user",
+    );
   }
   return principalFromUser(db, user.id, user.username, event.pubkey, true);
 }


### PR DESCRIPTION
**Merge-commit, do not squash.** Merging publishes `@openparachute/hub@0.7.18` to npm `@latest` + ghcr `:v0.7.18`/`:stable`/`:latest`. Other three packages (scope-guard 0.5.1, depcheck 0.1.1, door-contract 0.7.0) are already published at these versions and no-op.

Branched from `origin/next` HEAD, which **is** the `v0.7.18-rc.10` tag — so this brings the full rc chain (9 commits) onto `main` plus the bump. The suffix-drop guard diffs `v0.7.18-rc.10..HEAD`: package.json + CHANGELOG only. `next` must stay frozen until this merges (any non-release-path commit on next would not affect this PR, but keeps history clean).

What the 0.7.18 line ships (rc.1–rc.10): key-as-account — NIP-98 request auth (#882), account-MCP door (#883), NIP-98 + grant-by-pubkey at root `/mcp` (#888/#889), OAuth `account:vaults` at `/mcp` (#892), account-MCP note tools (#893/#896/#907), consent-picker XOR (#901), `account:self:*` extras (#904), vault-MCP proxying (#910), `X-Forwarded-Proto` NIP-98 fix (#914). Plus person-mint/Account SPA (#872/#874/#875) and release automation (#911/#913).

Soak: rc.10 live on this box + techne.coop since ~16:30Z today; GrokJi's 63-path gauntlet green; external agent (omni) verified NIP-98 end-to-end through techne's Cloudflare Tunnel. The account-MCP core (rc.9) has been live since ~05:00Z.

Auto-provision stays off by default. Leaves #880, #881, #899 open.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)