### PR TITLE
docs(hub#853): stale four-handlers comment + wizard MCP-URL self-contradiction

### DIFF
--- a/src/hub-server.ts
+++ b/src/hub-server.ts
@@ -3377,7 +3377,7 @@ export function hubFetch(
       // Admin screen-lock management (optional idle PIN lock for the admin
       // UI). Session-cookie-gated to the first admin; these manage the lock
       // itself so they are NOT behind the lock gate. The lock GATE lives in
-      // the four `/admin/*-token` mint handlers (admin-lock.ts:requireUnlocked)
+      // the three `/admin/*-token` mint handlers (admin-lock.ts:requireUnlocked)
       // — it does NOT touch `/oauth/*`, so the OAuth issuer is unaffected.
       if (pathname === "/api/admin-lock" || pathname.startsWith("/api/admin-lock/")) {
         if (!getDb) return dbNotConfigured();

--- a/src/setup-wizard.ts
+++ b/src/setup-wizard.ts
@@ -797,8 +797,9 @@ export function renderVaultStep(props: RenderVaultStepProps): string {
           <span class="preview-fine">— admin: you, MCP-ready for Claude Code</span>
         </div>
         <p class="preview-fine">
-          The name shows up in the MCP URL (<code>/vault/&lt;name&gt;/mcp</code>)
-          and on the admin UI. You can add or manage vaults later from the
+          The name labels the vault on the admin UI, and rides along as the
+          MCP server name (<code>parachute-&lt;name&gt;</code>) if you connect
+          this vault on its own. You can add or manage vaults later from the
           vault module's own admin at <code>/vault/admin/</code>.
         </p>
       </section>


### PR DESCRIPTION
## Why

Two copy drifts the #850-#852 docs sweep spotted and deliberately left for whoever next touched these files. Comments and user-facing copy only — no behavior change, no wire change, no new tests.

## What

**1. `hub-server.ts` — "the four `/admin/*-token` mint handlers" → three.**

The admin screen-lock comment still named four mint chokepoints. There have been three since the agent-token retirement; #851 corrected the design doc (`design/2026-06-17-admin-ui-lock.md`) and deliberately left the code comment.

Counted rather than assumed: `requireUnlocked` has four non-test call sites, but the fourth is `account-token.ts` (`/account/token`, friend-facing), which is not an `/admin/*-token` route. The three the sentence is about are exactly the ones `admin-lock.ts`'s own "single chokepoint" list already enumerates:

| Handler | Route |
|---|---|
| `admin-host-admin-token.ts` | `GET /admin/host-admin-token` |
| `admin-vault-admin-token.ts` | `GET /admin/vault-admin-token/<name>` |
| `admin-module-token.ts` | `GET /admin/module-token/<short>` |

**2. `setup-wizard.ts` — the wizard no longer contradicts itself about the MCP URL.**

The vault-naming preview sold the name as "the MCP URL (`/vault/<name>/mcp`)" while the same wizard's done screen now leads with root `/mcp` and calls the per-vault URL the skip-the-picker option (#852). Neither statement was wrong — the per-vault door exists — but an operator meets both screens minutes apart.

Reworded to what the name actually buys you now: the admin-UI label, plus the `parachute-<name>` MCP **server name** in the per-vault `claude mcp add` command (`assignedVaultClaudeMcpAddCommand`), which is the form the done screen itself prints. The paragraph no longer advertises a URL shape the next screen de-emphasizes.

## Verification

At `5edb7da`:

- `bun run typecheck` — clean (`tsc --noEmit`, exit 0)
- `bunx biome check` on both touched files — clean
- `bun test ./src` — counts pending a head-to-head run against clean `fd61508`; this diff changes one comment word and one HTML copy string, so it has no executable surface.

Grepped `src`, `web/ui/src`, and `e2e` for the old strings (`shows up in the MCP URL`, `vault/&lt;name&gt;/mcp`, ``four `/admin``) before editing: no test or other file asserts on them.

Not smoke-tested in a live wizard run: the change is a static copy string inside an already-rendered `<p>`, with no branching, and the surrounding markup is untouched.

Closes #853.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
