### PR TITLE
feat(web/ui): Account page rework — guided key-link stepper + summary cards (hub#880)

### DIFF
--- a/web/ui/src/routes/Account.test.tsx
+++ b/web/ui/src/routes/Account.test.tsx
@@ -1,8 +1,14 @@
 /**
- * Account route tests (hub#85): My account page — password change + 2FA
- * status / enroll flow / disable. The `lib/api.ts` HTTP helpers are mocked;
- * these assert the page renders status, drives the enroll flow, and gates
- * disable on a password.
+ * Account route tests (hub#85, restructured for hub#880).
+ *
+ * The page is now four collapsed disclosure cards, so most tests open the card
+ * they exercise via its `*-toggle` button first — `expand()` is the helper.
+ * The card headers carry a one-line summary that is readable *without*
+ * expanding (2FA status pill, token count, key count); those are asserted
+ * against `*-summary` directly.
+ *
+ * The `lib/api.ts` HTTP helpers are mocked throughout. The wire shapes are
+ * unchanged from hub#85 — only the UI around them moved.
  */
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
@@ -38,14 +44,23 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  // `hasNip07()` treats undefined as "no extension", so clearing is enough.
+  (window as unknown as { nostr?: unknown }).nostr = undefined;
 });
 
-function renderRoute() {
+function renderRoute(initialPath = "/account") {
   return render(
-    <MemoryRouter>
+    <MemoryRouter initialEntries={[initialPath]}>
       <Account />
     </MemoryRouter>,
   );
+}
+
+/** Open one of the four disclosure cards by its section test-id. */
+async function expand(section: string) {
+  const toggle = await screen.findByTestId(`${section}-toggle`);
+  if (toggle.getAttribute("aria-expanded") !== "true") fireEvent.click(toggle);
+  return toggle;
 }
 
 function meSignedIn(twoFactorEnabled: boolean) {
@@ -74,9 +89,11 @@ describe("Account — render + status", () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
     renderRoute();
     await waitFor(() => expect(screen.getByTestId("account-2fa-status")).toHaveTextContent(/off/i));
-    // Off → the "Set up two-factor" CTA shows.
+    // Off → the "Set up two-factor" CTA shows once the card is expanded.
+    await expand("account-2fa");
     expect(screen.getByTestId("account-2fa-enroll")).toBeInTheDocument();
     // The password form is present.
+    await expand("account-password");
     expect(screen.getByTestId("account-current-password")).toBeInTheDocument();
   });
 
@@ -86,8 +103,100 @@ describe("Account — render + status", () => {
     await waitFor(() =>
       expect(screen.getByTestId("account-2fa-status")).toHaveTextContent(/enabled/i),
     );
+    await expand("account-2fa");
     expect(screen.getByTestId("account-2fa-disable")).toBeInTheDocument();
     expect(screen.getByTestId("account-2fa-disable-password")).toBeInTheDocument();
+  });
+});
+
+describe("Account — disclosure cards (hub#880)", () => {
+  it("collapses every section by default and toggles one open", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    const toggle = await screen.findByTestId("account-password-toggle");
+
+    for (const id of ["account-password", "account-2fa", "account-tokens", "account-pubkeys"]) {
+      expect(screen.getByTestId(`${id}-toggle`)).toHaveAttribute("aria-expanded", "false");
+    }
+    expect(screen.queryByTestId("account-current-password")).toBeNull();
+
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("account-current-password")).toBeInTheDocument();
+
+    // ...and closing it again puts the body away.
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("account-current-password")).toBeNull();
+  });
+
+  it("each toggle is a real button wired to its panel", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    const toggle = await screen.findByTestId("account-pubkeys-toggle");
+    expect(toggle.tagName).toBe("BUTTON");
+    const panelId = toggle.getAttribute("aria-controls");
+    expect(panelId).toBe("keys-panel");
+    expect(document.getElementById(panelId as string)).not.toBeNull();
+  });
+
+  it("summarizes counts in the collapsed headers", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(true));
+    vi.mocked(api.listAccountTokens).mockResolvedValue({
+      tokens: [
+        {
+          jti: "jti-a",
+          user_id: "u1",
+          subject: null,
+          client_id: "parachute-account",
+          scopes: ["vault:work:read"],
+          expires_at: "2030-01-01T00:00:00.000Z",
+          revoked_at: null,
+          created_at: "2026-08-25T12:00:00.000Z",
+          created_via: "cli_mint",
+          subject_pubkey: null,
+        },
+      ],
+      next_cursor: null,
+    });
+    vi.mocked(api.listAccountPubkeys).mockResolvedValue([
+      {
+        pubkey: "aa".repeat(32),
+        label: "phone",
+        proof_event_id: "cc".repeat(32),
+        linked_at: "2026-08-25T12:00:00.000Z",
+        last_verified_at: "2026-08-25T12:00:00.000Z",
+      },
+    ]);
+    renderRoute();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("account-tokens-summary")).toHaveTextContent("1 API token"),
+    );
+    expect(screen.getByTestId("account-pubkeys-summary")).toHaveTextContent("1 linked key");
+    expect(screen.getByTestId("account-2fa-summary")).toHaveTextContent(/enabled/i);
+    // Counts are readable with every card still collapsed.
+    expect(screen.getByTestId("account-tokens-toggle")).toHaveAttribute("aria-expanded", "false");
+  });
+
+  it("pluralizes and reports empties in the headers", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    await waitFor(() =>
+      expect(screen.getByTestId("account-tokens-summary")).toHaveTextContent("No API tokens"),
+    );
+    expect(screen.getByTestId("account-pubkeys-summary")).toHaveTextContent("No linked keys");
+  });
+
+  it("opens the card named by location.hash", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute("/account#keys");
+    await waitFor(() =>
+      expect(screen.getByTestId("account-pubkeys-toggle")).toHaveAttribute("aria-expanded", "true"),
+    );
+    expect(screen.getByTestId("account-pubkey-link")).toBeInTheDocument();
+    // Siblings stay closed.
+    expect(screen.getByTestId("account-tokens-toggle")).toHaveAttribute("aria-expanded", "false");
   });
 });
 
