### PR TITLE
feat(account-mcp): optional hop-JWT reuse behind env (hub#918)

### DIFF
--- a/src/__tests__/account-mcp-hop.test.ts
+++ b/src/__tests__/account-mcp-hop.test.ts
@@ -1,0 +1,256 @@
+/**
+ * Account-MCP hop JWT reuse (hub#918).
+ *
+ * Default is today's per-call 60s mint. Reuse is env-gated and stays
+ * strictly under the registered-mint threshold so hops remain unregistered.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { mintVaultMcpToken } from "../account-mcp-backend.ts";
+import {
+  ACCOUNT_MCP_HOP_TTL_CAP_SECONDS,
+  ACCOUNT_MCP_HOP_TTL_ENV,
+  _resetAccountMcpHopCacheForTests,
+  hopCacheKey,
+  lookupHopToken,
+  parseAccountMcpHopTtl,
+  storeHopToken,
+} from "../account-mcp-hop.ts";
+import type { AccountToolContext } from "../account-mcp.ts";
+import { FANOUT_TOKEN_TTL_SECONDS } from "../account-mcp.ts";
+import { REGISTERED_MINT_TTL_THRESHOLD_SECONDS } from "../admin-connections.ts";
+import { hubDbPath, openHubDb } from "../hub-db.ts";
+import type { SignAccessTokenOpts } from "../jwt-sign.ts";
+import { rotateSigningKey } from "../signing-keys.ts";
+
+afterEach(() => {
+  _resetAccountMcpHopCacheForTests();
+});
+
+describe("parseAccountMcpHopTtl", () => {
+  test("unset / empty / junk fail closed to today's 60s per-call mint", () => {
+    expect(parseAccountMcpHopTtl({})).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "" })).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "   " })).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "banana" })).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "300.5" })).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "0300" })).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "0" })).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "-1" })).toEqual({
+      reuse: false,
+      ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    });
+  });
+
+  test("well-formed integer enables reuse and caps at 599", () => {
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "300" })).toEqual({
+      reuse: true,
+      ttlSeconds: 300,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "1" })).toEqual({
+      reuse: true,
+      ttlSeconds: 1,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "599" })).toEqual({
+      reuse: true,
+      ttlSeconds: 599,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "600" })).toEqual({
+      reuse: true,
+      ttlSeconds: ACCOUNT_MCP_HOP_TTL_CAP_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: "1000" })).toEqual({
+      reuse: true,
+      ttlSeconds: ACCOUNT_MCP_HOP_TTL_CAP_SECONDS,
+    });
+    expect(parseAccountMcpHopTtl({ [ACCOUNT_MCP_HOP_TTL_ENV]: " 300 " })).toEqual({
+      reuse: true,
+      ttlSeconds: 300,
+    });
+  });
+
+  test("cap sits strictly under the registered-mint threshold", () => {
+    expect(ACCOUNT_MCP_HOP_TTL_CAP_SECONDS).toBeLessThan(REGISTERED_MINT_TTL_THRESHOLD_SECONDS);
+    expect(FANOUT_TOKEN_TTL_SECONDS).toBeLessThan(REGISTERED_MINT_TTL_THRESHOLD_SECONDS);
+  });
+});
+
+describe("hop cache", () => {
+  test("lookup misses, hits, then expires at the 5s reuse floor", () => {
+    const key = hopCacheKey("u", "uni", "read", "http://127.0.0.1:1939");
+    const t0 = 1_000_000;
+    expect(lookupHopToken(key, t0)).toBeNull();
+    storeHopToken(key, "tok", t0 + 300_000);
+    expect(lookupHopToken(key, t0)).toBe("tok");
+    expect(lookupHopToken(key, t0 + 294_999)).toBe("tok");
+    expect(lookupHopToken(key, t0 + 295_000)).toBeNull();
+    expect(lookupHopToken(key, t0 + 295_000)).toBeNull();
+  });
+
+  test("store sweeps expired entries", () => {
+    const a = hopCacheKey("u", "a", "read", "iss");
+    const b = hopCacheKey("u", "b", "read", "iss");
+    const t0 = 1_000_000;
+    storeHopToken(a, "old", t0 + 1_000);
+    storeHopToken(b, "fresh", t0 + 300_000, t0 + 10_000);
+    expect(lookupHopToken(a, t0 + 10_000)).toBeNull();
+    expect(lookupHopToken(b, t0 + 10_000)).toBe("fresh");
+  });
+});
+
+describe("mintVaultMcpToken hop reuse", () => {
+  function harness() {
+    const dir = mkdtempSync(join(tmpdir(), "phub-hop-"));
+    const db = openHubDb(hubDbPath(dir));
+    rotateSigningKey(db);
+    const calls: SignAccessTokenOpts[] = [];
+    let n = 0;
+    const signToken = async (_db: unknown, opts: SignAccessTokenOpts) => {
+      n += 1;
+      calls.push(opts);
+      return { token: `hop.${n}.${opts.ttlSeconds}` };
+    };
+    let nowMs = 1_700_000_000_000;
+    const ctx: AccountToolContext = {
+      db,
+      issuer: "http://127.0.0.1:1939",
+      manifestPath: join(dir, "services.json"),
+      principal: {
+        userId: "user-1",
+        scopes: ["account:self:vaults"],
+        authKind: "bearer",
+        clientId: "parachute-account",
+        isHubAdmin: true,
+        grant: null,
+      },
+      now: () => new Date(nowMs),
+      signToken: signToken as AccountToolContext["signToken"],
+    };
+    const vault = { name: "uni", url: "http://127.0.0.1:1940/vault/uni", version: "0.7.8" };
+    return {
+      ctx,
+      vault,
+      calls,
+      minted: () => n,
+      setNow: (ms: number) => {
+        nowMs = ms;
+      },
+      now: () => nowMs,
+      cleanup: () => {
+        db.close();
+        rmSync(dir, { recursive: true, force: true });
+      },
+    };
+  }
+
+  test("default env: every call mints a fresh 60s token", async () => {
+    const h = harness();
+    try {
+      const a = await mintVaultMcpToken(h.ctx, h.vault, "read", {});
+      const b = await mintVaultMcpToken(h.ctx, h.vault, "read", {});
+      expect(h.minted()).toBe(2);
+      expect(a).not.toBe(b);
+      expect(h.calls[0]?.ttlSeconds).toBe(FANOUT_TOKEN_TTL_SECONDS);
+      expect(h.calls[1]?.ttlSeconds).toBe(FANOUT_TOKEN_TTL_SECONDS);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("TTL=300: second call reuses; third after floor remints", async () => {
+    const h = harness();
+    const env = { [ACCOUNT_MCP_HOP_TTL_ENV]: "300" };
+    try {
+      const t0 = h.now();
+      const a = await mintVaultMcpToken(h.ctx, h.vault, "read", env);
+      const b = await mintVaultMcpToken(h.ctx, h.vault, "read", env);
+      expect(a).toBe(b);
+      expect(h.minted()).toBe(1);
+      expect(h.calls[0]?.ttlSeconds).toBe(300);
+      expect(h.calls[0]?.scopes).toEqual(["vault:uni:read"]);
+      expect(h.calls[0]?.audience).toBe("vault.uni");
+
+      h.setNow(t0 + 294_999);
+      const still = await mintVaultMcpToken(h.ctx, h.vault, "read", env);
+      expect(still).toBe(a);
+      expect(h.minted()).toBe(1);
+
+      h.setNow(t0 + 295_000);
+      const c = await mintVaultMcpToken(h.ctx, h.vault, "read", env);
+      expect(c).not.toBe(a);
+      expect(h.minted()).toBe(2);
+      expect(h.calls[1]?.ttlSeconds).toBe(300);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("different user / vault / verb / issuer do not share", async () => {
+    const h = harness();
+    const env = { [ACCOUNT_MCP_HOP_TTL_ENV]: "300" };
+    try {
+      await mintVaultMcpToken(h.ctx, h.vault, "read", env);
+      await mintVaultMcpToken(h.ctx, { ...h.vault, name: "other" }, "read", env);
+      await mintVaultMcpToken(h.ctx, h.vault, "write", env);
+      const otherUser: AccountToolContext = {
+        ...h.ctx,
+        principal: { ...h.ctx.principal, userId: "user-2" },
+      };
+      await mintVaultMcpToken(otherUser, h.vault, "read", env);
+      const otherIss: AccountToolContext = { ...h.ctx, issuer: "http://127.0.0.1:1940" };
+      await mintVaultMcpToken(otherIss, h.vault, "read", env);
+      expect(h.minted()).toBe(5);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("TTL=1 enables reuse flag but the 5s floor means no reuse", async () => {
+    const h = harness();
+    const env = { [ACCOUNT_MCP_HOP_TTL_ENV]: "1" };
+    try {
+      const a = await mintVaultMcpToken(h.ctx, h.vault, "read", env);
+      const b = await mintVaultMcpToken(h.ctx, h.vault, "read", env);
+      expect(a).not.toBe(b);
+      expect(h.minted()).toBe(2);
+      expect(h.calls[0]?.ttlSeconds).toBe(1);
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  test("junk env does not enable reuse (no silent wire flip)", async () => {
+    const h = harness();
+    try {
+      await mintVaultMcpToken(h.ctx, h.vault, "read", { [ACCOUNT_MCP_HOP_TTL_ENV]: "nope" });
+      await mintVaultMcpToken(h.ctx, h.vault, "read", { [ACCOUNT_MCP_HOP_TTL_ENV]: "nope" });
+      expect(h.minted()).toBe(2);
+      expect(h.calls[0]?.ttlSeconds).toBe(FANOUT_TOKEN_TTL_SECONDS);
+    } finally {
+      h.cleanup();
+    }
+  });
+});

--- a/src/__tests__/account-mcp.test.ts
+++ b/src/__tests__/account-mcp.test.ts
@@ -26,6 +26,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { schnorr } from "@noble/curves/secp256k1.js";
 import { handleAccountCapabilities } from "../account-api.ts";
+import { ACCOUNT_MCP_HOP_TTL_ENV, _resetAccountMcpHopCacheForTests } from "../account-mcp-hop.ts";
 import {
   accountMcpProtectedResource,
   challengePrmPath,
@@ -2369,6 +2370,72 @@ describe("account MCP — grant-access", () => {
       ).toBe("username_taken");
       expect(findPubkeyLink(h.db, OTHER_PUBKEY)).toBeNull();
     } finally {
+      h.cleanup();
+    }
+  });
+});
+
+describe("account MCP — hop JWT reuse (hub#918)", () => {
+  function restoreHopEnv(prev: string | undefined): void {
+    if (prev === undefined) delete process.env[ACCOUNT_MCP_HOP_TTL_ENV];
+    else process.env[ACCOUNT_MCP_HOP_TTL_ENV] = prev;
+    _resetAccountMcpHopCacheForTests();
+  }
+
+  function countingFetch(): { bearers: Set<string>; fetchImpl: typeof fetch } {
+    const bearers = new Set<string>();
+    const fetchImpl = (input: string | URL | Request, init?: RequestInit) => {
+      const headers = input instanceof Request ? input.headers : new Headers(init?.headers);
+      const auth = headers.get("authorization");
+      if (auth) bearers.add(auth);
+      return routeVaultMcp(input, init);
+    };
+    return { bearers, fetchImpl: fetchImpl as typeof fetch };
+  }
+
+  test("default: two list-tags calls mint a fresh hop JWT per vault RPC", async () => {
+    const h = await makeHarness();
+    const prev = process.env[ACCOUNT_MCP_HOP_TTL_ENV];
+    delete process.env[ACCOUNT_MCP_HOP_TTL_ENV];
+    _resetAccountMcpHopCacheForTests();
+    const { bearers, fetchImpl } = countingFetch();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      for (let i = 0; i < 2; i++) {
+        const res = await handleAccountMcp(
+          bearerReq(token, rpc("tools/call", { name: "list-tags", arguments: { vault: "beta" } })),
+          mcpDeps(h, { fetchImpl }),
+        );
+        expect(res.status).toBe(200);
+      }
+      // Each tools/call does tools/list (catalog) then tools/call — 4 RPCs,
+      // 4 unregistered 60s mints. That is today's hop, and why manage-token
+      // never sees a repeated principal.
+      expect(bearers.size).toBe(4);
+    } finally {
+      restoreHopEnv(prev);
+      h.cleanup();
+    }
+  });
+
+  test("TTL=300: two list-tags calls share one hop JWT", async () => {
+    const h = await makeHarness();
+    const prev = process.env[ACCOUNT_MCP_HOP_TTL_ENV];
+    process.env[ACCOUNT_MCP_HOP_TTL_ENV] = "300";
+    _resetAccountMcpHopCacheForTests();
+    const { bearers, fetchImpl } = countingFetch();
+    try {
+      const token = await bearer(h, [HOST_ADMIN_SCOPE]);
+      for (let i = 0; i < 2; i++) {
+        const res = await handleAccountMcp(
+          bearerReq(token, rpc("tools/call", { name: "list-tags", arguments: { vault: "beta" } })),
+          mcpDeps(h, { fetchImpl }),
+        );
+        expect(res.status).toBe(200);
+      }
+      expect(bearers.size).toBe(1);
+    } finally {
+      restoreHopEnv(prev);
       h.cleanup();
     }
   });

--- a/src/account-mcp-backend.ts
+++ b/src/account-mcp-backend.ts
@@ -17,11 +17,16 @@
 import { COMPOSED_VERB_RANK, type ComposedVaultVerb } from "@openparachute/door-contract";
 import type { AccountVaultMeta } from "./account-api.ts";
 import {
+  hopCacheKey,
+  lookupHopToken,
+  parseAccountMcpHopTtl,
+  storeHopToken,
+} from "./account-mcp-hop.ts";
+import {
   ACCOUNT_MCP_CLIENT_ID,
   type AccountToolContext,
   AccountToolError,
   FANOUT_TIMEOUT_MS,
-  FANOUT_TOKEN_TTL_SECONDS,
   HUB_NATIVE_TOOL_NAMES,
   installedVaults,
   resolveCoverage,
@@ -61,7 +66,15 @@ export async function mintVaultMcpToken(
   ctx: AccountToolContext,
   vault: AccountVaultMeta,
   verb: ComposedVaultVerb,
+  env: NodeJS.ProcessEnv = process.env,
 ): Promise<string> {
+  const hop = parseAccountMcpHopTtl(env);
+  const nowMs = (ctx.now?.() ?? new Date()).getTime();
+  const key = hopCacheKey(ctx.principal.userId, vault.name, verb, ctx.issuer);
+  if (hop.reuse) {
+    const cached = lookupHopToken(key, nowMs);
+    if (cached) return cached;
+  }
   const sign = ctx.signToken ?? signAccessToken;
   const minted = await sign(ctx.db, {
     sub: ctx.principal.userId,
@@ -69,10 +82,13 @@ export async function mintVaultMcpToken(
     audience: `vault.${vault.name}`,
     clientId: ACCOUNT_MCP_CLIENT_ID,
     issuer: ctx.issuer,
-    ttlSeconds: FANOUT_TOKEN_TTL_SECONDS,
+    ttlSeconds: hop.ttlSeconds,
     vaultScope: [vault.name],
     ...(ctx.now !== undefined ? { now: ctx.now } : {}),
   });
+  if (hop.reuse) {
+    storeHopToken(key, minted.token, nowMs + hop.ttlSeconds * 1000, nowMs);
+  }
   return minted.token;
 }
 

--- a/src/account-mcp-hop.ts
+++ b/src/account-mcp-hop.ts
@@ -1,0 +1,111 @@
+/**
+ * Optional session-reuse for account-MCP → vault hop JWTs (hub#918).
+ *
+ * Default (env unset / empty / unparseable): every `tools/call` mints a
+ * fresh 60s token — today's hop. That is capability-shaped and stays
+ * under the registered-mint threshold, but the vault's `manage-token`
+ * ledger never sees the same principal twice.
+ *
+ * `PARACHUTE_ACCOUNT_MCP_HOP_TTL_SECONDS=N` (1..599): mint once per
+ * `(user, vault, verb, issuer)` and reuse until TTL. Capped strictly
+ * below `REGISTERED_MINT_TTL_THRESHOLD_SECONDS` (600) so these hops stay
+ * unregistered fire-and-forget. A longer hop needs a tokens-table row —
+ * not this module.
+ *
+ * Invalid values (non-integer, zero, negative, junk) do not enable
+ * reuse — fail closed to today's per-call mint. That is the safest
+ * option; a typo must not silently change hop lifetime.
+ *
+ * Clock: 5s remaining is the reuse floor so a token cannot be handed to
+ * a vault RPC already inside its expiry skew. A configured TTL of 1–5s
+ * therefore never reuses (equivalent to unset for the reuse path).
+ */
+import { FANOUT_TOKEN_TTL_SECONDS } from "./account-mcp.ts";
+
+/**
+ * Must stay strictly below `REGISTERED_MINT_TTL_THRESHOLD_SECONDS` in
+ * `admin-connections.ts` (600). Duplicated as a number so this module
+ * does not import the connections engine on the MCP hop path. The
+ * relationship is pinned in `account-mcp-hop.test.ts`.
+ */
+export const ACCOUNT_MCP_HOP_TTL_CAP_SECONDS = 599;
+
+const REUSE_FLOOR_MS = 5_000;
+
+export const ACCOUNT_MCP_HOP_TTL_ENV = "PARACHUTE_ACCOUNT_MCP_HOP_TTL_SECONDS";
+
+export interface AccountMcpHopTtl {
+  reuse: boolean;
+  ttlSeconds: number;
+}
+
+interface HopEntry {
+  token: string;
+  expMs: number;
+}
+
+const hops = new Map<string, HopEntry>();
+
+/**
+ * Parse the hop-reuse env. Unset / empty / unparseable → reuse off,
+ * 60s per-call mint. A well-formed integer ≥ 1 enables reuse, capped
+ * at {@link ACCOUNT_MCP_HOP_TTL_CAP_SECONDS}.
+ */
+export function parseAccountMcpHopTtl(env: NodeJS.ProcessEnv = process.env): AccountMcpHopTtl {
+  const raw = env[ACCOUNT_MCP_HOP_TTL_ENV];
+  if (raw === undefined) {
+    return { reuse: false, ttlSeconds: FANOUT_TOKEN_TTL_SECONDS };
+  }
+  const trimmed = raw.trim();
+  if (trimmed === "") {
+    return { reuse: false, ttlSeconds: FANOUT_TOKEN_TTL_SECONDS };
+  }
+  if (!/^[1-9][0-9]*$/.test(trimmed)) {
+    return { reuse: false, ttlSeconds: FANOUT_TOKEN_TTL_SECONDS };
+  }
+  const n = Number.parseInt(trimmed, 10);
+  return { reuse: true, ttlSeconds: Math.min(n, ACCOUNT_MCP_HOP_TTL_CAP_SECONDS) };
+}
+
+export function accountMcpHopReuse(env: NodeJS.ProcessEnv = process.env): boolean {
+  return parseAccountMcpHopTtl(env).reuse;
+}
+
+export function accountMcpHopTtlSeconds(env: NodeJS.ProcessEnv = process.env): number {
+  return parseAccountMcpHopTtl(env).ttlSeconds;
+}
+
+export function hopCacheKey(
+  userId: string,
+  vaultName: string,
+  verb: string,
+  issuer: string,
+): string {
+  return `${userId}\0${vaultName}\0${verb}\0${issuer}`;
+}
+
+function sweepExpired(nowMs: number): void {
+  for (const [key, hit] of hops) {
+    if (hit.expMs - nowMs <= REUSE_FLOOR_MS) hops.delete(key);
+  }
+}
+
+export function lookupHopToken(key: string, nowMs: number): string | null {
+  const hit = hops.get(key);
+  if (!hit) return null;
+  if (hit.expMs - nowMs <= REUSE_FLOOR_MS) {
+    hops.delete(key);
+    return null;
+  }
+  return hit.token;
+}
+
+export function storeHopToken(key: string, token: string, expMs: number, nowMs?: number): void {
+  if (nowMs !== undefined) sweepExpired(nowMs);
+  hops.set(key, { token, expMs });
+}
+
+/** Test seam. */
+export function _resetAccountMcpHopCacheForTests(): void {
+  hops.clear();
+}

--- a/src/account-mcp.ts
+++ b/src/account-mcp.ts
@@ -19,7 +19,9 @@
  * query-notes (the one account overlay) fans out through a 60s
  * `vault:<name>:read` mint to each vault's MCP `query-notes`. A failed
  * vault becomes that vault's `{ vault, error }` — never a whole-call
- * failure.
+ * failure. Opt-in reuse: `PARACHUTE_ACCOUNT_MCP_HOP_TTL_SECONDS` (1..599)
+ * mints once per (user, vault, verb) and reuses until TTL; unset keeps
+ * the per-call 60s hop. See `account-mcp-hop.ts` (hub#918). Default off.
  */
 import type { Database } from "bun:sqlite";
 import {


### PR DESCRIPTION
## Summary

Keep the hop JWT. The account door *is* the auth (NIP-98 or OAuth); the 60s mint is hop translation so vault can stay a resource server that only speaks hub JWTs. Teaching vault NIP-98 is a different project.

**Default (env unset): no wire-behavior change.** Every `tools/call` still mints a fresh unregistered 60s token.

**Opt-in:** `PARACHUTE_ACCOUNT_MCP_HOP_TTL_SECONDS=N` (1..599) mints once per `(user, vault, verb, issuer)` and reuses until TTL. Capped at 599 so hops stay under `REGISTERED_MINT_TTL_THRESHOLD_SECONDS` (600) — longer would need a tokens-table row, not this PR.

This is the recommended option for hub#918 consequence (1): `manage-token` list via account-MCP is empty because every call is a new 60s JWT. Reuse makes the vault ledger see a repeated principal. Default stays off until Aaron says flip.

## Not in this PR

Consequence (2) — hub `revoke-token` lags up to 60s because vault's scope-guard caches `/.well-known/parachute-revocation.json` (`REVOCATION_CACHE_TTL_MS = 60_000`). Prompt revoke needs the vault to honor a shorter Cache-Control or a bust. No vault change here; no flip without Aaron.

## Decisions (safest option)

- Invalid / empty / junk env → fail closed to today's per-call 60s mint. A typo must not silently change hop lifetime.
- 5s remaining is the reuse floor (a configured TTL of 1–5s therefore never reuses).
- Process-local `Map`; hub restart remints. Sweeps expired entries on store.

## Test plan

- [x] `parseAccountMcpHopTtl`: unset/junk/zero fail closed; `300` reuses; `600`/`1000` cap at 599; cap `<` registered-mint threshold
- [x] cache hit / 5s floor / sweep
- [x] `mintVaultMcpToken`: default two mints; TTL=300 reuses then remints after floor; different user/vault/verb/issuer do not share; TTL=1 never reuses
- [x] HTTP: two `list-tags` calls → 4 hop JWTs (catalog `tools/list` + `tools/call` × 2) by default; 1 JWT with TTL=300
- [x] `bun run typecheck` clean
- [x] `bun test ./src` at `fd61508`+this: **4857 pass / 1 skip / 3 fail**. All three fails are in untouched files and reproduce on clean `next` (git-credential timeout, TOTP floor timeout, well-known 10ms ENOENT race in `api-modules-ops.test.ts`).

Does not close #918 (revocation lag still open).

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.