### PR TITLE
fix(hub): pubkey-linkage follow-ups from #858 — label preservation on re-verify (#862) + non-zero busy_timeout (#861)

### DIFF
--- a/src/__tests__/api-account-pubkeys.test.ts
+++ b/src/__tests__/api-account-pubkeys.test.ts
@@ -334,6 +334,37 @@ describe("POST /verify — happy path", () => {
     expect(listUserPubkeys(db, alice.userId)).toHaveLength(1);
     expect(listUserPubkeys(db, alice.userId)[0]!.label).toBe("new");
   });
+
+  // hub#862. The wizard omits `label` entirely when its field is blank, so a
+  // plain "prove this key again" round trip used to silently wipe a label the
+  // user had set. Absent is now "unspecified"; only an explicit erase erases.
+  test("a re-verify carrying no label keeps the existing one", async () => {
+    const alice = await userWithSession("alice");
+    expect((await linkKey(alice, SECRET_A, { label: "laptop" })).status).toBe(200);
+
+    const res = await linkKey(alice, SECRET_A);
+    expect(res.status).toBe(200);
+    expect((await res.json()) as { relinked: boolean; label: string | null }).toMatchObject({
+      relinked: true,
+      label: "laptop",
+    });
+    expect(listUserPubkeys(db, alice.userId)[0]!.label).toBe("laptop");
+  });
+
+  test("a re-verify with an explicit null or empty label clears it", async () => {
+    for (const [name, cleared] of [
+      ["alice", null],
+      ["bob", ""],
+    ] as const) {
+      const user = await userWithSession(name);
+      const secret = name === "alice" ? SECRET_A : SECRET_B;
+      expect((await linkKey(user, secret, { label: "laptop" })).status).toBe(200);
+      const res = await linkKey(user, secret, { label: cleared });
+      expect(res.status).toBe(200);
+      expect(((await res.json()) as { label: string | null }).label).toBeNull();
+      expect(listUserPubkeys(db, user.userId)[0]!.label).toBeNull();
+    }
+  });
 });
 
 describe("POST /verify — the statement binding", () => {

--- a/src/__tests__/hub-db.test.ts
+++ b/src/__tests__/hub-db.test.ts
@@ -1,8 +1,9 @@
+import { Database } from "bun:sqlite";
 import { describe, expect, test } from "bun:test";
 import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { hubDbPath, migrate, openHubDb } from "../hub-db.ts";
+import { HUB_DB_BUSY_TIMEOUT_MS, hubDbPath, migrate, openHubDb } from "../hub-db.ts";
 
 interface Harness {
   configDir: string;
@@ -65,6 +66,35 @@ describe("openHubDb + migrate", () => {
         expect(versions).toContain(2);
       } finally {
         db2.close();
+      }
+    } finally {
+      h.cleanup();
+    }
+  });
+
+  // hub#861. Every hub write — the pubkey-linkage challenge-consume + link
+  // commit among them — runs on a connection from here, so the busy posture is
+  // set once, at open, rather than per call site.
+  test("opens with a non-zero busy_timeout so a contended write waits", () => {
+    const h = makeHarness();
+    try {
+      const db = openHubDb(h.dbPath);
+      try {
+        expect(HUB_DB_BUSY_TIMEOUT_MS).toBeGreaterThan(0);
+        expect(db.query<{ timeout: number }, []>("PRAGMA busy_timeout").get()?.timeout).toBe(
+          HUB_DB_BUSY_TIMEOUT_MS,
+        );
+      } finally {
+        db.close();
+      }
+      // Control: the pin above is not a tautology. A connection opened without
+      // our pragma reports 0 — SQLite's default, and the pre-fix behavior, in
+      // which the first SQLITE_BUSY fails the statement outright.
+      const bare = new Database(h.dbPath);
+      try {
+        expect(bare.query<{ timeout: number }, []>("PRAGMA busy_timeout").get()?.timeout).toBe(0);
+      } finally {
+        bare.close();
       }
     } finally {
       h.cleanup();

--- a/src/__tests__/pubkey-links.test.ts
+++ b/src/__tests__/pubkey-links.test.ts
@@ -387,6 +387,45 @@ describe("linkPubkey", () => {
     expect(listUserPubkeys(db, alice)).toHaveLength(1);
   });
 
+  // hub#862. A re-verify proves possession; it says nothing about the label
+  // unless the caller supplies one. `undefined` must therefore preserve, while
+  // an explicit `null` still clears — otherwise there is no way to erase.
+  test("a re-link with no label preserves the stored one; an explicit null clears it", async () => {
+    const alice = await user("alice");
+    const relink = (label: string | null | undefined, at: Date) => {
+      const c = issuePubkeyChallenge(db, alice, at);
+      return linkPubkey(db, {
+        userId: alice,
+        pubkey: PK_A,
+        challenge: c.challenge,
+        proofEvent: proof(PK_A, c.challenge),
+        ...(label === undefined ? {} : { label }),
+        now: at,
+      });
+    };
+    const stored = () => listUserPubkeys(db, alice)[0]?.label;
+
+    const first = relink("laptop", new Date(1_700_000_000_000));
+    expect(first.ok).toBe(true);
+    expect(stored()).toBe("laptop");
+
+    // The bug: this used to land as label = null.
+    const silent = relink(undefined, new Date(1_700_000_500_000));
+    expect(silent.ok && silent.relinked).toBe(true);
+    expect(silent.ok && silent.link.label).toBe("laptop");
+    expect(stored()).toBe("laptop");
+    // The retained proof archive keeps the same label, not a null one.
+    expect(attributionProofsForSubject(db, alice)[0]?.label).toBe("laptop");
+
+    // A new label still overwrites.
+    expect(relink("desktop", new Date(1_700_001_000_000)).ok).toBe(true);
+    expect(stored()).toBe("desktop");
+
+    // And an explicit null still erases.
+    expect(relink(null, new Date(1_700_001_500_000)).ok).toBe(true);
+    expect(stored()).toBeNull();
+  });
+
   test("enforces the per-user cap", async () => {
     const alice = await user("alice");
     const now = new Date();

--- a/src/api-account-pubkeys.ts
+++ b/src/api-account-pubkeys.ts
@@ -402,21 +402,30 @@ async function handleVerify(
   const unlinkable = unlinkableUsername(user.username);
   if (unlinkable) return unlinkable;
 
-  // 1. Label.
-  let label: string | null = null;
-  if (body.label !== undefined && body.label !== null) {
-    if (
-      typeof body.label !== "string" ||
-      body.label.length > MAX_PUBKEY_LABEL_LEN ||
-      LABEL_FORBIDDEN_RE.test(body.label)
-    ) {
-      return jsonError(
-        400,
-        "invalid_label",
-        `label must be printable single-line text of at most ${MAX_PUBKEY_LABEL_LEN} characters`,
-      );
+  // 1. Label. Three-valued on purpose (hub#862): ABSENT means "say nothing
+  //    about the label", which on a re-verify of an already-linked key leaves
+  //    the stored label standing. Only an explicit `null` (or empty string)
+  //    clears it. The old two-valued read collapsed absent into null and so
+  //    silently erased a label the user had set, on a request that was only
+  //    ever about re-proving possession.
+  let label: string | null | undefined;
+  if (body.label !== undefined) {
+    if (body.label === null || body.label === "") {
+      label = null;
+    } else {
+      if (
+        typeof body.label !== "string" ||
+        body.label.length > MAX_PUBKEY_LABEL_LEN ||
+        LABEL_FORBIDDEN_RE.test(body.label)
+      ) {
+        return jsonError(
+          400,
+          "invalid_label",
+          `label must be printable single-line text of at most ${MAX_PUBKEY_LABEL_LEN} characters`,
+        );
+      }
+      label = body.label;
     }
-    label = body.label;
   }
 
   // 2. Event shape. One generic error for every shape failure — the granular

--- a/src/hub-db.ts
+++ b/src/hub-db.ts
@@ -746,11 +746,36 @@ const MIGRATIONS: readonly Migration[] = [
   },
 ];
 
+/**
+ * How long a write waits for another connection's lock before giving up
+ * (hub#861). SQLite — and therefore `bun:sqlite` — defaults `busy_timeout` to
+ * **0**, which means the very first `SQLITE_BUSY` fails the statement
+ * immediately. WAL keeps readers out of the way, but it still allows only one
+ * writer at a time, and the hub has several: the server's request handlers,
+ * the CLI running against the same `hub.db`, and background sweeps. With a
+ * zero timeout, a transaction that merely overlapped another writer's
+ * millisecond-long commit surfaced as a user-visible failure — on the pubkey
+ * linkage path, a spuriously-rejected `/verify` that also burned the
+ * single-use challenge, which is the shape hub#861 reported.
+ *
+ * Five seconds is the widely-used SQLite default-ish value: long enough that
+ * ordinary contention is invisible, short enough that a genuinely stuck writer
+ * still returns an error instead of hanging a request forever.
+ *
+ * The busy handler only helps where a lock is acquired outright, not where a
+ * transaction upgrades from read to write (SQLite returns `SQLITE_BUSY`
+ * immediately there, by design, to avoid deadlock). The hub's contended write
+ * transactions take their write lock on the first statement, so they get the
+ * wait.
+ */
+export const HUB_DB_BUSY_TIMEOUT_MS = 5000;
+
 export function openHubDb(path: string = hubDbPath()): Database {
   mkdirSync(dirname(path), { recursive: true });
   const db = new Database(path);
   db.exec("PRAGMA journal_mode = WAL");
   db.exec("PRAGMA foreign_keys = ON");
+  db.exec(`PRAGMA busy_timeout = ${HUB_DB_BUSY_TIMEOUT_MS}`);
   migrate(db);
   return db;
 }

--- a/src/pubkey-links.ts
+++ b/src/pubkey-links.ts
@@ -217,6 +217,17 @@ export interface LinkPubkeyOpts {
   proofEvent: string;
   /** Id of that event (`nostrEventId`). */
   proofEventId?: string;
+  /**
+   * Three-valued, and the distinction is load-bearing on a re-verify (hub#862):
+   *
+   *   - `undefined` — "leave whatever is stored alone". A re-verify that
+   *     carries no label keeps the label the user set on an earlier link.
+   *   - `null` — "clear it". An explicit erase.
+   *   - a string — set it.
+   *
+   * On a FIRST link there is nothing to preserve, so `undefined` and `null`
+   * both land as a null label.
+   */
   label?: string | null;
   now?: Date;
 }
@@ -239,8 +250,11 @@ export type LinkPubkeyResult =
  *   3. Refuse a NEW key past the per-user cap. A re-verify of an existing key
  *      is exempt (it adds no row).
  *   4. Insert, or update-in-place when the same user re-verifies the same key.
- *      A re-verify refreshes `label`, `last_verified_at`, and the stored proof;
- *      `linked_at` is preserved as the original link time.
+ *      A re-verify refreshes `last_verified_at` and the stored proof;
+ *      `linked_at` is preserved as the original link time, and so is `label`
+ *      unless the caller supplied one (hub#862 — see `LinkPubkeyOpts.label`).
+ *      The label is the user's own annotation, not something the proof
+ *      establishes, so a ceremony that says nothing about it must not erase it.
  *
  * **A challenge that validated in step 1 stays consumed even when steps 2–3
  * refuse.** That is deliberate: the signed event has been presented, so it is
@@ -254,7 +268,11 @@ export type LinkPubkeyResult =
 export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult {
   const now = opts.now ?? new Date();
   const stamp = now.toISOString();
-  const label = opts.label ?? null;
+  // `undefined` means "unspecified" here, NOT "null" — the re-verify branch
+  // below reads it back to decide between keeping and overwriting the stored
+  // label. `?? null` is only correct on the insert branch, where there is no
+  // prior label to keep.
+  const label = opts.label;
   const proofEventId = opts.proofEventId ?? "";
 
   const run = db.transaction((): LinkPubkeyResult => {
@@ -282,15 +300,16 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
           .get(opts.userId) ?? { n: 0 }
       ).n;
       if (count >= MAX_PUBKEYS_PER_USER) return { ok: false, reason: "too_many_pubkeys" };
+      const newLabel = label ?? null;
       db.prepare(
         `INSERT INTO user_pubkeys
            (pubkey, user_id, label, proof_event, proof_event_id, linked_at, last_verified_at)
          VALUES (?, ?, ?, ?, ?, ?, ?)`,
-      ).run(opts.pubkey, opts.userId, label, opts.proofEvent, proofEventId, stamp, stamp);
+      ).run(opts.pubkey, opts.userId, newLabel, opts.proofEvent, proofEventId, stamp, stamp);
       retainAttributionProof(db, {
         subject: opts.userId,
         pubkey: opts.pubkey,
-        label,
+        label: newLabel,
         proofEvent: opts.proofEvent,
         proofEventId,
         linkedAt: stamp,
@@ -302,7 +321,7 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
         link: {
           pubkey: opts.pubkey,
           userId: opts.userId,
-          label,
+          label: newLabel,
           proofEventId,
           linkedAt: stamp,
           lastVerifiedAt: stamp,
@@ -310,15 +329,19 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
       };
     }
 
+    // hub#862: an unspecified label leaves the stored one standing. The row
+    // already exists, so "no label in this request" is the ceremony being
+    // silent about the label, not the user asking for it to be blank.
+    const nextLabel = label === undefined ? existing.label : label;
     db.prepare(
       `UPDATE user_pubkeys
          SET label = ?, proof_event = ?, proof_event_id = ?, last_verified_at = ?
        WHERE pubkey = ? AND user_id = ?`,
-    ).run(label, opts.proofEvent, proofEventId, stamp, opts.pubkey, opts.userId);
+    ).run(nextLabel, opts.proofEvent, proofEventId, stamp, opts.pubkey, opts.userId);
     retainAttributionProof(db, {
       subject: opts.userId,
       pubkey: opts.pubkey,
-      label,
+      label: nextLabel,
       proofEvent: opts.proofEvent,
       proofEventId,
       linkedAt: existing.linked_at,
@@ -330,7 +353,7 @@ export function linkPubkey(db: Database, opts: LinkPubkeyOpts): LinkPubkeyResult
       link: {
         pubkey: opts.pubkey,
         userId: opts.userId,
-        label,
+        label: nextLabel,
         proofEventId,
         linkedAt: existing.linked_at,
         lastVerifiedAt: stamp,


### PR DESCRIPTION
## Why

The three LOW/MEDIUM findings deferred out of #858's security review. One of them turned out to be already fixed on `next`; the other two are here.

## Fix → issue → test

| Issue | Fix | Test that pins it |
|---|---|---|
| #862 label-wipe | `LinkPubkeyOpts.label` becomes three-valued; `/verify` maps an absent body field to "unspecified" | `pubkey-links.test.ts` "a re-link with no label preserves the stored one; an explicit null clears it" + `api-account-pubkeys.test.ts` "a re-verify carrying no label keeps the existing one" / "…explicit null or empty label clears it" |
| #861 `busy_timeout=0` | `openHubDb` sets `PRAGMA busy_timeout = 5000` | `hub-db.test.ts` "opens with a non-zero busy_timeout so a contended write waits" |
| #859 duplicate binding tags | **none — already fixed on `next` by #866** | see below; not in this PR's Closes list |

### #862 — a re-verify with no label kept wiping the label

`LinkPubkeyOpts.label` was two-valued (`?? null`), so "the request said nothing about the label" and "the user asked to clear the label" were the same input. Re-verifying an already-linked key without a `label` overwrote the stored one with null. The wizard omits `label` entirely when its field is blank (`...(label.trim() ? { label: label.trim() } : {})`), so a plain "prove this key again" round trip *was* the wipe.

It is now three-valued, and the distinction only matters on the re-link branch:

- absent → keep whatever is stored
- `null` (or `""` on the wire) → clear it
- string → set it

The insert branch is unchanged in effect: on a first link there is no prior label, so absent and null both land as null. `attribution_proofs` follows the same value, so the retained proof row does not diverge from the live link.

Erasing a label is still possible — it just has to be asked for.

### #861 — `busy_timeout=0` on every hub write, not only the link path

`openHubDb` set `journal_mode` and `foreign_keys` and never touched `busy_timeout`, which SQLite (and so `bun:sqlite`) defaults to **0** — the first `SQLITE_BUSY` fails the statement outright rather than waiting. WAL keeps readers out of a writer's way but still allows one writer at a time, and the hub has several: the server's handlers, the CLI running against the same `hub.db`, background sweeps.

The issue observed it on the linkage path, where it is worst — a `/verify` that merely overlapped another writer's millisecond-long commit failed *after* the challenge-consume, burning a single-use challenge for a reason that had nothing to do with the request. But nothing about the fault is linkage-specific and `openHubDb` is the only write-side open in the tree (`grep -rn "new Database(" src` → `hub-db.ts` plus three `readonly: true` opens in `vault/auth-status.ts`), so the posture is set once at open rather than at one call site. That is what "align with the rest of the hub's write posture" means here: there was no other configured value to match, and now there is one, shared.

5000ms — ordinary contention becomes invisible; a genuinely stuck writer still errors instead of hanging a request forever. Documented in the same docblock: the busy handler covers acquiring a lock, not upgrading a read transaction to a write one, and the hub's contended transactions (`linkPubkey` included) take their write lock on the first statement, so they get the wait.

### #859 — no code in this PR; already fixed on `next`

`checkBinding` already calls `duplicateBindingTag`, which rejects a second `u` / `method` / `challenge` tag with the file's standard `400 invalid_event`, before any binding check runs. It landed in **#866** (`fix(hub#859): reject duplicate linkage binding tags`, merged 2026-08-24) and carries the test the issue asks for — `api-account-pubkeys.test.ts` "duplicate binding tags are refused even when the first value is valid", which walks a duplicate `u`, `method`, and `challenge` in turn with a valid first value. Verified present at `fd61508` (this branch's base), not just in the PR record.

So the issue is already resolved; this PR carries no code for it and does not claim to close it.

## Verification

At `eb83c34`:

- `bun run typecheck` — clean (`tsc --noEmit`, exit 0)
- `bunx biome check` on the six touched files — clean
- `bun test ./src` — full-suite counts are being re-measured head-to-head against clean `fd61508`; see the "attribution" note below.

**Each new test was watched fail before being believed.** Reverting `nextLabel` to `label ?? null` and deleting the `busy_timeout` exec, with the tests kept, reds exactly the three new cases and nothing else — 83 pass / 3 fail across the three touched files, vs 86 pass / 0 fail with the fixes. The `busy_timeout` assertion also carries a positive control (a bare `new Database(path)` on the same file must report `0`), so the pin cannot pass by accident if the pragma exec is dropped.

**On this box's full-suite noise.** A full `bun test ./src` here today is dominated by nondeterministic 5000ms timeout flakes concentrated in the argon2id / TOTP-heavy files — different members of that family fail on each run. Because `busy_timeout` could in principle turn a fast `SQLITE_BUSY` into a 5s block of `bun:sqlite`'s synchronous API, that possibility was checked directly rather than assumed away, running identical file sets on this branch and on a clean `fd61508` worktree:

| File set | clean `fd61508` | this branch |
|---|---|---|
| `two-factor` + `admin-host-admin-token` + `api-account-2fa` | 46 pass / 2 fail | 47 pass / 1 fail |
| `api-users` + `admin-module-token` + `admin-lock` | **110 pass / 0 fail** (113.7s) | **110 pass / 0 fail** (55.7s) |

The first row flakes on both, with *different* members failing — load-dependent, not caused by this change. The second row covers every non-argon2 failure seen in a full run (`handleListVaults`, `handleUpdateUserVaults`, `handlePromoteHubAdmin`, `handleResetUserPassword`, `handleModuleToken`, `handleHostAdminToken`) and is green on both — and faster with the change, which is the opposite of what a 5s stall would do.

Not smoke-tested through a live ceremony: both changes are below the HTTP layer and are covered at the store and the handler, and the box's live `~/.parachute` is out of bounds for lifecycle commands.

Closes #861, closes #862.

#859 is deliberately **not** in that list — #866 already fixed it, so there is no diff here to close it with. It should be closed against #866.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
