### PR TITLE
fix(release): skip a first publish out of a merge — OIDC cannot create a package

### DIFF
--- a/scripts/release-plan.ts
+++ b/scripts/release-plan.ts
@@ -36,6 +36,21 @@
  * published only when the trigger is a branch push of `main`. `isTagPush`
  * still overrides the registry guards for **rc** versions (re-release, an
  * older rc, an ambiguous registry). It does not override this gate.
+ *
+ * **A first publish out of a merge.** npm trusted publishing (OIDC) cannot
+ * CREATE a package — it can only publish a new version of one that already
+ * exists and already trusts this workflow. So a package with nothing on npm
+ * at all used to read as "not published → publish", and the job 404'd at the
+ * registry (surface#220, `@openparachute/account-client@0.1.0`; same hole
+ * here). Worse than the noise: "never published" and "registry unreachable"
+ * are the two ways to see an empty registry, and only one of them is safe
+ * to act on. So a never-published package SKIPS on a branch push, with a
+ * reason that says how to do it deliberately. Note this is about the
+ * package, not the version: once anything is on npm, merge-driven releases
+ * take over as before. An explicit **tag push** of an rc still
+ * short-circuits — a human pushing a tag is the deliberate act, and letting
+ * it try surfaces the real npm error (`404` / "you must be logged in")
+ * instead of hiding it behind our own skip.
  */
 
 import { appendFileSync } from "node:fs";
@@ -77,9 +92,13 @@ export interface RegistryView {
   currentDistTagVersion?: string;
   /**
    * Every version currently on npm. Used to require an `X.Y.Z-rc.*` of the
-   * same core before a stable. Omitted is treated as empty — a stable then
-   * refuses unless this is a first-ever package (nothing on the dist-tag
-   * either). Forgetting to plumb the list must not silently skip the gate.
+   * same core before a stable, and — when it is empty AND no dist-tag
+   * resolves — to recognise a package that has never been published at all.
+   * Omitted is treated as empty, which now means "never published" and skips.
+   * That is the safe direction for a plumbing mistake: a forgotten list can
+   * only cost a skip, never an attempted publish of a package npm won't
+   * create. An unreadable registry is `{ ambiguous: true }`, not an empty
+   * list, and stays a refusal — the two must not collapse into each other.
    */
   publishedVersions?: readonly string[];
 }
