### PR TITLE
fix(release): tag-record checkout fetches tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -534,6 +534,13 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          # The "already exists" dedupe below rev-parses the tag; a shallow
+          # tagless clone can't see pre-existing remote tags, so the push gets
+          # rejected and swallowed by continue-on-error. Same fix as `plan`'s
+          # checkout (and surface#216).
+          fetch-depth: 0
+          fetch-tags: true
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.4


### PR DESCRIPTION
Port of [surface#216](https://github.com/ParachuteComputer/parachute-surface/pull/216) — hub's `tag-record` job had the same bare checkout, flagged in that review. `fetch-depth: 0` + `fetch-tags: true`, same as hub's own `plan` checkout. Workflow-file only; no publish triggers on this merge (paths filter is package.json-only). Does not affect hub#917 — that PR is a snapshot branch cut before this.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)