### PR TITLE
fix(hub): 401 challenge at /mcp names the root PRM (hub#899)

### DIFF
--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -26,7 +26,11 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { handleAccountCapabilities } from "../account-api.ts";
-import { accountMcpProtectedResource, handleAccountMcp } from "../account-mcp-http.ts";
+import {
+  accountMcpProtectedResource,
+  challengePrmPath,
+  handleAccountMcp,
+} from "../account-mcp-http.ts";
 import { ACCOUNT_MCP_TOOLS } from "../account-mcp.ts";
 import { hubDbPath, openHubDb } from "../hub-db.ts";
 import { signAccessToken } from "../jwt-sign.ts";
@@ -373,6 +377,41 @@ describe("account MCP — descriptor + PRM", () => {
       );
       const body = (await res.json()) as { account_mcp_endpoint: string };
       expect(body.account_mcp_endpoint).toBe(MCP_URL);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("challengePrmPath follows the request URL (hub#899)", () => {
+    expect(challengePrmPath(new Request("http://hub.example.com/mcp"))).toBe(
+      "/.well-known/oauth-protected-resource/mcp",
+    );
+    expect(challengePrmPath(new Request("http://hub.example.com/mcp/"))).toBe(
+      "/.well-known/oauth-protected-resource/mcp",
+    );
+    expect(challengePrmPath(new Request("http://hub.example.com/account/mcp"))).toBe(
+      "/.well-known/oauth-protected-resource/account/mcp",
+    );
+    expect(challengePrmPath(new Request("http://hub.example.com/account/mcp?x=1"))).toBe(
+      "/.well-known/oauth-protected-resource/account/mcp",
+    );
+  });
+
+  test("unauthed handleAccountMcp at /mcp names the root PRM (hub#899)", async () => {
+    const h = await makeHarness();
+    try {
+      const res = await handleAccountMcp(
+        new Request("http://hub.example.com/mcp", {
+          method: "POST",
+          headers: { accept: BOTH_ACCEPT, "content-type": "application/json" },
+          body: JSON.stringify(rpc("initialize")),
+        }),
+        mcpDeps(h),
+      );
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain("/.well-known/oauth-protected-resource/mcp");
+      expect(challenge).not.toContain("/.well-known/oauth-protected-resource/account/mcp");
     } finally {
       h.cleanup();
     }

--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -7358,7 +7358,7 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
     });
   }
 
-  test("NIP-98 POST /mcp does not reach the daemon — same 401 shape as /account/mcp", async () => {
+  test("NIP-98 POST /mcp 401 names the root PRM, not /account/mcp (hub#899)", async () => {
     const h = makeHarness();
     const upstream = startRecordingUpstream();
     const db = openHubDb(hubDbPath(h.dir));
@@ -7377,7 +7377,49 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
       expect(body.error_description).toBe("Nostr pubkey is not linked to a hub user");
       const challenge = res.headers.get("www-authenticate") ?? "";
       expect(challenge).toContain("resource_metadata=");
-      expect(challenge).toContain("/.well-known/oauth-protected-resource/account/mcp");
+      // RFC 9728 §3.3: WWW-Authenticate metadata must describe the URL the
+      // client requested. Root PRM stays vault-only; do not mix families.
+      expect(challenge).toContain("/.well-known/oauth-protected-resource/mcp");
+      expect(challenge).not.toContain("/.well-known/oauth-protected-resource/account/mcp");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      db.close();
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("invalid aud=account Bearer POST /mcp 401 names the root PRM (hub#899)", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      await createUser(db, "owner", "pw", { passwordChanged: true });
+      const fetcher = hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath });
+      // Peekable aud=account (decodeJwt, no verify) so dispatch hands this
+      // to handleAccountMcp; authenticate then 401s.
+      const peekable = [
+        Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url"),
+        Buffer.from(JSON.stringify({ aud: "account", sub: "nobody" })).toString("base64url"),
+        "sig",
+      ].join(".");
+      const res = await fetcher(
+        new Request("http://hub.example.com/mcp", {
+          method: "POST",
+          headers: {
+            authorization: `Bearer ${peekable}`,
+            accept: BOTH_ACCEPT,
+            "content-type": "application/json",
+            host: "hub.example.com",
+          },
+          body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize" }),
+        }),
+      );
+      expect(res.status).toBe(401);
+      const challenge = res.headers.get("www-authenticate") ?? "";
+      expect(challenge).toContain("/.well-known/oauth-protected-resource/mcp");
+      expect(challenge).not.toContain("/.well-known/oauth-protected-resource/account/mcp");
       expect(upstream.requests().length).toBe(0);
     } finally {
       db.close();

--- a/src/account-mcp-http.ts
+++ b/src/account-mcp-http.ts
@@ -124,17 +124,28 @@ function accountMcpResource(issuer: string): string {
   return `${issuer.replace(/\/$/, "")}/account/mcp`;
 }
 
-function accountMcpChallenge(issuer: string): string {
-  // Always names the /account/mcp PRM. When handleAccountMcp answers a
-  // request that arrived at root /mcp (NIP-98 or the aud=account routing
-  // peek), RFC 9728 §3.3 wants resource_metadata to describe the URL the
-  // client requested — this PRM's `resource` is `/account/mcp`, so a
-  // strict client MUST discard the challenge. Valid-token dispatch at
-  // root is still the right alias. Tracked as hub#899. Do not "fix" by
-  // advertising `account:vaults` on the root PRM: catalog-copy +
-  // combine-refusal is a total `invalid_scope` bounce.
+/**
+ * RFC 9728 §3.3: WWW-Authenticate `resource_metadata` must describe the
+ * requested URL. handleAccountMcp answers both `/mcp` (root dispatch) and
+ * `/account/mcp`. Do not advertise `account:vaults` on the root PRM —
+ * catalog-copy + combine-refusal is a total `invalid_scope` bounce.
+ */
+export function challengePrmPath(req: Request): string {
+  let pathname = "";
+  try {
+    pathname = new URL(req.url).pathname;
+  } catch {
+    pathname = "";
+  }
+  if (pathname === "/mcp" || pathname.startsWith("/mcp/")) {
+    return "/.well-known/oauth-protected-resource/mcp";
+  }
+  return "/.well-known/oauth-protected-resource/account/mcp";
+}
+
+function accountMcpChallenge(issuer: string, req: Request): string {
   const origin = issuer.replace(/\/$/, "");
-  return `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/account/mcp"`;
+  return `Bearer resource_metadata="${origin}${challengePrmPath(req)}"`;
 }
 
 /** RFC 9728 PRM for `/account/mcp`. Public + wildcard CORS. */
@@ -167,10 +178,11 @@ function authFailure(
   error: string,
   message: string,
   issuer: string,
+  req: Request,
   scope?: string,
 ): Response {
   const challenge = [
-    accountMcpChallenge(issuer),
+    accountMcpChallenge(issuer, req),
     `error="${error}"`,
     `error_description="${message.replace(/"/g, "'")}"`,
   ];
@@ -363,16 +375,16 @@ async function handleOne(m: JsonRpcMessage, ctx: AccountToolContext): Promise<Js
   }
 }
 
-function translateAuthError(err: unknown, issuer: string): Response {
+function translateAuthError(err: unknown, issuer: string, req: Request): Response {
   if (err instanceof NostrHttpAuthError) {
-    return authFailure(err.status === 403 ? 403 : 401, "invalid_token", err.message, issuer);
+    return authFailure(err.status === 403 ? 403 : 401, "invalid_token", err.message, issuer, req);
   }
   if (err instanceof AdminAuthError) {
     const res = adminAuthErrorResponse(err);
-    const challenge = res.headers.get("www-authenticate") ?? accountMcpChallenge(issuer);
+    const challenge = res.headers.get("www-authenticate") ?? accountMcpChallenge(issuer, req);
     const withMeta = challenge.includes("resource_metadata=")
       ? challenge
-      : `${accountMcpChallenge(issuer)}, ${challenge}`;
+      : `${accountMcpChallenge(issuer, req)}, ${challenge}`;
     const headers = new Headers(res.headers);
     headers.set("www-authenticate", withMeta);
     headers.set("access-control-allow-origin", "*");
@@ -380,7 +392,7 @@ function translateAuthError(err: unknown, issuer: string): Response {
     return new Response(res.body, { status: res.status, headers });
   }
   const message = err instanceof Error ? err.message : "unauthorized";
-  return authFailure(401, "invalid_token", message, issuer);
+  return authFailure(401, "invalid_token", message, issuer, req);
 }
 
 /**
@@ -400,7 +412,7 @@ export async function handleAccountMcp(req: Request, deps: AccountMcpDeps): Prom
   try {
     principal = await authenticate(deps.db, req, deps, body);
   } catch (err) {
-    return translateAuthError(err, deps.issuer);
+    return translateAuthError(err, deps.issuer, req);
   }
 
   if (req.method === "DELETE") return withMcpCors(new Response(null, { status: 200 }));

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -4393,10 +4393,9 @@ export function hubFetch(
         }
         const accountMcp = isNostrAuthorization(req) || peekBearerAudience(req) === "account";
         if (accountMcp) {
-          // Success path: same handler as /account/mcp. Failure path: that
-          // handler's 401 challenge still points at the /account/mcp PRM
-          // (RFC 9728 §3.3 mismatch vs the requested /mcp URL). hub#899;
-          // do not mix scope families on the root PRM to paper over it.
+          // Success path: same handler as /account/mcp. Failure path
+          // (hub#899): challenge builders take the request URL, so a /mcp
+          // 401 names the root PRM. Do not mix scope families there.
           if (!getDb) return dbNotConfigured();
           return handleAccountMcp(req, {
             db: getDb(),


### PR DESCRIPTION
## Why

Invalid `aud=account` Bearer (or unlinked NIP-98) at **root `/mcp`** was 401ing with `WWW-Authenticate` `resource_metadata` pointing at `/.well-known/oauth-protected-resource/account/mcp`. That PRM's `resource` is `/account/mcp`. [RFC 9728 §3.3](https://www.rfc-editor.org/rfc/rfc9728.html#section-3.3) requires metadata reached through the challenge to name the URL the client requested, or the client MUST discard it.

Valid-token dispatch at `/mcp` is already SHIP (hub#892). This is only the **failure challenge**.

## What

`accountMcpChallenge` takes the request URL:

| Request | Challenge PRM | `resource` | scopes |
|---|---|---|---|
| `/mcp` | `/.well-known/oauth-protected-resource/mcp` | `/mcp` | vault-only |
| `/account/mcp` | `/.well-known/oauth-protected-resource/account/mcp` | `/account/mcp` | `account:vaults` |

Root PRM stays vault-only. Do **not** add `account:vaults` beside `vault:*` there — catalog-copy would request both families, and `accountVaultsCombinedWithOtherScopes` returns `invalid_scope` for the entire authorize request.

## Tests

`bun run typecheck` 0. `bunx biome check` on the four files: clean.

`bun test ./src` at `fd157fb`: **4815 pass / 1 skip / 1 fail**. The fail is pre-existing and untouched by this PR: `surface-command.test.ts` `deploy token → real git push via git-credential-parachute` times out at 5000ms (reproduced in isolation; `git diff origin/next -- src/__tests__/surface-command.test.ts` empty). CI should still be the authority on that helper.

New pins:

- `challengePrmPath` maps `/mcp` vs `/account/mcp`
- unauthed `handleAccountMcp` at `/mcp` names the root PRM
- hubFetch NIP-98 POST `/mcp` 401 names the root PRM
- hubFetch invalid `aud=account` Bearer POST `/mcp` 401 names the root PRM
- existing unauthed `/account/mcp` still names the account PRM

## Not this PR

Version bump (feature PR; rc.11 cut later). Mixing scope families on root PRM. Cloud twin. Main merge.

Fixes #899

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.