@@ -218,6 +237,17 @@ export function decidePublish(
   if (registry.versionExists) {
     return { publish: false, reason: `${version} is already on npm` };
   }
+  // Nothing on npm under this name AT ALL — not "this version is new", but
+  // "this package does not exist". Trusted publishing cannot create it, so a
+  // merge-driven run would 404 (surface#220). Distinct from `ambiguous`
+  // above: that is a registry we couldn't read, this is a registry that
+  // answered 404. Only the second one is knowledge.
+  if ((registry.publishedVersions ?? []).length === 0 && !registry.currentDistTagVersion) {
+    return {
+      publish: false,
+      reason: `nothing is published under this name yet, and ${version} would be its first release — a first publish is a deliberate act, not a merge side-effect. npm trusted publishing cannot create a package, only add versions to one that already trusts this workflow. Publish once by hand (or push an explicit rc tag), wire up the trusted publisher, and merge-driven releases take over from the second version on.`,
+    };
+  }
   const current = registry.currentDistTagVersion;
   if (current && compareVersions(version, current) < 0) {
     return {
@@ -229,17 +259,17 @@ export function decidePublish(
     };
   }
   if (distTagFor(version) === "latest") {
+    // No first-ever carve-out here any more: a package with nothing published
+    // returned above, so by this point npm has *something* and a stable owes
+    // us a matching rc unconditionally.
     const published = registry.publishedVersions ?? [];
-    const firstEver = published.length === 0 && !current;
-    if (!firstEver) {
-      const rcs = matchingRcVersions(version, published);
-      if (rcs.length === 0) {
-        const core = coreVersion(version);
-        return {
-          refuse: true,
-          reason: `${version} is a stable release but npm has no ${core}-rc.* — stable is a suffix-drop from an rc, never a skip. Cut an rc first, soak, then drop the suffix.`,
-        };
-      }
+    const rcs = matchingRcVersions(version, published);
+    if (rcs.length === 0) {
+      const core = coreVersion(version);
+      return {
+        refuse: true,
+        reason: `${version} is a stable release but npm has no ${core}-rc.* — stable is a suffix-drop from an rc, never a skip. Cut an rc first, soak, then drop the suffix.`,
+      };
     }
   }
   return { publish: true, reason: `${version} is not on npm` };
@@ -255,7 +285,8 @@ export async function readRegistry(
   try {
     const res = await fetchImpl(`https://registry.npmjs.org/${encoded}`);
     if (res.status === 404) {
-      // Package has never been published at all — first release.
+      // Package does not exist. publishedVersions: [] (present-and-empty)
+      // is what decidePublish reads as never-published (surface#220).
       return { versionExists: false, publishedVersions: [] };
     }
     if (!res.ok) return { ambiguous: true };
@@ -374,8 +405,9 @@ if (import.meta.main) {
   }
   // Stable must be a suffix-drop from the latest matching rc tag.
   // decidePublish already required that npm has an X.Y.Z-rc.*; this is the
-  // "no new code" half. First-ever packages have no rc to diff against and
-  // skip. Tag-push overrides, same as decidePublish.
+  // "no new code" half. (Never-published packages don't reach here at all —
+  // decidePublish skips them, surface#220.) Tag-push overrides, same as
+  // decidePublish.
   if (
     decision.publish &&
     distTagFor(version) === "latest" &&

--- a/src/__tests__/release-plan.test.ts
+++ b/src/__tests__/release-plan.test.ts
@@ -71,9 +71,73 @@ describe("decidePublish", () => {
     expect(d).toMatchObject({ publish: false });
   });
 
-  test("first-ever release of a package publishes", () => {
-    const d = decidePublish("0.1.0", { versionExists: false }, { branch: "main" });
+  test("a never-published package SKIPS on a branch push — a first publish is deliberate", () => {
+    // surface#220 verbatim, same hole here: a 404 package used to read
+    // "0.1.0 is not on npm" → should_publish=true, and the OIDC publish 404'd.
+    const d = decidePublish(
+      "0.1.0",
+      { versionExists: false, publishedVersions: [] },
+      { branch: "main" },
+    );
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/first publish is a deliberate act/);
+    expect("reason" in d && d.reason).toMatch(/cannot create a package/);
+  });
+
+  test("an rc of a never-published package skips too — it's the package, not the channel", () => {
+    const d = decidePublish(
+      "0.1.0-rc.1",
+      { versionExists: false, publishedVersions: [] },
+      { branch: "next" },
+    );
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/nothing is published under this name yet/);
+  });
+
+  test("omitted publishedVersions with no dist-tag reads as never-published — skip, don't publish", () => {
+    const d = decidePublish("0.1.0-rc.1", { versionExists: false });
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/nothing is published under this name yet/);
+  });
+
+  test("a never-published package on an rc TAG PUSH still tries — a human said release this", () => {
+    const d = decidePublish(
+      "0.1.0-rc.1",
+      { versionExists: false, publishedVersions: [] },
+      { isTagPush: true },
+    );
     expect(d).toMatchObject({ publish: true });
+    expect("reason" in d && d.reason).toMatch(/explicit tag push/);
+  });
+
+  test("a never-published STABLE on a tag push is still refused by the from-main gate", () => {
+    const d = decidePublish(
+      "0.1.0",
+      { versionExists: false, publishedVersions: [] },
+      { isTagPush: true },
+    );
+    expect(d).toMatchObject({ publish: false });
+    expect("reason" in d && d.reason).toMatch(/from main only/);
+  });
+
+  test("an existing package is unaffected — one published version is enough", () => {
+    const d = decidePublish(
+      "0.1.0-rc.2",
+      {
+        versionExists: false,
+        currentDistTagVersion: "0.1.0-rc.1",
+        publishedVersions: ["0.1.0-rc.1"],
+      },
+      { branch: "next" },
+    );
+    expect(d).toMatchObject({ publish: true });
+    expect("reason" in d && d.reason).toMatch(/is not on npm/);
+  });
+
+  test("an unreadable registry is still a REFUSAL, not a never-published skip", () => {
+    const ambiguous = decidePublish("0.1.0-rc.1", { ambiguous: true }, { branch: "next" });
+    expect(ambiguous).toMatchObject({ refuse: true });
+    expect("refuse" in ambiguous && ambiguous.reason).toMatch(/refusing to guess/);
   });
 
   test("REFUSES to move a dist-tag backwards — the parallel-merge hazard", () => {
@@ -341,10 +405,17 @@ describe("readRegistry", () => {
     expect(v).toMatchObject({ currentDistTagVersion: "0.7.8" });
   });
 
-  test("a never-published package is not ambiguous — it's a first release", async () => {
+  test("a never-published package is not ambiguous — a 404 is knowledge", async () => {
     const v = await readRegistry("@openparachute/new", "0.1.0", (() =>
       json({}, 404)) as unknown as typeof fetch);
-    expect(v).toMatchObject({ versionExists: false });
+    expect(v).toMatchObject({ versionExists: false, publishedVersions: [] });
+    expect(v).not.toHaveProperty("ambiguous");
+  });
+
+  test("the 404 view composes into a skip — the two halves of surface#220 line up", async () => {
+    const v = await readRegistry("@openparachute/account-client", "0.1.0", (() =>
+      json({}, 404)) as unknown as typeof fetch);
+    expect(decidePublish("0.1.0", v, { branch: "main" })).toMatchObject({ publish: false });
   });
 
   test("a 5xx is ambiguous", async () => {


### PR DESCRIPTION
## Why

[surface#221](https://github.com/ParachuteComputer/parachute-surface/pull/221) closed the merge-driven first-publish hole for surface. Hub has the same `decidePublish` + `firstEver` carve-out. Port now, before the next new package.

## What

`scripts/release-plan.ts` `decidePublish` only, same shape as surface#221:

- Never-published (`publishedVersions` empty AND no dist-tag) **skips** on a branch push — OIDC cannot create a package.
- `{ambiguous: true}` still **refuses**.
- `isTagPush` of an **rc** still tries (sits above the new skip).
- `firstEver` carve-out removed; a stable now unconditionally owes a matching `X.Y.Z-rc.*`.
- Existing packages with ≥1 published version unchanged.

## Tests

`bun test src/__tests__/release-plan.test.ts` at `c85f46f`+this: **65 pass / 0 fail** (was 57). Did **not** run `bun test ./src` on this box — that suite can touch the live launchd hub (verify skill). CI PR-verify is the full typecheck + unit tests.

Vault's hole is a different shape (inline shell on the per-version URL). App's `readRegistry` 404 doesn't set `publishedVersions` — needs plumbing first. Not this PR.

Originating channel: parachute `3d4ee4fa-249b-4c6c-be0a-b0cea4c1610d`.