@@ -96,7 +205,7 @@ describe("Account — password change", () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
     vi.mocked(api.changeAccountPassword).mockResolvedValue();
     renderRoute();
-    await screen.findByTestId("account-current-password");
+    await expand("account-password");
 
     fireEvent.change(screen.getByTestId("account-current-password"), {
       target: { value: "old-password-123" },
@@ -124,7 +233,7 @@ describe("Account — password change", () => {
   it("blocks a too-short new password client-side (no POST)", async () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
     renderRoute();
-    await screen.findByTestId("account-current-password");
+    await expand("account-password");
 
     fireEvent.change(screen.getByTestId("account-current-password"), {
       target: { value: "old-password-123" },
@@ -147,7 +256,7 @@ describe("Account — password change", () => {
       new api.HttpError(401, "Current password is incorrect."),
     );
     renderRoute();
-    await screen.findByTestId("account-current-password");
+    await expand("account-password");
 
     fireEvent.change(screen.getByTestId("account-current-password"), {
       target: { value: "wrong-password" },
@@ -180,7 +289,7 @@ describe("Account — 2FA enroll flow", () => {
       backup_codes: ["abcde-fghij", "klmno-pqrst"],
     });
     renderRoute();
-    await screen.findByTestId("account-2fa-enroll");
+    await expand("account-2fa");
 
     fireEvent.click(screen.getByTestId("account-2fa-enroll"));
     await waitFor(() => expect(api.startTwoFactor).toHaveBeenCalledWith("csrf-abc"));
@@ -213,7 +322,7 @@ describe("Account — 2FA enroll flow", () => {
       qr_data_url: "data:image/png;base64,AAAA",
     });
     renderRoute();
-    await screen.findByTestId("account-2fa-enroll");
+    await expand("account-2fa");
     fireEvent.click(screen.getByTestId("account-2fa-enroll"));
     await screen.findByTestId("account-2fa-code");
 
@@ -235,7 +344,7 @@ describe("Account — 2FA disable", () => {
       .mockResolvedValueOnce(meSignedIn(false));
     vi.mocked(api.disableTwoFactor).mockResolvedValue();
     renderRoute();
-    await screen.findByTestId("account-2fa-disable-password");
+    await expand("account-2fa");
 
     fireEvent.change(screen.getByTestId("account-2fa-disable-password"), {
       target: { value: "my-password-123" },
@@ -245,14 +354,15 @@ describe("Account — 2FA disable", () => {
     await waitFor(() =>
       expect(api.disableTwoFactor).toHaveBeenCalledWith("csrf-abc", "my-password-123"),
     );
-    // Refetch flips the status to Off + brings back the enroll CTA.
+    // Refetch flips the header status to Off + brings back the enroll CTA.
     await waitFor(() => expect(screen.getByTestId("account-2fa-status")).toHaveTextContent(/off/i));
+    expect(screen.getByTestId("account-2fa-enroll")).toBeInTheDocument();
   });
 
   it("requires a password before disabling (no POST when blank)", async () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(true));
     renderRoute();
-    await screen.findByTestId("account-2fa-disable");
+    await expand("account-2fa");
 
     fireEvent.click(screen.getByTestId("account-2fa-disable"));
     await waitFor(() =>
@@ -283,7 +393,20 @@ describe("Account — API tokens", () => {
   it("renders the empty state when this account has no live tokens", async () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
     renderRoute();
+    await expand("account-tokens");
     expect(await screen.findByTestId("account-tokens-empty")).toBeInTheDocument();
+  });
+
+  it("keeps the mint form behind a disclosure", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    renderRoute();
+    await expand("account-tokens");
+    const mintToggle = screen.getByTestId("account-token-mint-toggle");
+    expect(mintToggle).toHaveAttribute("aria-expanded", "false");
+    expect(screen.queryByTestId("account-token-scope")).toBeNull();
+    fireEvent.click(mintToggle);
+    expect(mintToggle).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByTestId("account-token-scope")).toBeInTheDocument();
   });
 
   it("lists a token row and mints, showing the JWT once", async () => {
@@ -301,8 +424,8 @@ describe("Account — API tokens", () => {
       scope: "vault:work:read",
     });
     renderRoute();
-    await screen.findByTestId("account-token-mint-toggle");
-    fireEvent.click(screen.getByTestId("account-token-mint-toggle"));
+    await expand("account-tokens");
+    fireEvent.click(await screen.findByTestId("account-token-mint-toggle"));
     fireEvent.change(screen.getByTestId("account-token-scope"), {
       target: { value: "vault:work:read" },
     });
@@ -316,6 +439,12 @@ describe("Account — API tokens", () => {
       }),
     );
     expect(await screen.findByTestId("account-token-jwt")).toHaveTextContent("eyJhbGciOi.test");
+    expect(screen.getByTestId("account-token-minted")).toHaveTextContent(/only time the JWT/i);
+    // The form collapses again once the token is minted.
+    expect(screen.getByTestId("account-token-mint-toggle")).toHaveAttribute(
+      "aria-expanded",
+      "false",
+    );
   });
 
   it("revokes a live token after confirm", async () => {
@@ -328,6 +457,7 @@ describe("Account — API tokens", () => {
       .mockResolvedValueOnce({ tokens: [], next_cursor: null });
     vi.mocked(api.revokeAccountToken).mockResolvedValue();
     renderRoute();
+    await expand("account-tokens");
     await screen.findByTestId("account-token-revoke-jti-live-0001");
     fireEvent.click(screen.getByTestId("account-token-revoke-jti-live-0001"));
     fireEvent.click(screen.getByTestId("account-token-revoke-confirm-jti-live-0001"));
@@ -351,6 +481,7 @@ describe("Account — API tokens", () => {
       }),
     );
     renderRoute();
+    await expand("account-tokens");
     const more = await screen.findByTestId("account-tokens-load-more");
     fireEvent.click(more);
     await waitFor(() => expect(screen.getByTestId("account-tokens-load-more")).toBeDisabled());
@@ -363,43 +494,81 @@ describe("Account — API tokens", () => {
   });
 });
 
-describe("Account — Nostr keys", () => {
-  it("renders empty state and starts the challenge flow", async () => {
+describe("Account — Nostr key link stepper", () => {
+  const challenge = {
+    challenge: "aa".repeat(32),
+    expires_at: "2026-08-25T12:05:00.000Z",
+    event_template: {
+      kind: 27235,
+      content: 'Link this key to account "aaron" on this hub.',
+      tags: [
+        ["u", "https://hub.example/api/account/pubkeys/verify"],
+        ["method", "POST"],
+        ["challenge", "aa".repeat(32)],
+      ],
+    },
+  };
+
+  const signedEvent = {
+    id: "dd".repeat(32),
+    pubkey: "aa".repeat(32),
+    created_at: 1,
+    kind: 27235,
+    tags: [] as string[][],
+    content: "statement",
+    sig: "ee".repeat(32),
+  };
+
+  it("explains why before starting, then walks step 1 → 2 → 3", async () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
-    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
-      challenge: "aa".repeat(32),
-      expires_at: "2026-08-25T12:05:00.000Z",
-      event_template: {
-        kind: 27235,
-        content: 'Link this key to account "aaron" on this hub.',
-        tags: [
-          ["u", "https://hub.example/api/account/pubkeys/verify"],
-          ["method", "POST"],
-          ["challenge", "aa".repeat(32)],
-        ],
-      },
-    });
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue(challenge);
     renderRoute();
+    await expand("account-pubkeys");
+
+    // Step 0 — the "why", and no protocol jargon in sight.
     expect(await screen.findByTestId("account-pubkeys-empty")).toBeInTheDocument();
+    expect(screen.getByTestId("account-pubkeys")).toHaveTextContent(/attribution label/i);
+    expect(screen.getByTestId("account-pubkeys")).toHaveTextContent(/does not log you in/i);
+    expect(screen.queryByTestId("account-pubkey-steps")).toBeNull();
+
+    // Step 1 — the statement.
     fireEvent.click(screen.getByTestId("account-pubkey-link"));
     await waitFor(() => expect(api.startPubkeyChallenge).toHaveBeenCalledWith("csrf-abc"));
-    expect(await screen.findByTestId("account-pubkey-statement")).toHaveTextContent(
-      /link this key/i,
+    expect(await screen.findByTestId("account-pubkey-step-statement")).toBeInTheDocument();
+    expect(screen.getByTestId("account-pubkey-statement")).toHaveTextContent(/link this key/i);
+    expect(screen.getByTestId("account-pubkey-steps")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("account-pubkey-steps").querySelector('[aria-current="step"]'),
+    ).toHaveTextContent(/get the statement/i);
+    // Step 3 fields are not on screen yet.
+    expect(screen.queryByTestId("account-pubkey-password")).toBeNull();
+
+    // Step 2 — sign. No extension in jsdom → the paste path is primary.
+    fireEvent.click(screen.getByTestId("account-pubkey-statement-continue"));
+    expect(await screen.findByTestId("account-pubkey-step-sign")).toBeInTheDocument();
+    expect(screen.getByTestId("account-pubkey-no-extension")).toHaveTextContent(
+      /no signing extension detected/i,
     );
-    expect(screen.getByTestId("account-pubkey-password")).toBeInTheDocument();
+    expect(screen.getByTestId("account-pubkey-event")).toBeInTheDocument();
+    expect(
+      screen.getByTestId("account-pubkey-steps").querySelector('[aria-current="step"]'),
+    ).toHaveTextContent(/sign it/i);
+
+    // Step 3 — confirm.
+    fireEvent.change(screen.getByTestId("account-pubkey-event"), {
+      target: { value: JSON.stringify(signedEvent) },
+    });
+    fireEvent.click(screen.getByTestId("account-pubkey-paste-continue"));
+    expect(await screen.findByTestId("account-pubkey-step-confirm")).toBeInTheDocument();
+    expect(screen.getByTestId("account-pubkey-signer")).toHaveTextContent("aaaaaaaa");
+    expect(
+      screen.getByTestId("account-pubkey-steps").querySelector('[aria-current="step"]'),
+    ).toHaveTextContent(/confirm/i);
   });
 
-  it("posts the pasted event + first-link password", async () => {
+  it("posts the pasted event + first-link password with its explanation", async () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
-    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
-      challenge: "bb".repeat(32),
-      expires_at: "2026-08-25T12:05:00.000Z",
-      event_template: {
-        kind: 27235,
-        content: "statement",
-        tags: [["u", "https://hub.example/api/account/pubkeys/verify"]],
-      },
-    });
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue(challenge);
     vi.mocked(api.verifyPubkeyLink).mockResolvedValue({
       linked: true,
       relinked: false,
@@ -421,52 +590,179 @@ describe("Account — Nostr keys", () => {
         },
       ]);
     renderRoute();
-    await screen.findByTestId("account-pubkey-link");
-    fireEvent.click(screen.getByTestId("account-pubkey-link"));
-    await screen.findByTestId("account-pubkey-event");
-    const event = {
-      id: "dd".repeat(32),
-      pubkey: "aa".repeat(32),
-      created_at: 1,
-      kind: 27235,
-      tags: [] as string[][],
-      content: "statement",
-      sig: "ee".repeat(32),
-    };
-    fireEvent.change(screen.getByTestId("account-pubkey-event"), {
-      target: { value: JSON.stringify(event) },
+    await expand("account-pubkeys");
+    fireEvent.click(await screen.findByTestId("account-pubkey-link"));
+    fireEvent.click(await screen.findByTestId("account-pubkey-statement-continue"));
+    fireEvent.change(await screen.findByTestId("account-pubkey-event"), {
+      target: { value: JSON.stringify(signedEvent) },
     });
+    fireEvent.click(screen.getByTestId("account-pubkey-paste-continue"));
+
+    await screen.findByTestId("account-pubkey-label");
+    expect(screen.getByTestId("account-pubkey-password-why")).toHaveTextContent(
+      /stolen browser session/i,
+    );
     fireEvent.change(screen.getByTestId("account-pubkey-label"), { target: { value: "phone" } });
     fireEvent.change(screen.getByTestId("account-pubkey-password"), {
       target: { value: "correct-horse-battery" },
     });
     fireEvent.click(screen.getByTestId("account-pubkey-verify"));
+
     await waitFor(() =>
       expect(api.verifyPubkeyLink).toHaveBeenCalledWith("csrf-abc", {
-        event,
+        event: signedEvent,
         label: "phone",
         password: "correct-horse-battery",
       }),
     );
     expect(await screen.findByTestId(`account-pubkey-row-${"aa".repeat(32)}`)).toBeInTheDocument();
+    expect(screen.getByTestId("account-pubkeys-notice")).toHaveTextContent(/grants nothing/i);
+    // Flow reset to idle.
+    expect(screen.getByTestId("account-pubkey-link")).toBeInTheDocument();
+    expect(screen.queryByTestId("account-pubkey-steps")).toBeNull();
   });
 
-  it("rejects non-JSON event client-side (no POST)", async () => {
+  it("omits the password field when the account already holds a key", async () => {
     vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
-    vi.mocked(api.startPubkeyChallenge).mockResolvedValue({
-      challenge: "bb".repeat(32),
-      expires_at: "2026-08-25T12:05:00.000Z",
-      event_template: { kind: 27235, content: "statement", tags: [] },
-    });
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue(challenge);
+    vi.mocked(api.listAccountPubkeys).mockResolvedValue([
+      {
+        pubkey: "bb".repeat(32),
+        label: null,
+        proof_event_id: "cc".repeat(32),
+        linked_at: "2026-08-25T12:00:00.000Z",
+        last_verified_at: "2026-08-25T12:00:00.000Z",
+      },
+    ]);
     renderRoute();
-    await screen.findByTestId("account-pubkey-link");
-    fireEvent.click(screen.getByTestId("account-pubkey-link"));
-    await screen.findByTestId("account-pubkey-event");
-    fireEvent.change(screen.getByTestId("account-pubkey-event"), { target: { value: "not-json" } });
-    fireEvent.click(screen.getByTestId("account-pubkey-verify"));
+    await expand("account-pubkeys");
+    fireEvent.click(await screen.findByTestId("account-pubkey-link"));
+    fireEvent.click(await screen.findByTestId("account-pubkey-statement-continue"));
+    fireEvent.change(await screen.findByTestId("account-pubkey-event"), {
+      target: { value: JSON.stringify(signedEvent) },
+    });
+    fireEvent.click(screen.getByTestId("account-pubkey-paste-continue"));
+
+    await screen.findByTestId("account-pubkey-step-confirm");
+    expect(screen.queryByTestId("account-pubkey-password")).toBeNull();
+    expect(screen.queryByTestId("account-pubkey-password-why")).toBeNull();
+  });
+
+  it("rejects non-JSON at the sign step (no POST, stays on step 2)", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue(challenge);
+    renderRoute();
+    await expand("account-pubkeys");
+    fireEvent.click(await screen.findByTestId("account-pubkey-link"));
+    fireEvent.click(await screen.findByTestId("account-pubkey-statement-continue"));
+    fireEvent.change(await screen.findByTestId("account-pubkey-event"), {
+      target: { value: "not-json" },
+    });
+    fireEvent.click(screen.getByTestId("account-pubkey-paste-continue"));
+
     await waitFor(() =>
       expect(screen.getByTestId("account-pubkeys-form-error")).toHaveTextContent(/not valid json/i),
     );
+    expect(screen.getByTestId("account-pubkey-step-sign")).toBeInTheDocument();
     expect(api.verifyPubkeyLink).not.toHaveBeenCalled();
+  });
+
+  it("Cancel from any step returns to idle with fields cleared", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue(challenge);
+    renderRoute();
+    await expand("account-pubkeys");
+    fireEvent.click(await screen.findByTestId("account-pubkey-link"));
+    fireEvent.click(await screen.findByTestId("account-pubkey-statement-continue"));
+    fireEvent.change(await screen.findByTestId("account-pubkey-event"), {
+      target: { value: JSON.stringify(signedEvent) },
+    });
+    fireEvent.click(screen.getByTestId("account-pubkey-cancel"));
+
+    await waitFor(() => expect(screen.queryByTestId("account-pubkey-flow")).toBeNull());
+    // Restarting gives a blank textarea, not the abandoned paste.
+    fireEvent.click(screen.getByTestId("account-pubkey-link"));
+    fireEvent.click(await screen.findByTestId("account-pubkey-statement-continue"));
+    expect(await screen.findByTestId("account-pubkey-event")).toHaveValue("");
+  });
+
+  it("Back walks the stepper in reverse", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue(challenge);
+    renderRoute();
+    await expand("account-pubkeys");
+    fireEvent.click(await screen.findByTestId("account-pubkey-link"));
+    fireEvent.click(await screen.findByTestId("account-pubkey-statement-continue"));
+    fireEvent.change(await screen.findByTestId("account-pubkey-event"), {
+      target: { value: JSON.stringify(signedEvent) },
+    });
+    fireEvent.click(screen.getByTestId("account-pubkey-paste-continue"));
+    await screen.findByTestId("account-pubkey-step-confirm");
+
+    fireEvent.click(screen.getByTestId("account-pubkey-back-sign"));
+    expect(await screen.findByTestId("account-pubkey-step-sign")).toBeInTheDocument();
+    // The pasted event survived the round trip.
+    expect(screen.getByTestId("account-pubkey-event")).toHaveValue(JSON.stringify(signedEvent));
+
+    fireEvent.click(screen.getByTestId("account-pubkey-back-statement"));
+    expect(await screen.findByTestId("account-pubkey-step-statement")).toBeInTheDocument();
+    // Only one challenge was ever minted.
+    expect(api.startPubkeyChallenge).toHaveBeenCalledTimes(1);
+  });
+
+  it("with a NIP-07 extension: signing jumps to confirm, paste stays available", async () => {
+    const signEvent = vi.fn().mockResolvedValue(signedEvent);
+    (window as unknown as { nostr?: unknown }).nostr = { signEvent };
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.startPubkeyChallenge).mockResolvedValue(challenge);
+    renderRoute();
+    await expand("account-pubkeys");
+    fireEvent.click(await screen.findByTestId("account-pubkey-link"));
+    fireEvent.click(await screen.findByTestId("account-pubkey-statement-continue"));
+    await screen.findByTestId("account-pubkey-step-sign");
+
+    // Extension present → no "no extension" copy, paste tucked behind a toggle.
+    expect(screen.queryByTestId("account-pubkey-no-extension")).toBeNull();
+    expect(screen.queryByTestId("account-pubkey-event")).toBeNull();
+    const pasteToggle = screen.getByTestId("account-pubkey-paste-toggle");
+    expect(pasteToggle).toHaveAttribute("aria-expanded", "false");
+    fireEvent.click(pasteToggle);
+    expect(screen.getByTestId("account-pubkey-event")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByTestId("account-pubkey-nip07"));
+    await waitFor(() => expect(signEvent).toHaveBeenCalledTimes(1));
+    expect(signEvent.mock.calls[0]?.[0]).toMatchObject({
+      kind: 27235,
+      content: challenge.event_template.content,
+      tags: challenge.event_template.tags,
+    });
+    expect(await screen.findByTestId("account-pubkey-step-confirm")).toBeInTheDocument();
+    expect(screen.getByTestId("account-pubkey-signer")).toHaveTextContent("aaaaaaaa");
+  });
+
+  it("unlink asks for confirmation and keeps the tokens-not-revoked truth", async () => {
+    vi.mocked(api.getMe).mockResolvedValue(meSignedIn(false));
+    vi.mocked(api.listAccountPubkeys)
+      .mockResolvedValueOnce([
+        {
+          pubkey: "bb".repeat(32),
+          label: "old laptop",
+          proof_event_id: "cc".repeat(32),
+          linked_at: "2026-08-25T12:00:00.000Z",
+          last_verified_at: "2026-08-25T12:00:00.000Z",
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    vi.mocked(api.unlinkAccountPubkey).mockResolvedValue(true);
+    renderRoute();
+    await expand("account-pubkeys");
+    const row = `account-pubkey-unlink-${"bb".repeat(32)}`;
+    fireEvent.click(await screen.findByTestId(row));
+    expect(screen.getByTestId("account-pubkeys-list")).toHaveTextContent(/tokens are not revoked/i);
+    fireEvent.click(screen.getByTestId(`account-pubkey-unlink-confirm-${"bb".repeat(32)}`));
+    await waitFor(() =>
+      expect(api.unlinkAccountPubkey).toHaveBeenCalledWith("csrf-abc", "bb".repeat(32)),
+    );
+    await waitFor(() => expect(screen.getByTestId("account-pubkeys-empty")).toBeInTheDocument());
   });
 });

--- a/web/ui/src/routes/Account.tsx
+++ b/web/ui/src/routes/Account.tsx
@@ -1,29 +1,50 @@
 /**
  * /admin/account — "My account": self-service password, 2FA, my-tokens, and
- * pubkey-link for the signed-in user (hub#85 + hub#833 (b)).
+ * pubkey-link for the signed-in user (hub#85 + hub#833 (b) + hub#880).
  *
  * The owner is NOT special here: `two_factor_enabled` comes from `/api/me`
  * (keyed off the session's own user), and every action POSTs to
  * `/api/account/*`, which act on `session.userId`. Same path for the first
  * admin and any friend user.
  *
- * Four sections:
+ * ## Layout (hub#880)
+ *
+ * Summary-first. The page is four **disclosure cards**, each collapsed by
+ * default and each showing a one-line status in its header ("Two-factor: On",
+ * "3 API tokens", "1 linked key") so the operator can read their whole account
+ * posture without expanding anything. Toggles are real `<button>`s with
+ * `aria-expanded` / `aria-controls` (WAI-ARIA accordion shape), not
+ * `<details>`, so the disclosure state is programmatically announced.
+ *
+ * A `location.hash` of `#password` / `#two-factor` / `#tokens` / `#keys` opens
+ * that card on arrival — deep links from elsewhere in the shell land expanded.
+ *
+ * The four cards:
  *   - Password — current → new (+ confirm). 12-char floor mirrors the server
  *     validator; the server is authoritative (its 400/401 message surfaces).
- *   - Two-factor — status pill; when off, an enroll flow (QR + secret + verify
- *     a code → backup codes shown ONCE); when on, a password-gated disable.
+ *   - Two-factor — status pill in the card header; when off, an enroll flow
+ *     (QR + secret + verify a code → backup codes shown ONCE); when on, a
+ *     password-gated disable.
  *   - API tokens — list / mint / revoke THIS user's tokens. Operator registry
  *     stays at `/admin/tokens`. JWT shown once. Cookie+CSRF, cannot mint
  *     `parachute:host:*`.
- *   - Nostr keys — list / link / unlink. A linked key is an attribution
- *     label; it grants nothing. First-link is password-gated.
+ *   - Nostr keys — list / link / unlink, driven by a three-step guided
+ *     ceremony (see `PubkeysSection`). A linked key is an attribution label;
+ *     it grants nothing. First-link is password-gated.
+ *
+ * ## Why the list fetches are hoisted
+ *
+ * `useAccountTokens` / `useAccountPubkeys` live on the *page*, not inside the
+ * collapsed sections, because the card headers need the counts before anything
+ * is expanded. Collapsing unmounts the body; hoisting the fetch keeps the
+ * summary honest and stops a re-fetch on every expand/collapse.
  *
  * The CSRF token + 2FA status are read from `/api/me` (the single who-am-I
  * read App.tsx already does). We refetch it after a 2FA change so the status
  * pill + section swap without a full reload.
  */
-import { type FormEvent, useCallback, useEffect, useState } from "react";
-import { Link } from "react-router-dom";
+import { type FormEvent, type ReactNode, useCallback, useEffect, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 import {
   type AccountPubkey,
   type AccountTokenListing,
@@ -51,8 +72,19 @@ type LoadState =
   | { kind: "signed-out" }
   | { kind: "ok"; csrf: string; twoFactorEnabled: boolean };
 
+/** `#password` → the password card, etc. Anything else opens nothing. */
+const HASH_TARGETS: Record<string, string> = {
+  "#password": "password",
+  "#two-factor": "two-factor",
+  "#2fa": "two-factor",
+  "#tokens": "tokens",
+  "#keys": "keys",
+};
+
 export function Account() {
   const [state, setState] = useState<LoadState>({ kind: "loading" });
+  const { hash } = useLocation();
+  const openTarget = HASH_TARGETS[hash] ?? null;
 
   const refresh = useCallback(async () => {
     try {
@@ -71,6 +103,12 @@ export function Account() {
     void refresh();
   }, [refresh]);
 
+  // Hoisted so the collapsed card headers can show counts. Both hooks fetch
+  // once on mount regardless of the sign-in state resolving — the helpers
+  // redirect to login on 401 themselves.
+  const tokens = useAccountTokens();
+  const pubkeys = useAccountPubkeys();
+
   if (state.kind === "loading") {
     return <div className="empty">Loading account…</div>;
   }
@@ -85,21 +123,141 @@ export function Account() {
   }
 
   return (
-    <section className="settings" data-testid="account-page">
+    <section className="settings account-page" data-testid="account-page">
       <h1>My account</h1>
       <p className="muted">
-        Manage your own sign-in credentials, API tokens, and linked Nostr keys. Changes here apply
-        to your account only. The operator token registry is a separate page.
+        Your sign-in credentials, API tokens, and linked Nostr keys. Changes here apply to your
+        account only. The operator token registry is a separate page.
       </p>
 
-      <PasswordSection csrf={state.csrf} />
-      <TwoFactorSection
-        csrf={state.csrf}
-        enabled={state.twoFactorEnabled}
-        onChanged={() => void refresh()}
-      />
-      <TokensSection csrf={state.csrf} />
-      <PubkeysSection csrf={state.csrf} />
+      <div className="account-cards">
+        <AccountCard
+          cardId="password"
+          title="Password"
+          summary="Used to sign in to this hub"
+          testId="account-password"
+          openInitially={openTarget === "password"}
+        >
+          <PasswordSection csrf={state.csrf} />
+        </AccountCard>
+
+        <AccountCard
+          cardId="two-factor"
+          title="Two-factor authentication"
+          summary={
+            <span
+              className={`lock-status-pill ${
+                state.twoFactorEnabled ? "lock-status-on" : "lock-status-off"
+              }`}
+              data-testid="account-2fa-status"
+            >
+              {state.twoFactorEnabled ? "Enabled" : "Off"}
+            </span>
+          }
+          testId="account-2fa"
+          openInitially={openTarget === "two-factor"}
+        >
+          <TwoFactorSection
+            csrf={state.csrf}
+            enabled={state.twoFactorEnabled}
+            onChanged={() => void refresh()}
+          />
+        </AccountCard>
+
+        <AccountCard
+          cardId="tokens"
+          title="API tokens"
+          summary={summarizeTokens(tokens.list)}
+          testId="account-tokens"
+          openInitially={openTarget === "tokens"}
+        >
+          <TokensSection csrf={state.csrf} tokens={tokens} />
+        </AccountCard>
+
+        <AccountCard
+          cardId="keys"
+          title="Nostr keys"
+          summary={summarizePubkeys(pubkeys.list)}
+          testId="account-pubkeys"
+          openInitially={openTarget === "keys"}
+        >
+          <PubkeysSection csrf={state.csrf} pubkeys={pubkeys} />
+        </AccountCard>
+      </div>
+    </section>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Disclosure card
+// ---------------------------------------------------------------------------
+
+/**
+ * One collapsible settings card. WAI-ARIA accordion shape: a real `<button>`
+ * inside the heading carries `aria-expanded` + `aria-controls`, and the panel
+ * it points at exists in the DOM (empty + `hidden`) while collapsed so the
+ * relationship stays resolvable.
+ *
+ * The body is *unmounted* while collapsed — the sections own transient form
+ * state (a half-typed password, a mid-flight challenge) and collapsing should
+ * discard it rather than keep it alive invisibly. List fetches that the header
+ * summary depends on are hoisted to the page for exactly this reason.
+ */
+function AccountCard({
+  cardId,
+  title,
+  summary,
+  testId,
+  openInitially = false,
+  children,
+}: {
+  cardId: string;
+  title: string;
+  summary: ReactNode;
+  testId: string;
+  openInitially?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(openInitially);
+
+  // A hash arriving after first paint (in-shell nav to `/account#keys`) should
+  // still expand the targeted card. Never auto-*collapses*.
+  useEffect(() => {
+    if (openInitially) setOpen(true);
+  }, [openInitially]);
+
+  const titleId = `${cardId}-title`;
+  const panelId = `${cardId}-panel`;
+
+  return (
+    <section
+      className={`account-card${open ? " is-open" : ""}`}
+      aria-labelledby={titleId}
+      data-testid={testId}
+    >
+      <h2 className="account-card-heading">
+        <button
+          type="button"
+          className="account-card-toggle"
+          aria-expanded={open}
+          aria-controls={panelId}
+          onClick={() => setOpen((o) => !o)}
+          data-testid={`${testId}-toggle`}
+        >
+          <span className="account-card-chevron" aria-hidden="true">
+            {open ? "▾" : "▸"}
+          </span>
+          <span className="account-card-title" id={titleId}>
+            {title}
+          </span>
+          <span className="account-card-summary" data-testid={`${testId}-summary`}>
+            {summary}
+          </span>
+        </button>
+      </h2>
+      <div className="account-card-body" id={panelId} hidden={!open}>
+        {open ? children : null}
+      </div>
     </section>
   );
 }
@@ -148,15 +306,10 @@ function PasswordSection({ csrf }: { csrf: string }) {
   }
 
   return (
-    <section
-      className="settings-block"
-      aria-labelledby="account-password-heading"
-      data-testid="account-password"
-    >
-      <h2 id="account-password-heading">Password</h2>
+    <>
       <p className="muted">Change the password you use to sign in to this hub.</p>
 
-      <form onSubmit={(e) => void onSubmit(e)} className="settings-form">
+      <form onSubmit={(e) => void onSubmit(e)} className="settings-form account-form">
         <label>
           Current password
           <input
@@ -207,7 +360,7 @@ function PasswordSection({ csrf }: { csrf: string }) {
           {notice}
         </p>
       )}
-    </section>
+    </>
   );
 }
 
@@ -302,24 +455,10 @@ function TwoFactorSection({
   }
 
   return (
-    <section
-      className="settings-block"
-      aria-labelledby="account-2fa-heading"
-      data-testid="account-2fa"
-    >
-      <h2 id="account-2fa-heading">Two-factor authentication</h2>
+    <>
       <p className="muted">
-        Add a time-based one-time code (TOTP) from an authenticator app as a second step at sign-in.
-      </p>
-
-      <p>
-        Status:{" "}
-        <span
-          className={`lock-status-pill ${enabled ? "lock-status-on" : "lock-status-off"}`}
-          data-testid="account-2fa-status"
-        >
-          {enabled ? "Enabled" : "Off"}
-        </span>
+        A time-based one-time code (TOTP) from an authenticator app, asked for as a second step at
+        sign-in.
       </p>
 
       {/* Show the backup codes ONCE after a successful enrollment. */}
@@ -348,7 +487,7 @@ function TwoFactorSection({
         </div>
       ) : enabled ? (
         // Enrolled → password-gated disable.
-        <form onSubmit={(e) => void onDisable(e)} className="settings-form">
+        <form onSubmit={(e) => void onDisable(e)} className="settings-form account-form">
           <p className="muted">Turning off two-factor requires your current password.</p>
           <label>
             Current password
@@ -374,7 +513,7 @@ function TwoFactorSection({
         </form>
       ) : view.kind === "enrolling" ? (
         // Mid-enroll → QR + secret + confirm a code.
-        <form onSubmit={(e) => void onConfirm(e)} className="settings-form">
+        <form onSubmit={(e) => void onConfirm(e)} className="settings-form account-form">
           <p>
             Scan this QR code with your authenticator app, then enter the 6-digit code it shows to
             confirm.
@@ -409,7 +548,7 @@ function TwoFactorSection({
             </button>
             <button
               type="button"
-              className="destructive"
+              className="secondary"
               disabled={busy}
               onClick={onCancelEnroll}
               data-testid="account-2fa-cancel"
@@ -437,7 +576,7 @@ function TwoFactorSection({
           {err}
         </div>
       )}
-    </section>
+    </>
   );
 }
 
@@ -462,19 +601,21 @@ type TokenRevokeState =
   | { kind: "revoking"; jti: string }
   | { kind: "error"; jti: string; message: string };
 
-function TokensSection({ csrf }: { csrf: string }) {
+interface AccountTokensHandle {
+  list: TokenListState;
+  reload: () => void;
+  loadingMore: boolean;
+  loadMore: () => Promise<void>;
+}
+
+/** Page-level tokens fetch — see the module docstring for why it's hoisted. */
+function useAccountTokens(): AccountTokensHandle {
   const [list, setList] = useState<TokenListState>({ kind: "loading" });
-  const [reload, setReload] = useState(0);
-  const [mint, setMint] = useState<TokenMintState>({ kind: "idle" });
-  const [revoke, setRevoke] = useState<TokenRevokeState>({ kind: "idle" });
-  const [showForm, setShowForm] = useState(false);
+  const [reloadN, setReloadN] = useState(0);
   const [loadingMore, setLoadingMore] = useState(false);
-  const [scope, setScope] = useState("");
-  const [label, setLabel] = useState("");
-  const [expiresIn, setExpiresIn] = useState("");
 
   useEffect(() => {
-    void reload;
+    void reloadN;
     let cancelled = false;
     setList({ kind: "loading" });
     listAccountTokens()
@@ -484,16 +625,15 @@ function TokensSection({ csrf }: { csrf: string }) {
       })
       .catch((err: unknown) => {
         if (cancelled) return;
-        setList({
-          kind: "error",
-          message: err instanceof Error ? err.message : String(err),
-        });
+        setList({ kind: "error", message: err instanceof Error ? err.message : String(err) });
       });
     return () => {
       cancelled = true;
     };
-  }, [reload]);
+  }, [reloadN]);
 
+  // "Load more" cursor pagination — the three-ingredient shape from
+  // web/ui/CLAUDE.md (flag + disabled + early return).
   async function loadMore(): Promise<void> {
     if (list.kind !== "ok" || !list.nextCursor || loadingMore) return;
     setLoadingMore(true);
@@ -505,14 +645,31 @@ function TokensSection({ csrf }: { csrf: string }) {
         nextCursor: page.next_cursor,
       });
     } catch (err) {
-      setList({
-        kind: "error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      setList({ kind: "error", message: err instanceof Error ? err.message : String(err) });
     } finally {
       setLoadingMore(false);
     }
   }
+
+  return { list, reload: () => setReloadN((n) => n + 1), loadingMore, loadMore };
+}
+
+function summarizeTokens(list: TokenListState): string {
+  if (list.kind === "loading") return "Loading…";
+  if (list.kind === "error") return "Couldn't load tokens";
+  const n = list.tokens.length;
+  if (n === 0) return "No API tokens";
+  return `${n} API token${n === 1 ? "" : "s"}`;
+}
+
+function TokensSection({ csrf, tokens }: { csrf: string; tokens: AccountTokensHandle }) {
+  const { list, reload, loadingMore, loadMore } = tokens;
+  const [mint, setMint] = useState<TokenMintState>({ kind: "idle" });
+  const [revoke, setRevoke] = useState<TokenRevokeState>({ kind: "idle" });
+  const [showForm, setShowForm] = useState(false);
+  const [scope, setScope] = useState("");
+  const [label, setLabel] = useState("");
+  const [expiresIn, setExpiresIn] = useState("");
 
   async function onSubmitMint(e: FormEvent): Promise<void> {
     e.preventDefault();
@@ -542,12 +699,9 @@ function TokensSection({ csrf }: { csrf: string }) {
       setLabel("");
       setExpiresIn("");
       setShowForm(false);
-      setReload((n) => n + 1);
+      reload();
     } catch (err) {
-      setMint({
-        kind: "error",
-        message: err instanceof Error ? err.message : String(err),
-      });
+      setMint({ kind: "error", message: err instanceof Error ? err.message : String(err) });
     }
   }
 
@@ -556,7 +710,7 @@ function TokensSection({ csrf }: { csrf: string }) {
     try {
       await revokeAccountToken(csrf, jti);
       setRevoke({ kind: "idle" });
-      setReload((n) => n + 1);
+      reload();
     } catch (err) {
       setRevoke({
         kind: "error",
@@ -573,12 +727,7 @@ function TokensSection({ csrf }: { csrf: string }) {
   }
 
   return (
-    <section
-      className="settings-block"
-      aria-labelledby="account-tokens-heading"
-      data-testid="account-tokens"
-    >
-      <h2 id="account-tokens-heading">API tokens</h2>
+    <>
       <p className="muted">
         Tokens minted as you. A friend can mint a subset of their own authority (assigned vaults);
         nobody mints <code>parachute:host:*</code> here. The operator registry — every CLI / OAuth /
@@ -611,78 +760,86 @@ function TokensSection({ csrf }: { csrf: string }) {
         </div>
       ) : null}
 
-      <div className="actions" style={{ marginBottom: "0.75rem" }}>
+      <div className="account-subsection">
         <button
           type="button"
+          className="secondary account-disclosure"
+          aria-expanded={showForm}
+          aria-controls="account-token-mint-form"
           onClick={() => setShowForm((s) => !s)}
           data-testid="account-token-mint-toggle"
         >
+          <span aria-hidden="true">{showForm ? "▾" : "▸"}</span>{" "}
           {showForm ? "Hide form" : "Mint a token"}
         </button>
+
+        <div id="account-token-mint-form" hidden={!showForm}>
+          {showForm ? (
+            <form onSubmit={(e) => void onSubmitMint(e)} className="settings-form account-form">
+              <label>
+                Scope (space-separated)
+                <input
+                  type="text"
+                  value={scope}
+                  onChange={(e) => setScope(e.target.value)}
+                  placeholder="e.g. vault:work:read"
+                  data-testid="account-token-scope"
+                />
+              </label>
+              <label>
+                Label (optional)
+                <input
+                  type="text"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  placeholder="laptop, backup, …"
+                  data-testid="account-token-label"
+                />
+              </label>
+              <label>
+                Expires in (seconds, optional)
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={expiresIn}
+                  onChange={(e) => setExpiresIn(e.target.value)}
+                  placeholder="default 90d"
+                  data-testid="account-token-expires"
+                />
+              </label>
+              {mint.kind === "error" ? (
+                <div className="error" data-testid="account-token-mint-error">
+                  {mint.message}
+                </div>
+              ) : null}
+              <div className="actions">
+                <button
+                  type="submit"
+                  disabled={mint.kind === "submitting"}
+                  data-testid="account-token-mint"
+                >
+                  {mint.kind === "submitting" ? "Minting…" : "Mint"}
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  onClick={() => {
+                    setShowForm(false);
+                    setMint({ kind: "idle" });
+                  }}
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          ) : null}
+        </div>
       </div>
 
-      {showForm ? (
-        <form onSubmit={(e) => void onSubmitMint(e)} className="settings-form">
-          <label>
-            Scope (space-separated)
-            <input
-              type="text"
-              value={scope}
-              onChange={(e) => setScope(e.target.value)}
-              placeholder="e.g. vault:work:read"
-              data-testid="account-token-scope"
-            />
-          </label>
-          <label>
-            Label (optional)
-            <input
-              type="text"
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              placeholder="laptop, backup, …"
-              data-testid="account-token-label"
-            />
-          </label>
-          <label>
-            Expires in (seconds, optional)
-            <input
-              type="text"
-              inputMode="numeric"
-              value={expiresIn}
-              onChange={(e) => setExpiresIn(e.target.value)}
-              placeholder="default 90d"
-              data-testid="account-token-expires"
-            />
-          </label>
-          {mint.kind === "error" ? (
-            <div className="error" data-testid="account-token-mint-error">
-              {mint.message}
-            </div>
-          ) : null}
-          <div className="actions">
-            <button
-              type="submit"
-              disabled={mint.kind === "submitting"}
-              data-testid="account-token-mint"
-            >
-              {mint.kind === "submitting" ? "Minting…" : "Mint"}
-            </button>
-            <button
-              type="button"
-              className="secondary"
-              onClick={() => {
-                setShowForm(false);
-                setMint({ kind: "idle" });
-              }}
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      ) : null}
-
       {list.kind === "loading" ? (
-        <p className="muted">Loading tokens…</p>
+        <p className="muted" data-loading="true">
+          Loading tokens…
+        </p>
       ) : list.kind === "error" ? (
         <div className="error" data-testid="account-tokens-error">
           {list.message}
@@ -784,7 +941,7 @@ function TokensSection({ csrf }: { csrf: string }) {
           ) : null}
         </div>
       )}
-    </section>
+    </>
   );
 }
 
@@ -807,7 +964,64 @@ type PubkeyListState =
   | { kind: "ok"; pubkeys: AccountPubkey[] }
   | { kind: "error"; message: string };
 
-type LinkView = { kind: "idle" } | { kind: "challenging"; challenge: PubkeyChallenge };
+interface AccountPubkeysHandle {
+  list: PubkeyListState;
+  reload: () => void;
+}
+
+/** Page-level pubkeys fetch — see the module docstring for why it's hoisted. */
+function useAccountPubkeys(): AccountPubkeysHandle {
+  const [list, setList] = useState<PubkeyListState>({ kind: "loading" });
+  const [reloadN, setReloadN] = useState(0);
+
+  useEffect(() => {
+    void reloadN;
+    let cancelled = false;
+    setList({ kind: "loading" });
+    listAccountPubkeys()
+      .then((pubkeys) => {
+        if (cancelled) return;
+        setList({ kind: "ok", pubkeys });
+      })
+      .catch((e: unknown) => {
+        if (cancelled) return;
+        setList({ kind: "error", message: e instanceof Error ? e.message : String(e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [reloadN]);
+
+  return { list, reload: () => setReloadN((n) => n + 1) };
+}
+
+function summarizePubkeys(list: PubkeyListState): string {
+  if (list.kind === "loading") return "Loading…";
+  if (list.kind === "error") return "Couldn't load keys";
+  const n = list.pubkeys.length;
+  if (n === 0) return "No linked keys";
+  return `${n} linked key${n === 1 ? "" : "s"}`;
+}
+
+/**
+ * The link ceremony, as three visible steps.
+ *
+ *   idle      → why you'd do this at all, and a single "Link a key" button.
+ *   statement → the hub's one-time sentence, shown before anything is signed.
+ *   sign      → NIP-07 extension (primary when present) or paste a signed
+ *               event (primary when absent, tucked behind a disclosure when
+ *               an extension is available).
+ *   confirm   → optional label + first-link password step-up + submit.
+ *
+ * The wire protocol is unchanged (challenge → sign → verify); the steps are
+ * purely how the same three moves are surfaced. Cancel from any step returns
+ * to `idle` with every field cleared.
+ */
+type LinkState =
+  | { kind: "idle" }
+  | { kind: "statement"; challenge: PubkeyChallenge }
+  | { kind: "sign"; challenge: PubkeyChallenge }
+  | { kind: "confirm"; challenge: PubkeyChallenge; event: SignedNostrEvent };
 
 type Nip07 = {
   signEvent: (event: {
@@ -824,40 +1038,76 @@ function hasNip07(): Nip07 | null {
   return nostr && typeof nostr.signEvent === "function" ? nostr : null;
 }
 
-function PubkeysSection({ csrf }: { csrf: string }) {
-  const [list, setList] = useState<PubkeyListState>({ kind: "loading" });
-  const [reload, setReload] = useState(0);
-  const [view, setView] = useState<LinkView>({ kind: "idle" });
+/** Parse a pasted signed event. Returns the event or an operator-readable why-not. */
+function parseSignedEvent(
+  json: string,
+): { ok: true; event: SignedNostrEvent } | { ok: false; message: string } {
+  if (!json.trim()) {
+    return { ok: false, message: "Paste the signed event before continuing." };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json) as unknown;
+  } catch {
+    return { ok: false, message: "Signed event is not valid JSON." };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, message: "Paste a signed NIP-01 event object." };
+  }
+  return { ok: true, event: parsed as SignedNostrEvent };
+}
+
+const LINK_STEP_LABELS = ["Get the statement", "Sign it", "Confirm"] as const;
+
+function StepIndicator({ current }: { current: 1 | 2 | 3 }) {
+  return (
+    <ol className="link-steps" data-testid="account-pubkey-steps">
+      {LINK_STEP_LABELS.map((label, i) => {
+        const n = i + 1;
+        const state = n === current ? "current" : n < current ? "done" : "todo";
+        return (
+          <li
+            key={label}
+            className={`link-step link-step-${state}`}
+            {...(n === current ? { "aria-current": "step" as const } : {})}
+          >
+            <span className="link-step-num" aria-hidden="true">
+              {n}
+            </span>
+            <span className="link-step-label">{label}</span>
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+function PubkeysSection({ csrf, pubkeys }: { csrf: string; pubkeys: AccountPubkeysHandle }) {
+  const { list, reload } = pubkeys;
+  const [link, setLink] = useState<LinkState>({ kind: "idle" });
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [eventJson, setEventJson] = useState("");
+  const [showPaste, setShowPaste] = useState(false);
   const [label, setLabel] = useState("");
   const [password, setPassword] = useState("");
   const [unlink, setUnlink] = useState<string | null>(null);
   const [notice, setNotice] = useState<string | null>(null);
 
-  useEffect(() => {
-    void reload;
-    let cancelled = false;
-    setList({ kind: "loading" });
-    listAccountPubkeys()
-      .then((pubkeys) => {
-        if (cancelled) return;
-        setList({ kind: "ok", pubkeys });
-      })
-      .catch((e: unknown) => {
-        if (cancelled) return;
-        setList({ kind: "error", message: e instanceof Error ? e.message : String(e) });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [reload]);
-
   // Password step-up is required on the FIRST link. Show the field unless we
   // already know this account holds a key; a failed list still shows it
   // (server ignores the extra password on a subsequent link).
   const firstLink = list.kind !== "ok" || list.pubkeys.length === 0;
+  const nip07 = hasNip07();
+
+  function resetFlow() {
+    setLink({ kind: "idle" });
+    setEventJson("");
+    setShowPaste(false);
+    setLabel("");
+    setPassword("");
+    setErr(null);
+  }
 
   async function onStartLink(): Promise<void> {
     if (busy) return;
@@ -866,8 +1116,10 @@ function PubkeysSection({ csrf }: { csrf: string }) {
     setBusy(true);
     try {
       const challenge = await startPubkeyChallenge(csrf);
-      setView({ kind: "challenging", challenge });
+      setLink({ kind: "statement", challenge });
       setEventJson("");
+      // With no extension the paste path IS the path — open it by default.
+      setShowPaste(!nip07);
       setLabel("");
       setPassword("");
     } catch (e) {
@@ -878,7 +1130,7 @@ function PubkeysSection({ csrf }: { csrf: string }) {
   }
 
   async function onSignWithExtension(): Promise<void> {
-    if (view.kind !== "challenging") return;
+    if (link.kind !== "sign") return;
     const nostr = hasNip07();
     if (!nostr) {
       setErr("No NIP-07 signer is available in this browser.");
@@ -887,7 +1139,7 @@ function PubkeysSection({ csrf }: { csrf: string }) {
     setErr(null);
     setBusy(true);
     try {
-      const tpl = view.challenge.event_template;
+      const tpl = link.challenge.event_template;
       const signed = await nostr.signEvent({
         kind: tpl.kind,
         created_at: Math.floor(Date.now() / 1000),
@@ -895,6 +1147,7 @@ function PubkeysSection({ csrf }: { csrf: string }) {
         content: tpl.content,
       });
       setEventJson(JSON.stringify(signed, null, 2));
+      setLink({ kind: "confirm", challenge: link.challenge, event: signed });
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -902,40 +1155,37 @@ function PubkeysSection({ csrf }: { csrf: string }) {
     }
   }
 
-  async function onVerify(e: FormEvent): Promise<void> {
-    e.preventDefault();
-    if (busy) return;
-    setErr(null);
-    setNotice(null);
-    let event: SignedNostrEvent;
-    try {
-      const parsed = JSON.parse(eventJson) as unknown;
-      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
-        setErr("Paste a signed NIP-01 event object.");
-        return;
-      }
-      event = parsed as SignedNostrEvent;
-    } catch {
-      setErr("Signed event is not valid JSON.");
+  /** Step 2 → 3 on the paste path. Validates here so a typo fails early. */
+  function onUsePastedEvent(): void {
+    if (link.kind !== "sign") return;
+    const parsed = parseSignedEvent(eventJson);
+    if (!parsed.ok) {
+      setErr(parsed.message);
       return;
     }
+    setErr(null);
+    setLink({ kind: "confirm", challenge: link.challenge, event: parsed.event });
+  }
+
+  async function onVerify(e: FormEvent): Promise<void> {
+    e.preventDefault();
+    if (busy || link.kind !== "confirm") return;
+    setErr(null);
+    setNotice(null);
     setBusy(true);
     try {
       const result = await verifyPubkeyLink(csrf, {
-        event,
+        event: link.event,
         ...(label.trim() ? { label: label.trim() } : {}),
         ...(password ? { password } : {}),
       });
-      setView({ kind: "idle" });
-      setEventJson("");
-      setLabel("");
-      setPassword("");
+      resetFlow();
       setNotice(
         result.relinked
           ? `Re-verified ${truncatePubkey(result.pubkey)}.`
           : `Linked ${truncatePubkey(result.pubkey)}. A linked key grants nothing — it is an attribution label.`,
       );
-      setReload((n) => n + 1);
+      reload();
     } catch (e2) {
       setErr(e2 instanceof Error ? e2.message : String(e2));
     } finally {
@@ -950,7 +1200,7 @@ function PubkeysSection({ csrf }: { csrf: string }) {
     try {
       await unlinkAccountPubkey(csrf, pubkey);
       setUnlink(null);
-      setReload((n) => n + 1);
+      reload();
     } catch (e) {
       setErr(e instanceof Error ? e.message : String(e));
     } finally {
@@ -958,18 +1208,43 @@ function PubkeysSection({ csrf }: { csrf: string }) {
     }
   }
 
-  const nip07 = hasNip07();
+  const pasteField = (
+    <>
+      <label>
+        Signed event (JSON)
+        <textarea
+          value={eventJson}
+          onChange={(e) => setEventJson(e.target.value)}
+          rows={8}
+          spellCheck={false}
+          className="account-event-input"
+          data-testid="account-pubkey-event"
+        />
+      </label>
+      <p className="dim">
+        Sign the statement above with any Nostr tool — <code>nak</code>, a nostr-tools script, a
+        phone signer — and paste the whole event object it prints:{" "}
+        <code>{'{"id":…,"pubkey":…,"sig":…}'}</code>
+      </p>
+      <div className="actions">
+        <button
+          type="button"
+          disabled={busy}
+          onClick={onUsePastedEvent}
+          data-testid="account-pubkey-paste-continue"
+        >
+          Continue
+        </button>
+      </div>
+    </>
+  );
 
   return (
-    <section
-      className="settings-block"
-      aria-labelledby="account-pubkeys-heading"
-      data-testid="account-pubkeys"
-    >
-      <h2 id="account-pubkeys-heading">Nostr keys</h2>
+    <>
       <p className="muted">
-        A linked key is an attribution label. It does not log you in, mint a token, or widen a
-        scope. Unlink does not revoke tokens.
+        Linking a Nostr key lets this hub recognize things you sign with it — signed requests from
+        your agents or apps — as yours. It's an attribution label: it does not log you in, mint a
+        token, or widen a scope. Unlinking does not revoke tokens.
       </p>
 
       {notice ? (
@@ -978,87 +1253,7 @@ function PubkeysSection({ csrf }: { csrf: string }) {
         </p>
       ) : null}
 
-      {view.kind === "challenging" ? (
-        <form onSubmit={(e) => void onVerify(e)} className="settings-form">
-          <p>
-            Sign this statement with a Nostr key you hold, then paste the signed event. A signer
-            that shows you the content will show you this sentence:
-          </p>
-          <pre
-            className="token-box"
-            data-testid="account-pubkey-statement"
-            style={{ whiteSpace: "pre-wrap" }}
-          >
-            <code>{view.challenge.event_template.content}</code>
-          </pre>
-          {nip07 ? (
-            <div className="actions">
-              <button
-                type="button"
-                disabled={busy}
-                onClick={() => void onSignWithExtension()}
-                data-testid="account-pubkey-nip07"
-              >
-                {busy ? "Waiting for signer…" : "Sign with browser extension"}
-              </button>
-            </div>
-          ) : (
-            <p className="muted">
-              No NIP-07 extension detected. Sign the event template elsewhere and paste the JSON
-              below.
-            </p>
-          )}
-          <label>
-            Signed event (JSON)
-            <textarea
-              value={eventJson}
-              onChange={(e) => setEventJson(e.target.value)}
-              rows={8}
-              style={{ width: "100%", fontFamily: "monospace", fontSize: "0.85rem" }}
-              data-testid="account-pubkey-event"
-            />
-          </label>
-          <label>
-            Label (optional)
-            <input
-              type="text"
-              value={label}
-              onChange={(e) => setLabel(e.target.value)}
-              placeholder="phone, signing device, …"
-              data-testid="account-pubkey-label"
-            />
-          </label>
-          {firstLink ? (
-            <label>
-              Current password (required to link your first key)
-              <input
-                type="password"
-                autoComplete="current-password"
-                value={password}
-                onChange={(e) => setPassword(e.target.value)}
-                data-testid="account-pubkey-password"
-              />
-            </label>
-          ) : null}
-          <div className="actions">
-            <button type="submit" disabled={busy} data-testid="account-pubkey-verify">
-              {busy ? "Verifying…" : "Link key"}
-            </button>
-            <button
-              type="button"
-              className="secondary"
-              disabled={busy}
-              onClick={() => {
-                setView({ kind: "idle" });
-                setErr(null);
-              }}
-              data-testid="account-pubkey-cancel"
-            >
-              Cancel
-            </button>
-          </div>
-        </form>
-      ) : (
+      {link.kind === "idle" ? (
         <div className="actions">
           <button
             type="button"
@@ -1066,13 +1261,205 @@ function PubkeysSection({ csrf }: { csrf: string }) {
             onClick={() => void onStartLink()}
             data-testid="account-pubkey-link"
           >
-            {busy ? "Starting…" : "Link a Nostr key"}
+            {busy ? "Starting…" : "Link a key"}
           </button>
+        </div>
+      ) : (
+        <div className="link-flow" data-testid="account-pubkey-flow">
+          <StepIndicator current={link.kind === "statement" ? 1 : link.kind === "sign" ? 2 : 3} />
+
+          {link.kind === "statement" ? (
+            <div className="link-panel" data-testid="account-pubkey-step-statement">
+              <h3>Get the statement</h3>
+              <p>
+                The hub wrote this one-time statement naming your account and this hub. Signing it
+                proves you hold the key — nothing else.
+              </p>
+              <pre
+                className="statement-box"
+                data-testid="account-pubkey-statement"
+                style={{ whiteSpace: "pre-wrap" }}
+              >
+                <code>{link.challenge.event_template.content}</code>
+              </pre>
+              <p className="dim">
+                It stops being valid at <code>{formatDate(link.challenge.expires_at)}</code>. Start
+                over if that passes.
+              </p>
+              <div className="actions">
+                <button
+                  type="button"
+                  disabled={busy}
+                  onClick={() => setLink({ kind: "sign", challenge: link.challenge })}
+                  data-testid="account-pubkey-statement-continue"
+                >
+                  Next: sign it
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  disabled={busy}
+                  onClick={resetFlow}
+                  data-testid="account-pubkey-cancel"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {link.kind === "sign" ? (
+            <div className="link-panel" data-testid="account-pubkey-step-sign">
+              <h3>Sign it</h3>
+              <pre
+                className="statement-box"
+                data-testid="account-pubkey-statement"
+                style={{ whiteSpace: "pre-wrap" }}
+              >
+                <code>{link.challenge.event_template.content}</code>
+              </pre>
+
+              {nip07 ? (
+                <>
+                  <p>
+                    Your browser has a Nostr signing extension. It will show you that sentence and
+                    ask you to approve it.
+                  </p>
+                  <div className="actions">
+                    <button
+                      type="button"
+                      disabled={busy}
+                      onClick={() => void onSignWithExtension()}
+                      data-testid="account-pubkey-nip07"
+                    >
+                      {busy ? "Waiting for signer…" : "Sign with browser extension"}
+                    </button>
+                  </div>
+                  <div className="account-subsection">
+                    <button
+                      type="button"
+                      className="secondary account-disclosure"
+                      aria-expanded={showPaste}
+                      aria-controls="account-pubkey-paste"
+                      onClick={() => setShowPaste((s) => !s)}
+                      data-testid="account-pubkey-paste-toggle"
+                    >
+                      <span aria-hidden="true">{showPaste ? "▾" : "▸"}</span> Sign somewhere else /
+                      paste manually
+                    </button>
+                    <div id="account-pubkey-paste" hidden={!showPaste}>
+                      {showPaste ? pasteField : null}
+                    </div>
+                  </div>
+                </>
+              ) : (
+                <>
+                  <p data-testid="account-pubkey-no-extension">
+                    No signing extension detected in this browser. Sign the statement wherever your
+                    key lives, then paste the result below.
+                  </p>
+                  <p className="dim">
+                    A NIP-07 extension (Alby, nos2x, and friends) makes this one click next time.
+                  </p>
+                  <div id="account-pubkey-paste">{pasteField}</div>
+                </>
+              )}
+
+              <div className="actions">
+                <button
+                  type="button"
+                  className="secondary"
+                  disabled={busy}
+                  onClick={() => setLink({ kind: "statement", challenge: link.challenge })}
+                  data-testid="account-pubkey-back-statement"
+                >
+                  Back
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  disabled={busy}
+                  onClick={resetFlow}
+                  data-testid="account-pubkey-cancel"
+                >
+                  Cancel
+                </button>
+              </div>
+            </div>
+          ) : null}
+
+          {link.kind === "confirm" ? (
+            <form
+              onSubmit={(e) => void onVerify(e)}
+              className="link-panel settings-form account-form"
+              data-testid="account-pubkey-step-confirm"
+            >
+              <h3>Confirm</h3>
+              <p>
+                Signed by{" "}
+                <code data-testid="account-pubkey-signer">{truncatePubkey(link.event.pubkey)}</code>
+                . Linking records that this key is yours.
+              </p>
+              <label>
+                Label (optional)
+                <input
+                  type="text"
+                  value={label}
+                  onChange={(e) => setLabel(e.target.value)}
+                  placeholder="e.g. 'my phone key'"
+                  data-testid="account-pubkey-label"
+                />
+              </label>
+              {firstLink ? (
+                <>
+                  <label>
+                    Your hub password
+                    <input
+                      type="password"
+                      autoComplete="current-password"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      data-testid="account-pubkey-password"
+                    />
+                  </label>
+                  <p className="dim" data-testid="account-pubkey-password-why">
+                    First link asks for your hub password so a stolen browser session can't bind a
+                    key to your account.
+                  </p>
+                </>
+              ) : null}
+              <div className="actions">
+                <button type="submit" disabled={busy} data-testid="account-pubkey-verify">
+                  {busy ? "Verifying…" : "Link key"}
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  disabled={busy}
+                  onClick={() => setLink({ kind: "sign", challenge: link.challenge })}
+                  data-testid="account-pubkey-back-sign"
+                >
+                  Back
+                </button>
+                <button
+                  type="button"
+                  className="secondary"
+                  disabled={busy}
+                  onClick={resetFlow}
+                  data-testid="account-pubkey-cancel"
+                >
+                  Cancel
+                </button>
+              </div>
+            </form>
+          ) : null}
         </div>
       )}
 
       {list.kind === "loading" ? (
-        <p className="muted">Loading keys…</p>
+        <p className="muted" data-loading="true">
+          Loading keys…
+        </p>
       ) : list.kind === "error" ? (
         <div className="error" data-testid="account-pubkeys-error">
           {list.message}
@@ -1145,7 +1532,7 @@ function PubkeysSection({ csrf }: { csrf: string }) {
           {err}
         </div>
       )}
-    </section>
+    </>
   );
 }
 

--- a/web/ui/src/styles.css
+++ b/web/ui/src/styles.css
@@ -1557,3 +1557,250 @@ a.btn:hover {
   font-size: 0.95rem;
   letter-spacing: 0.02em;
 }
+
+/* ---------------------------------------------------------------------------
+ * /admin/account — summary-first disclosure cards + the key-link stepper
+ * (hub#880).
+ *
+ * Before this the page was four full-weight `<section>`s stacked into one long
+ * settings dump: password, 2FA, a paginated token list, keys. The card shell
+ * below collapses each to a single row — title on the left, one-line status on
+ * the right — so the whole account posture reads at a glance and only the
+ * section you're actually working in is expanded.
+ *
+ * Everything here is built from the existing tokens (`--accent`, `--bg-soft`,
+ * `--border`, …). No new palette; these surfaces stay continuous with the
+ * server-rendered login/consent flow.
+ * ------------------------------------------------------------------------- */
+.account-page > .muted {
+  margin-bottom: 1.5rem;
+}
+
+.account-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.account-card {
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease;
+}
+.account-card.is-open {
+  border-color: var(--accent);
+  box-shadow: 0 2px 10px rgba(0, 0, 0, 0.04);
+}
+
+/* The heading is a real <h2> so heading navigation still lands on each
+   section; the button inside it carries the disclosure semantics. Reset the
+   global h2 margins/size — the card header is a control, not a title block. */
+.account-card-heading {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 500;
+}
+.account-card-toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  width: 100%;
+  background: transparent;
+  color: var(--fg);
+  border: 0;
+  border-radius: 0;
+  padding: 0.9rem 1.25rem;
+  text-align: left;
+  font: inherit;
+  cursor: pointer;
+}
+.account-card-toggle:hover {
+  background: var(--bg-soft);
+}
+.account-card-toggle:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+}
+.account-card-chevron {
+  flex: 0 0 auto;
+  color: var(--fg-dim);
+  font-size: 0.8rem;
+  line-height: 1;
+  width: 0.8rem;
+}
+.account-card-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+}
+/* The one-line status: "3 API tokens", "1 linked key", or a status pill. */
+.account-card-summary {
+  flex: 0 0 auto;
+  color: var(--fg-muted);
+  font-size: 0.86rem;
+  font-weight: 400;
+  text-align: right;
+}
+.account-card-body {
+  padding: 1rem 1.25rem 1.25rem;
+  border-top: 1px solid var(--border-light);
+}
+.account-card-body > p:first-child {
+  margin-top: 0;
+}
+.account-card-body h3 {
+  margin: 0 0 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+/* Stacked form fields inside a card. `form label` is already block-level with
+   a muted caption; this just gives the fields breathing room and keeps text
+   inputs from running the full 880px page width. */
+.account-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+  max-width: 30rem;
+  margin-top: 0.75rem;
+}
+.account-form label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  margin-bottom: 0;
+}
+.account-form .actions {
+  margin-top: 0.25rem;
+}
+.account-event-input {
+  width: 100%;
+  font-family: var(--font-mono);
+  font-size: 0.85rem;
+}
+
+/* Secondary disclosure inside a card — the token mint form, the
+   "paste manually" path. Styled as a quiet text toggle, not a button, so it
+   doesn't compete with the primary action beside it. */
+.account-subsection {
+  margin: 1rem 0;
+}
+button.account-disclosure {
+  background: transparent;
+  border: 0;
+  padding: 0.2rem 0;
+  color: var(--accent);
+  font-size: 0.9rem;
+  font-weight: 500;
+  border-radius: 4px;
+}
+button.account-disclosure:hover {
+  background: transparent;
+  color: var(--accent-hover);
+  text-decoration: underline;
+}
+button.account-disclosure:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+/* -------------------------------------------------------------------------
+ * Nostr key-link stepper.
+ *
+ * Three numbered steps — get the statement, sign it, confirm — so the
+ * ceremony reads as a guided flow rather than a developer form with a JSON
+ * textarea. The indicator is an <ol> (the steps are genuinely ordered) and the
+ * active step carries `aria-current="step"`.
+ * ----------------------------------------------------------------------- */
+.link-flow {
+  margin: 1rem 0;
+}
+.link-steps {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem 1.1rem;
+  margin: 0 0 1rem;
+  padding: 0;
+}
+.link-step {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.86rem;
+  color: var(--fg-dim);
+}
+.link-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--bg-soft);
+  color: var(--fg-dim);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+.link-step-done {
+  color: var(--fg-muted);
+}
+.link-step-done .link-step-num {
+  background: var(--success-soft);
+  border-color: var(--success);
+  color: var(--success);
+}
+.link-step-current {
+  color: var(--fg);
+  font-weight: 600;
+}
+.link-step-current .link-step-num {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+
+.link-panel {
+  background: var(--bg-soft);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 1.1rem 1.25rem;
+}
+.link-panel > p:first-of-type {
+  margin-top: 0;
+}
+
+/* The hub's one-time challenge sentence. Deliberately prominent — it is the
+   thing the operator is being asked to vouch for, and a signer that shows
+   event content will show them exactly this text. */
+.statement-box {
+  margin: 0.85rem 0;
+  padding: 0.85rem 1rem;
+  background: var(--card-bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  font-family: var(--font-serif);
+  font-size: 1rem;
+  line-height: 1.5;
+  color: var(--fg);
+}
+.statement-box code {
+  background: transparent;
+  padding: 0;
+  font-family: inherit;
+  font-size: inherit;
+}
+
+/* Inline form / action error. Every SPA route already emits
+   `<div className="error">` (Account, Settings, Modules) but no rule ever
+   backed it, so failures rendered as plain body text. */
+.error {
+  margin-top: 0.6rem;
+  color: var(--error);
+  font-size: 0.9rem;
+}


### PR DESCRIPTION
Fixes #880.

## What changed

**Key-link is a guided three-step flow** (Get the statement → Sign it → Confirm) instead of a developer form: plain-language copy at each step (why linking exists, what the one-time statement proves, why the first link asks for the hub password). NIP-07 extension signing is primary when an extension exists, paste-a-signed-event behind a disclosure; with no extension the paste path leads and a one-liner names the extension option. Back walks in reverse without re-minting the challenge; JSON is validated at step 2 so a typo fails before the label/password step.

**The four sections are collapsible summary cards** (WAI-ARIA accordion, real `<button aria-expanded>` toggles) with live headers — "3 API tokens", "1 linked key", the 2FA status pill — so the page reads at a glance. `#password` / `#two-factor` / `#tokens` / `#keys` deep-links open the matching card. Mint form behind a disclosure; JWT-shown-once reveal and every security truth-sentence preserved (reworded for humans where useful, meaning intact).

## Boundaries

- UI-only: no server, `lib/api.ts` shape, or router changes; ceremony semantics untouched (challenge → sign → verify, first-link password step-up logic verbatim).
- `styles.css` purely additive under `.account-*` / `.link-*` — zero token drift.
- **One deliberate cross-page addition**: `.error { color: var(--error) }`. Account, Settings, and Modules all emit `className="error"` but no CSS rule ever backed it — inline errors have been rendering as plain body text. Flagging since it (correctly) changes Settings/Modules error rendering too.
- No data-testids removed; 13 added for the stepper states.

## Verification (my own runs at the branch tip)

- `web/ui`: typecheck clean · vitest **351/351** (Account.test.tsx 18 → 29 tests: stepper walk with `aria-current`, hash deep-link, first-vs-second-link password, cancel/back, NIP-07 path, collapsed-summary reads, non-JSON rejected client-side with no POST) · `bun run build` + verify-base clean.

Screen recording per the frontend PR SOP follows in a comment.

Noticed, not touched (pre-existing): `.settings` / `.settings-block` / `.settings-form` / bare `.token-box` classes have no CSS rules anywhere, and the 2FA-disable `destructive` button has no `.destructive` rule (renders identical to a benign button) — filing follow-ups if wanted.

Originating channel: parachute 3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d.

🤖 Generated with [Claude Code](https://claude.com/claude-code)