### PR TITLE
release: hub 0.7.18 publish retrigger — homepage field + changelog note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,10 @@ All notable changes to `@openparachute/hub` are documented here. The format foll
 **Stable promotion of 0.7.18-rc.11.** No new code. Suffix-drop only. npm `@rc`
 is 0.7.18-rc.11; this is the matching `@latest`. (An earlier promotion cut
 from rc.10 — hub#917 — was refused by the plan gate after rc.11 published on
-the same core; this entry supersedes its changelog text.)
+the same core; this entry supersedes its changelog text. The take-2 merge
+then left package.json byte-identical to main, so Release's paths filter
+never fired — the actual publish rode a retrigger merge that also added
+package.json `homepage`. Filter fixed for the future on the rc line.)
 
 The 0.7.18 line (rc.1-rc.11) ships key-as-account: a Nostr key is now a
 first-class hub identity. NIP-98 request auth (#882) and the account-MCP

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@openparachute/hub",
   "version": "0.7.18",
   "description": "parachute — the local hub for the Parachute ecosystem (discovery, ports, lifecycle, soon OAuth).",
+  "homepage": "https://github.com/ParachuteComputer/parachute-hub#readme",
   "license": "AGPL-3.0",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**Merge-commit (not squash) actually publishes hub 0.7.18 to `@latest` this time.**

#926 merged the right content but published nothing: its merge left package.json byte-identical to `main` (the version string 0.7.18 had already landed via the refused #917), so the Release workflow's `paths` filter never matched and no run fired — silent no-op, no error anywhere.

This PR touches package.json inside the allowed promotion paths by adding the `homepage` field (a real gap — npm shows it on the package page) plus a changelog note documenting the publish path. `git diff v0.7.18-rc.11..HEAD` = `package.json` + `CHANGELOG.md` only → the suffix-drop gate passes, Release fires on the merge push, version 0.7.18 vs npm (`@latest` 0.7.17, matching rc chain present) → publishes.

The durable fix — CHANGELOG.md added to the paths filter — is [#927](https://github.com/ParachuteComputer/parachute-hub/pull/927) against `next`, riding the 0.7.19 line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)