### PR TITLE
fix: honor X-Forwarded-Proto for NIP-98 only on non-loopback (hub#915)

### DIFF
--- a/src/__tests__/hub-server.test.ts
+++ b/src/__tests__/hub-server.test.ts
@@ -7335,13 +7335,18 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
     return { ...unsigned, id, sig };
   }
 
-  function nostrMcpReq(secret: Uint8Array, url: string, body: unknown): Request {
+  function nostrMcpReq(
+    secret: Uint8Array,
+    url: string,
+    body: unknown,
+    opts?: { signedUrl?: string; extraHeaders?: Record<string, string> },
+  ): Request {
     const encoded = JSON.stringify(body);
     const bytes = new TextEncoder().encode(encoded);
     const event = signNostrEvent(secret, {
       content: `${Date.now()}-${Math.random()}`,
       tags: [
-        ["u", url],
+        ["u", opts?.signedUrl ?? url],
         ["method", "POST"],
         ["payload", createHash("sha256").update(bytes).digest("hex")],
       ],
@@ -7353,6 +7358,7 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
         accept: BOTH_ACCEPT,
         "content-type": "application/json",
         host: new URL(url).host,
+        ...opts?.extraHeaders,
       },
       body: encoded,
     });
@@ -7510,6 +7516,79 @@ describe("hubFetch root /mcp forwarding (vault 0.7.3 canonical root MCP)", () =>
       expect(res.status).toBe(200);
       const body = (await res.json()) as { result?: { serverInfo?: { name?: string } } };
       expect(body.result?.serverInfo?.name).toBe("parachute-account");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      db.close();
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("loopback peer + forged XFP does not accept a captured https u-tag (hub#915)", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      await createUser(db, "owner", "pw", { passwordChanged: true });
+      const fetcher = hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath });
+      const httpUrl = "http://uni.taildf9ce2.ts.net/mcp";
+      const httpsUrl = "https://uni.taildf9ce2.ts.net/mcp";
+      const secret = hexToBytes("22".repeat(32));
+      const res = await fetcher(
+        nostrMcpReq(
+          secret,
+          httpUrl,
+          { jsonrpc: "2.0", id: 1, method: "initialize" },
+          {
+            signedUrl: httpsUrl,
+            extraHeaders: { "x-forwarded-proto": "https" },
+          },
+        ),
+        fakeServer("127.0.0.1"),
+      );
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error_description?: string };
+      expect(body.error_description).toBe("Nostr event u tag must equal this request URL");
+      expect(upstream.requests().length).toBe(0);
+    } finally {
+      db.close();
+      upstream.stop();
+      h.cleanup();
+    }
+  });
+
+  test("Tailscale Serve XFP+XFF on loopback peer still reconstructs https (hub#915)", async () => {
+    const h = makeHarness();
+    const upstream = startRecordingUpstream();
+    const db = openHubDb(hubDbPath(h.dir));
+    try {
+      writeManifest({ services: [canonicalVaultRow(upstream.port)] }, h.manifestPath);
+      await createUser(db, "owner", "pw", { passwordChanged: true });
+      const fetcher = hubFetch(h.dir, { getDb: () => db, manifestPath: h.manifestPath });
+      const httpUrl = "http://uni.taildf9ce2.ts.net/mcp";
+      const httpsUrl = "https://uni.taildf9ce2.ts.net/mcp";
+      const secret = hexToBytes("33".repeat(32));
+      const res = await fetcher(
+        nostrMcpReq(
+          secret,
+          httpUrl,
+          { jsonrpc: "2.0", id: 1, method: "initialize" },
+          {
+            signedUrl: httpsUrl,
+            extraHeaders: {
+              "x-forwarded-proto": "https",
+              "x-forwarded-for": "100.64.0.12",
+              "tailscale-user-login": "aaron@example.com",
+            },
+          },
+        ),
+        fakeServer("127.0.0.1"),
+      );
+      // URL reconstructed; pubkey is unlinked — not a u-tag mismatch.
+      expect(res.status).toBe(401);
+      const body = (await res.json()) as { error_description?: string };
+      expect(body.error_description).toBe("Nostr pubkey is not linked to a hub user");
       expect(upstream.requests().length).toBe(0);
     } finally {
       db.close();

--- a/src/__tests__/nostr-http-auth.test.ts
+++ b/src/__tests__/nostr-http-auth.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../nostr-http-auth.ts";
 import { bindPubkeyFromHttpAuth, findPubkeyLink } from "../pubkey-links.ts";
 import { issuePubkeyChallenge, linkPubkey } from "../pubkey-links.ts";
+import { bindRequestPeer } from "../request-layer.ts";
 import { createUser } from "../users.ts";
 
 const hexToBytes = (hex: string): Uint8Array => Uint8Array.from(Buffer.from(hex, "hex"));
@@ -122,6 +123,56 @@ describe("requestAbsoluteUrl", () => {
     const req = new Request("https://uni.taildf9ce2.ts.net/mcp", { method: "POST" });
     expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp");
   });
+
+  test("loopback peer + forged XFP does not upgrade (hub#915)", () => {
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp", {
+      method: "POST",
+      headers: { "x-forwarded-proto": "https" },
+    });
+    expect(requestAbsoluteUrl(req, "127.0.0.1")).toBe("http://uni.taildf9ce2.ts.net/mcp");
+    expect(requestAbsoluteUrl(req, "::1")).toBe("http://uni.taildf9ce2.ts.net/mcp");
+    expect(requestAbsoluteUrl(req, "::ffff:127.0.0.1")).toBe("http://uni.taildf9ce2.ts.net/mcp");
+  });
+
+  test("loopback peer + XFP + X-Forwarded-For still upgrades (Tailscale Serve)", () => {
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp", {
+      method: "POST",
+      headers: {
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "100.64.0.12",
+      },
+    });
+    expect(requestAbsoluteUrl(req, "127.0.0.1")).toBe("https://uni.taildf9ce2.ts.net/mcp");
+  });
+
+  test("loopback peer + XFP + Tailscale-User-Login still upgrades", () => {
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp", {
+      method: "POST",
+      headers: {
+        "x-forwarded-proto": "https",
+        "tailscale-user-login": "aaron@example.com",
+      },
+    });
+    expect(requestAbsoluteUrl(req, "127.0.0.1")).toBe("https://uni.taildf9ce2.ts.net/mcp");
+  });
+
+  test("unknown peer still upgrades — hub#914 tests, fail-closed to public", () => {
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp", {
+      method: "POST",
+      headers: { "x-forwarded-proto": "https" },
+    });
+    expect(requestAbsoluteUrl(req)).toBe("https://uni.taildf9ce2.ts.net/mcp");
+    expect(requestAbsoluteUrl(req, null)).toBe("https://uni.taildf9ce2.ts.net/mcp");
+  });
+
+  test("hubFetch bindRequestPeer is enough — no explicit peerAddr needed", () => {
+    const req = new Request("http://uni.taildf9ce2.ts.net/mcp", {
+      method: "POST",
+      headers: { "x-forwarded-proto": "https" },
+    });
+    bindRequestPeer(req, "127.0.0.1");
+    expect(requestAbsoluteUrl(req)).toBe("http://uni.taildf9ce2.ts.net/mcp");
+  });
 });
 
 describe("verifyNostrHttpEvent", () => {
@@ -195,6 +246,24 @@ describe("verifyNostrHttpEvent", () => {
         reqFor(behindTls, "POST", event, undefined, { "x-forwarded-proto": "https" }),
         event,
         { replay: new NostrReplayCache() },
+      ),
+    ).toThrow(/u tag/);
+  });
+
+  test("rejects a captured https u-tag replayed on loopback with forged XFP (hub#915)", () => {
+    const publicUrl = "https://uni.taildf9ce2.ts.net/mcp";
+    const behindTls = "http://uni.taildf9ce2.ts.net/mcp";
+    const event = signEvent({
+      tags: [
+        ["u", publicUrl],
+        ["method", "POST"],
+      ],
+    });
+    expect(() =>
+      verifyNostrHttpEvent(
+        reqFor(behindTls, "POST", event, undefined, { "x-forwarded-proto": "https" }),
+        event,
+        { replay: new NostrReplayCache(), peerAddr: "127.0.0.1" },
       ),
     ).toThrow(/u tag/);
   });

