### PR TITLE
fix(release): trigger on CHANGELOG.md — promotion merges can leave package.json unchanged

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,14 +67,23 @@ on:
     # pass those two and publish `@latest`. The `paths` filter below means
     # an ordinary feature merge (no version bump) never even runs this
     # workflow a second time — `pr-verify.yml` already tested it before merge.
+    #
+    # CHANGELOG.md is in the filter because a promotion merge can leave
+    # package.json byte-identical to main's tip: hub#926 re-promoted a
+    # version main already carried (0.7.18, from the refused #917 cut), so
+    # only the changelog differed and Release never fired. Every release
+    # cut touches the changelog; ordinary feature merges don't.
     branches:
       - main
       - next
     paths:
       - 'package.json'
+      - 'CHANGELOG.md'
       - 'packages/scope-guard/package.json'
+      - 'packages/scope-guard/CHANGELOG.md'
       - 'packages/depcheck/package.json'
       - 'packages/door-contract/package.json'
+      - 'packages/door-contract/CHANGELOG.md'
     tags:
       # Hub release tags
       - 'v[0-9]+.[0-9]+.[0-9]+'


### PR DESCRIPTION
The hub#926 gap: a take-2 stable promotion whose version already sits on `main` (from a refused earlier cut) leaves package.json byte-identical — the `paths` filter sees nothing and **Release never fires**, so the merge publishes nothing with no error anywhere. That happened today: [#926](https://github.com/ParachuteComputer/parachute-hub/pull/926) merged and hub 0.7.18 silently didn't publish.

Fix: add the changelogs to the push `paths` filter (root + the two sub-packages that keep one). Every release cut touches its changelog; ordinary feature merges don't, so the don't-run-twice economy is intact. A CHANGELOG-only run that finds nothing new to publish no-ops — `decidePublish` is idempotent on already-published versions.

Workflow-only change; no runtime code. The 0.7.18 retrigger itself is a separate PR to `main` (in Aaron's click batch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)