--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -369,6 +369,7 @@ import { assertSameOriginForCookieMutation, buildHubBoundOrigins } from "./origi
 import { clearPid, writePid } from "./process-state.ts";
 import { toResponse as proxyErrorToResponse, renderProxyError } from "./proxy-error-ui.ts";
 import { classifyUpstream } from "./proxy-state.ts";
+import { type RequestLayer, bindRequestPeer, isLoopbackPeer, layerOf } from "./request-layer.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import { makeAppDistResolver, serveAppAtRoot } from "./root-serve.ts";
 import {
@@ -402,6 +403,9 @@ import {
 } from "./well-known.ts";
 import { type WsBridgeData, createWsBridgeHandlers } from "./ws-bridge.ts";
 import { type WsConnectionTracker, defaultWsConnectionTracker } from "./ws-connection-caps.ts";
+
+export type { RequestLayer };
+export { layerOf };
 
 interface Args {
   port: number;
@@ -625,138 +629,6 @@ function makeResolveModuleOrigin(manifestPath: string): (short: string) => strin
     const entry = services.find((s) => (shortNameForManifest(s.name) ?? s.name) === short);
     return entry ? `http://127.0.0.1:${entry.port}` : null;
   };
-}
-
-/**
- * The trust layer a request arrived through. Hub binds `127.0.0.1:1939`, so
- * every request reaches it via one of three trusted forwarders (or directly
- * over loopback). The forwarder injects characteristic headers that we use to
- * classify; nothing else can reach the listener, so spoofing isn't a concern.
- *
- *   "loopback" — direct localhost call (CLI, on-box service, dev shell).
- *   "tailnet"  — `tailscale serve` forwarding an authed tailnet user.
- *   "public"   — `tailscale funnel` (public-over-tailnet, unauthed) OR a
- *                cloudflared tunnel forwarding from the public internet.
- *
- * Used to gate `publicExposure: "loopback"` services on the generic
- * `/<svc>/*` dispatch (the hub's only layer-gate). Hub-owned paths (`/`,
- * `/admin/*`, `/api/*`, `/hub/*`, `/oauth/*`, `/.well-known/*`, `/vault/*`,
- * `/vaults`) reach all layers and rely on app-level auth (admin session
- * cookie + 2FA, OAuth, per-service tokens) — they are NOT layer-blocked.
- */
-export type RequestLayer = "loopback" | "tailnet" | "public";
-
-/**
- * Classify the trust layer for an incoming request by inspecting proxy
- * headers. Order matters: cloudflared headers come first because cloudflared
- * could in principle be deployed alongside tailscale on the same node.
- *
- * Header reference (verified against tailscale serve.go on 2026-05-08):
- *   - `Tailscale-User-Login` is set ONLY by `tailscale serve` for an authed
- *     tailnet user. Tagged-source nodes don't get it. Funnel never sets it.
- *   - `Tailscale-Funnel-Request: ?1` is set ONLY by Tailscale Funnel.
- *     Mutually exclusive with `Tailscale-User-Login` (the serve.go path
- *     returns early when funneled).
- *   - `CF-Ray` and `CF-Connecting-IP` are set by Cloudflare's edge for
- *     anything proxied through a cloudflared tunnel.
- *
- * Spoofing isn't a concern for the proxy-injected layers: the trusted
- * forwarders (tailscale serve/funnel, cloudflared) set these headers and a
- * peer can't forge them past the forwarder. Tailscale specifically strips the
- * same headers from incoming requests before re-injecting them, so even a
- * malicious tailnet peer can't impersonate a different user.
- *
- * Header-absence is NOT a loopback signal (item E / hub#526). The old default
- * returned "loopback" — the most-trusted layer — for any request with no proxy
- * headers, on the premise (true only on a loopback bind) that "external
- * requests can't reach the listener." Containers / Render legitimately bind
- * `0.0.0.0`, where a network peer can reach the listener directly with no proxy
- * headers and would be misclassified `loopback`, bypassing the
- * `publicExposure:"loopback"` 404-cloak on `proxyToService` / `proxyToVault`.
- *
- * Fix: derive loopback from the actual PEER ADDRESS (`peerAddr`, resolved by
- * the caller from `server.requestIP(req)` — `requestIP` lives on the Bun
- * Server, not the Request; see rate-limit.ts:282-285). A header-absent request
- * is `loopback` ONLY when its peer is `127.0.0.1` / `::1` (the on-box CLI
- * caller, which must stay loopback). A header-absent NON-loopback peer is the
- * untrusted direct-network case and is classified `public` (least-trusted) so
- * the cloak fires. When `peerAddr` is unknown (null/undefined — no Server
- * threaded, e.g. a unit test calling `layerOf(req)` directly), we fail CLOSED
- * to `public` rather than open to `loopback`.
- *
- * Caddy/nginx-direct (hub#704): a SAME-BOX reverse proxy dials loopback (peer
- * is 127.0.0.1) but, unlike cloudflared/tailscale, sets NO cf/tailscale header
- * — so a header-only-or-peer-only classifier would call every public request
- * through it "loopback" (most-trusted). The discriminator is the standard
- * reverse-proxy forwarding headers (X-Forwarded-For / X-Forwarded-Host /
- * Forwarded): a loopback peer that carries one is a proxied PUBLIC request →
- * `public`; a header-less loopback peer (direct on-box caller — CLI, probes,
- * the init bootstrap-token loopback probe) stays `loopback`. See the inline
- * comment in the function for the full rationale + spoof analysis.
- */
-export function layerOf(req: Request, peerAddr?: string | null): RequestLayer {
-  const h = req.headers;
-  if (h.get("cf-ray") !== null || h.get("cf-connecting-ip") !== null) return "public";
-  // Match the structured-header value (`?1`) rather than mere presence:
-  // serve.go only ever emits `?1`, so insisting on the canonical value keeps
-  // the classifier's intent obvious to a future reader (don't loosen this to
-  // `!== null` — Tailscale's contract is the value, not the header name).
-  // CF-Ray / CF-Connecting-IP are open-string identifiers with no canonical
-  // value to compare against, hence the presence-check above.
-  if (h.get("tailscale-funnel-request") === "?1") return "public";
-  if (h.get("tailscale-user-login") !== null) return "tailnet";
-  // Caddy/nginx-direct deploy (hub#704): a same-box reverse proxy terminates
-  // TLS and `reverse_proxy 127.0.0.1:1939` — so it dials loopback (peer is
-  // 127.0.0.1) and, unlike cloudflared/tailscale, stamps NO cf/tailscale
-  // header. Without this branch every PUBLIC request through such a proxy
-  // would classify "loopback" (the MOST-trusted layer): the GET /admin/setup
-  // bootstrap-token JSON probe would hand the token to any public visitor, and
-  // the publicExposure:"loopback" 404-cloak would stop hiding loopback-only
-  // services/vaults from the network.
-  //
-  // The discriminator is the standard reverse-proxy forwarding headers. A
-  // same-box proxy carrying a PUBLIC request sets X-Forwarded-For /
-  // X-Forwarded-Host / Forwarded; a direct on-box caller (the CLI, health
-  // probes, the init bootstrap-token loopback probe `curl 127.0.0.1/admin/setup`,
-  // the hub's own loopback self-requests) sets none of them — the hub never
-  // injects X-Forwarded-* on the INBOUND request it classifies (it only stamps
-  // X-Forwarded-Host/Proto on OUTBOUND proxy requests to modules). So a
-  // loopback peer that ALSO carries a forwarding header is a proxied public
-  // request → "public"; a header-less loopback peer stays "loopback".
-  //
-  // No spoof vector: a NON-loopback peer is already "public" regardless of
-  // headers (the branch below), so adding these headers can only DOWNGRADE a
-  // loopback caller (the on-box operator hurting only their own request) —
-  // never upgrade a network peer to "loopback".
-  //
-  // Presence check (`!== null`), NOT a trim: an empty/whitespace forwarding
-  // header still means "a proxy is in front" → err to public. Downgrading on
-  // ambiguity is the safe direction for a trust classifier; a future ".trim()
-  // tidy-up" that let an empty XFF fall back to loopback would re-open the leak.
-  if (
-    isLoopbackPeer(peerAddr) &&
-    (h.get("x-forwarded-for") !== null ||
-      h.get("x-forwarded-host") !== null ||
-      h.get("forwarded") !== null)
-  ) {
-    return "public";
-  }
-  // No proxy headers — classify by peer address, failing closed when unknown.
-  return isLoopbackPeer(peerAddr) ? "loopback" : "public";
-}
-
-/**
- * True when `peerAddr` (a `server.requestIP(req)?.address`) is a loopback
- * address. Handles the IPv4-mapped IPv6 form (`::ffff:127.0.0.1`) Bun can emit
- * on a dual-stack listener. A null/undefined/unparseable address is NOT
- * loopback — `layerOf` fails closed to `public` in that case.
- */
-function isLoopbackPeer(peerAddr: string | null | undefined): boolean {
-  if (!peerAddr) return false;
-  const addr = peerAddr.trim().toLowerCase();
-  return (
-    addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1" || addr.startsWith("127.")
-  );
 }
 
 /**
@@ -2333,6 +2205,10 @@ export function hubFetch(
     // `server` is absent when a unit test calls this fn directly; `peerAddr`
     // is then null and `layerOf` fails closed to `public`.
     const peerAddr = server?.requestIP(req)?.address ?? null;
+    // hub#915: NIP-98 `requestAbsoluteUrl` consults the same peer `layerOf`
+    // used for the publicExposure cloak, without threading `peerAddr` through
+    // every auth call site. Bind the Request object handlers will authenticate.
+    bindRequestPeer(req, peerAddr);
 
     // Self-heal-or-die wrapper (#594). Any DB throw that escapes a route
     // handler lands here. A persistent-corruption error (disk I/O error /

--- a/src/nostr-http-auth.ts
+++ b/src/nostr-http-auth.ts
@@ -25,6 +25,7 @@ import {
   verifyNostrEvent,
 } from "./nostr-event.ts";
 import { bindPubkeyFromHttpAuth, findPubkeyLink } from "./pubkey-links.ts";
+import { layerOf, peerAddrOf } from "./request-layer.ts";
 import { isHttpsRequest } from "./request-protocol.ts";
 import {
   createUser,
@@ -137,10 +138,23 @@ export function extractNostrEvent(req: Request): NostrEvent {
  * stay on `req.url`. We do not honor `X-Forwarded-Host` here, and we do
  * not substitute stored `hub_origin` — loopback NIP-98 stays bound to
  * loopback.
+ *
+ * hub#915: `X-Forwarded-Proto` is honored only when `layerOf` has classified
+ * the request as non-loopback. A request that hits :1939 directly (loopback
+ * peer, no forwarding headers) can carry a forged XFP + Host; upgrading that
+ * would let a captured tailnet NIP-98 event replay against the loopback
+ * listener. Real Tailscale Serve stamps `X-Forwarded-For` (and usually
+ * `Tailscale-User-Login`), so those requests classify tailnet/public and
+ * still upgrade. Unknown peer (unit tests, no Server) fails closed to
+ * `public`, so the hub#914 tests keep passing. Production `hubFetch` binds
+ * the peer via `bindRequestPeer`; tests may pass `peerAddr` explicitly.
  */
-export function requestAbsoluteUrl(req: Request): string {
+export function requestAbsoluteUrl(req: Request, peerAddr?: string | null): string {
   const url = new URL(req.url);
-  if (isHttpsRequest(req) && url.protocol === "http:") {
+  if (url.protocol !== "http:") return req.url;
+  const peer = peerAddr !== undefined ? peerAddr : peerAddrOf(req);
+  // Direct `https:` URLs already returned above. Remaining signal is XFP.
+  if (layerOf(req, peer) !== "loopback" && isHttpsRequest(req)) {
     url.protocol = "https:";
     return url.href;
   }
@@ -163,6 +177,8 @@ export function verifyNostrHttpEvent(
     replay?: NostrReplayCache;
     /** Raw body bytes; required when the request has a body. */
     body?: Uint8Array;
+    /** Peer address; falls back to `bindRequestPeer` then unknown→public. */
+    peerAddr?: string | null;
   } = {},
 ): void {
   const now = opts.now?.() ?? new Date();
@@ -197,7 +213,7 @@ export function verifyNostrHttpEvent(
   }
 
   const u = tagValue(event, "u");
-  const expectedUrl = requestAbsoluteUrl(req);
+  const expectedUrl = requestAbsoluteUrl(req, opts.peerAddr);
   if (u !== expectedUrl) {
     throw new NostrHttpAuthError(
       401,
@@ -361,6 +377,7 @@ export async function authenticateNostrRequest(
     now?: () => Date;
     replay?: NostrReplayCache;
     body?: Uint8Array;
+    peerAddr?: string | null;
   },
 ): Promise<NostrPrincipal> {
   const event = extractNostrEvent(req);
@@ -368,6 +385,7 @@ export async function authenticateNostrRequest(
     now: opts.now,
     replay: opts.replay,
     body: opts.body,
+    peerAddr: opts.peerAddr,
   });
   return resolveNostrPrincipal(db, event, {
     autoProvision: opts.autoProvision,

--- a/src/request-layer.ts
+++ b/src/request-layer.ts
@@ -1,0 +1,163 @@
+/**
+ * Trust-layer classification for an incoming hub request.
+ *
+ * Extracted from `hub-server.ts` so NIP-98 URL reconstruction
+ * (`requestAbsoluteUrl`) can consult `layerOf` without importing the
+ * server module — `hub-server` already imports `nostr-http-auth`, and a
+ * reverse import is a cycle.
+ *
+ * The classifier itself is unchanged (item E / hub#526, hub#704).
+ */
+
+/**
+ * The trust layer a request arrived through. Hub binds `127.0.0.1:1939`, so
+ * every request reaches it via one of three trusted forwarders (or directly
+ * over loopback). The forwarder injects characteristic headers that we use to
+ * classify; nothing else can reach the listener, so spoofing isn't a concern.
+ *
+ *   "loopback" — direct localhost call (CLI, on-box service, dev shell).
+ *   "tailnet"  — `tailscale serve` forwarding an authed tailnet user.
+ *   "public"   — `tailscale funnel` (public-over-tailnet, unauthed) OR a
+ *                cloudflared tunnel forwarding from the public internet.
+ *
+ * Used to gate `publicExposure: "loopback"` services on the generic
+ * `/<svc>/*` dispatch (the hub's only layer-gate). Hub-owned paths (`/`,
+ * `/admin/*`, `/api/*`, `/hub/*`, `/oauth/*`, `/.well-known/*`, `/vault/*`,
+ * `/vaults`) reach all layers and rely on app-level auth (admin session
+ * cookie + 2FA, OAuth, per-service tokens) — they are NOT layer-blocked.
+ */
+export type RequestLayer = "loopback" | "tailnet" | "public";
+
+/**
+ * Peer address as resolved by Bun `Server.requestIP`. Bound once per
+ * request in `hubFetch` so NIP-98 reconstruction (and anything else that
+ * only has the `Request`) can see the same peer `layerOf` used for the
+ * publicExposure cloak — without threading `peerAddr` through every
+ * `requireScope` / `authenticateNostrRequest` call site.
+ *
+ * Same-object: `Request.clone()` is a new key. Bind the object the
+ * handler will authenticate, which is the one `hubFetch` received.
+ */
+const peers = new WeakMap<Request, string | null>();
+
+export function bindRequestPeer(req: Request, peerAddr: string | null): void {
+  peers.set(req, peerAddr);
+}
+
+/** `undefined` when unbound; `null` when bound with no Server. */
+export function peerAddrOf(req: Request): string | null | undefined {
+  return peers.has(req) ? peers.get(req)! : undefined;
+}
+
+/**
+ * Classify the trust layer for an incoming request by inspecting proxy
+ * headers. Order matters: cloudflared headers come first because cloudflared
+ * could in principle be deployed alongside tailscale on the same node.
+ *
+ * Header reference (verified against tailscale serve.go on 2026-05-08):
+ *   - `Tailscale-User-Login` is set ONLY by `tailscale serve` for an authed
+ *     tailnet user. Tagged-source nodes don't get it. Funnel never sets it.
+ *   - `Tailscale-Funnel-Request: ?1` is set ONLY by Tailscale Funnel.
+ *     Mutually exclusive with `Tailscale-User-Login` (the serve.go path
+ *     returns early when funneled).
+ *   - `CF-Ray` and `CF-Connecting-IP` are set by Cloudflare's edge for
+ *     anything proxied through a cloudflared tunnel.
+ *
+ * Spoofing isn't a concern for the proxy-injected layers: the trusted
+ * forwarders (tailscale serve/funnel, cloudflared) set these headers and a
+ * peer can't forge them past the forwarder. Tailscale specifically strips the
+ * same headers from incoming requests before re-injecting them, so even a
+ * malicious tailnet peer can't impersonate a different user.
+ *
+ * Header-absence is NOT a loopback signal (item E / hub#526). The old default
+ * returned "loopback" — the most-trusted layer — for any request with no proxy
+ * headers, on the premise (true only on a loopback bind) that "external
+ * requests can't reach the listener." Containers / Render legitimately bind
+ * `0.0.0.0`, where a network peer can reach the listener directly with no proxy
+ * headers and would be misclassified `loopback`, bypassing the
+ * `publicExposure:"loopback"` 404-cloak on `proxyToService` / `proxyToVault`.
+ *
+ * Fix: derive loopback from the actual PEER ADDRESS (`peerAddr`, resolved by
+ * the caller from `server.requestIP(req)` — `requestIP` lives on the Bun
+ * Server, not the Request; see rate-limit.ts:282-285). A header-absent request
+ * is `loopback` ONLY when its peer is `127.0.0.1` / `::1` (the on-box CLI
+ * caller, which must stay loopback). A header-absent NON-loopback peer is the
+ * untrusted direct-network case and is classified `public` (least-trusted) so
+ * the cloak fires. When `peerAddr` is unknown (null/undefined — no Server
+ * threaded, e.g. a unit test calling `layerOf(req)` directly), we fail CLOSED
+ * to `public` rather than open to `loopback`.
+ *
+ * Caddy/nginx-direct (hub#704): a SAME-BOX reverse proxy dials loopback (peer
+ * is 127.0.0.1) but, unlike cloudflared/tailscale, sets NO cf/tailscale header
+ * — so a header-only-or-peer-only classifier would call every public request
+ * through it "loopback" (most-trusted). The discriminator is the standard
+ * reverse-proxy forwarding headers (X-Forwarded-For / X-Forwarded-Host /
+ * Forwarded): a loopback peer that carries one is a proxied PUBLIC request →
+ * `public`; a header-less loopback peer (direct on-box caller — CLI, probes,
+ * the init bootstrap-token loopback probe) stays `loopback`. See the inline
+ * comment in the function for the full rationale + spoof analysis.
+ */
+export function layerOf(req: Request, peerAddr?: string | null): RequestLayer {
+  const h = req.headers;
+  if (h.get("cf-ray") !== null || h.get("cf-connecting-ip") !== null) return "public";
+  // Match the structured-header value (`?1`) rather than mere presence:
+  // serve.go only ever emits `?1`, so insisting on the canonical value keeps
+  // the classifier's intent obvious to a future reader (don't loosen this to
+  // `!== null` — Tailscale's contract is the value, not the header name).
+  // CF-Ray / CF-Connecting-IP are open-string identifiers with no canonical
+  // value to compare against, hence the presence-check above.
+  if (h.get("tailscale-funnel-request") === "?1") return "public";
+  if (h.get("tailscale-user-login") !== null) return "tailnet";
+  // Caddy/nginx-direct deploy (hub#704): a same-box reverse proxy terminates
+  // TLS and `reverse_proxy 127.0.0.1:1939` — so it dials loopback (peer is
+  // 127.0.0.1) and, unlike cloudflared/tailscale, stamps NO cf/tailscale
+  // header. Without this branch every PUBLIC request through such a proxy
+  // would classify "loopback" (the MOST-trusted layer): the GET /admin/setup
+  // bootstrap-token JSON probe would hand the token to any public visitor, and
+  // the publicExposure:"loopback" 404-cloak would stop hiding loopback-only
+  // services/vaults from the network.
+  //
+  // The discriminator is the standard reverse-proxy forwarding headers. A
+  // same-box proxy carrying a PUBLIC request sets X-Forwarded-For /
+  // X-Forwarded-Host / Forwarded; a direct on-box caller (the CLI, health
+  // probes, the init bootstrap-token loopback probe `curl 127.0.0.1/admin/setup`,
+  // the hub's own loopback self-requests) sets none of them — the hub never
+  // injects X-Forwarded-* on the INBOUND request it classifies (it only stamps
+  // X-Forwarded-Host/Proto on OUTBOUND proxy requests to modules). So a
+  // loopback peer that ALSO carries a forwarding header is a proxied public
+  // request → "public"; a header-less loopback peer stays "loopback".
+  //
+  // No spoof vector: a NON-loopback peer is already "public" regardless of
+  // headers (the branch below), so adding these headers can only DOWNGRADE a
+  // loopback caller (the on-box operator hurting only their own request) —
+  // never upgrade a network peer to "loopback".
+  //
+  // Presence check (`!== null`), NOT a trim: an empty/whitespace forwarding
+  // header still means "a proxy is in front" → err to public. Downgrading on
+  // ambiguity is the safe direction for a trust classifier; a future ".trim()
+  // tidy-up" that let an empty XFF fall back to loopback would re-open the leak.
+  if (
+    isLoopbackPeer(peerAddr) &&
+    (h.get("x-forwarded-for") !== null ||
+      h.get("x-forwarded-host") !== null ||
+      h.get("forwarded") !== null)
+  ) {
+    return "public";
+  }
+  // No proxy headers — classify by peer address, failing closed when unknown.
+  return isLoopbackPeer(peerAddr) ? "loopback" : "public";
+}
+
+/**
+ * True when `peerAddr` (a `server.requestIP(req)?.address`) is a loopback
+ * address. Handles the IPv4-mapped IPv6 form (`::ffff:127.0.0.1`) Bun can emit
+ * on a dual-stack listener. A null/undefined/unparseable address is NOT
+ * loopback — `layerOf` fails closed to `public` in that case.
+ */
+export function isLoopbackPeer(peerAddr: string | null | undefined): boolean {
+  if (!peerAddr) return false;
+  const addr = peerAddr.trim().toLowerCase();
+  return (
+    addr === "127.0.0.1" || addr === "::1" || addr === "::ffff:127.0.0.1" || addr.startsWith("127.")
+  );
+}


### PR DESCRIPTION
## Summary

`requestAbsoluteUrl` (hub#914) reconstructed the NIP-98 `u` tag by trusting `X-Forwarded-Proto` independent of `layerOf`. A request that hits `:1939` directly — loopback peer, no forwarding headers, forged `X-Forwarded-Proto: https` + `Host` — classified `loopback` (most trusted) while the reconstructed URL became `https://<public-host>/…`. A captured tailnet NIP-98 event inside its 60s window could replay against the loopback listener as that same pubkey. Doesn't mint a new principal; the `u`-tag bind was just failing at its one job. Practical bar is high (loopback access + a live event). Defense in depth.

This PR honors XFP for NIP-98 reconstruction **only when `layerOf` is non-loopback**.

- Real Tailscale Serve stamps `X-Forwarded-For` (and usually `Tailscale-User-Login`) → `public`/`tailnet` → still upgrades. hub#914 path intact.
- Unknown peer (unit tests, no Server) fails closed to `public` → existing tests still upgrade.
- `layerOf` extracted to `src/request-layer.ts` so `nostr-http-auth` can consult it without importing `hub-server` (cycle: hub-server already imports nostr-http-auth). Re-exported from `hub-server` — existing `layerOf` tests unchanged.
- `hubFetch` binds the peer on the Request via WeakMap (`bindRequestPeer`) so `requireScope`'s call sites stay untouched.

Cookie `Secure` / `isHttpsRequest` is **not** in this PR. Same Host-from-request trust `resolveIssuer` already documents.

Feature PR — no version bump. rc.12 is a separate cut.

Fixes #915

## Test plan

- [x] Watch-fail: `requestAbsoluteUrl(req, "127.0.0.1")` with forged XFP expected `http://…`; on the old upgrade received `https://…` (red), then green after the layer check.
- [x] `bun test ./src/__tests__/nostr-http-auth.test.ts` — 27 pass, including loopback+XFP no-upgrade, Tailscale XFF/login still-upgrade, unknown-peer still-upgrade, `bindRequestPeer` path, verifyNostrHttpEvent url_mismatch on captured https u-tag.
- [x] `bun test ./src/__tests__/hub-server.test.ts -t hub#915` — 2 pass: hubFetch + fakeServer `127.0.0.1` rejects captured https u-tag; same request with XFF+Tailscale-User-Login reconstructs https (401 is unlinked pubkey, not u-mismatch).
- [x] `bun run typecheck` — clean.
- [x] `bun test ./src` — **4847 pass / 1 skip / 1 fail**. The fail is pre-existing `surface-command.test.ts` git-credential timeout (file untouched; same fail on `next` before this PR).
- [ ] CI typecheck + unit tests on this PR.
- Not smoke-tested against a live Tailscale Serve hop — the hubFetch fakeServer cases cover the two classifications. Live rc.12 would be the deploy-shaped check if this is bundled.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.